### PR TITLE
docs: Update READMEs for Agent Toolkit for AWS launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Help AI coding agents build, deploy, and manage applications on AWS.
 
-The Agent Toolkit for AWS gives AI coding agents the tools, knowledge, and guardrails they need to work with AWS services. It works with the coding agents developers already use — including Claude Code, Cursor, and Codex.
+The Agent Toolkit for AWS gives AI coding agents the tools, knowledge, and guardrails they need to work with AWS services. It works with the coding agents developers already use — including Claude Code and Codex.
 
 ## Quick start
 
@@ -10,7 +10,7 @@ The Agent Toolkit for AWS gives AI coding agents the tools, knowledge, and guard
 
 ```
 /plugin marketplace add aws/agent-toolkit-for-aws
-/plugin install aws-core@aws-agent-toolkit-for-aws
+/plugin install aws-core@agent-toolkit-for-aws
 /reload-plugins
 ```
 
@@ -86,10 +86,6 @@ The [AWS MCP Server](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/
 
 - [User guide](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/) — Setup, configuration, and reference documentation.
 - [AWS MCP Server tools](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/understanding-mcp-server-tools.html) — Reference for all available MCP tools.
-
-## Security
-
-If you discover a potential security issue, please follow the [AWS Vulnerability Reporting](https://aws.amazon.com/security/vulnerability-reporting/) process. Do not create a public GitHub issue.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,74 +1,96 @@
 # Agent Toolkit for AWS
 
-A plugin marketplace hosting installable agent plugins for AWS. Ships with the `aws-core` plugin and supports Claude Code, Codex, and Kiro.
+Help AI coding agents build, deploy, and manage applications on AWS.
 
-## Scope
+The Agent Toolkit for AWS gives AI coding agents the tools, knowledge, and guardrails they need to work with AWS services. It works with the coding agents developers already use — including Claude Code, Cursor, and Codex.
 
-This project provides agent skills, plugin configurations, and MCP server connections for AWS services. It covers operational tasks, best-practice workflows, and service-specific guidance.
-
-Out of scope: non-AWS content, executable applications, infrastructure deployment tools, and standalone CLI utilities.
-
-## Plugins
-
-| Plugin | Description | Skills | MCP Servers |
-|--------|-------------|--------|-------------|
-| [aws-core](plugins/aws-core/) | AWS agent plugin with skills and MCP server connections | [find-aws-skills](skills/find-aws-skills/) | [aws-mcp](https://aws-mcp.us-east-1.api.aws/mcp) |
-
-## Installation
+## Quick start
 
 ### Claude Code
 
-```bash
-# Add the marketplace
+```
 /plugin marketplace add aws/agent-toolkit-for-aws
-
-# Install a plugin
-/plugin install aws-core@agent-toolkit-for-aws
+/plugin install aws-core@aws-agent-toolkit-for-aws
+/reload-plugins
 ```
 
 ### Codex
 
-The Codex marketplace manifest is at `.agents/plugins/marketplace.json`. Codex discovers plugins from the repository automatically.
+In your terminal:
 
-### Kiro
-
-Kiro support is provided via the `@every-env/compound-plugin` converter, which reads the Claude Code plugin structure and generates `.kiro/` format externally.
-
-## Skills
-
-All skills live in the top-level [`skills/`](skills/) directory. This is the canonical source. The `aws-core` plugin bundles a default subset for out-of-the-box use.
-
-| Skill | Description |
-|-------|-------------|
-| [find-aws-skills](skills/find-aws-skills/) | Discover and load AWS skills at runtime |
-
-## Rules
-
-Platform-agnostic agent configuration snippets are in [`rules/`](rules/). Copy the relevant sections into your `AGENTS.md`, `CLAUDE.md`, or `.kiro/steering/` files.
-
-## Development
-
-This project uses [Mise](https://mise.jdx.dev/) as a task runner.
-
-```bash
-# Run full build (lint + validate + security)
-mise run build
-
-# Run only validation
-python3 tools/validate.py
-
-# Validate a single plugin
-python3 tools/validate.py --plugin aws-core
+```
+codex plugin marketplace add aws/agent-toolkit-for-aws
 ```
 
-## Contributing
+Then launch Codex and run `/plugins` to browse and install the **aws-core** plugin.
 
-This project is not accepting external contributions at this time.
+### Agents that do not support plugins
+
+Add the AWS MCP Server to your agent's MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "aws": {
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws@latest",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--metadata", "AWS_REGION=us-west-2"
+      ]
+    }
+  }
+}
+```
+
+Then copy skills from this repository to your agent's skills directory.
+
+> **Prerequisites:** You need [uv](https://docs.astral.sh/uv/) installed. An AWS account with credentials configured locally is required for API calls and script execution, but not for documentation search or skill discovery. See the [user guide](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/) for detailed setup instructions.
+
+## What's included
+
+### Plugins
+
+Plugins bundle the AWS MCP Server configuration and agent skills into a single install for your coding agent.
+
+| Plugin | Description |
+|--------|-------------|
+| [aws-core](plugins/aws-core/) | Core AWS skills and MCP Server configuration. Covers service selection, CDK/CloudFormation, serverless, containers, storage, observability, billing, SDK usage, and deployment. **Start here.** |
+| [aws-agent-building](plugins/aws-agent-building/) | Skills for building AI agents on AWS with Amazon Bedrock and AgentCore. |
+| [aws-data-analytics](plugins/aws-data-analytics/) | Skills for data lake, analytics, and ETL workflows with S3 Tables, Glue, and Athena. |
+
+Plugins are currently available for Claude Code and Codex. For other agents, configure the AWS MCP Server directly and install skills from this repository.
+
+### Skills
+
+Agent skills are curated packages of instructions and reference materials that help agents complete specific AWS tasks. Skills are loaded on demand — agents discover and retrieve only what's relevant to the current task.
+
+Browse the [`skills/`](skills/) directory to see all available skills.
+
+### Rules files
+
+Recommended project-level configuration files that tell agents how to use AWS most effectively — for example, by using the AWS MCP Server, discovering available skills, or searching documentation before acting.
+
+See [`rules/`](rules/) for details.
+
+### AWS MCP Server
+
+The [AWS MCP Server](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/understanding-mcp-server-tools.html) is a managed server that gives agents access to AWS through the Model Context Protocol. It provides:
+
+- **Full AWS API coverage** — Interact with any of the 300+ AWS services through a single authenticated endpoint.
+- **Sandboxed script execution** — Agents can run Python scripts in an isolated environment for complex multi-step operations.
+- **Real-time documentation access** — Search and retrieve current AWS documentation, API references, and service capabilities without authentication.
+- **Enterprise controls** — Amazon CloudWatch metrics, IAM context keys for agent-specific policies, and AWS CloudTrail audit logging.
+
+## Documentation
+
+- [User guide](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/) — Setup, configuration, and reference documentation.
+- [AWS MCP Server tools](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/understanding-mcp-server-tools.html) — Reference for all available MCP tools.
 
 ## Security
 
-If you discover a potential security issue in this project, please notify AWS/Amazon Security via the [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
+If you discover a potential security issue, please follow the [AWS Vulnerability Reporting](https://aws.amazon.com/security/vulnerability-reporting/) process. Do not create a public GitHub issue.
 
 ## License
 
-This project is licensed under the Apache-2.0 License.
+This project is licensed under the Apache-2.0 License. See [LICENSE](LICENSE) for details.

--- a/plugins/aws-core/README.md
+++ b/plugins/aws-core/README.md
@@ -8,7 +8,7 @@ The primary plugin for the Agent Toolkit for AWS. This plugin gives your AI codi
 
 ```
 /plugin marketplace add aws/agent-toolkit-for-aws
