### PR TITLE
chore: add missing plugins to marketplace manifests

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,6 +15,30 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Cloud"
+    },
+    {
+      "name": "aws-agent-building",
+      "source": {
+        "source": "local",
+        "path": "./plugins/aws-agent-building"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Cloud"
+    },
+    {
+      "name": "aws-data-analytics",
+      "source": {
+        "source": "local",
+        "path": "./plugins/aws-data-analytics"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Cloud"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,6 +17,27 @@
       "name": "aws-core",
       "source": "./plugins/aws-core",
       "version": "0.1.0"
+    },
+    {
+      "category": "cloud",
+      "description": "AWS agent plugin with skills and MCP server connections.",
+      "keywords": [
+        "aws"
+      ],
+      "name": "aws-agent-building",
+      "source": "./plugins/aws-agent-building",
+      "version": "0.1.0"
+    },
+    {
+      "category": "cloud",
+      "description": "AWS agent plugin with skills and MCP server connections.",
+      "keywords": [
+        "aws",
+        "analytics"
+      ],
+      "name": "aws-data-analytics",
+      "source": "./plugins/aws-data-analytics",
+      "version": "0.1.0"
     }
   ]
 }


### PR DESCRIPTION
## Description

Add `aws-agent-building` and `aws-data-analytics` plugins to both the Claude Code (`.claude-plugin/marketplace.json`) and Codex (`.agents/plugins/marketplace.json`) marketplace manifests. These plugins already exist under `plugins/` but were not listed in the marketplace files.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [x] Documentation update
- [ ] CI/CD change
- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*