### PR TITLE
ci: add merge_group trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build
 on:
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The merge queue times out because `.github/workflows/build.yml` only triggers on `pull_request` events. Adding `merge_group` so CI runs on merge queue commits.

This is a one-line fix — adds `merge_group:` to the `on:` block.