-/plugin install aws-core@aws-agent-toolkit-for-aws
+/plugin install aws-core@agent-toolkit-for-aws
 /reload-plugins
 ```
 
@@ -51,7 +51,7 @@ This plugin includes the following default skills:
 | observability | Monitor applications with CloudWatch |
 | containers | Run containerized workloads on AWS |
 | storage | Store and manage data with AWS storage services |
-| amplify | Build full-stack web and mobile applications with AWS Amplify |
+| amplify-gen2 | Build full-stack web and mobile applications with AWS Amplify Gen2 |
 
 <!-- [TODO] Confirm final skill list matches what ships in the plugin. deploy-to-aws status is RED in tracker. -->
 

--- a/plugins/aws-core/README.md
+++ b/plugins/aws-core/README.md
@@ -1,32 +1,65 @@
-# Agent Plugin for AWS
+# aws-core
 
-AWS agent plugin with skills and MCP server connections.
+The primary plugin for the Agent Toolkit for AWS. This plugin gives your AI coding agent the AWS MCP Server configuration and a curated set of agent skills — everything it needs to build, deploy, and manage applications on AWS.
 
-## Skills
-
-| Skill | Description |
-|-------|-------------|
-| [find-aws-skills](skills/find-aws-skills/) | Discover and load AWS skills at runtime |
-
-## MCP Servers
-
-| Server | Transport | Description |
-|--------|-----------|-------------|
-| aws-mcp | stdio | AWS MCP server via `mcp-proxy-for-aws` |
-
-## Installation
+## Install
 
 ### Claude Code
 
-```bash
+```
 /plugin marketplace add aws/agent-toolkit-for-aws
-/plugin install aws-core@agent-toolkit-for-aws
+/plugin install aws-core@aws-agent-toolkit-for-aws
+/reload-plugins
 ```
 
 ### Codex
 
-Discovered automatically from the marketplace manifest.
+In your terminal:
 
-## License
+```
+codex plugin marketplace add aws/agent-toolkit-for-aws
+```
 
-Apache-2.0
+Then launch Codex and run `/plugins` to browse and install the **aws-core** plugin.
+
+## What's included
+
+### AWS MCP Server
+
+This plugin configures the [AWS MCP Server](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/understanding-mcp-server-tools.html), a managed server that gives your agent:
+
+- Real-time AWS documentation search through `search_documentation` (no authentication required)
+- On-demand skill discovery and retrieval through `retrieve_skill` (no authentication required)
+- Authenticated access to any of the 300+ AWS services through `call_aws`
+- Sandboxed Python script execution through `run_script`
+
+### Skills
+
+This plugin includes the following default skills:
+
+| Skill | Description |
+|-------|-------------|
+| billing-and-cost-management | Analyze, monitor, and optimize AWS costs |
+| aws-sdk-js-v3-usage | Best practices for the AWS SDK for JavaScript v3 |
+| aws-sdk-python-usage | Best practices for the AWS SDK for Python (boto3) |
+| aws-sdk-swift-usage | Best practices for the AWS SDK for Swift |
+| find-aws-skills | Discover additional AWS skills |
+| aws-serverless | Build serverless applications on AWS |
+| bedrock | Build with Amazon Bedrock foundation models |
+| cdk | Define and manage AWS infrastructure with CDK and CloudFormation |
+| cloudformation | CloudFormation deployment, validation, and troubleshooting |
+| observability | Monitor applications with CloudWatch |
+| containers | Run containerized workloads on AWS |
+| storage | Store and manage data with AWS storage services |
+| amplify | Build full-stack web and mobile applications with AWS Amplify |
+
+<!-- [TODO] Confirm final skill list matches what ships in the plugin. deploy-to-aws status is RED in tracker. -->
+
+### Rules files
+
+Recommended AWS rules files are available separately in the [`rules/`](../rules/) directory of this repository. See the [rules README](../rules/README.md) for details.
+
+## Documentation
+
+- [User guide](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/)
+- [AWS MCP Server tools reference](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/understanding-mcp-server-tools.html)

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,48 @@
+# Agent Skills for AWS
+
+This directory contains agent skills — curated packages of instructions and reference materials that help AI coding agents complete AWS tasks effectively.
+
+## How skills work
+
+Each skill is a directory containing a `SKILL.md` file with a description and instructions, plus optional reference files and scripts. Skills use progressive disclosure:
+
+1. At startup, your agent reads only the skill name and description (~50-100 tokens per skill).
+2. When a task matches a skill's description, the agent loads the full instructions.
+3. The agent follows the skill's procedures, loading reference files only as needed.
+4. When the task is complete, the skill context is released.
+
+This means having many skills installed doesn't slow your agent down or consume your context window.
+
+## Using skills
+
+There are three ways to get skills:
+
+- **Install a plugin** — If you installed a plugin (aws-core, aws-agent-building, or aws-data-analytics), the skills bundled with that plugin are already available to your agent.
+
+- **Install locally** — Copy skill directories from this repository to your agent's skills location, or use `npx skills add aws/agent-toolkit-for-aws`.
+
+- **Discover at runtime** — Agents can search for and load skills on demand through the AWS MCP Server, without any local installation. Ask your agent: "Search for AWS skills related to databases."
+
+To install skills locally, copy the skill directory to your agent's skills location:
+
+| Agent | Global skills path | Project skills path |
+|-------|-------------------|-------------------|
+| Claude Code | `~/.claude/skills/` | `.claude/skills/` |
+| Codex | `~/.codex/skills/` | `.agents/skills/` |
+| Cursor | `~/.cursor/skills/` | `.cursor/skills/` |
+
+## Skill format
+
+Each skill follows this structure:
+
+```
+skill-name/
+├── SKILL.md              # Required: description + instructions
+├── references/           # Optional: detailed guidance for subtasks
+│   ├── topic-a.md
+│   └── topic-b.md
+└── scripts/              # Optional: code scripts for deterministic operations
+    └── validate.sh
+```
+
+The `SKILL.md` file includes YAML frontmatter with a `name` and `description`, followed by the skill's instructions in markdown. Skills can also include slash commands that let you invoke them directly.


### PR DESCRIPTION
Updates READMEs for the 4/30 GA launch.

**Changes:**
- Top-level README: comprehensive overview, quick start for Claude Code/Codex/other agents, component descriptions
- plugins/aws-core/README.md: install instructions, default skill list, MCP Server capabilities
- skills/README.md (new): explains skill format, three ways to use skills, directory structure

**Note:** Plugin is still named aws-agent-building in the repo — rename to aws-agents is a separate change.