### PR TITLE
feat(aws-data-analytics): Add aws-data-analytics plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,10 +30,17 @@
     },
     {
       "category": "cloud",
-      "description": "AWS agent plugin with skills and MCP server connections.",
+      "description": "Data lake, analytics, and ETL workflows with S3 Tables, AWS Glue, and Athena.",
       "keywords": [
         "aws",
-        "analytics"
+        "analytics",
+        "data-lake",
+        "athena",
+        "glue",
+        "s3-tables",
+        "s3-vectors",
+        "iceberg",
+        "etl"
       ],
       "name": "aws-data-analytics",
       "source": "./plugins/aws-data-analytics",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Plugins bundle the AWS MCP Server configuration and agent skills into a single i
 |--------|-------------|
 | [aws-core](plugins/aws-core/) | Core AWS skills and MCP Server configuration. Covers service selection, CDK/CloudFormation, serverless, containers, storage, observability, billing, SDK usage, and deployment. **Start here.** |
 | [aws-agents](plugins/aws-agents/) | Skills for building AI agents on AWS with Amazon Bedrock and AgentCore. |
-| [aws-data-analytics](plugins/aws-data-analytics/) | Skills for data lake, analytics, and ETL workflows with S3 Tables, Glue, and Athena. |
+| [aws-data-analytics](plugins/aws-data-analytics/) | Skills for data lake, analytics, and ETL workflows with S3 Tables, AWS Glue, and Athena. |
 
 Plugins are currently available for Claude Code and Codex. For other agents, configure the AWS MCP Server directly and install skills from this repository.
 

--- a/plugins/aws-data-analytics/.claude-plugin/plugin.json
+++ b/plugins/aws-data-analytics/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "author": {
     "name": "Amazon Web Services"
   },
-  "description": "Data lake, analytics, and ETL workflows with S3 Tables, Glue, and Athena.",
+  "description": "Data lake, analytics, and ETL workflows with S3 Tables, AWS Glue, and Athena.",
   "homepage": "https://github.com/aws/agent-toolkit-for-aws",
   "keywords": [
     "aws",

--- a/plugins/aws-data-analytics/.claude-plugin/plugin.json
+++ b/plugins/aws-data-analytics/.claude-plugin/plugin.json
@@ -2,10 +2,18 @@
   "author": {
     "name": "Amazon Web Services"
   },
-  "description": "AWS agent plugin with skills and MCP server connections.",
+  "description": "Data lake, analytics, and ETL workflows with S3 Tables, Glue, and Athena.",
   "homepage": "https://github.com/aws/agent-toolkit-for-aws",
   "keywords": [
-    "aws"
+    "aws",
+    "analytics",
+    "data-lake",
+    "athena",
+    "glue",
+    "s3-tables",
+    "s3-vectors",
+    "iceberg",
+    "etl"
   ],
   "license": "Apache-2.0",
   "name": "aws-data-analytics",

--- a/plugins/aws-data-analytics/.codex-plugin/plugin.json
+++ b/plugins/aws-data-analytics/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-data-analytics",
   "version": "0.1.0",
-  "description": "AWS agent plugin with skills and MCP server connections.",
+  "description": "Data lake, analytics, and ETL workflows with S3 Tables, Glue, and Athena.",
   "author": {
     "name": "Amazon Web Services"
   },
@@ -9,9 +9,9 @@
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
-    "displayName": "Agent Plugin for AWS",
-    "shortDescription": "AWS agent plugin with skills and MCP servers",
-    "longDescription": "AWS agent plugin with skills and MCP server connections.",
+    "displayName": "AWS Data Analytics",
+    "shortDescription": "Data lake, analytics, and ETL workflows with S3 Tables, Glue, and Athena",
+    "longDescription": "Skills for building and operating data lakes on AWS. Covers table creation, data ingestion, querying, discovery, vector storage, and external connectivity across S3 Tables, Glue, Athena, and more.",
     "developerName": "Amazon Web Services",
     "category": "Cloud",
     "capabilities": [

--- a/plugins/aws-data-analytics/.codex-plugin/plugin.json
+++ b/plugins/aws-data-analytics/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-data-analytics",
   "version": "0.1.0",
-  "description": "Data lake, analytics, and ETL workflows with S3 Tables, Glue, and Athena.",
+  "description": "Data lake, analytics, and ETL workflows with S3 Tables, AWS Glue, and Athena.",
   "author": {
     "name": "Amazon Web Services"
   },
@@ -10,8 +10,8 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "AWS Data Analytics",
-    "shortDescription": "Data lake, analytics, and ETL workflows with S3 Tables, Glue, and Athena",
-    "longDescription": "Skills for building and operating data lakes on AWS. Covers table creation, data ingestion, querying, discovery, vector storage, and external connectivity across S3 Tables, Glue, Athena, and more.",
+    "shortDescription": "Data lake, analytics, and ETL workflows with S3 Tables, AWS Glue, and Athena",
+    "longDescription": "Skills for building and operating data lakes on AWS. Covers table creation, data ingestion, querying, discovery, vector storage, and external connectivity across S3 Tables, AWS Glue, Athena, and more.",
     "developerName": "Amazon Web Services",
     "category": "Cloud",
     "capabilities": [

--- a/plugins/aws-data-analytics/README.md
+++ b/plugins/aws-data-analytics/README.md
@@ -4,8 +4,8 @@
 
 This plugin brings AWS data engineering expertise directly into your coding assistant, covering the full data lifecycle across [AWS Analytics](https://aws.amazon.com/big-data/datalakes-and-analytics/) services; currently, skills are provided to assist with the following capability areas:
 
-- **Data Lake Operations** — Build and operate a data lake on AWS: create managed Iceberg tables on Amazon S3 Tables, ingest data from diverse sources (S3, JDBC databases, Snowflake, BigQuery, DynamoDB, Glue catalog tables), and query across default and federated catalogs with Amazon Athena.
-- **Data Discovery** — Inventory and audit your AWS Glue Data Catalog across S3 Tables, Redshift-federated, and remote Iceberg catalogs. Resolve data asset references by name, keyword, column, or reverse-lookup from S3 location metadata in the catalog.
+- **Data Lake Operations** — Build and operate a data lake on AWS: create managed Iceberg tables on Amazon S3 Tables, ingest data from diverse sources (S3, JDBC databases, Snowflake, BigQuery, DynamoDB, AWS Glue catalog tables), and query across default and federated catalogs with Amazon Athena.
+- **Data Discovery** — Inventory and audit your AWS Glue Data Catalog across S3 Tables, Amazon Redshift-federated, and remote Iceberg catalogs. Resolve data asset references by name, keyword, column, or reverse-lookup from S3 location metadata in the catalog.
 - **Vector Storage** — Store and query vector embeddings using Amazon S3 Vectors for cost-effective semantic search and RAG workloads.
 - **External Connectivity** — Create and troubleshoot AWS Glue connections to JDBC databases (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora), Amazon Redshift, Snowflake, and BigQuery.
 
@@ -13,13 +13,13 @@ This plugin brings AWS data engineering expertise directly into your coding assi
 
 | # | Skill | Description | Documentation |
 | -- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
-| 1 | `create-data-lake-table` | Create managed Iceberg tables using Amazon S3 Tables with automatic compaction, Glue catalog registration, and partitioning | [SKILL.md](skills/create-data-lake-table/SKILL.md) |
-| 2 | `ingest-into-data-lake` | Import data from S3 files, JDBC databases, Snowflake, BigQuery, DynamoDB, or existing Glue catalog tables into S3 Tables or standard Iceberg | [SKILL.md](skills/ingest-into-data-lake/SKILL.md) |
-| 3 | `query-data-lake` | Execute and manage Athena SQL queries across default and federated catalogs (Glue, S3 Tables, Redshift) | [SKILL.md](skills/query-data-lake/SKILL.md) |
-| 4 | `find-data-lake-assets` | Resolve data lake asset references across Glue Data Catalog, S3, S3 Tables, and Redshift by name, keyword, column, or S3 path | [SKILL.md](skills/find-data-lake-assets/SKILL.md) |
-| 5 | `exploring-data-catalog` | Full inventory and audit of AWS Glue Data Catalog assets across S3 Tables, Redshift-federated, and remote Iceberg catalogs | [SKILL.md](skills/exploring-data-catalog/SKILL.md) |
+| 1 | `create-data-lake-table` | Create managed Iceberg tables using Amazon S3 Tables with automatic compaction, AWS Glue catalog registration, and partitioning | [SKILL.md](skills/create-data-lake-table/SKILL.md) |
+| 2 | `ingest-into-data-lake` | Import data from S3 files, JDBC databases, Snowflake, BigQuery, DynamoDB, or existing AWS Glue catalog tables into S3 Tables or standard Iceberg | [SKILL.md](skills/ingest-into-data-lake/SKILL.md) |
+| 3 | `query-data-lake` | Execute and manage Athena SQL queries across default and federated catalogs (AWS Glue, S3 Tables, Amazon Redshift) | [SKILL.md](skills/query-data-lake/SKILL.md) |
+| 4 | `find-data-lake-assets` | Resolve data lake asset references across AWS Glue Data Catalog, S3, S3 Tables, and Amazon Redshift by name, keyword, column, or S3 path | [SKILL.md](skills/find-data-lake-assets/SKILL.md) |
+| 5 | `exploring-data-catalog` | Full inventory and audit of AWS Glue Data Catalog assets across S3 Tables, Amazon Redshift-federated, and remote Iceberg catalogs | [SKILL.md](skills/exploring-data-catalog/SKILL.md) |
 | 6 | `store-and-query-vectors` | Store and query vector embeddings using Amazon S3 Vectors for semantic search and RAG workloads | [SKILL.md](skills/store-and-query-vectors/SKILL.md) |
-| 7 | `connect-to-data-source` | Create and troubleshoot AWS Glue connections to JDBC databases, Redshift, Snowflake, and BigQuery | [SKILL.md](skills/connect-to-data-source/SKILL.md) |
+| 7 | `connect-to-data-source` | Create and troubleshoot AWS Glue connections to JDBC databases, Amazon Redshift, Snowflake, and BigQuery | [SKILL.md](skills/connect-to-data-source/SKILL.md) |
 
 ## MCP Servers
 
@@ -72,12 +72,12 @@ Then copy skills from the [`skills/`](skills/) directory to your agent's skills 
 
 ## Data Lake Operations
 
-The data lake skills cover the jobs-to-be-done for building and operating a data lake on AWS. They encode AWS best practices into agent-readable instruction packages, guiding you from table creation through ingestion and querying.
+The data lake skills cover the jobs-to-be-done for building and operating a data lake on AWS. They follow AWS best practices as agent-readable instruction packages, guiding you from table creation through ingestion and querying.
 
 ### How It Works
 
-- **Create tables** — The `create-data-lake-table` skill sets up managed Iceberg tables on Amazon S3 Tables with automatic compaction, snapshot management, Glue catalog registration, partitioning, and IAM access control.
-- **Ingest data** — The `ingest-into-data-lake` skill moves data from local files, S3, JDBC databases (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora, Redshift), Snowflake, BigQuery, DynamoDB, or existing Glue catalog tables into your data lake. Supports one-time loads, recurring pipelines, and migrations.
+- **Create tables** — The `create-data-lake-table` skill sets up managed Iceberg tables on Amazon S3 Tables with automatic compaction, snapshot management, AWS Glue catalog registration, partitioning, and IAM access control.
+- **Ingest data** — The `ingest-into-data-lake` skill moves data from local files, S3, JDBC databases (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora, Amazon Redshift), Snowflake, BigQuery, DynamoDB, or existing AWS Glue catalog tables into your data lake. Supports one-time loads, recurring pipelines, and migrations.
 - **Query data** — The `query-data-lake` skill executes Athena SQL queries across default and federated catalogs, with workgroup selection, statement classification, cost tracking, and error recovery.
 
 ### Examples
@@ -91,8 +91,8 @@ The data lake skills cover the jobs-to-be-done for building and operating a data
 
 The discovery skills help you understand what data exists in your AWS account and find specific assets quickly.
 
-- **`exploring-data-catalog`** — Full inventory and audit across Glue Data Catalog, S3 Tables, Redshift-federated, and remote Iceberg catalogs. Maps your data landscape, flags stale tables, and suggests improvements.
-- **`find-data-lake-assets`** — Resolves fuzzy data references ("our orders table", "the sales dataset") to concrete catalog entries using layered search across Glue, S3, S3 Tables, and Redshift.
+- **`exploring-data-catalog`** — Full inventory and audit across AWS Glue Data Catalog, S3 Tables, Amazon Redshift-federated, and remote Iceberg catalogs. Maps your data landscape, flags stale tables, and suggests improvements.
+- **`find-data-lake-assets`** — Resolves fuzzy data references ("our orders table", "the sales dataset") to concrete catalog entries using layered search across AWS Glue, S3, S3 Tables, and Amazon Redshift.
 
 ### Examples
 
@@ -118,7 +118,7 @@ The `connect-to-data-source` skill creates and troubleshoots AWS Glue connection
 ### Examples
 
 - "Connect to our Oracle production database"
-- "Set up a Glue connection to Snowflake"
+- "Set up an AWS Glue connection to Snowflake"
 - "Test my existing BigQuery connection"
 - "Troubleshoot the connection timeout on my RDS connection"
 
@@ -130,7 +130,7 @@ In your local environment, configure AWS credentials and set your target region 
 
 #### Prerequisites
 
-- An AWS account with access to AWS Analytics services (Glue, Athena, S3 Tables, S3 Vectors)
+- An AWS account with access to AWS Analytics services (AWS Glue, Athena, S3 Tables, S3 Vectors)
 - Local AWS credentials and config
 - [uv](https://docs.astral.sh/uv/getting-started/installation/) (for MCP server)
 

--- a/plugins/aws-data-analytics/README.md
+++ b/plugins/aws-data-analytics/README.md
@@ -1,32 +1,187 @@
-# Agent Plugin for AWS
+# aws-data-analytics
 
-AWS agent plugin with skills and MCP server connections.
+## Overview
 
-## Skills
+This plugin brings AWS data engineering expertise directly into your coding assistant, covering the full data lifecycle across [AWS Analytics](https://aws.amazon.com/big-data/datalakes-and-analytics/) services; currently, skills are provided to assist with the following capability areas:
 
-| Skill | Description |
-|-------|-------------|
-| [find-aws-skills](skills/find-aws-skills/) | Discover and load AWS skills at runtime |
+- **Data Lake Operations** — Create managed Iceberg tables on Amazon S3 Tables, ingest data from S3, JDBC databases, Snowflake, BigQuery, DynamoDB, and existing Glue catalog tables, and query across default and federated catalogs with Amazon Athena.
+- **Data Discovery** — Inventory and audit your AWS Glue Data Catalog across S3 Tables, Redshift-federated, and remote Iceberg catalogs. Resolve data asset references by name, keyword, column, or S3 path.
+- **Vector Storage** — Store and query vector embeddings using Amazon S3 Vectors for cost-effective semantic search and RAG workloads.
+- **External Connectivity** — Create and troubleshoot AWS Glue connections to JDBC databases (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora), Amazon Redshift, Snowflake, and BigQuery.
+
+## Agent Skills
+
+| # | Skill | Description | Documentation |
+| -- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| 1 | `create-data-lake-table` | Create managed Iceberg tables using Amazon S3 Tables with automatic compaction, Glue catalog registration, and partitioning | [SKILL.md](skills/create-data-lake-table/SKILL.md) |
+| 2 | `ingest-into-data-lake` | Import data from S3 files, JDBC databases, Snowflake, BigQuery, DynamoDB, or existing Glue catalog tables into S3 Tables or standard Iceberg | [SKILL.md](skills/ingest-into-data-lake/SKILL.md) |
+| 3 | `query-data-lake` | Execute and manage Athena SQL queries across default and federated catalogs (Glue, S3 Tables, Redshift) | [SKILL.md](skills/query-data-lake/SKILL.md) |
+| 4 | `find-data-lake-assets` | Resolve data lake asset references across Glue Data Catalog, S3, S3 Tables, and Redshift by name, keyword, column, or S3 path | [SKILL.md](skills/find-data-lake-assets/SKILL.md) |
+| 5 | `exploring-data-catalog` | Full inventory and audit of AWS Glue Data Catalog assets across S3 Tables, Redshift-federated, and remote Iceberg catalogs | [SKILL.md](skills/exploring-data-catalog/SKILL.md) |
+| 6 | `store-and-query-vectors` | Store and query vector embeddings using Amazon S3 Vectors for semantic search and RAG workloads | [SKILL.md](skills/store-and-query-vectors/SKILL.md) |
+| 7 | `connect-to-data-source` | Create and troubleshoot AWS Glue connections to JDBC databases, Redshift, Snowflake, and BigQuery | [SKILL.md](skills/connect-to-data-source/SKILL.md) |
 
 ## MCP Servers
 
-| Server | Transport | Description |
-|--------|-----------|-------------|
-| aws-mcp | stdio | AWS MCP server via `mcp-proxy-for-aws` |
+| # | Server | Description |
+| - | --------- | ----------------------------------------------------------- |
+| 1 | `aws-mcp` | AWS documentation, SOP retrieval, and AWS API access via `mcp-proxy-for-aws` |
 
 ## Installation
 
+**Prerequisite:** [Install uv](https://docs.astral.sh/uv/getting-started/installation/)
+
+### Kiro
+
+Install the skills and MCP server using the [Skills CLI](https://github.com/vercel-labs/skills):
+
+```
+npx skills add https://github.com/aws/agent-toolkit-for-aws/tree/main/plugins/aws-data-analytics/skills --all --agent kiro-cli --copy
+```
+
+Then copy the MCP server configuration to your project:
+
+```
+cp .mcp.json .kiro/settings/mcp.json
+```
+
+The skills and MCP server are installed into the `.kiro/` directory in your current project. Kiro loads them automatically when launched from that directory.
+
 ### Claude Code
 
-```bash
-/plugin marketplace add aws/agent-toolkit-for-aws
+Run in your terminal:
+
+```
+claude plugin install aws-data-analytics@agent-toolkit-for-aws
+```
+
+Or if you're already inside Claude Code, run:
+
+```
 /plugin install aws-data-analytics@agent-toolkit-for-aws
 ```
 
-### Codex
+### Cursor
 
-Discovered automatically from the marketplace manifest.
+Install from the [Cursor Marketplace](https://cursor.com/marketplace/aws/aws-data-analytics) by selecting **Add to Cursor**, or run within Cursor:
+
+```
+/add-plugin aws-data-analytics
+```
+
+### Other Agents
+
+For other agents, install the skills and MCP server manually.
+
+**Install skills** using the [Skills CLI](https://github.com/vercel-labs/skills):
+
+```
+npx skills add https://github.com/aws/agent-toolkit-for-aws/tree/main/plugins/aws-data-analytics/skills --all --agent <AGENT> --copy
+```
+
+Replace `<AGENT>` with your agent name. See [Skills supported agents](https://github.com/vercel-labs/skills#supported-agents).
+
+**Add the MCP server** by copying `.mcp.json` to your agent's configuration path.
+
+## Data Lake Operations
+
+The data lake skills cover the jobs-to-be-done for building and operating a data lake on AWS. They encode AWS best practices into agent-readable instruction packages, guiding you from table creation through ingestion and querying.
+
+### How It Works
+
+- **Create tables** — The `create-data-lake-table` skill sets up managed Iceberg tables on Amazon S3 Tables with automatic compaction, snapshot management, Glue catalog registration, partitioning, and IAM access control.
+- **Ingest data** — The `ingest-into-data-lake` skill moves data from local files, S3, JDBC databases (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora, Redshift), Snowflake, BigQuery, DynamoDB, or existing Glue catalog tables into your data lake. Supports one-time loads, recurring pipelines, and migrations.
+- **Query data** — The `query-data-lake` skill executes Athena SQL queries across default and federated catalogs, with workgroup selection, statement classification, cost tracking, and error recovery.
+
+### Examples
+
+- "Create an Iceberg table for our order events with daily partitioning"
+- "Import our PostgreSQL sales data into the data lake"
+- "Query the top 10 customers by revenue from our analytics table"
+- "Migrate our existing Hive tables to Iceberg on S3 Tables"
+
+## Data Discovery
+
+The discovery skills help you understand what data exists in your AWS account and find specific assets quickly.
+
+- **`exploring-data-catalog`** — Full inventory and audit across Glue Data Catalog, S3 Tables, Redshift-federated, and remote Iceberg catalogs. Maps your data landscape, flags stale tables, and suggests improvements.
+- **`find-data-lake-assets`** — Resolves fuzzy data references ("our orders table", "the sales dataset") to concrete catalog entries using layered search across Glue, S3, S3 Tables, and Redshift.
+
+### Examples
+
+- "What data do we have in our account?"
+- "Inventory all catalogs and databases"
+- "Find the table that has customer_id"
+- "Where is our quarterly revenue data?"
+
+## Vector Storage
+
+The `store-and-query-vectors` skill provides cost-effective vector embedding storage and retrieval using Amazon S3 Vectors, optimized for long-term storage with subsecond query latency.
+
+### Examples
+
+- "Create a vector index for our product embeddings"
+- "Store these document embeddings for RAG"
+- "Find the most similar items to this query vector"
+
+## External Connectivity
+
+The `connect-to-data-source` skill creates and troubleshoots AWS Glue connections to external databases. It discovers existing connections and candidate sources in your account, registers credentials securely via Secrets Manager or IAM DB auth, configures VPC networking, and tests end-to-end connectivity.
+
+### Examples
+
+- "Connect to our Oracle production database"
+- "Set up a Glue connection to Snowflake"
+- "Test my existing BigQuery connection"
+- "Troubleshoot the connection timeout on my RDS connection"
+
+## Supported Environments
+
+### Using the plugin in your local compute
+
+In your local environment, configure AWS credentials and set your target region to get started.
+
+#### Prerequisites
+
+- An AWS account with access to AWS Analytics services (Glue, Athena, S3 Tables, S3 Vectors)
+- Local AWS credentials and config
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) (for MCP server)
+
+#### Authentication and Authorization
+
+Configure AWS credentials using one of the following methods:
+
+- **AWS CLI** — Run [`aws configure`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html) (IAM credentials) or [`aws sso login`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html) (IAM Identity Center)
+- **Environment variables** — Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`. See [Configuring environment variables](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html) for details.
+
+Your IAM role needs permissions for the AWS services used by the skills you install. The relevant IAM action namespaces are:
+
+- `athena` - Query execution and workgroup management
+- `glue` - Data Catalog operations and ETL jobs
+- `s3` - Object storage operations
+- `s3tables` - Managed Iceberg table operations (separate from `s3`)
+- `s3vectors` - Vector storage operations (separate from `s3`)
+
+Scope permissions to the resources your workload uses.
+
+#### Configuration
+
+- Set `AWS_DEFAULT_REGION` to your preferred AWS region (e.g., `us-east-1`). See [Configuring environment variables](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html) for details.
+
+## Customizing Skills for Your Organization
+
+The skills in this plugin encode AWS best practices, but they are fully customizable. You can fork the repository and modify any `SKILL.md` to reflect your organization's standards, naming conventions, approved data formats, or internal tooling. Workspace-level skills take precedence over global skills, so teams can maintain their own versions without affecting other users.
+
+## Related Resources
+
+- [AWS Analytics Services](https://aws.amazon.com/big-data/datalakes-and-analytics/)
+- [Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html)
+- [Amazon S3 Vectors](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors.html)
+- [Amazon Athena User Guide](https://docs.aws.amazon.com/athena/latest/ug/what-is.html)
+- [AWS Glue Developer Guide](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html)
+- [Agent Skills open standard — Anthropic](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)
+- [AWS Agent Toolkit for AWS](https://github.com/aws/agent-toolkit-for-aws)
 
 ## License
 
-Apache-2.0
+This project is licensed under the Apache 2.0 License.

--- a/plugins/aws-data-analytics/README.md
+++ b/plugins/aws-data-analytics/README.md
@@ -4,8 +4,8 @@
 
 This plugin brings AWS data engineering expertise directly into your coding assistant, covering the full data lifecycle across [AWS Analytics](https://aws.amazon.com/big-data/datalakes-and-analytics/) services; currently, skills are provided to assist with the following capability areas:
 
-- **Data Lake Operations** — Create managed Iceberg tables on Amazon S3 Tables, ingest data from S3, JDBC databases, Snowflake, BigQuery, DynamoDB, and existing Glue catalog tables, and query across default and federated catalogs with Amazon Athena.
-- **Data Discovery** — Inventory and audit your AWS Glue Data Catalog across S3 Tables, Redshift-federated, and remote Iceberg catalogs. Resolve data asset references by name, keyword, column, or S3 path.
+- **Data Lake Operations** — Build and operate a data lake on AWS: create managed Iceberg tables on Amazon S3 Tables, ingest data from diverse sources (S3, JDBC databases, Snowflake, BigQuery, DynamoDB, Glue catalog tables), and query across default and federated catalogs with Amazon Athena.
+- **Data Discovery** — Inventory and audit your AWS Glue Data Catalog across S3 Tables, Redshift-federated, and remote Iceberg catalogs. Resolve data asset references by name, keyword, column, or reverse-lookup from S3 location metadata in the catalog.
 - **Vector Storage** — Store and query vector embeddings using Amazon S3 Vectors for cost-effective semantic search and RAG workloads.
 - **External Connectivity** — Create and troubleshoot AWS Glue connections to JDBC databases (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora), Amazon Redshift, Snowflake, and BigQuery.
 
@@ -25,63 +25,50 @@ This plugin brings AWS data engineering expertise directly into your coding assi
 
 | # | Server | Description |
 | - | --------- | ----------------------------------------------------------- |
-| 1 | `aws-mcp` | AWS documentation, SOP retrieval, and AWS API access via `mcp-proxy-for-aws` |
+| 1 | `aws-mcp` | AWS API access, documentation search, and SOP retrieval via [AWS MCP Server](https://docs.aws.amazon.com/aws-mcp/latest/userguide/understanding-mcp-server-tools.html) |
 
 ## Installation
 
 **Prerequisite:** [Install uv](https://docs.astral.sh/uv/getting-started/installation/)
 
-### Kiro
-
-Install the skills and MCP server using the [Skills CLI](https://github.com/vercel-labs/skills):
-
-```
-npx skills add https://github.com/aws/agent-toolkit-for-aws/tree/main/plugins/aws-data-analytics/skills --all --agent kiro-cli --copy
-```
-
-Then copy the MCP server configuration to your project:
-
-```
-cp .mcp.json .kiro/settings/mcp.json
-```
-
-The skills and MCP server are installed into the `.kiro/` directory in your current project. Kiro loads them automatically when launched from that directory.
-
 ### Claude Code
 
-Run in your terminal:
-
 ```
-claude plugin install aws-data-analytics@agent-toolkit-for-aws
-```
-
-Or if you're already inside Claude Code, run:
-
-```
+/plugin marketplace add aws/agent-toolkit-for-aws
 /plugin install aws-data-analytics@agent-toolkit-for-aws
+/reload-plugins
 ```
 
-### Cursor
+### Codex
 
-Install from the [Cursor Marketplace](https://cursor.com/marketplace/aws/aws-data-analytics) by selecting **Add to Cursor**, or run within Cursor:
+In your terminal:
 
 ```
-/add-plugin aws-data-analytics
+codex plugin marketplace add aws/agent-toolkit-for-aws
 ```
+
+Then launch Codex and run `/plugins` to browse and install the **aws-data-analytics** plugin.
 
 ### Other Agents
 
-For other agents, install the skills and MCP server manually.
+Add the AWS MCP Server to your agent's MCP configuration:
 
-**Install skills** using the [Skills CLI](https://github.com/vercel-labs/skills):
-
+```json
+{
+  "mcpServers": {
+    "aws": {
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws@latest",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--metadata", "AWS_REGION=us-west-2"
+      ]
+    }
+  }
+}
 ```
-npx skills add https://github.com/aws/agent-toolkit-for-aws/tree/main/plugins/aws-data-analytics/skills --all --agent <AGENT> --copy
-```
 
-Replace `<AGENT>` with your agent name. See [Skills supported agents](https://github.com/vercel-labs/skills#supported-agents).
-
-**Add the MCP server** by copying `.mcp.json` to your agent's configuration path.
+Then copy skills from the [`skills/`](skills/) directory to your agent's skills directory.
 
 ## Data Lake Operations
 
@@ -170,7 +157,7 @@ Scope permissions to the resources your workload uses.
 
 ## Customizing Skills for Your Organization
 
-The skills in this plugin encode AWS best practices, but they are fully customizable. You can fork the repository and modify any `SKILL.md` to reflect your organization's standards, naming conventions, approved data formats, or internal tooling. Workspace-level skills take precedence over global skills, so teams can maintain their own versions without affecting other users.
+The skills in this plugin follow AWS best practices, but they are fully customizable. You can fork the repository and modify any `SKILL.md` to reflect your organization's standards, naming conventions, approved data formats, or internal tooling. Workspace-level skills take precedence over global skills, so teams can maintain their own versions without affecting other users.
 
 ## Related Resources
 

--- a/plugins/aws-data-analytics/skills/connect-to-data-source/SKILL.md
+++ b/plugins/aws-data-analytics/skills/connect-to-data-source/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: connect-to-data-source
+description: >
+  Create and troubleshoot AWS Glue connections to JDBC databases (Oracle,
+  SQL Server, PostgreSQL, MySQL, RDS), Redshift, Snowflake, and BigQuery.
+  Gathers connection hints from user, discovers existing connections and
+  RDS/Redshift candidates, registers credentials in Secrets Manager or IAM
+  DB auth, configures VPC, and tests. Triggers on: connect to database,
+  set up Glue connection, register data source, connect to
+  Snowflake/BigQuery/RDS, connection timeout, test connection, troubleshoot
+  connection. Do NOT use for moving data (use ingest-into-data-lake),
+  creating tables (use create-data-lake-table), queries
+  (use query-data-lake), catalog exploration (use exploring-data-catalog),
+  or SaaS (Salesforce, ServiceNow, SAP, MongoDB, Kafka).
+argument-hint: "[source-type|connection-name|hostname]"
+owner_team: AWS Analytics
+owner_cti: AWS/Analytics/Agent Skills
+stages: [preprod]
+version: 1
+metadata:
+  service: [glue, secretsmanager, rds, redshift]
+  task: [deploy, debug]
+  persona: [developer, data-engineer]
+  workload: [data-analytics]
+---
+
+# Connect to Data Source
+
+Register an external data source with AWS Glue so downstream skills (ingest-into-data-lake) can move data from it. A Glue connection stores the network config, driver, and credential reference for one source. Create once per source, reuse across jobs.
+
+## Philosophy
+
+**A connection is a named pipe, not a pipeline.** This skill produces a tested, reusable Glue connection. It does not move data.
+
+## Common Tasks
+
+You MUST execute commands using AWS MCP server tools when connected -- they provide validation, sandboxed execution, and audit logging. Fall back to AWS CLI only if MCP is unavailable. You MUST explain each step before executing.
+
+## Workflow
+
+### 1. Verify Dependencies and Context
+
+- You MUST check whether AWS MCP tools or AWS CLI are available and inform the user if missing
+- You MUST confirm target AWS region and verify credentials with `aws sts get-caller-identity`
+
+### 2. Classify the Source
+
+Ask the user which source type they want to connect to, or infer from hints:
+
+| User says... | Source type | Connection type | Reference |
+|---|---|---|---|
+| "Oracle", "SQL Server", "Postgres", "MySQL", "RDS \<engine\>" | JDBC database | `JDBC` | [jdbc-setup.md](references/jdbc-setup.md) |
+| "Redshift", "my cluster", "my data warehouse on AWS" | Redshift | `JDBC` | [jdbc-setup.md](references/jdbc-setup.md) (Redshift section) |
+| "Snowflake" | Snowflake | `SNOWFLAKE` | [snowflake-setup.md](references/snowflake-setup.md) |
+| "BigQuery", "Google analytics warehouse" | BigQuery | `BIGQUERY` | [bigquery-setup.md](references/bigquery-setup.md) |
+
+If the user names DynamoDB or a local file, stop and tell them: DynamoDB is read directly by Glue without a connection, and local files belong in the ingest-into-data-lake skill's local-upload workflow.
+
+### 3. Gather Connection Hints from the User
+
+You MUST ask for hints the user can provide -- do not guess.
+
+**For all sources:**
+
+- Desired connection name (lowercase, hyphens: `oracle-prod-sales`, `snowflake-analytics`)
+- Existing Secrets Manager secret, or create one
+- Is source reachable from a Glue VPC (same, peered, VPN, Direct Connect)
+
+**JDBC:** hostname/endpoint, port, database, whether RDS/Aurora/self-managed, IAM DB auth enabled (Aurora/RDS MySQL/Postgres), SSL required.
+
+**Snowflake:** account identifier, warehouse, role, default database, auth (password, key-pair, OAuth).
+
+**BigQuery:** GCP project ID, location, whether service account JSON is provisioned.
+
+### 4. Discover Existing Connections and Candidate Sources
+
+Check what exists before creating.
+
+**Existing Glue connections:**
+
+```bash
+aws glue get-connections --filter ConnectionType=<TYPE> --region <REGION>
+```
+
+If a suitable one exists, confirm and skip to Step 7.
+
+**Candidate sources in account** (JDBC/Redshift only):
+
+- RDS: `aws rds describe-db-instances`
+- Aurora: `aws rds describe-db-clusters`
+- Redshift: `aws redshift describe-clusters`
+
+Present candidates to user; let them pick. See [discovery.md](references/discovery.md).
+
+### 5. Register Credentials
+
+You MUST encourage AWS Secrets Manager over plaintext passwords. You SHOULD prefer IAM database authentication where supported (Aurora/RDS MySQL and PostgreSQL, Redshift). See [credential-security.md](references/credential-security.md).
+
+- You MUST confirm with user before creating a new Secrets Manager secret
+- You MUST NOT write plaintext credentials into chat or logs
+- For IAM DB auth, no secret is needed
+
+### 6. Create the Glue Connection
+
+Follow the source-specific reference for connection properties:
+
+```bash
+aws glue create-connection --connection-input '<JSON>' --region <REGION>
+```
+
+Private sources require `PhysicalConnectionRequirements` (SubnetId, SecurityGroupIdList, AvailabilityZone). See [network-setup.md](references/network-setup.md).
+
+### 7. Test the Connection
+
+You MUST test before handing off. Testing is two-phase: a quick API check, then an engine-level verification.
+
+#### Phase A: Glue TestConnection (network and credential sanity check)
+
+```bash
+aws glue test-connection --connection-name <NAME> --region <REGION>
+```
+
+This validates that Glue can reach the source and authenticate. It does NOT prove the connection works end-to-end with the query engine the user plans to use.
+
+#### Phase B: Engine-level verification
+
+After TestConnection passes, verify the connection works with the user's intended engine by running a minimal query through it:
+
+- **Glue ETL (default):** Run a smoke-test Glue job that reads one row via the connection. See [troubleshooting.md](references/troubleshooting.md#smoke-test-glue-job-template).
+- **Athena:** If the user plans to query via Athena with a federated connector, run a `SELECT 1` through the Athena connection to confirm the Lambda-based connector can reach the source.
+- **Glue Crawler:** If the user plans to crawl the source, run a test crawl on a single table.
+
+Phase B catches issues that TestConnection misses: driver compatibility at job runtime, catalog configuration, Spark-level serialization, and engine-specific auth flows (e.g., Snowflake SNOWFLAKE type works in ETL but not via JDBC crawlers).
+
+On success in both phases, tell user the connection name is ready for `ingest-into-data-lake`. On failure in either phase, Step 8.
+
+### 8. Troubleshoot (only if test failed)
+
+Diagnose in order: network, credentials, driver. See [troubleshooting.md](references/troubleshooting.md).
+
+**Constraints:**
+
+- You MUST check VPC routing, security groups, and S3 VPC endpoint before blaming credentials
+- You MUST verify Glue role can read the Secrets Manager secret
+- You MUST NOT rotate credentials without user confirmation
+
+## Argument Routing
+
+- No args: Walk through Steps 1-7 interactively
+- Source type keyword (e.g., `snowflake`, `oracle`): Skip to Step 2 with the type prefilled
+- Existing connection name: Skip to Step 7 (test) then Step 8 if failing
+- Hostname or RDS endpoint: Skip to Step 4 with the candidate prefilled
+
+## Gotchas
+
+- Glue's `SNOWFLAKE` connection type is distinct from `JDBC` configured for Snowflake. You MUST use `SNOWFLAKE` for Spark ETL jobs; do not use JDBC.
+- Connection names are immutable. Choose carefully.
+- `PhysicalConnectionRequirements.AvailabilityZone` MUST match the subnet's AZ or the connection fails at job runtime, not creation time.
+- IAM database authentication tokens expire in 15 minutes. The Glue job generates a fresh token on each connection; do not cache.
+- An S3 VPC gateway endpoint MUST exist in the VPC used by private-source connections. Without it, Glue jobs cannot read their scripts or write results to S3.
+
+## Troubleshooting
+
+| Error | Likely cause | Fix |
+|---|---|---|
+| `Connect timed out` | VPC routing, SG rule, or NAT gateway missing | See [troubleshooting.md](references/troubleshooting.md#network) |
+| `Access denied for user` / `ORA-01017` | Credentials wrong, Secrets Manager access missing, or IAM DB auth misconfigured | See [troubleshooting.md](references/troubleshooting.md#credentials) |
+| `No suitable driver found` | Custom driver JAR not set or wrong class name | See [troubleshooting.md](references/troubleshooting.md#driver) |
+| `SSL handshake failed` | `JDBC_ENFORCE_SSL` mismatch between Glue and source | See [troubleshooting.md](references/troubleshooting.md#ssl) |
+| `UnableToFindVpcEndpoint` | S3 VPC endpoint missing | Create S3 gateway endpoint in the connection's VPC |
+
+## References
+
+- [jdbc-setup.md](references/jdbc-setup.md) -- Oracle, SQL Server, PostgreSQL, MySQL, RDS, Redshift
+- [snowflake-setup.md](references/snowflake-setup.md) -- Glue `SNOWFLAKE` type, auth modes
+- [bigquery-setup.md](references/bigquery-setup.md) -- Glue `BIGQUERY` type, GCP service accounts
+- [discovery.md](references/discovery.md) -- Finding existing connections and candidate sources
+- [credential-security.md](references/credential-security.md) -- Secrets Manager and IAM DB auth
+- [network-setup.md](references/network-setup.md) -- VPC, subnets, security groups, endpoints
+- [troubleshooting.md](references/troubleshooting.md) -- Connection errors and diagnostic flow

--- a/plugins/aws-data-analytics/skills/connect-to-data-source/references/bigquery-setup.md
+++ b/plugins/aws-data-analytics/skills/connect-to-data-source/references/bigquery-setup.md
@@ -1,0 +1,64 @@
+# BigQuery Connection Setup
+
+AWS Glue native BigQuery connection (type `BIGQUERY`). Authentication is via a GCP service account; credentials flow through AWS Secrets Manager.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Service Account Setup](#service-account-setup)
+- [Secrets Manager Storage](#secrets-manager-storage)
+- [Connection JSON Template](#connection-json-template)
+- [Further Reading](#further-reading)
+
+## Prerequisites
+
+- GCP project with BigQuery enabled
+- Service account in that project with BigQuery access (typically `roles/bigquery.dataViewer` plus `roles/bigquery.jobUser` for running jobs)
+- Service account JSON key file from GCP
+- AWS Secrets Manager secret in the same region as the Glue job
+
+## Service Account Setup
+
+Service account and key generation happen in GCP, not AWS. For current steps see [GCP service account docs](https://cloud.google.com/iam/docs/service-accounts-create) and [BigQuery access control](https://cloud.google.com/bigquery/docs/access-control).
+
+Minimum GCP IAM roles for read-only ingestion:
+
+- `roles/bigquery.dataViewer` on the target dataset
+- `roles/bigquery.jobUser` on the project (to run queries)
+
+For cross-project reads, grant both roles in each source project.
+
+## Secrets Manager Storage
+
+Base64-encode the service account JSON and store in Secrets Manager. The Glue BigQuery connection expects the secret value to be the base64 string directly, not a JSON wrapper.
+
+```bash
+base64 -i <service-account>.json | tr -d '\n' > sa.b64
+aws secretsmanager create-secret \
+  --name glue/bigquery/<project-id>/credentials \
+  --secret-string file://sa.b64 \
+  --region <region>
+rm sa.b64
+```
+
+Rotate by creating a new key in GCP and updating the secret value. Glue picks up the new value on next job run.
+
+## Connection JSON Template
+
+```json
+{
+  "Name": "bigquery-<project-id>",
+  "ConnectionType": "BIGQUERY",
+  "ConnectionProperties": {
+    "SECRET_ID": "glue/bigquery/<project-id>/credentials"
+  }
+}
+```
+
+Glue's BigQuery connection talks to Google APIs over the internet. No `PhysicalConnectionRequirements` needed unless the Glue job itself must run in a specific VPC for other reasons (e.g., also reading from a private RDS). In that case, ensure the subnet has NAT gateway egress so Glue can reach `bigquery.googleapis.com`.
+
+## Further Reading
+
+- [AWS Glue: Creating a BigQuery connection](https://docs.aws.amazon.com/glue/latest/dg/creating-bigquery-connection.html)
+- [AWS Glue: Creating a BigQuery source node](https://docs.aws.amazon.com/glue/latest/dg/creating-bigquery-source-node.html)
+- [GCP service account keys](https://cloud.google.com/iam/docs/keys-create-delete)

--- a/plugins/aws-data-analytics/skills/connect-to-data-source/references/credential-security.md
+++ b/plugins/aws-data-analytics/skills/connect-to-data-source/references/credential-security.md
@@ -1,0 +1,152 @@
+# Credential Security
+
+Order of preference for authenticating Glue connections to data sources:
+
+1. IAM database authentication (where supported)
+2. AWS Secrets Manager (`SECRET_ID`)
+3. Plaintext `USERNAME`/`PASSWORD` in connection properties (not recommended)
+
+## Contents
+
+- [IAM Database Authentication](#iam-database-authentication)
+- [AWS Secrets Manager](#aws-secrets-manager)
+- [Plaintext Credentials](#plaintext-credentials)
+- [Rotation](#rotation)
+
+## IAM Database Authentication
+
+Supported sources:
+
+- Aurora MySQL, Aurora PostgreSQL
+- RDS MySQL, RDS PostgreSQL
+- Amazon Redshift (via `GetClusterCredentials` / `GetCredentials`)
+
+Benefits:
+
+- No long-lived database passwords
+- No secret to rotate
+- Database access controlled by IAM policies
+- Audit trail via CloudTrail
+
+### RDS / Aurora Setup
+
+1. Enable IAM DB auth on the cluster or instance:
+
+   ```bash
+   aws rds modify-db-instance \
+     --db-instance-identifier <ID> \
+     --enable-iam-database-authentication \
+     --apply-immediately
+   ```
+
+2. Create a DB user that authenticates via IAM (MySQL):
+
+   ```sql
+   CREATE USER 'etl_user'@'%' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
+   GRANT SELECT ON app_db.* TO 'etl_user'@'%';
+   ```
+
+   PostgreSQL:
+
+   ```sql
+   CREATE USER etl_user;
+   GRANT rds_iam TO etl_user;
+   GRANT SELECT ON ALL TABLES IN SCHEMA public TO etl_user;
+   ```
+
+3. Grant the Glue job role the `rds-db:connect` action:
+
+   ```json
+   {
+     "Effect": "Allow",
+     "Action": "rds-db:connect",
+     "Resource": "arn:aws:rds-db:<region>:<account>:dbuser:<resource-id>/etl_user"
+   }
+   ```
+
+4. In the Glue connection, omit `SECRET_ID`, `USERNAME`, and `PASSWORD`. Glue generates an auth token on each connection.
+
+### Redshift Setup
+
+Grant the Glue role `redshift:GetClusterCredentials` (provisioned) or `redshift-serverless:GetCredentials` (serverless), scoped to the cluster/workgroup and DB user.
+
+Configure the connection with the Redshift endpoint and a DB user. No password.
+
+## AWS Secrets Manager
+
+When IAM DB auth is not available (Oracle, SQL Server, Snowflake, BigQuery, self-managed), use Secrets Manager.
+
+### Create Secret
+
+JDBC sources:
+
+```bash
+aws secretsmanager create-secret \
+  --name glue/<connection-name>/credentials \
+  --secret-string '{"username":"etl_user","password":"<password>"}' \
+  --region <region>
+```
+
+Snowflake (key names are Glue-specific):
+
+```bash
+aws secretsmanager create-secret \
+  --name glue/snowflake-analytics/credentials \
+  --secret-string '{"snowflakeUser":"ETL_USER","snowflakePassword":"<password>"}' \
+  --region <region>
+```
+
+BigQuery (base64 of service account JSON, stored as the secret string directly):
+
+```bash
+base64 -i <sa>.json | tr -d '\n' | \
+aws secretsmanager create-secret \
+  --name glue/bigquery/<project-id>/credentials \
+  --secret-string file:///dev/stdin \
+  --region <region>
+```
+
+### Grant Glue Role Access
+
+```json
+{
+  "Effect": "Allow",
+  "Action": "secretsmanager:GetSecretValue",
+  "Resource": "arn:aws:secretsmanager:<region>:<account>:secret:glue/<connection-name>/credentials-*"
+}
+```
+
+The `-*` suffix matches the random 6-character suffix Secrets Manager appends.
+
+### Reference in Connection
+
+```json
+"ConnectionProperties": {
+  "JDBC_CONNECTION_URL": "...",
+  "SECRET_ID": "glue/<connection-name>/credentials"
+}
+```
+
+Omit `USERNAME` and `PASSWORD`. Glue reads them from the secret at job runtime.
+
+## Plaintext Credentials
+
+Not recommended. Use only for:
+
+- Disposable developer sandboxes
+- Sources where Secrets Manager integration is not supported by the Glue connector
+
+If you must, use `USERNAME` and `PASSWORD` in `ConnectionProperties`. The password is encrypted at rest in the Data Catalog but visible in `get-connection` responses to any principal with `glue:GetConnection`.
+
+## Rotation
+
+Secrets Manager rotation:
+
+- Enable automatic rotation on the secret (7, 30, 60, or 90 days)
+- Rotation Lambda updates the password in the source database and writes the new value to the secret
+- Glue picks up the new value on the next job run; no connection update needed
+- For Aurora/RDS, use the AWS-provided rotation template
+
+IAM DB auth: no rotation -- tokens are minted per-connection and expire in 15 minutes.
+
+Service account keys (BigQuery) / key-pairs (Snowflake): rotate by generating a new key at the source, updating the Secrets Manager value, and letting the old key expire or be deleted in the source.

--- a/plugins/aws-data-analytics/skills/connect-to-data-source/references/discovery.md
+++ b/plugins/aws-data-analytics/skills/connect-to-data-source/references/discovery.md
@@ -1,0 +1,89 @@
+# Discovering Connections and Candidate Sources
+
+Before creating a new Glue connection, check what exists and what the user has available in their account. Users often forget about previously registered connections or don't realize they already have running databases that can be registered.
+
+## Contents
+
+- [Existing Glue Connections](#existing-glue-connections)
+- [RDS and Aurora Candidates](#rds-and-aurora-candidates)
+- [Redshift Candidates](#redshift-candidates)
+- [Presenting Candidates](#presenting-candidates)
+
+## Existing Glue Connections
+
+List all connections, optionally filtered by type:
+
+```bash
+# All connections
+aws glue get-connections --region <REGION> --query 'ConnectionList[].{Name:Name,Type:ConnectionType,LastUpdated:LastUpdatedTimestamp}'
+
+# Filter by type
+aws glue get-connections --filter ConnectionType=JDBC --region <REGION>
+aws glue get-connections --filter ConnectionType=SNOWFLAKE --region <REGION>
+aws glue get-connections --filter ConnectionType=BIGQUERY --region <REGION>
+```
+
+Inspect a specific connection's properties (credentials are redacted in the response):
+
+```bash
+aws glue get-connection --name <NAME> --region <REGION>
+```
+
+If a connection matching the user's intent already exists, confirm with the user and skip creation. Re-test it (Step 7 of the skill) before handing off.
+
+## RDS and Aurora Candidates
+
+**RDS instances:**
+
+```bash
+aws rds describe-db-instances \
+  --query 'DBInstances[].{Id:DBInstanceIdentifier,Endpoint:Endpoint.Address,Port:Endpoint.Port,Engine:Engine,DBName:DBName,VpcId:DBSubnetGroup.VpcId,Status:DBInstanceStatus,IAMAuth:IAMDatabaseAuthenticationEnabled}' \
+  --region <REGION>
+```
+
+**Aurora clusters:**
+
+```bash
+aws rds describe-db-clusters \
+  --query 'DBClusters[].{Id:DBClusterIdentifier,Endpoint:Endpoint,ReaderEndpoint:ReaderEndpoint,Port:Port,Engine:Engine,DatabaseName:DatabaseName,IAMAuth:IAMDatabaseAuthenticationEnabled}' \
+  --region <REGION>
+```
+
+Prefer the Aurora reader endpoint for ETL reads to avoid impacting the writer. The reader endpoint is load-balanced across reader instances.
+
+Note `IAMDatabaseAuthenticationEnabled: true` -- if set, recommend IAM DB auth over password per [credential-security.md](credential-security.md).
+
+## Redshift Candidates
+
+**Provisioned clusters:**
+
+```bash
+aws redshift describe-clusters \
+  --query 'Clusters[].{Id:ClusterIdentifier,Endpoint:Endpoint.Address,Port:Endpoint.Port,DBName:DBName,VpcId:VpcId,IAMRoles:IamRoles[*].IamRoleArn,Status:ClusterStatus}' \
+  --region <REGION>
+```
+
+**Serverless workgroups:**
+
+```bash
+aws redshift-serverless list-workgroups \
+  --query 'workgroups[].{Name:workgroupName,Endpoint:endpoint.address,Port:endpoint.port,Status:status}' \
+  --region <REGION>
+```
+
+## Presenting Candidates
+
+When you find candidates, present them as a numbered list and let the user pick. Example:
+
+```
+I found these databases in your account. Which would you like to register?
+
+1. RDS PostgreSQL: analytics-prod (analytics-prod.abc123.us-east-1.rds.amazonaws.com:5432, DB: analytics, IAM auth: enabled)
+2. Aurora MySQL cluster: orders-writer (orders.cluster-abc123.us-east-1.rds.amazonaws.com, reader: orders.cluster-ro-abc123..., DB: orders)
+3. Redshift: warehouse-prod (warehouse-prod.abc123.us-east-1.redshift.amazonaws.com:5439, DB: analytics)
+4. None of these -- I want to register a source outside my account.
+```
+
+Never auto-select. The user may have multiple candidates or want to register a source that isn't visible to these discovery APIs (on-premises, peered account, Snowflake, BigQuery).
+
+Snowflake and BigQuery sources are not discoverable via AWS APIs -- always ask the user for account/project details directly.

--- a/plugins/aws-data-analytics/skills/connect-to-data-source/references/jdbc-setup.md
+++ b/plugins/aws-data-analytics/skills/connect-to-data-source/references/jdbc-setup.md
@@ -1,0 +1,90 @@
+# JDBC Connection Setup
+
+AWS Glue JDBC connections for Oracle, SQL Server, PostgreSQL, MySQL, MariaDB, Amazon RDS, Amazon Aurora, and Amazon Redshift.
+
+## Contents
+
+- [URL Formats and Drivers](#url-formats-and-drivers)
+- [Built-in Drivers](#built-in-drivers)
+- [Custom Driver Upload](#custom-driver-upload)
+- [Connection JSON Template](#connection-json-template)
+- [Redshift](#redshift)
+- [RDS and Aurora Considerations](#rds-and-aurora-considerations)
+
+## URL Formats and Drivers
+
+| Engine | JDBC URL template | Driver class |
+|---|---|---|
+| Oracle | `jdbc:oracle:thin:@//<host>:<port>/<service>` | `oracle.jdbc.OracleDriver` |
+| SQL Server | `jdbc:sqlserver://<host>:<port>;databaseName=<db>` | `com.microsoft.sqlserver.jdbc.SQLServerDriver` |
+| PostgreSQL | `jdbc:postgresql://<host>:<port>/<db>` | `org.postgresql.Driver` |
+| MySQL / MariaDB | `jdbc:mysql://<host>:<port>/<db>` | `com.mysql.cj.jdbc.Driver` |
+| Redshift | `jdbc:redshift://<cluster>.<region>.redshift.amazonaws.com:5439/<db>` | `com.amazon.redshift.jdbc.Driver` |
+
+For Oracle, prefer the service name form (`@//host:port/service`). SID form (`@host:port:SID`) works but is deprecated in Oracle 12c+.
+
+## Built-in Drivers
+
+Glue includes drivers for Oracle, SQL Server, PostgreSQL, MySQL, and Redshift. No `JDBC_DRIVER_JAR_URI` needed.
+
+## Custom Driver Upload
+
+For driver versions not built into Glue, upload the JAR to S3 and reference:
+
+```bash
+aws s3 cp ojdbc8-21.jar s3://<scripts-bucket>/jdbc-drivers/
+```
+
+Add to connection properties:
+
+```json
+"JDBC_DRIVER_JAR_URI": "s3://<scripts-bucket>/jdbc-drivers/ojdbc8-21.jar",
+"JDBC_DRIVER_CLASS_NAME": "oracle.jdbc.OracleDriver"
+```
+
+## Connection JSON Template
+
+```json
+{
+  "Name": "<connection-name>",
+  "ConnectionType": "JDBC",
+  "ConnectionProperties": {
+    "JDBC_CONNECTION_URL": "<url>",
+    "SECRET_ID": "<secrets-manager-arn-or-name>",
+    "JDBC_ENFORCE_SSL": "true"
+  },
+  "PhysicalConnectionRequirements": {
+    "SubnetId": "subnet-xxxxx",
+    "SecurityGroupIdList": ["sg-xxxxx"],
+    "AvailabilityZone": "<region>-<az>"
+  }
+}
+```
+
+The secret should contain `username` and `password` keys. Omit `USERNAME`/`PASSWORD` from properties when using `SECRET_ID`.
+
+## Redshift
+
+Redshift accepts both JDBC password auth and IAM-based GetClusterCredentials.
+
+**Password-based:** use the JDBC template above.
+
+**IAM-based (preferred for human/role users):** search AWS docs for `"Redshift GetClusterCredentials Glue"`. The Glue role needs `redshift:GetClusterCredentials` on the cluster; no Secrets Manager secret.
+
+For Redshift Serverless, use the workgroup endpoint and `redshift-serverless:GetCredentials`.
+
+## RDS and Aurora Considerations
+
+- RDS endpoint format: `<instance-id>.<hash>.<region>.rds.amazonaws.com`
+- Aurora cluster endpoint (writer): `<cluster-id>.cluster-<hash>.<region>.rds.amazonaws.com`
+- Aurora reader endpoint (read-only, load balanced): `<cluster-id>.cluster-ro-<hash>.<region>.rds.amazonaws.com` -- prefer for ETL reads
+- Aurora custom endpoints: target a subset of instances, useful for dedicated ETL reader pools
+
+**IAM database authentication** (Aurora MySQL, Aurora PostgreSQL, RDS MySQL, RDS PostgreSQL):
+
+- Enable on the DB cluster/instance: `--enable-iam-database-authentication`
+- Create a DB user `CREATE USER etl_user IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'`
+- No Secrets Manager secret needed; the Glue role calls `rds-db:connect` at runtime to get a 15-minute token
+- See [credential-security.md](credential-security.md) for the full IAM policy
+
+Prefer IAM auth over password auth where supported.

--- a/plugins/aws-data-analytics/skills/connect-to-data-source/references/network-setup.md
+++ b/plugins/aws-data-analytics/skills/connect-to-data-source/references/network-setup.md
@@ -1,0 +1,119 @@
+# Network Setup
+
+VPC, subnet, and security group configuration for Glue connections to private data sources. Skip this reference if the source is reachable over the public internet (Snowflake default, BigQuery, public RDS).
+
+## Contents
+
+- [When Networking Is Required](#when-networking-is-required)
+- [VPC and Subnet](#vpc-and-subnet)
+- [Security Group Rules](#security-group-rules)
+- [S3 VPC Endpoint](#s3-vpc-endpoint)
+- [NAT Gateway](#nat-gateway)
+- [Cross-VPC and On-Prem](#cross-vpc-and-on-prem)
+
+## When Networking Is Required
+
+Required:
+
+- RDS/Aurora in private subnets
+- Redshift in private subnets
+- Self-managed databases in a VPC
+- Snowflake with PrivateLink
+- BigQuery if the Glue job also needs private AWS resources (then the Glue subnet needs NAT egress for Google APIs)
+
+Not required:
+
+- Public Snowflake endpoints
+- Public BigQuery (default)
+- Public RDS instances (not recommended for production)
+
+## VPC and Subnet
+
+The Glue connection's `SubnetId` determines where Glue provisions ENIs at job runtime. Constraints:
+
+- MUST be in the same VPC as the source (or a peered/VPN-connected VPC)
+- SHOULD be a private subnet with NAT gateway egress (Glue needs internet access to pull dependencies and write to CloudWatch)
+- MUST have route to source's VPC
+- `AvailabilityZone` in `PhysicalConnectionRequirements` MUST match the subnet's AZ
+
+Match AZ to source for lower latency:
+
+```bash
+aws rds describe-db-instances --db-instance-identifier <ID> \
+  --query 'DBInstances[0].AvailabilityZone'
+```
+
+## Security Group Rules
+
+Two security groups are involved: Glue's and the source's.
+
+**Glue security group (outbound):**
+
+- Allow TCP to source port (1521 Oracle, 1433 SQL Server, 5432 Postgres, 3306 MySQL, 5439 Redshift)
+- Destination: source's security group ID
+- Self-referencing rule on all ports: Glue ENIs must talk to each other during a job. Required even for single-worker jobs.
+
+**Source security group (inbound):**
+
+- Allow TCP on source port from Glue's security group ID (not CIDR -- ENIs change)
+
+Verify:
+
+```bash
+aws ec2 describe-security-groups --group-ids <glue-sg> \
+  --query 'SecurityGroups[0].IpPermissionsEgress'
+aws ec2 describe-security-groups --group-ids <source-sg> \
+  --query 'SecurityGroups[0].IpPermissions'
+```
+
+## S3 VPC Endpoint
+
+Glue jobs read their scripts from S3 and write results to S3. The Glue subnet MUST have either a NAT gateway or an S3 VPC gateway endpoint; endpoint is preferred (no NAT costs, stays on AWS backbone).
+
+Check:
+
+```bash
+aws ec2 describe-vpc-endpoints \
+  --filters Name=vpc-id,Values=<VPC_ID> Name=service-name,Values=com.amazonaws.<region>.s3
+```
+
+Create if missing:
+
+```bash
+aws ec2 create-vpc-endpoint \
+  --vpc-id <VPC_ID> \
+  --service-name com.amazonaws.<region>.s3 \
+  --route-table-ids <RTB_ID>
+```
+
+Without this, Glue jobs fail at startup with `UnableToFindVpcEndpoint`.
+
+## NAT Gateway
+
+Required if:
+
+- Glue needs to reach the internet (BigQuery, public Snowflake, external APIs)
+- The subnet has no S3 VPC endpoint
+
+Not required if:
+
+- Source is in the same VPC AND S3 VPC endpoint exists AND no other internet access needed
+
+NAT gateway costs per-hour plus per-GB processed. For pure private-VPC ETL with S3 endpoint, omit it.
+
+## Cross-VPC and On-Prem
+
+**Peered VPCs:** Glue subnet's route table MUST have a route to the source VPC's CIDR via the peering connection. Both VPCs must be in the same region.
+
+**Transit Gateway:** Route tables in both VPCs attached to the TGW MUST have routes to each other's CIDR.
+
+**On-premises via VPN/Direct Connect:** Route table for Glue subnet MUST have a route to on-prem CIDR via virtual private gateway (VPN) or transit gateway (DX). Source firewall must allow inbound from Glue's ENI IPs (which change per-job -- use subnet CIDR).
+
+Test reachability from an EC2 instance in the same subnet before creating the Glue connection:
+
+```bash
+# From EC2 in Glue's intended subnet
+telnet <source-host> <source-port>
+```
+
+If EC2 can't reach the source, neither will Glue. Fix routing first.

--- a/plugins/aws-data-analytics/skills/connect-to-data-source/references/snowflake-setup.md
+++ b/plugins/aws-data-analytics/skills/connect-to-data-source/references/snowflake-setup.md
@@ -1,0 +1,58 @@
+# Snowflake Connection Setup
+
+AWS Glue native Snowflake connection (type `SNOWFLAKE`, not `JDBC`). Required for Glue for Spark ETL jobs reading from or writing to Snowflake.
+
+## Contents
+
+- [Connection Type](#connection-type)
+- [Authentication Modes](#authentication-modes)
+- [Connection JSON Template](#connection-json-template)
+- [PrivateLink](#privatelink)
+- [Further Reading](#further-reading)
+
+## Connection Type
+
+Use `ConnectionType: SNOWFLAKE`. Do NOT use a JDBC connection configured with the Snowflake JDBC URL -- that path is for Glue crawlers only and cannot be used by Glue for Spark ETL jobs. The two credential types are stored separately in the Data Catalog.
+
+## Authentication Modes
+
+| Mode | When to use | Secret contents |
+|---|---|---|
+| User + password | Quick start, non-production | `username`, `password` |
+| Key-pair (RSA) | Production, long-lived workloads | `username`, `private_key` (PEM, base64) |
+| OAuth 2.0 | Enterprise SSO, credential-free for end users | `client_id`, `client_secret`, `refresh_token`, token URL |
+
+OAuth 2.0 for Glue Snowflake connections was released April 2026. For current Snowflake OAuth setup steps, cite [Snowflake's OAuth docs](https://docs.snowflake.com/en/user-guide/oauth-intro) rather than repeating them.
+
+## Connection JSON Template
+
+Password-based:
+
+```json
+{
+  "Name": "snowflake-analytics",
+  "ConnectionType": "SNOWFLAKE",
+  "ConnectionProperties": {
+    "HOST": "<account>.<region>.snowflakecomputing.com",
+    "WAREHOUSE": "<warehouse-name>",
+    "ROLE": "<role-name>",
+    "DATABASE": "<default-database>",
+    "SECRET_ID": "<secrets-manager-arn>"
+  }
+}
+```
+
+The secret must contain `snowflakeUser` and `snowflakePassword` keys per Glue's Snowflake connection convention.
+
+Account identifier formats vary -- see [Snowflake account identifier docs](https://docs.snowflake.com/en/user-guide/admin-account-identifier) for the correct form for your region/cloud.
+
+Private sources add `PhysicalConnectionRequirements` as in [jdbc-setup.md](jdbc-setup.md#connection-json-template).
+
+## PrivateLink
+
+Snowflake accounts configured for AWS PrivateLink have a different hostname pattern. Glue jobs use the privatelink hostname directly. Configure the Glue connection's security group to allow outbound to the privatelink endpoint. See [Snowflake PrivateLink docs](https://docs.snowflake.com/en/user-guide/admin-security-privatelink).
+
+## Further Reading
+
+- [AWS Glue: Creating a Snowflake connection](https://docs.aws.amazon.com/glue/latest/ug/creating-snowflake-connection.html)
+- [AWS Glue: Snowflake connections (programming)](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-connect-snowflake-home.html)

--- a/plugins/aws-data-analytics/skills/connect-to-data-source/references/troubleshooting.md
+++ b/plugins/aws-data-analytics/skills/connect-to-data-source/references/troubleshooting.md
@@ -1,0 +1,253 @@
+# Connection Troubleshooting
+
+Diagnose Glue connection failures. Run checks in order: network → credentials → driver → SSL. Most failures are network.
+
+## Contents
+
+- [Test Decision Tree](#test-decision-tree)
+- [Network](#network)
+- [Credentials](#credentials)
+- [Driver](#driver)
+- [SSL](#ssl)
+- [Smoke-Test Glue Job Template](#smoke-test-glue-job-template)
+
+## Test Decision Tree
+
+1. Run `aws glue test-connection --connection-name <NAME>`. If it fails, read the error message.
+2. If error mentions `timeout`, `unreachable`, `UnableToFindVpcEndpoint`, or `ENI` -- go to [Network](#network).
+3. If error mentions `authentication`, `Access denied`, `invalid username/password`, `ORA-01017`, `28000` -- go to [Credentials](#credentials).
+4. If error mentions `No suitable driver`, `ClassNotFoundException` -- go to [Driver](#driver).
+5. If error mentions `SSL handshake`, `certificate`, `TLS` -- go to [SSL](#ssl).
+6. If TestConnection passes but the engine-level smoke test fails, the issue is engine-specific (driver version, catalog config, Spark serialization). Run the smoke-test Glue job for a more informative error. See [Smoke-Test Glue Job Template](#smoke-test-glue-job-template).
+
+## Network
+
+Most connection failures are network. Check in order:
+
+### 1. Subnet and routing
+
+```bash
+aws glue get-connection --name <NAME> \
+  --query 'Connection.PhysicalConnectionRequirements'
+```
+
+Note the SubnetId. Check its route table:
+
+```bash
+aws ec2 describe-route-tables \
+  --filters Name=association.subnet-id,Values=<SUBNET_ID>
+```
+
+Verify: route to source's VPC CIDR exists.
+
+### 2. Security groups
+
+Verify Glue SG allows outbound to source port AND has self-referencing rule:
+
+```bash
+aws ec2 describe-security-groups --group-ids <GLUE_SG>
+```
+
+Verify source SG allows inbound from Glue SG:
+
+```bash
+aws ec2 describe-security-groups --group-ids <SOURCE_SG>
+```
+
+### 3. S3 VPC endpoint
+
+```bash
+aws ec2 describe-vpc-endpoints \
+  --filters Name=vpc-id,Values=<VPC_ID> Name=service-name,Values=com.amazonaws.<region>.s3
+```
+
+If missing and subnet has no NAT gateway, create the endpoint. See [network-setup.md](network-setup.md#s3-vpc-endpoint).
+
+### 4. Test from EC2 in the same subnet
+
+Launch or use an existing EC2 in the Glue subnet with the Glue SG attached:
+
+```bash
+telnet <source-host> <source-port>
+nc -zv <source-host> <source-port>
+```
+
+If EC2 can't reach the source, fix routing/SG/NACL before blaming Glue.
+
+### 5. Database firewall
+
+Source-side ACLs beyond AWS SGs:
+
+- Oracle: `listener.ora` restricts connecting hosts
+- SQL Server: Windows Firewall on the host
+- PostgreSQL: `pg_hba.conf`
+- MySQL: user host restrictions (`SELECT user, host FROM mysql.user`)
+- Self-managed in a VPC: NACLs on the subnet
+
+## Credentials
+
+Run through this checklist:
+
+### 1. Secrets Manager access
+
+```bash
+# Impersonate the Glue role and fetch the secret
+aws sts assume-role --role-arn <GLUE_ROLE_ARN> --role-session-name test \
+  | jq -r '.Credentials'
+# then with those creds:
+aws secretsmanager get-secret-value --secret-id <SECRET_ID>
+```
+
+If AccessDenied: Glue role lacks `secretsmanager:GetSecretValue` on the secret ARN. See [credential-security.md](credential-security.md).
+
+### 2. Secret contents match expected keys
+
+- JDBC: `username`, `password`
+- Snowflake: `snowflakeUser`, `snowflakePassword`
+- BigQuery: bare base64 string (no JSON keys)
+
+### 3. IAM DB auth (if enabled)
+
+Verify the Glue role has `rds-db:connect` on `arn:aws:rds-db:<region>:<account>:dbuser:<resource-id>/<db-user>`.
+
+Verify the DB user exists with `IDENTIFIED WITH AWSAuthenticationPlugin` (MySQL) or `GRANT rds_iam TO <user>` (PostgreSQL).
+
+### 4. Direct credential test
+
+From EC2 in the Glue subnet:
+
+```bash
+# Oracle
+sqlplus <user>/<password>@//host:1521/service
+# PostgreSQL
+PGPASSWORD=<password> psql -h host -U user -d db -c "SELECT 1"
+# MySQL
+mysql -h host -u user -p<password> -e "SELECT 1"
+```
+
+### 5. Password edge cases
+
+- Special characters (`@`, `#`, `%`, `:`) in the password can break JDBC URL parsing. Store in Secrets Manager (avoids URL encoding entirely).
+- Expired password: Oracle `SELECT account_status FROM dba_users`; MySQL / Postgres check user's password expiry.
+- Locked account: Oracle `ALTER USER <user> ACCOUNT UNLOCK`.
+
+## Driver
+
+For built-in drivers (Oracle, SQL Server, PostgreSQL, MySQL, Redshift), no action needed.
+
+For custom drivers:
+
+### 1. JAR accessible
+
+Verify the Glue role can read the JAR:
+
+```bash
+aws s3 head-object --bucket <SCRIPTS_BUCKET> --key jdbc-drivers/<driver>.jar
+```
+
+### 2. Driver class name matches
+
+| Engine | Correct class |
+|---|---|
+| Oracle | `oracle.jdbc.OracleDriver` |
+| SQL Server | `com.microsoft.sqlserver.jdbc.SQLServerDriver` |
+| PostgreSQL | `org.postgresql.Driver` |
+| MySQL 8.x | `com.mysql.cj.jdbc.Driver` |
+| MySQL 5.x | `com.mysql.jdbc.Driver` (deprecated but sometimes needed) |
+| Redshift | `com.amazon.redshift.jdbc.Driver` |
+
+### 3. Driver version compatibility
+
+Driver major version must match or exceed the database major version. Downgrading works for minor versions, not major.
+
+## SSL
+
+### 1. Enforcement mismatch
+
+Source requires SSL but connection doesn't enable it:
+
+```json
+"JDBC_ENFORCE_SSL": "true"
+```
+
+### 2. Self-signed certificates
+
+Source uses a cert not in the default Java truststore:
+
+- Import the cert into a custom truststore
+- Upload truststore to S3
+- Add to Glue job args: `--extra-jars s3://...` and JVM args pointing at the truststore
+
+For AWS RDS and Aurora, the default truststore includes the RDS CA bundle.
+
+### 3. TLS version
+
+Older databases may require TLS 1.0/1.1; Glue 5.1 or higher defaults to 1.2+. Update database or use connection property to downgrade (not recommended).
+
+## Smoke-Test Glue Job Template
+
+When `test-connection` passes but the engine-level verification fails (or when `test-connection` fails with an unhelpful message), a minimal Glue job produces a clearer error.
+
+Save to `s3://<scripts>/test-connection.py`:
+
+```python
+import sys
+from awsglue.utils import getResolvedOptions
+from awsglue.context import GlueContext
+from pyspark.context import SparkContext
+
+args = getResolvedOptions(sys.argv, ['JOB_NAME', 'connection_name', 'source_type'])
+sc = SparkContext()
+glueContext = GlueContext(sc)
+
+test_queries = {
+    'oracle': '(SELECT 1 FROM DUAL) AS t',
+    'sqlserver': '(SELECT 1) AS t',
+    'postgresql': '(SELECT 1) AS t',
+    'mysql': '(SELECT 1) AS t',
+    'redshift': '(SELECT 1) AS t',
+}
+
+source_type = args['source_type']
+if source_type not in test_queries:
+    raise ValueError(
+        f"Unsupported source_type '{source_type}'. "
+        "This JDBC smoke test supports: oracle, sqlserver, postgresql, mysql, redshift. "
+        "For Snowflake/BigQuery, use their native connection_type."
+    )
+
+try:
+    df = glueContext.create_dynamic_frame.from_options(
+        connection_type='jdbc',
+        connection_options={
+            'useConnectionProperties': 'true',
+            'connectionName': args['connection_name'],
+            'dbtable': test_queries[args['source_type']]
+        }
+    ).toDF()
+    print(f"SUCCESS: {df.collect()}")
+except Exception as e:
+    print(f"FAIL: {type(e).__name__}: {e}")
+    raise
+```
+
+Create and run the job:
+
+```bash
+aws glue create-job \
+  --name test-connection-smoke \
+  --role <GLUE_ROLE_ARN> \
+  --command Name=glueetl,ScriptLocation=s3://<scripts>/test-connection.py,PythonVersion=3 \
+  --connections Connections=<CONNECTION_NAME> \
+  --glue-version 5.1 \
+  --number-of-workers 2 \
+  --worker-type G.1X
+
+aws glue start-job-run \
+  --job-name test-connection-smoke \
+  --arguments '{"--connection_name":"<CONNECTION_NAME>","--source_type":"<TYPE>"}'
+```
+
+Read CloudWatch logs for the specific JDBC error. Most common errors are more descriptive in logs than in `get-connection-test` output.
+
+Delete the test job after use.

--- a/plugins/aws-data-analytics/skills/create-data-lake-table/SKILL.md
+++ b/plugins/aws-data-analytics/skills/create-data-lake-table/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: create-data-lake-table
+description: >
+  Create managed Iceberg tables using Amazon S3 Tables (s3tables API namespace)
+  with automatic compaction and snapshot management. Sets up table bucket,
+  namespace, table, schema, Glue catalog registration, partitioning, IAM access control.
+  Triggers on: create table, data lake table, analytics table, structured data storage,
+  S3 Tables, Iceberg, Athena table, partitioning strategy, access permissions. Do NOT use
+  for: importing files (use ingest-into-data-lake), vector storage (use store-and-query-vectors),
+  querying existing tables (use query-data-lake), or locating existing table
+  (use find-data-lake-assets).
+argument-hint: "[table-description|schema-spec]"
+owner_team: Amazon S3
+owner_cti: AWS/S3 Tables/Tools
+stages: [preprod, prod]
+version: 1
+metadata:
+  service: [s3tables, glue, athena]
+  task: [deploy, debug]
+  persona: [developer, data-engineer]
+  workload: [data-analytics]
+---
+
+# Create Data Lake Tables with Amazon S3 Tables
+
+## Overview
+
+Amazon S3 Tables provides managed Iceberg tables with automatic compaction and snapshot management. Queryable via Athena and Iceberg-compatible engines.
+
+## Common Tasks
+
+You MUST use AWS MCP server tools when connected, they provide command validation, sandboxed execution, and audit logging. Fall back to AWS CLI if MCP unavailable.
+
+## Decision Guide
+
+**Before creating, You MUST check what exists:**
+
+You MUST run `aws glue get-tables --database-name <NAME>` when user mentions a database.
+
+| What you find | Action |
+|---------------|--------|
+| Fuzzy database name ("our analytics db") | You MUST STOP. Delegate to `find-data-lake-assets` to resolve. |
+| Non-S3-Tables table with matching name | You MUST STOP. Delegate to `find-data-lake-assets`. You MUST NOT create until user confirms. |
+| Existing S3 Tables table with matching name | You MUST check schema match. Reuse if compatible, recreate only if user confirms. |
+| No matching tables | Proceed with creation (Steps 1-8). |
+| User explicitly requests new S3 Tables table | Skip checks, proceed with creation. |
+
+**Creation paths:**
+
+- **Existing data in S3**: Create empty table (Steps 1-8), then use `ingest-into-data-lake` skill.
+- **Glue ETL pipeline**: Read `references/table-creation-glue-etl.md` first, then Steps 1-6.
+- **Lake Formation access control**: Search AWS docs for `"S3 Tables integration with Lake Formation"`.
+
+### 1. Verify Dependencies
+
+**Constraints:**
+
+- You MUST check whether AWS MCP server tools or AWS CLI are available and inform user if missing
+- You MUST confirm target AWS region and verify credentials with `aws sts get-caller-identity`
+
+### 2. Understand the Schema
+
+- **Explicit schema**: Validate Iceberg types.
+- **Loose description**: Ask columns, types, grain. Propose and confirm.
+- **Existing S3 data**: Infer schema from file headers only. Create empty table first, then use `ingest-into-data-lake` skill.
+
+**Constraints:**
+
+- You MUST read `references/best-practices.md` for Iceberg type mapping, partitions, and naming.
+- You MUST ask for all required parameters upfront: table name, columns, types, partition strategy. For schema evolution, see `references/athena-ddl-path.md`.
+- You MUST use all lowercase names -- Glue rejects mixed case with `GENERIC_INTERNAL_ERROR`. Namespace and table names MUST NOT contain hyphens.
+- You SHOULD suggest partition columns based on access patterns.
+
+### 3. Create Table Bucket
+
+Names: 3-63 chars, lowercase, numbers, hyphens.
+
+```bash
+aws s3tables create-table-bucket --name <BUCKET_NAME> --region <REGION>
+```
+
+Capture `table-bucket-arn`. Encryption (SSE-S3 default, SSE-KMS) and storage class (STANDARD, INTELLIGENT_TIERING) set at creation. See `references/best-practices.md`.
+
+**Constraints:**
+
+- You MUST check existing buckets with `aws s3tables list-table-buckets` and ask user to select or create new.
+- If using SSE-KMS, KMS key policy MUST allow S3 Tables maintenance service principal to read data. Search AWS docs for `"S3 Tables KMS key policy"` for required policy.
+- If bucket creation fails, see `references/best-practices.md` for common errors.
+
+### 4. Create Namespace
+
+```bash
+aws s3tables create-namespace --table-bucket-arn <ARN> --namespace <NAMESPACE>
+```
+
+**Constraints:**
+
+- You MUST list existing namespaces first and suggest reusing if relevant
+- You MUST use lowercase names with no hyphens
+
+### 5. Create Glue Data Catalog Integration
+
+Check if `s3tablescatalog` exists (create once per region per account):
+
+```bash
+aws glue get-catalog --catalog-id s3tablescatalog
+```
+
+If not found, create (requires `glue:CreateCatalog`, `glue:passConnection`):
+
+```bash
+aws glue create-catalog --name "s3tablescatalog" --catalog-input '{
+  "FederatedCatalog": {
+    "Identifier": "arn:aws:s3tables:<REGION>:<ACCOUNT_ID>:bucket/*",
+    "ConnectionName": "aws:s3tables"
+  },
+  "CreateDatabaseDefaultPermissions": [{"Principal": {"DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"}, "Permissions": ["ALL"]}],
+  "CreateTableDefaultPermissions": [{"Principal": {"DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"}, "Permissions": ["ALL"]}],
+  "AllowFullTableExternalDataAccess": "True"
+}'
+```
+
+Verify with `aws glue get-catalogs --parent-catalog-id s3tablescatalog`.
+
+### 6. Configure Access Control
+
+S3 Tables uses `s3tables:*` IAM namespace (not `s3:*`).
+
+**Querying principal permissions (bucket policy):**
+
+- `s3tables:GetTableBucket`, `s3tables:GetNamespace`, `s3tables:GetTable`, `s3tables:GetTableMetadataLocation`, `s3tables:GetTableData`
+
+**Querying principal permissions (IAM policy):**
+
+- `glue:GetCatalog`, `glue:GetDatabase`, `glue:GetTable`
+
+You MUST scope to correct ARN patterns. You MUST read `references/access-control.md` for exact resource ARNs.
+
+**Constraints:**
+
+- You MUST ask user for querying principal ARN
+- You MUST NOT grant broader permissions than necessary
+- You MUST NOT create IAM roles automatically, verify existing and guide user
+
+### 7. Create the Table
+
+| Context | Path |
+|---------|------|
+| Default (any user) | **S3 Tables API** (below) |
+| User specifically wants SQL DDL | **Athena DDL** (see `references/athena-ddl-path.md`) |
+| Glue ETL pipeline | **Spark DDL** via `--conf` job args (not `spark.conf.set()`). You MUST read `references/table-creation-glue-etl.md` for the `--conf` string. |
+
+**Default: S3 Tables API:**
+
+```bash
+aws s3tables create-table \
+  --table-bucket-arn <ARN> \
+  --namespace <NAMESPACE> \
+  --name <TABLE_NAME> \
+  --format ICEBERG \
+  --metadata '<METADATA_JSON>'
+```
+
+Metadata JSON MUST nest under `"iceberg"` key:
+
+```json
+{"iceberg":{"schema":{"fields":[
+  {"name":"order_date","type":"date","required":true},
+  {"name":"customer_id","type":"string","required":true},
+  {"name":"amount","type":"double","required":false}
+]},
+"partitionSpec":{"fields":[
+  {"sourceId":1,"fieldId":1000,"transform":"month","name":"order_date_month"}
+]}}}
+```
+
+**Constraints:**
+
+- `partitionSpec.sourceId` MUST reference a valid schema field ID
+- For schema evolution after creation, use Athena DDL. See `references/athena-ddl-path.md`
+- You MUST use `schemaV2` for complex types (list, map, struct) with explicit field IDs. See `references/best-practices.md`.
+- You SHOULD search AWS docs for `"IcebergPartitionField S3 Tables"` for supported partition transforms
+
+### 8. Verify and Confirm
+
+You MUST verify with `aws s3tables get-table` and confirm queryability with `DESCRIBE <table_name>` via Athena using `--query-execution-context '{"Catalog":"s3tablescatalog/<BUCKET_NAME>","Database":"<NAMESPACE>"}'`. Do NOT put catalog in SQL. Present summary: bucket ARN, namespace, table, schema, partitions.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "Table location can not be specified" | LOCATION in CREATE TABLE | Remove LOCATION clause. S3 Tables manages storage automatically. |
+| `AccessDeniedException` with `s3:*` policy | Using `s3:*` not `s3tables:*` | S3 Tables uses `s3tables:*` namespace. Update IAM policy. |
+
+## Additional Resources
+
+- [access-control.md](references/access-control.md) -- IAM permissions, ARN patterns, permission errors
+- [best-practices.md](references/best-practices.md) -- Iceberg types, partitions, naming, common errors
+- [athena-ddl-path.md](references/athena-ddl-path.md) -- Athena DDL, schema evolution
+- [table-creation-glue-etl.md](references/table-creation-glue-etl.md) -- Spark DDL via Glue ETL
+- Loading data: `ingest-into-data-lake` skill

--- a/plugins/aws-data-analytics/skills/create-data-lake-table/references/access-control.md
+++ b/plugins/aws-data-analytics/skills/create-data-lake-table/references/access-control.md
@@ -1,0 +1,38 @@
+# S3 Tables Access Control
+
+You MUST use least-privilege permissions when configuring access to S3 Tables.
+
+## Bucket Policy (s3tables actions)
+
+Actions: `s3tables:GetTableBucket`, `s3tables:GetNamespace`, `s3tables:GetTable`, `s3tables:GetTableMetadataLocation`, `s3tables:GetTableData`
+
+Resources:
+
+- `arn:aws:s3tables:{region}:{account_id}:bucket/{bucket_name}`
+- `arn:aws:s3tables:{region}:{account_id}:bucket/{bucket_name}/table/*`
+
+Set with `aws s3tables put-table-bucket-policy --table-bucket-arn <ARN> --resource-policy '<POLICY_JSON>'`.
+
+## IAM Policy (glue actions)
+
+Actions: `glue:GetCatalog`, `glue:GetDatabase`, `glue:GetTable`
+
+Resources (all three actions on each):
+
+- `arn:aws:glue:{region}:{account_id}:catalog` (root -- required for federated catalog resolution)
+- `arn:aws:glue:{region}:{account_id}:catalog/s3tablescatalog`
+- `arn:aws:glue:{region}:{account_id}:catalog/s3tablescatalog/*`
+- `arn:aws:glue:{region}:{account_id}:database/s3tablescatalog/*/*`
+- `arn:aws:glue:{region}:{account_id}:table/s3tablescatalog/*/*/*`
+
+## SSE-KMS
+
+If the table bucket uses SSE-KMS, the querying principal also needs `kms:Decrypt` and `kms:GenerateDataKey` on the KMS key.
+
+## Glue ETL Service Role
+
+See `table-creation-glue-etl.md` for the Glue job service role permissions.
+
+## Additional Resources
+
+For latest IAM guidance, search AWS docs for `"S3 Tables identity-based policies IAM"`, `"S3 Tables access management"`, and `"S3 Tables Glue catalog prerequisites"`.

--- a/plugins/aws-data-analytics/skills/create-data-lake-table/references/athena-ddl-path.md
+++ b/plugins/aws-data-analytics/skills/create-data-lake-table/references/athena-ddl-path.md
@@ -1,0 +1,79 @@
+# Creating Tables via Athena DDL
+
+Alternative to the S3 Tables API. Use when the user specifically wants SQL DDL or needs schema evolution via ALTER TABLE after creation.
+
+## Prerequisites
+
+- Glue catalog (`s3tablescatalog`) MUST be registered (see Step 5 in SKILL.md)
+- Athena workgroup MUST use engine version 3 (required for Iceberg support)
+- Output S3 bucket MUST exist in the same region as the table bucket for Athena query results. If Athena has never been used in this region, the user MUST first configure a query result location in the Athena workgroup settings or via `--result-configuration` on each query.
+
+## CREATE TABLE
+
+The catalog reference goes in `--query-execution-context`, NOT in the SQL statement. Use `<database>.<table>` format in SQL:
+
+```sql
+CREATE TABLE <namespace>.<table_name> (
+  <column_definitions>
+)
+PARTITIONED BY (<partition_columns>)
+TBLPROPERTIES ('table_type' = 'ICEBERG')
+```
+
+**CRITICAL: Do NOT include a LOCATION clause.** S3 Tables manages storage automatically. This differs from regular Athena external tables.
+
+**CRITICAL: Do NOT put the catalog name in the SQL.** Athena cannot parse `s3tablescatalog/<bucket>` as a catalog identifier in DDL. It goes in the execution context only.
+
+## Execute via Athena
+
+```bash
+aws athena start-query-execution \
+  --query-string "<DDL>" \
+  --query-execution-context '{"Catalog": "s3tablescatalog/<BUCKET_NAME>", "Database": "<NAMESPACE>"}' \
+  --work-group "<WORKGROUP>" \
+  --result-configuration '{"OutputLocation": "s3://<RESULTS_BUCKET>/output/"}'
+```
+
+Check status with `aws athena get-query-execution --query-execution-id <ID>`.
+
+The results bucket MUST be in the same region as the table bucket.
+
+## Querying
+
+Use the same execution context pattern for SELECT queries:
+
+```bash
+aws athena start-query-execution \
+  --query-string "SELECT * FROM <namespace>.<table_name> LIMIT 10" \
+  --query-execution-context '{"Catalog": "s3tablescatalog/<BUCKET_NAME>", "Database": "<NAMESPACE>"}' \
+  --work-group "<WORKGROUP>" \
+  --result-configuration '{"OutputLocation": "s3://<RESULTS_BUCKET>/output/"}'
+```
+
+## Constraints
+
+- All table and column names MUST be lowercase
+- You MUST NOT include a LOCATION clause
+- You MUST NOT put catalog name in the SQL -- use execution context
+- Output S3 bucket MUST be in the same region
+- The querying principal needs `athena:StartQueryExecution`, `athena:GetQueryExecution`, `athena:GetQueryResults` plus S3 access to the results bucket. Also requires S3 Tables and Glue permissions — see `access-control.md`.
+
+## Schema Evolution
+
+ALTER TABLE uses the same `--query-execution-context` pattern:
+
+```bash
+aws athena start-query-execution \
+  --query-string "ALTER TABLE <namespace>.<table_name> ADD COLUMNS (<col> <type>)" \
+  --query-execution-context '{"Catalog": "s3tablescatalog/<BUCKET_NAME>", "Database": "<NAMESPACE>"}' \
+  --work-group "<WORKGROUP>" \
+  --result-configuration '{"OutputLocation": "s3://<RESULTS_BUCKET>/output/"}'
+```
+
+Supported operations: `ALTER TABLE ADD COLUMNS`, `ALTER TABLE DROP COLUMN`. WARNING: schema changes affect all future queries. You MUST confirm with the user before executing.
+
+**Alternative**: Schema evolution is also supported via the S3 Tables Iceberg REST API or the S3 Tables Catalog for Apache Iceberg (open-source). Search AWS docs for `"S3 Tables Catalog for Apache Iceberg"` for setup.
+
+## Additional Resources
+
+For latest Athena DDL syntax, search AWS docs for `"Creating Iceberg tables in Athena"` and `"Supported data types for Iceberg tables in Athena"`.

--- a/plugins/aws-data-analytics/skills/create-data-lake-table/references/best-practices.md
+++ b/plugins/aws-data-analytics/skills/create-data-lake-table/references/best-practices.md
@@ -1,0 +1,82 @@
+# S3 Tables Best Practices
+
+## Iceberg Type Mapping
+
+For the full list of supported Iceberg data types and their mappings to query engine types, search AWS docs for `"Supported data types for Iceberg tables in Athena"`. Complex types (list, map, struct) require `schemaV2` instead of `schema` in API metadata. Search AWS docs for `"IcebergSchemaV2 S3 Tables"` for the full spec. Example with nested struct:
+
+```json
+{"iceberg":{"schemaV2":{"type":"struct","fields":[
+  {"id":1,"name":"device_id","required":true,"type":"string"},
+  {"id":2,"name":"location","required":false,"type":{
+    "type":"struct","fields":[
+      {"id":3,"name":"latitude","required":true,"type":"double"},
+      {"id":4,"name":"longitude","required":true,"type":"double"}
+    ]}}
+]}}}
+```
+
+Key: top-level must have `"type":"struct"`, all fields need explicit `"id"`, nested struct uses `"type":{"type":"struct","fields":[...]}`.
+
+**Default choices when ambiguous:**
+
+- IDs: use `long` (safer than `int` for growth)
+- Text: use `string` (no need to specify length in Iceberg)
+- Timestamps: use `timestamp` unless timezone awareness is needed, then `timestamptz`
+- Money: use `int` or `long` storing cents/smallest unit to avoid floating-point errors. Use `decimal(p,s)` only when fractional amounts are required.
+
+## Partition Strategy
+
+Choose partitions based on query access patterns, not data structure.
+
+**Time-series** (events, logs, metrics):
+
+- High/medium-volume (≥100K rows/day): `PARTITIONED BY (event_date)` with identity transform
+- Low-volume (<100K rows/day): partition by month transform
+
+**Multi-tenant**: `PARTITIONED BY (tenant_id)`, add date if high volume per tenant.
+
+**No clear pattern**: Start without partitions. Iceberg supports adding partitions later without rewriting data.
+
+**Partition guidelines:**
+
+- Use columns with low cardinality (10-10,000 unique values) frequently in WHERE clauses
+- Limit to 2-3 partition levels
+- Do NOT partition by high-cardinality columns (user_id, transaction_id)
+- Aim for partition sizes of 100MB-1GB
+
+## Naming Conventions
+
+All names MUST be lowercase (Glue Data Catalog requirement).
+
+- **Table bucket**: lowercase, numbers, hyphens. 3-63 chars. Name by team/domain (e.g., `analytics-tables`, `marketing-data`)
+- **Namespace**: lowercase, underscores. Name by data stage or domain (e.g., `raw_events`, `processed`, `analytics`)
+- **Table**: lowercase, underscores. Name by entity (e.g., `customer_orders`, `click_events`)
+- **Columns**: lowercase, snake_case. Descriptive names, avoid abbreviations.
+
+## Schema Design
+
+- Use descriptive names that won't need renaming
+- Avoid packing JSON strings into single columns -- use Iceberg struct/map/array types
+- For schema evolution, see `athena-ddl-path.md`.
+
+## Storage Class
+
+Default is STANDARD. For tables with infrequently accessed historical data, set Intelligent Tiering at bucket creation:
+
+```bash
+aws s3tables create-table-bucket --name <NAME> --region <REGION> \
+  --storage-class-configuration '{"storageClass":"INTELLIGENT_TIERING"}'
+```
+
+Bucket default can be changed with `aws s3tables put-table-bucket-storage-class` (applies to new tables only). Per-table storage class is set at creation via `create-table --storage-class-configuration` and cannot be changed after.
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| "Access denied creating table bucket" | Need `s3tables:CreateTableBucket`, `s3tables:ListTableBuckets`. For full workflow see Step 6 in SKILL.md and `references/table-creation-glue-etl.md` for granular permissions. |
+| "Namespace not found" | Namespaces must exist before tables. Create with `aws s3tables create-namespace`. |
+| Table not visible in Athena | Run `aws glue get-catalog --catalog-id s3tablescatalog`. If missing, follow Step 5 in SKILL.md. If present, check execution context format in `athena-ddl-path.md`. |
+| Write operations fail | Verify IAM role has `s3tables:PutTableData` and `s3tables:UpdateTableMetadataLocation`. |
+| `AccessDeniedException` despite correct IAM policy | `s3tablescatalog` may be in Lake Formation mode. Check with `aws glue get-catalog --catalog-id s3tablescatalog` — if `CreateDatabaseDefaultPermissions` is empty, the catalog is in LF mode. Migrate with `aws glue update-catalog` using `OverwriteChildResourcePermissionsWithDefault: Accept`. WARNING: this propagates to ALL child resources and removes existing LF grants. You MUST confirm with user. Search AWS docs for `"Change access control from Lake Formation to IAM"`. |
+| Shell escaping errors with `--catalog-input` JSON | Save JSON to a file and use `--catalog-input file://catalog-input.json` instead of inline JSON. |

--- a/plugins/aws-data-analytics/skills/create-data-lake-table/references/table-creation-glue-etl.md
+++ b/plugins/aws-data-analytics/skills/create-data-lake-table/references/table-creation-glue-etl.md
@@ -1,0 +1,142 @@
+# Creating S3 Tables with Spark DDL in Glue ETL
+
+Use when building Glue ETL pipelines that create and write to S3 Tables. Tables created via the S3 Tables API (`aws s3tables create-table --metadata`) are also readable by Spark.
+
+## Critical Requirements
+
+- **Glue 5.1 or higher** is required (Spark 3.5.6, Iceberg 1.10.0). Do NOT use Glue 4.0.
+- **`--datalake-formats iceberg`** MUST be set as a job argument
+- Table bucket and namespace MUST exist before running the job
+
+## Static Config Gotcha (Most Common Failure)
+
+In Glue 5.x, catalog configs are **static** and MUST go in `--conf` job arguments. Using `spark.conf.set()` throws:
+
+```
+AnalysisException: Cannot modify the value of a static config: spark.sql.extensions
+```
+
+**Rule:** All `spark.sql.catalog.*` configuration goes in `--conf`, never in the PySpark script.
+
+**Rule:** Catalog and database names containing hyphens MUST be backtick-escaped in Spark SQL (e.g., `` `my-catalog`.`my-db`.my_table ``). Without backticks, Spark returns `INVALID_IDENTIFIER`.
+
+## Access Methods
+
+| Method | Athena/Redshift access | Recommended |
+|--------|----------------------|-------------|
+| Analytics Integration (GlueCatalog) | Yes | Yes, if multi-service |
+| REST Endpoint | No (Glue-only) | Yes, if Glue-only |
+
+### REST Endpoint (simplest)
+
+```
+spark.sql.catalog.<name>=org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.<name>.type=rest
+spark.sql.catalog.<name>.uri=https://s3tables.<region>.amazonaws.com/iceberg
+spark.sql.catalog.<name>.warehouse=<table_bucket_arn>
+spark.sql.catalog.<name>.rest.sigv4-enabled=true
+spark.sql.catalog.<name>.rest.signing-name=s3tables
+spark.sql.catalog.<name>.rest.signing-region=<region>
+spark.sql.catalog.<name>.io-impl=org.apache.iceberg.aws.s3.S3FileIO
+```
+
+### Analytics Integration (for Athena/Redshift access)
+
+```
+spark.sql.catalog.<name>=org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.<name>.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog
+spark.sql.catalog.<name>.glue.id=<account_id>:s3tablescatalog/<table_bucket_name>
+spark.sql.catalog.<name>.warehouse=<table_bucket_arn>
+```
+
+The `warehouse` parameter is required — without it Spark fails with "Cannot derive default warehouse location".
+
+## `--conf` Format Rules
+
+The `--conf` argument is a single string with space-separated `--conf key=value` pairs:
+
+```json
+"--conf": "spark.sql.catalog.s3tables=org.apache.iceberg.spark.SparkCatalog --conf spark.sql.catalog.s3tables.type=rest --conf ..."
+```
+
+First key-value has no `--conf` prefix. Use `--cli-input-json file://config.json` to avoid shell escaping.
+
+## Glue Job Config Example (REST Endpoint)
+
+**job-config.json:**
+
+```json
+{
+    "Name": "my-etl-job",
+    "Role": "arn:aws:iam::<ACCOUNT>:role/<GLUE_ROLE>",
+    "Command": {
+        "Name": "glueetl",
+        "ScriptLocation": "s3://<BUCKET>/scripts/my_etl.py",
+        "PythonVersion": "3"
+    },
+    "DefaultArguments": {
+        "--datalake-formats": "iceberg",
+        "--conf": "spark.sql.catalog.s3tables=org.apache.iceberg.spark.SparkCatalog --conf spark.sql.catalog.s3tables.type=rest --conf spark.sql.catalog.s3tables.uri=https://s3tables.<REGION>.amazonaws.com/iceberg --conf spark.sql.catalog.s3tables.warehouse=<TABLE_BUCKET_ARN> --conf spark.sql.catalog.s3tables.rest.sigv4-enabled=true --conf spark.sql.catalog.s3tables.rest.signing-name=s3tables --conf spark.sql.catalog.s3tables.rest.signing-region=<REGION> --conf spark.sql.catalog.s3tables.io-impl=org.apache.iceberg.aws.s3.S3FileIO",
+        "--catalog_name": "s3tables",
+        "--namespace": "<NAMESPACE>",
+        "--table_name": "<TABLE_NAME>"
+    },
+    "GlueVersion": "5.1",
+    "NumberOfWorkers": 2,
+    "WorkerType": "G.1X"
+}
+```
+
+For Analytics Integration, replace the `--conf` value with: `spark.sql.catalog.s3tablescatalog=org.apache.iceberg.spark.SparkCatalog --conf spark.sql.catalog.s3tablescatalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog --conf spark.sql.catalog.s3tablescatalog.glue.id=<ACCOUNT>:s3tablescatalog/<BUCKET_NAME> --conf spark.sql.catalog.s3tablescatalog.warehouse=<TABLE_BUCKET_ARN>`
+
+## PySpark Script
+
+Catalog config is in `--conf`, so the script is clean:
+
+```python
+import sys
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+
+args = getResolvedOptions(sys.argv, ['JOB_NAME', 'catalog_name', 'namespace', 'table_name'])
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+# Do NOT call spark.conf.set() for catalog config in Glue 5.x
+# catalog_name must match spark.sql.catalog.<name> from --conf
+
+spark.sql(f"""
+CREATE TABLE IF NOT EXISTS {args['catalog_name']}.{args['namespace']}.{args['table_name']} (
+  col1 STRING,
+  col2 INT
+)
+USING iceberg
+PARTITIONED BY (col1)
+""")
+# No LOCATION clause -- S3 Tables manages storage
+
+job.commit()
+```
+
+## IAM Requirements
+
+The Glue service role needs: `AWSGlueServiceRole` plus `s3tables:GetTableBucket`, `s3tables:GetNamespace`, `s3tables:ListNamespaces`, `s3tables:CreateTable`, `s3tables:GetTable`, `s3tables:ListTables`, `s3tables:UpdateTableMetadataLocation`, `s3tables:GetTableMetadataLocation`, `s3tables:GetTableData`, `s3tables:PutTableData`, and `glue:GetCatalog`, `glue:GetDatabase`, `glue:GetTable`, `glue:passConnection`. Table bucket, namespace, and Glue catalog MUST be created before the Glue job runs (Steps 3-5 in SKILL.md). For exact resource ARN scoping, see `access-control.md`.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| "Cannot modify static config" | Remove `spark.conf.set()`. Use `--conf` job argument. |
+| "Access Denied" on S3 Tables | Check Glue role has granular `s3tables:` permissions. See IAM Requirements above. |
+| Shell escaping breaks `--conf` | Use `--cli-input-json file://config.json`. |
+| Table not visible in Athena | REST endpoint tables aren't in Athena. Use Analytics Integration. |
+| Catalog not found | Ensure catalog name in script matches `spark.sql.catalog.<name>` from `--conf`. |
+
+## Additional Resources
+
+For latest Glue ETL guidance, search AWS docs for `"Running ETL jobs on Amazon S3 tables with AWS Glue"`.

--- a/plugins/aws-data-analytics/skills/exploring-data-catalog/SKILL.md
+++ b/plugins/aws-data-analytics/skills/exploring-data-catalog/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: exploring-data-catalog
+description: >
+  Full inventory and audit of AWS Glue Data Catalog assets across
+  S3 Tables, Redshift-federated, and remote Iceberg
+  catalogs. Triggers on: inventory the catalog, audit databases, list all
+  tables, catalog overview, data landscape, enumerate catalogs, data
+  inventory, search the catalog. Do NOT use
+  for finding specific data (use find-data-lake-assets), running queries
+  (use query-data-lake), or creating tables (use create-data-lake-table).
+argument-hint: "[search-term|catalog-name|database-name|s3://bucket-path|table-name]"
+owner_team: AWS Analytics
+owner_cti: AWS/Analytics/Agent Skills
+stages: [preprod]
+version: 1
+metadata:
+  service: [glue, s3, s3tables]
+  task: [debug, audit]
+  persona: [developer, data-engineer, architect]
+  workload: [data-analytics]
+---
+
+Structured inventory and cataloging across your AWS data landscape: Glue Data Catalog with S3 Tables, Redshift-federated, and remote Iceberg catalogs.
+
+## Overview
+
+Maps data in an AWS account. Starts with catalog landscape (Glue, S3 Tables, federated), then drills into databases and tables. Read-only — no query execution.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask for the target AWS region upfront if not provided
+- You MUST support a single optional argument: search term, catalog name, database name, S3 path, or table name
+- You MUST accept the argument as direct input or a pointer to a file containing the spec
+- You MUST confirm the scope (full landscape vs. targeted deep dive) before making API calls
+- You MUST respect the user's decision to abort at any step
+
+## Common Tasks
+
+**Pagination:** All list and search calls in this workflow may return paginated results. You MUST pass `--next-token` from the previous response until no more tokens are returned. You MUST NOT assume a single page contains all results.
+
+### 1. Verify Dependencies
+
+Check for required tools and AWS access before discovery.
+
+**Constraints:**
+
+- You MUST verify AWS MCP server tools are available (`aws___call_aws`, `aws___search_documentation`) and fall back to AWS CLI if not
+- You MUST confirm credentials are valid: `aws sts get-caller-identity`
+- You MUST inform the user about any missing tools and ask whether to proceed
+
+### 2. Discover Catalogs
+
+List catalogs in account:
+
+```bash
+aws glue get-catalogs --recursive --include-root
+```
+
+Classify each catalog by type:
+
+| Field Present | Catalog Type | What It Contains |
+|---|---|---|
+| Neither `TargetRedshiftCatalog` nor `FederatedCatalog` | **Default (Glue)** | Standard Glue databases and tables |
+| `FederatedCatalog.ConnectionName` = `aws:s3tables` | **S3 Tables** | Managed Iceberg table buckets |
+| `TargetRedshiftCatalog` | **Redshift-federated** | Redshift databases exposed as Glue catalogs |
+| `FederatedCatalog` with `ConnectionName` ≠ `aws:s3tables` | **Remote Iceberg** | External catalogs (Snowflake, Databricks, Iceberg REST) |
+
+**Constraints:**
+
+- You MUST include `--include-root` to capture default account catalog
+- You MUST present summary of catalog counts by type
+- If only default catalog exists, You SHOULD skip catalog overview and go to step 3
+
+### 3. Enumerate Databases and Tables
+
+For each catalog (or the user-specified one):
+
+```bash
+aws glue get-databases --catalog-id <catalog-id>
+aws glue get-tables --database-name <db> --catalog-id <catalog-id>
+```
+
+For S3 Tables catalogs, also enumerate via the S3 Tables API:
+
+```bash
+aws s3tables list-table-buckets
+aws s3tables list-namespaces --table-bucket-arn <arn>
+aws s3tables list-tables --table-bucket-arn <arn> --namespace <ns>
+```
+
+**Constraints:**
+
+- You MUST flag S3 Tables not registered in Glue; You SHOULD suggest registration
+- For sub-catalogs, `--catalog-id` accepts the catalog name (not the ARN)
+- For the default catalog, omit `--catalog-id` or pass the account ID
+
+### 4. Capture Details and Analyze
+
+For each database, capture table count, formats, partitioning, and S3 locations. For each table of interest, capture column schemas, types, partition keys, SerDe format, and last access time.
+
+You MUST report data formats in human-readable terms (Parquet, CSV, JSON), not raw SerDe class names.
+
+See [discovery-checklist.md](references/discovery-checklist.md) for analysis framework.
+
+### Argument Routing
+
+Resolve the argument in this order; stop at the first match:
+
+1. Starts with `s3://` — S3 path (explore unregistered data, detect formats)
+2. Matches a known catalog from step 2 (`get-catalogs`) — deep dive into that catalog
+3. Matches a known database (`get-databases`) — deep dive into that database
+4. Matches a known table (`get-tables`) — detailed table analysis with schema and partitions
+5. No match — treat as search term (Glue `search-tables`)
+6. No args — full landscape discovery (catalogs, then databases and tables)
+
+### Principles
+
+- Start with catalog landscape, then narrow based on user interest
+- Always report catalog types — users need to know where data lives
+- Always report data formats — they drive cost and performance decisions
+- Flag stale tables and missing descriptions
+- Suggest partitioning for large unpartitioned tables
+- Summary first, details on request
+- You MUST NOT execute Athena queries (`start-query-execution`) during discovery; query execution belongs to `query-data-lake`
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Only sub-catalogs returned, default missing | `--include-root` omitted | Re-run `get-catalogs` with `--include-root` |
+| Federated catalog query slow or failing | Network call to remote source; connection misconfigured | Report connection errors clearly rather than silently skipping |
+| S3 Tables not queryable via Athena | Tables exist in S3 Tables API but not registered in Glue | Flag as "not queryable"; suggest registration |
+| `get-databases`/`get-tables` fails with catalog-id | Default catalog requires omit or account ID | Omit `--catalog-id` or pass account ID for the default catalog |
+
+## Additional Resources
+
+- [Discovery checklist](references/discovery-checklist.md)
+- [AWS Glue Data Catalog API](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html)
+- [S3 Tables list operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-buckets-operations.html)

--- a/plugins/aws-data-analytics/skills/exploring-data-catalog/references/discovery-checklist.md
+++ b/plugins/aws-data-analytics/skills/exploring-data-catalog/references/discovery-checklist.md
@@ -1,0 +1,65 @@
+# Discovery Checklist
+
+## Output Structure
+
+Present findings in this order:
+
+1. Catalog Landscape: catalog count by type (Glue, S3 Tables, Redshift-federated, Remote Iceberg), connection status for federated catalogs
+2. Executive Summary: total databases, total tables, primary formats, estimated volume
+3. Database Inventory: organized by catalog and database with table counts
+4. Unregistered Assets: S3 Tables not in Glue (not queryable via Athena), with registration instructions
+5. Schema Analysis: data types, nullable fields, key patterns
+6. Storage Analysis: formats, partitioning strategies, S3 locations
+7. Recommendations: optimization opportunities, quality issues, missing metadata, unregistered tables to register
+
+## Column Classification
+
+Categorize each column as one of:
+
+- **Identifier**: Unique keys, foreign keys, entity IDs
+- **Dimension**: Categorical attributes for grouping/filtering (status, type, region)
+- **Metric**: Quantitative values for measurement (revenue, count, duration)
+- **Temporal**: Dates and timestamps (created_at, updated_at, event_date)
+- **Text**: Free-form text fields (description, notes)
+- **Boolean**: True/false flags
+- **Structural**: JSON, arrays, nested structures (common in Glue tables from JSON sources)
+
+## Quality Scoring
+
+Rate each column's completeness:
+
+- **Complete** (>99% non-null): reliable for analysis
+- **Mostly complete** (95-99%): investigate the nulls before using in calculations
+- **Incomplete** (80-95%): understand why, may need imputation or filtering
+- **Sparse** (<80%): likely not usable without significant cleanup
+
+## Column Profiling (when deep-diving a table)
+
+For numeric columns: min, max, mean, median, p5, p95, zero count, negative count
+For string columns: min/max length, empty string count, distinct values, pattern consistency
+For date columns: min/max date, null dates, future dates (if unexpected), gap detection
+For boolean columns: true/false/null distribution
+
+## What to Flag
+
+- Tables with no partition keys on datasets > 1GB
+- CSV tables that should be Parquet (cost and performance)
+- Databases or tables with no descriptions
+- Tables with no recent data (stale/abandoned)
+- Inconsistent naming conventions across databases
+- Tables with high null percentages in key columns
+- Columns that appear to be foreign keys (potential join targets)
+- Hierarchical dimensions (country > state > city)
+- Columns with suspiciously low cardinality (possible default values)
+- S3 Tables not registered in Glue (exist but not queryable via Athena)
+- Federated catalogs with connection errors or stale metadata
+
+## Format Detection
+
+Map SerDe libraries to human-readable format names:
+
+- `org.apache.hadoop.hive.ql.io.parquet` = Parquet
+- `org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe` = CSV/TSV
+- `org.openx.data.jsonserde.JsonSerDe` = JSON
+- `org.apache.hadoop.hive.serde2.OpenCSVSerde` = CSV
+- `org.apache.hadoop.hive.ql.io.orc` = ORC

--- a/plugins/aws-data-analytics/skills/find-data-lake-assets/SKILL.md
+++ b/plugins/aws-data-analytics/skills/find-data-lake-assets/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: find-data-lake-assets
+description: >
+  Resolve data lake and lakehouse asset references across Glue Data Catalog,
+  S3, S3 Tables, and Redshift. Triggers on: find the table, where
+  is our data, which table has, locate dataset, find data for, search catalog,
+  what tables match, Redshift table, lakehouse table, data lake table,
+  warehouse table, reverse lookup S3 path. Do NOT use for: full catalog
+  audits (use exploring-data-catalog), running queries (use query-data-lake),
+  creating tables (use create-data-lake-table).
+argument-hint: "[table-name|keyword|column-name|s3://path]"
+owner_team: AWS Analytics
+owner_cti: AWS/Analytics/Agent Skills
+stages: [preprod]
+version: 1
+metadata:
+  service: [glue, s3, s3tables, redshift]
+  task: [debug]
+  persona: [developer, data-engineer, architect]
+  workload: [data-analytics]
+---
+
+# Find Data Lake Assets
+
+## Overview
+
+Resolves data lake asset references to concrete catalog entries. Acts as a
+resolver for other skills and direct user requests. Covers Glue,
+S3, S3 Tables, and Redshift. Optimized for low token usage — return the
+answer fast and get out of the way.
+
+**Constraints for parameter acquisition:**
+
+- You MUST accept a single argument: table name, keyword, column name, or S3 path
+- You MUST accept the argument as direct input or a pointer to a file containing the spec
+- You MUST ask for the target AWS region if not already set
+- You MUST confirm ambiguous input before searching (e.g., "Did you mean table X or bucket Y?")
+- You MUST respect the user's decision to abort at any step
+
+## Common Tasks
+
+You MUST execute commands using AWS MCP server tools when connected — they
+provide validation, sandboxed execution, and audit logging. Fall back to
+AWS CLI only if MCP is unavailable. You MUST explain each step before
+executing.
+
+### 1. Verify Dependencies
+
+Check for required tools and AWS access before searching.
+
+**Constraints:**
+
+- You MUST verify AWS MCP server tools (`aws___call_aws`) are available; fall back to AWS CLI if not
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You MUST inform the user about any missing tools and ask whether to proceed
+
+### 2. Classify the Request
+
+Determine the mode:
+
+- **Resolve** (most common): User/skill references something specific.
+
+  Signals: possessive/definite articles ("our X table", "the Y
+  dataset") imply the asset exists. Goal: find it, return the
+  reference, done.
+
+- **Search**: User is exploring. Signals: "find tables with", "what
+
+  has customer_id". Goal: rank candidates, present top matches.
+
+You SHOULD default to Resolve mode when ambiguous.
+
+### 3. Extract Search Terms
+
+Parse the request into search dimensions:
+
+- **Name terms**: Table or database names mentioned
+- **Domain terms**: Business concepts (billing, orders, churn)
+- **Column terms**: Specific column names (customer_id, event_type)
+- **Location terms**: S3 paths, bucket names, prefixes
+
+### 4. Layered Search (stop early)
+
+Search sources in order. Stop at the first layer that returns a
+high-confidence match. Do NOT search all layers every time.
+
+You MUST track which layers were searched and which were skipped.
+Report this in the output (see Step 6).
+
+**Layer 1: Glue Data Catalog** (always start here)
+
+You SHOULD use `SearchTables` as the primary API — it searches table
+names, column names, and column comments across the entire catalog in
+one call. You MUST NOT loop over databases with `get-tables` unless
+you already know the database name. See
+[search-strategy.md](references/search-strategy.md) for patterns.
+
+```
+aws glue search-tables --search-text "orders"
+aws glue get-tables --database-name sales --expression "order.*"
+```
+
+**Layer 2: S3 Reverse Lookup** (S3 path provided)
+
+When a user provides an S3 path, you SHOULD default to reverse lookup first —
+they usually want the Glue table, not the file contents.
+
+```
+aws glue search-tables --search-text "<path-keyword>"
+aws s3api list-objects-v2 --bucket <bucket-name> --prefix <prefix>
+```
+
+**Layer 3: Redshift Catalog** (if user mentions Redshift, warehouse, or lakehouse)
+
+```sql
+SELECT schema_name, table_name, table_type
+FROM svv_all_tables
+WHERE table_name ILIKE '%orders%';
+```
+
+Redshift Spectrum external tables also appear in Glue. If Layer 1
+found the table with a Spectrum SerDe, skip Layer 3.
+
+### 4b. Broad Scan Fallback (single turn)
+
+When `search-tables` returns nothing and S3 Tables enumeration also
+misses, you MAY need to scan across databases. Do NOT issue separate
+CLI calls per database — that burns turns and tokens. Instead, write a
+short Python script using boto3 paginators that does the full scan in
+one execution. Write the script to a file and run it with `python3`.
+
+The script MUST:
+
+- Paginate `get_databases()` to collect all database names
+- For each database, paginate `get_tables()` with an `Expression`
+
+  filter matching the search term
+
+- Print only matching results as structured output (JSON or table)
+- Accept the region and search term as arguments or variables
+
+```python
+import boto3, sys, json
+
+region = sys.argv[1]
+term = sys.argv[2]
+
+glue = boto3.client("glue", region_name=region)
+matches = []
+
+db_paginator = glue.get_paginator("get_databases")
+for db_page in db_paginator.paginate():
+    for db in db_page["DatabaseList"]:
+        db_name = db["Name"]
+        tbl_paginator = glue.get_paginator("get_tables")
+        for tbl_page in tbl_paginator.paginate(
+            DatabaseName=db_name, Expression=f".*{term}.*"
+        ):
+            for tbl in tbl_page["TableList"]:
+                matches.append({
+                    "database": db_name,
+                    "table": tbl["Name"],
+                    "format": tbl.get("Parameters", {}).get("classification", "unknown"),
+                    "location": tbl.get("StorageDescriptor", {}).get("Location", ""),
+                })
+
+print(json.dumps(matches, indent=2) if matches else "No matches found.")
+```
+
+You MUST only use this fallback after `search-tables` and S3 Tables
+enumeration have already returned nothing. This is a last resort, not
+a first choice.
+
+### 5. Apply the Confidence Gate
+
+- **High confidence** (exact name match, single result): Return the resolved
+
+  reference immediately. No summary, no options.
+
+- **Medium confidence** (fuzzy match, 2-3 results): Present top matches with
+
+  one line each: name, why it matched, format. Let the user pick.
+
+- **Low confidence** (many weak matches or none): Report what was searched
+
+  and what was skipped, suggest refining the query or running
+  `exploring-data-catalog`.
+
+### 6. Return the Reference
+
+For high-confidence resolve, return a structured reference. Always
+include a "Sources searched / skipped" line so the user knows which
+data stores were checked and which were not.
+
+```
+Table: database_name.table_name
+Catalog: default | catalog_name
+Format: Parquet | CSV | JSON | ORC | Iceberg
+Location: s3://bucket/prefix/
+Partition keys: [key1, key2] or none
+Sources searched: Glue Data Catalog
+Sources skipped: S3, Redshift (stopped early — high-confidence match in Glue)
+```
+
+S3 Tables use a 4-level hierarchy (catalog / table-bucket / namespace /
+table), and `search-tables` does not index `s3tablescatalog/*`. If the
+user mentions S3 Tables explicitly or Layer 1 returns nothing for an
+expected S3 Tables asset, enumerate via `aws s3tables list-table-buckets`
+and `list-namespaces`. Return as:
+
+```
+Table: s3tablescatalog/<table-bucket>/<namespace>/<table>
+Format: Iceberg
+Location: arn:aws:s3tables:<region>:<account>:bucket/<table-bucket>/table/<table-uuid>
+Sources searched: Glue Data Catalog, S3 Tables
+Sources skipped: Redshift (not relevant to S3 Tables lookup)
+```
+
+SQL reference: `"s3tablescatalog/<table-bucket>"."<namespace>"."<table>"`.
+
+You MUST always include both "Sources searched" and "Sources skipped"
+in the output. List the reason for skipping in parentheses. Valid
+reasons: "stopped early", "not relevant to this request", "access
+denied", "no results in prior layer".
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `get-tables` fails with missing database | Requires `--database-name` | For cross-database search, use `search-tables` instead |
+| `search-tables` returns nothing for S3 Tables | Does not cover S3 Tables federated catalogs | Use `aws s3tables list-table-buckets` when S3 Tables is in play |
+| `AccessDeniedException` on `search-tables` | Caller lacks `glue:SearchTables` permission | Request the permission or fall back to Glue `get-tables` with a known database |
+| API call times out or throttles (`ThrottlingException`) | Throttled by service-level rate limits | Retry with exponential backoff; reduce parallel calls |
+| Resource not in expected region | Cross-region lookup | Confirm AWS region; the Glue catalog is region-scoped |
+| Delegating caller expects verbose output | Other skill called this as a resolver | Return minimal output — caller needs a catalog reference, not a formatted summary |
+
+## Principles
+
+- You MUST prefer `search-tables` over iterating databases. One API call beats N.
+- You MUST pass an `Expression` filter when calling `get-tables`; never call it without one.
+- You MUST NOT issue separate CLI calls per database. If a broad scan is needed, use the boto3 paginator script from Step 4b to do it in a single turn.
+- You SHOULD resolve fast and stop early. Every extra API call costs tokens.
+- You SHOULD assume the asset exists in Resolve mode — search to find it, not to confirm it.
+
+## Additional Resources
+
+- [Search strategy details](references/search-strategy.md)
+- [AWS Glue SearchTables API](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-tables.html#aws-glue-api-catalog-tables-SearchTables)
+- [S3 Tables overview](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html)
+- [S3 Metadata tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html)

--- a/plugins/aws-data-analytics/skills/find-data-lake-assets/references/search-strategy.md
+++ b/plugins/aws-data-analytics/skills/find-data-lake-assets/references/search-strategy.md
@@ -1,0 +1,129 @@
+# Search Strategy
+
+## Layer Priority and Stop Conditions
+
+Layers are searched in order. Stop searching when a stop condition is met.
+
+| Layer | Source | Best for | Stop condition |
+|-------|--------|----------|----------------|
+| 1 | Glue Data Catalog | Technical names, columns, keywords | Exact name match (1 result) |
+| 2 | S3 Reverse Lookup or Prefix | S3 path to Glue, or uncataloged data | Files or catalog entry found |
+| 3 | Redshift Catalog | Warehouse/lakehouse tables | Table found in svv_all_tables |
+
+## Glue Search Patterns
+
+`search-tables` is the default. It searches across all databases and matches
+against table names, column names, column comments, and other metadata.
+
+```
+# Find tables by name, keyword, or business domain
+aws glue search-tables --search-text "orders"
+aws glue search-tables --search-text "billing"
+
+# Find tables containing a specific column
+aws glue search-tables --search-text "customer_id"
+
+# Find tables pointing to an S3 path fragment (reverse lookup)
+aws glue search-tables --search-text "clickstream/events"
+
+# Filtered search (e.g., by owner or parameters)
+aws glue search-tables \
+  --search-text "orders" \
+  --filters '[{"Key":"Parameters.classification","Value":"parquet"}]'
+```
+
+Use `get-tables` only when the database is already known:
+
+```
+# Exact name within a known database
+aws glue get-tables --database-name sales --expression "orders"
+
+# Prefix match within a known database (Expression is a regex, not a glob)
+aws glue get-tables --database-name sales --expression "order.*"
+```
+
+## S3 Reverse Lookup
+
+When a user provides an S3 path, they usually want to know the catalog entry,
+not the file contents. Use `search-tables` with a path fragment first.
+
+```
+# User says: what's at s3://my-bucket/data/clickstream/?
+# Step 1: reverse lookup in Glue
+aws glue search-tables --search-text "clickstream"
+
+# Step 2: verify by checking StorageDescriptor.Location on candidates
+aws glue get-table --database-name <db> --name <table> \
+  --query 'Table.StorageDescriptor.Location'
+
+# Only fall back to listing objects if no catalog match:
+aws s3 list-objects-v2 --bucket my-bucket --prefix data/clickstream/
+```
+
+## Redshift Search Patterns
+
+```sql
+-- All tables (native + Spectrum external)
+SELECT schema_name, table_name, table_type
+FROM svv_all_tables
+WHERE table_name ILIKE '%orders%';
+
+-- Spectrum external tables only
+SELECT schemaname, tablename
+FROM svv_external_tables
+WHERE tablename ILIKE '%orders%';
+
+-- Column search
+SELECT schema_name, table_name, column_name
+FROM svv_all_columns
+WHERE column_name = 'customer_id';
+```
+
+Redshift Spectrum external tables are also registered in Glue. If Layer 1
+already found the table in Glue with a Spectrum SerDe, skip Layer 4.
+
+## S3 Tables Naming Hierarchy
+
+S3 Tables use 4 levels instead of the standard Glue 2-level database.table. The correct order is catalog / table-bucket / namespace / table.
+
+| Level | Glue standard | S3 Tables |
+|-------|---------------|-----------|
+| 1 | (catalog, usually default) | catalog: `s3tablescatalog/<bucket>` |
+| 2 | database | table-bucket (inside the catalog string) |
+| 3 | table | namespace |
+| 4 | (none) | table |
+
+Example references:
+
+```
+# Glue standard (2-level)
+sales.orders
+
+# S3 Tables (4-level, qualified for SQL)
+"s3tablescatalog/analytics-bucket"."events"."clickstream"
+
+# S3 Tables in ARN form
+arn:aws:s3tables:us-east-1:123456789012:bucket/analytics-bucket/table/<uuid>
+```
+
+## Confidence Scoring
+
+| Signal | Score | Example |
+|--------|-------|---------|
+| Exact table name match | High | "orders table", found `sales.orders` |
+| Single fuzzy match | High | "order data", only `sales.orders` matches |
+| Database + partial name | High | "sales orders", found `sales.orders` |
+| Multiple name matches | Medium | "orders" matches `sales.orders` and `legacy.orders` |
+| Column name match only | Medium | "customer_id" found in 3 tables |
+| No direct match, prefix exists in S3 | Low | S3 path has data but no catalog entry |
+| No matches anywhere | None | Suggest exploring-data-catalog or refine query |
+
+## Disambiguation
+
+When multiple candidates match (medium confidence):
+
+1. Prefer tables in the default Glue catalog over federated catalogs
+2. Prefer Iceberg/Parquet tables over CSV/JSON (more likely production)
+3. Prefer tables with recent partitions over stale tables
+4. Prefer tables with descriptions over undocumented tables
+5. Present top 3 with: name, format, last partition date, match reason

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/SKILL.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: ingest-into-data-lake
+description: >
+  Import data into the AWS data lake from S3 files, local uploads, JDBC
+  databases (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora), Amazon
+  Redshift, Snowflake, BigQuery, DynamoDB, or existing Glue catalog tables
+  (migration). Default target is S3 Tables; standard Iceberg on a general
+  purpose bucket is supported where S3 Tables is not adopted. Handles
+  one-time loads, recurring pipelines, migrations. Triggers on: import
+  data, load data, ingest, sync database, migrate table, move data to AWS,
+  set up pipeline, ETL, pull from Snowflake, query BigQuery into S3,
+  export DynamoDB, CTAS, convert to Iceberg. Do NOT use for setting up or
+  troubleshooting Glue connections (use connect-to-data-source), creating
+  empty tables (use create-data-lake-table), running queries
+  (use query-data-lake), finding tables by fuzzy name
+  (use find-data-lake-assets), catalog audit (use exploring-data-catalog), or
+  SaaS platforms like Salesforce, ServiceNow, SAP, MongoDB, Kafka.
+argument-hint: "[source-path|connection-name|table-name] [--target s3-tables|iceberg|parquet]"
+owner_team: AWS Analytics
+owner_cti: AWS/Analytics/Agent Skills
+stages: [preprod]
+version: 1
+metadata:
+  service: [glue, s3, s3tables, athena, dynamodb]
+  task: [deploy, migrate]
+  persona: [developer, data-engineer]
+  workload: [data-analytics]
+---
+
+# Ingest into Data Lake
+
+Move data from a source into a queryable table in the data lake. This skill assumes the source connection (if one is needed) already exists. For Glue connection setup or troubleshooting, delegate to `connect-to-data-source`.
+
+## Philosophy
+
+**Default to S3 Tables unless the environment says otherwise.** S3 Tables is the recommended target for new data lake work. If the user's catalog inventory shows they haven't adopted S3 Tables, recommend standard Iceberg on their existing general-purpose bucket instead of forcing them to change posture.
+
+## Common Tasks
+
+You MUST execute commands using AWS MCP server tools when connected -- they provide validation, sandboxed execution, and audit logging. Fall back to AWS CLI only if MCP is unavailable. You MUST explain each step before executing.
+
+## Workflow
+
+### 1. Verify Dependencies and Context
+
+- You MUST check whether AWS MCP tools or AWS CLI are available and inform the user if missing
+- You MUST confirm target AWS region and verify credentials with `aws sts get-caller-identity`
+- For SageMaker Unified Studio project roles, note that target tables and connections may be scoped to the project. See the caller ARN detection pattern in `query-data-lake`.
+
+### 2. Classify the Source
+
+| User says... | Source type | Reference |
+|---|---|---|
+| "upload my file", "local CSV", "move to S3" | Local file | [local-upload.md](references/local-upload.md) |
+| "load from S3", "import CSV/JSON/Parquet from s3://" | S3 files | [s3-files.md](references/s3-files.md) |
+| "import from Oracle/Postgres/MySQL/SQL Server/Redshift/RDS/Aurora" | JDBC | [jdbc-ingest.md](references/jdbc-ingest.md) |
+| "pull from Snowflake", "Snowflake table to S3" | Snowflake | [snowflake-ingest.md](references/snowflake-ingest.md) |
+| "import from BigQuery", "GCP analytics to S3" | BigQuery | [bigquery-ingest.md](references/bigquery-ingest.md) |
+| "export DynamoDB", "DynamoDB to data lake" | DynamoDB | [dynamodb-ingest.md](references/dynamodb-ingest.md) |
+| "migrate Glue table", "convert Hive to Iceberg" | Catalog migration | [catalog-migration.md](references/catalog-migration.md) |
+
+If the user names Salesforce, ServiceNow, SAP, MongoDB, Kafka, or another SaaS/streaming source, decline -- these are not supported in this release.
+
+If the source table is referenced by a fuzzy or business name ("migrate our orders table", "pull from the sales warehouse"), delegate to `find-data-lake-assets` to resolve before proceeding.
+
+### 3. Confirm Connection Exists (if applicable)
+
+For JDBC, Snowflake, and BigQuery sources, a Glue connection is required. Check:
+
+```bash
+aws glue get-connection --name <CONNECTION_NAME> --region <REGION>
+```
+
+If the connection does not exist, stop and delegate to `connect-to-data-source` to create and test it. Do not proceed with ingest until the connection is verified.
+
+Local files, S3 files, DynamoDB, and catalog migration do not need a Glue connection.
+
+### 4. Clarify the Target
+
+You MUST ask the user (or suggest based on catalog inventory) before creating or writing to any table:
+
+- **Database/namespace**: Does a specific target database exist? Or should one be created?
+- **Table**: Existing table (append/merge) or new table (delegate to `create-data-lake-table`)?
+- **Format**: S3 Tables (default), standard Iceberg, or raw Parquet?
+
+**Inventory-aware defaults:**
+
+If you have already run `exploring-data-catalog` or can quickly check, use what exists:
+
+- Account has an `s3tablescatalog` federated catalog and active table buckets: recommend S3 Tables
+- Account has general-purpose buckets with Iceberg tables and no S3 Tables usage: recommend standard Iceberg on their existing bucket
+- Account uses Parquet/ORC on S3 without Iceberg metadata: ask whether to adopt Iceberg now (recommend yes) or continue with raw files
+
+Do not force S3 Tables on customers who haven't adopted it. See [iceberg-catalog-config-and-usage.md](references/iceberg-catalog-config-and-usage.md).
+
+**Delegations from this step:**
+
+- Target table doesn't exist -> `create-data-lake-table`
+- Target database named by fuzzy term -> `find-data-lake-assets`
+- User doesn't know what exists -> `exploring-data-catalog`
+
+### 5. Execute Source Workflow
+
+Read the source-specific reference and follow its phases. Each is self-contained with job templates, gotchas, and troubleshooting:
+
+- Local / S3 / JDBC / Snowflake / BigQuery / DynamoDB / catalog migration -- one reference per source
+
+Common Glue 5.1 or higher job configuration and PySpark templates are shared in [glue-job-config.md](references/glue-job-config.md) and [glue-job-scripts.md](references/glue-job-scripts.md).
+
+### 6. Validate
+
+Run all three, do not skip:
+
+1. Row count matches expected (source vs target)
+2. Null check on critical columns
+3. Spot-check 3-5 sample rows
+
+See [data-quality-validation.md](references/data-quality-validation.md).
+
+### 7. Schedule (if recurring)
+
+For recurring pipelines, create a Glue Trigger with a cron schedule. See [testing-and-scheduling.md](references/testing-and-scheduling.md). Simple single-step pipelines use Glue Triggers; multi-step with branching uses MWAA.
+
+## Argument Routing
+
+- S3 path only: Infer one-time load, start Step 2 with S3 files
+- Connection name: Start Step 3 with the named connection
+- Table name: Start Step 4, ask whether this is source or target
+- `--target` flag: Pre-fill the target format in Step 4
+- No args: Walk through interactively
+
+## Gotchas
+
+- S3 Tables requires Glue 5.1 or higher and `--datalake-formats iceberg` job argument
+- All `spark.sql.catalog.*` config MUST go in `--conf` job arguments, never in `spark.conf.set()`. Glue 5.x throws `AnalysisException: Cannot modify the value of a static config` otherwise. See [iceberg-catalog-config-and-usage.md](references/iceberg-catalog-config-and-usage.md) for correct catalog configs.
+- The `warehouse` parameter is required in S3 Tables catalog config. Without it Spark fails with "Cannot derive default warehouse location".
+- Table and column names in S3 Tables MUST be all lowercase
+- `overwritePartitions()` only replaces partitions present in the DataFrame -- for full refresh with deletes, use `createOrReplace()`
+- Standard Iceberg targets MUST include a LOCATION clause; S3 Tables MUST NOT
+- DynamoDB does not need a Glue connection -- do not attempt to create one
+- Connection failures during ingest delegate back to `connect-to-data-source`; do not debug network/credentials in this skill
+- For target tables in SageMaker Unified Studio projects, ensure the project role has write access to the target namespace before the Glue job runs
+
+## Troubleshooting
+
+| Error | Likely cause | Action |
+|---|---|---|
+| Access Denied on S3 | Missing IAM permissions | Check Glue role has s3:GetObject, s3:PutObject |
+| Access Denied on S3 Tables | Missing s3tables:* permissions | Add S3 Tables inline policy to Glue role |
+| CTAS timeout | Dataset too large for Athena | Switch to Glue ETL or batch with WHERE filters |
+| JDBC connection timeout/auth failure | Connection-level issue | Delegate to `connect-to-data-source` |
+| Throughput exceeded (DynamoDB) | Read percent too high | Lower `read.percent` or use native export |
+
+See [error-handling.md](references/error-handling.md) for the full catalog.
+
+## References
+
+### Source-specific
+
+- [local-upload.md](references/local-upload.md) -- Local files
+- [s3-files.md](references/s3-files.md) -- S3 files (CSV, JSON, Parquet, Avro, ORC)
+- [jdbc-ingest.md](references/jdbc-ingest.md) -- Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora, Redshift
+- [snowflake-ingest.md](references/snowflake-ingest.md) -- Snowflake
+- [bigquery-ingest.md](references/bigquery-ingest.md) -- BigQuery
+- [dynamodb-ingest.md](references/dynamodb-ingest.md) -- DynamoDB (export and Glue direct read)
+- [catalog-migration.md](references/catalog-migration.md) -- Existing Glue catalog tables (Hive, self-managed Iceberg)
+
+### Cross-cutting
+
+- [iceberg-catalog-config-and-usage.md](references/iceberg-catalog-config-and-usage.md) -- S3 Tables, standard Iceberg, raw files: catalog config, engine access patterns
+- [glue-job-config.md](references/glue-job-config.md) -- Job sizing, monitoring, retry
+- [glue-job-scripts.md](references/glue-job-scripts.md) -- PySpark templates (append, upsert, custom SQL, full refresh)
+- [incremental-loading.md](references/incremental-loading.md) -- Watermark strategies
+- [testing-and-scheduling.md](references/testing-and-scheduling.md) -- Glue Triggers, MWAA
+- [data-quality-validation.md](references/data-quality-validation.md) -- Row counts, null checks, Glue Data Quality
+- [schema-evolution.md](references/schema-evolution.md) -- ALTER TABLE ADD COLUMNS, nested JSON
+- [type-transformations.md](references/type-transformations.md) -- Type conflict resolution
+- [format-specific-loading.md](references/format-specific-loading.md) -- CSV/JSON/Parquet/Avro/ORC specifics
+- [athena-loading.md](references/athena-loading.md) -- Athena INSERT INTO as simple-load fallback
+- [error-handling.md](references/error-handling.md) -- Ingest errors (connection errors delegate to connect-to-data-source)
+- [upload-options.md](references/upload-options.md) -- aws s3 cp vs sync, multipart
+
+### Migration-specific
+
+- [ctas-patterns.md](references/ctas-patterns.md) -- Athena CTAS syntax and partition transforms
+- [glue-etl-migration.md](references/glue-etl-migration.md) -- Large-table migration via Glue 5.1 or higher PySpark
+- [migration-validation.md](references/migration-validation.md) -- Full validation checklist
+- [migration-troubleshooting.md](references/migration-troubleshooting.md) -- CTAS failures, visibility, partitions
+
+### JDBC-specific
+
+- [jdbc-schema-discovery.md](references/jdbc-schema-discovery.md) -- Crawler, direct inspection, custom SQL
+- [jdbc-performance.md](references/jdbc-performance.md) -- Parallel reads, partitioning

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/athena-loading.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/athena-loading.md
@@ -1,0 +1,115 @@
+# Data Loading via Athena INSERT INTO
+
+Fallback approach for simple one-time data loads when Glue ETL is unavailable or unnecessary.
+
+## Step 1: Create External Table for Source
+
+Create a temporary external table pointing to source files in S3.
+
+### CSV
+
+```sql
+CREATE EXTERNAL TABLE temp_source_<timestamp> (
+  customer_id INT,
+  first_name STRING,
+  last_name STRING,
+  email STRING,
+  signup_date STRING
+)
+ROW FORMAT DELIMITED
+FIELDS TERMINATED BY ','
+STORED AS TEXTFILE
+LOCATION 's3://<bucket>/<prefix>/'
+TBLPROPERTIES ('skip.header.line.count'='1');
+```
+
+### JSON
+
+```sql
+CREATE EXTERNAL TABLE temp_source_<timestamp> (
+  order_id BIGINT,
+  customer_id BIGINT,
+  order_date STRING,
+  total DECIMAL(10,2)
+)
+ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'
+LOCATION 's3://<bucket>/<prefix>/';
+```
+
+### Parquet / ORC
+
+```sql
+CREATE EXTERNAL TABLE temp_source_<timestamp> (
+  event_id BIGINT,
+  event_type STRING,
+  timestamp TIMESTAMP
+)
+STORED AS PARQUET  -- or ORC
+LOCATION 's3://<bucket>/<prefix>/';
+```
+
+## Step 2: Transform and Insert
+
+```sql
+INSERT INTO "<catalog>"."<namespace>"."<target_table>"
+SELECT
+  CAST(customer_id AS BIGINT) AS customer_id,
+  first_name,
+  last_name,
+  email,
+  DATE_PARSE(signup_date, '%Y-%m-%d') AS signup_date
+FROM temp_source_<timestamp>
+WHERE customer_id IS NOT NULL
+```
+
+For detailed type casting, date parsing, null handling, and boolean conversion patterns, see [type-transformations.md](type-transformations.md).
+
+### Execute via CLI
+
+```bash
+QUERY_ID=$(aws athena start-query-execution \
+  --query-string "<INSERT INTO query>" \
+  --query-execution-context Database=<namespace> \
+  --result-configuration OutputLocation=s3://<results-bucket>/ \
+  --region <region> \
+  --query 'QueryExecutionId' --output text)
+
+aws athena get-query-execution --query-execution-id "$QUERY_ID" --region <region>
+```
+
+## Step 3: Validate
+
+```sql
+-- Row count
+SELECT COUNT(*) as row_count FROM "<catalog>"."<namespace>"."<target_table>";
+
+-- Spot check
+SELECT * FROM "<catalog>"."<namespace>"."<target_table>" LIMIT 10;
+
+-- Null check on critical columns
+SELECT
+  SUM(CASE WHEN customer_id IS NULL THEN 1 ELSE 0 END) as null_ids,
+  COUNT(*) as total
+FROM "<catalog>"."<namespace>"."<target_table>";
+```
+
+## Step 4: Clean Up
+
+```sql
+DROP TABLE IF EXISTS temp_source_<timestamp>;
+```
+
+## Large Datasets
+
+If Athena times out (30-minute limit):
+
+1. **Batch by partition**: Load one month/day at a time
+2. **Switch to Glue ETL**: Better for datasets > 1GB — handles larger data with more workers, provides monitoring and retries
+
+## Limitations
+
+| Limitation | Workaround |
+|-----------|------------|
+| No scheduling | Use EventBridge or Step Functions to trigger queries |
+| Limited transformations | Use Glue ETL for complex PySpark logic |
+| 30-minute timeout | Batch loads or switch to Glue ETL |

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/bigquery-ingest.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/bigquery-ingest.md
@@ -1,0 +1,114 @@
+# BigQuery Ingest
+
+Move data from Google BigQuery into the data lake. Assumes a Glue `BIGQUERY` connection exists. If not, delegate to `connect-to-data-source`.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Read Pattern](#read-pattern)
+- [Incremental Loading](#incremental-loading)
+- [Partition Decorators](#partition-decorators)
+- [Type Mapping](#type-mapping)
+- [Further Reading](#further-reading)
+
+## Prerequisites
+
+- Glue connection of type `BIGQUERY` with service account credentials in Secrets Manager
+- GCP project ID and source table (full form: `project.dataset.table`)
+- Target table in the data lake
+- Egress from the Glue subnet to `bigquery.googleapis.com` (public internet or Google Private Service Connect)
+
+## Read Pattern
+
+```python
+bigquery_df = glueContext.create_dynamic_frame.from_options(
+    connection_type="bigquery",
+    connection_options={
+        "connectionName": args['connection_name'],
+        "parentProject": args['gcp_project'],
+        "sourceType": "table",
+        "table": "my_dataset.customers"
+    }
+).toDF()
+```
+
+For custom SQL:
+
+```python
+connection_options={
+    "connectionName": args['connection_name'],
+    "parentProject": args['gcp_project'],
+    "sourceType": "query",
+    "query": "SELECT id, name, updated_at FROM `project.dataset.customers` WHERE country = 'US'"
+}
+```
+
+BigQuery billing note: the query reads bytes from table storage. Filter aggressively at source to minimize bytes scanned.
+
+## Incremental Loading
+
+BigQuery has strong timestamp semantics. Watermark columns commonly used:
+
+- Application-maintained `updated_at` / `last_modified`
+- BigQuery-maintained `_PARTITIONTIME` / `_PARTITIONDATE` on partitioned tables
+- `INFORMATION_SCHEMA.PARTITIONS.last_modified_time` for partition-level freshness
+
+Example incremental read with watermark filter:
+
+```python
+query = f"""
+SELECT *
+FROM `{project}.{dataset}.{table}`
+WHERE updated_at > TIMESTAMP('{last_watermark}')
+"""
+```
+
+See [incremental-loading.md](incremental-loading.md) for watermark storage.
+
+## Partition Decorators
+
+For time-partitioned BigQuery tables, use partition decorators to target specific partitions and reduce bytes scanned:
+
+```python
+# Read only 2026-04 partitions
+query = f"""
+SELECT *
+FROM `{project}.{dataset}.{table}`
+WHERE _PARTITIONTIME BETWEEN TIMESTAMP('2026-04-01') AND TIMESTAMP('2026-04-30')
+"""
+```
+
+Clustered tables benefit similarly from filter push-down on clustering columns. Check clustering:
+
+```sql
+SELECT clustering_fields FROM `<project>.<dataset>.INFORMATION_SCHEMA.TABLES` WHERE table_name = '<table>';
+```
+
+## Type Mapping
+
+| BigQuery | Iceberg | Notes |
+|---|---|---|
+| STRING | STRING | |
+| INT64, INTEGER | BIGINT | All BQ integers are 64-bit |
+| NUMERIC | DECIMAL(38,9) | BQ NUMERIC is fixed precision |
+| BIGNUMERIC | STRING | Iceberg DECIMAL caps at (38,38); store as STRING, cast on read |
+| FLOAT64, FLOAT | DOUBLE | |
+| BOOL, BOOLEAN | BOOLEAN | |
+| BYTES | BINARY | |
+| DATE | DATE | |
+| TIME | STRING | Iceberg has no TIME type |
+| DATETIME | TIMESTAMP | No timezone |
+| TIMESTAMP | TIMESTAMPTZ | UTC-anchored |
+| GEOGRAPHY | STRING | WKT or GeoJSON |
+| STRUCT | STRUCT | |
+| ARRAY | ARRAY | |
+| JSON | STRING | Parse if needed |
+
+BIGNUMERIC (up to 76.38 precision) exceeds Iceberg DECIMAL's 38-digit cap. For full-precision needs, store as STRING and cast on read.
+
+## Further Reading
+
+- [AWS Glue: Creating a BigQuery connection](https://docs.aws.amazon.com/glue/latest/dg/creating-bigquery-connection.html)
+- [AWS Glue: Creating a BigQuery source node](https://docs.aws.amazon.com/glue/latest/dg/creating-bigquery-source-node.html)
+- [BigQuery partitioned tables](https://cloud.google.com/bigquery/docs/partitioned-tables)
+- [BigQuery clustered tables](https://cloud.google.com/bigquery/docs/clustered-tables)

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/catalog-migration.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/catalog-migration.md
@@ -1,0 +1,116 @@
+# Catalog Migration to S3 Tables
+
+Migrate existing Glue Data Catalog tables into Amazon S3 Tables. Source tables can be Hive-format, self-managed Iceberg, or any format Athena can read. The result is a fully managed S3 Table with automatic compaction, snapshot management, and multi-engine access.
+
+## Reference Documentation
+
+- [ctas-patterns.md](ctas-patterns.md) -- Athena CTAS syntax for S3 Tables, format options, partition transforms
+- [migration-validation.md](migration-validation.md) -- Row count, schema, and data integrity checks
+- [glue-etl-migration.md](glue-etl-migration.md) -- Glue 5.1 or higher PySpark migration for large tables
+- [migration-troubleshooting.md](migration-troubleshooting.md) -- Common errors and fixes
+
+## Why Migrate?
+
+Self-managed Iceberg and Hive tables require manual compaction, snapshot cleanup, and storage optimization. S3 Tables handles all of this automatically. Migration also enables the four-part catalog hierarchy (`s3tablescatalog/<bucket>/<namespace>/<table>`) for unified access from Athena, EMR, Redshift, and Spark.
+
+Note: The target for catalog migration is always S3 Tables -- that is the purpose of this workflow.
+
+## Workflow
+
+### Phase 1: Understand the Source
+
+1. **Identify the source table**: Get the fully qualified name (`database.table` or `catalog.database.table`). If the user gives a fuzzy or business name ("our orders table", "the sales data"), delegate to the `find-data-lake-assets` skill to resolve it before continuing -- the rest of this workflow assumes a concrete reference.
+2. **Inspect the source**:
+   - **With MCP**: Use `aws-mcp` to get table metadata (format, location, schema, partitions)
+   - **Without MCP**: `aws glue get-table --database-name <db> --name <table>`
+3. **Classify the source format**:
+   - **Hive (CSV, Parquet, ORC, JSON, Avro)**: Standard external table backed by S3 general purpose bucket
+   - **Self-managed Iceberg**: Iceberg table in general purpose bucket with manual maintenance
+   - **Other**: Any format Athena can query (federated sources, etc.)
+4. **Assess size and complexity**:
+   - **Small/medium** (under ~100 GB, simple schema): Path A (Athena CTAS) -- single SQL statement
+   - **Large** (over ~100 GB, complex transforms, or needs scheduling): Path B (Glue ETL)
+   - **Partitioned source**: Note partition columns and strategy for conversion
+
+### Phase 2: Prepare the Target
+
+1. **Ensure table bucket exists**: Check with `aws s3tables list-table-buckets`. If none, delegate to [create-data-lake-table](../../create-data-lake-table/SKILL.md) Phase 2.
+2. **Ensure analytics integration is enabled**: Verify `s3tablescatalog` exists. Delegate to [create-data-lake-table](../../create-data-lake-table/SKILL.md) Phase 2, step 4 if not set up.
+3. **Create or select namespace**: Use existing or create new via `aws s3tables create-namespace`.
+4. **Plan partition strategy**: Iceberg supports hidden partition transforms (`day()`, `month()`, `year()`, `hour()`, `bucket()`). Recommend converting Hive-style explicit partition columns to Iceberg transforms where possible.
+
+### Phase 3: Migrate the Data
+
+#### Path A: Athena CTAS (default for small/medium tables)
+
+Single SQL statement that creates the S3 Table and populates it in one step. See [ctas-patterns.md](ctas-patterns.md) for full syntax and examples.
+
+Key points:
+
+- Target path: `"s3tablescatalog/<table_bucket_name>"."<namespace>"."<new_table_name>"`
+- Default format: `PARQUET`. Also supports `AVRO`, `ORC`.
+- Use Iceberg partition transforms (`day()`, `month()`, `bucket()`) instead of Hive-style explicit partition columns.
+- No `LOCATION` clause -- S3 Tables manages storage.
+- Table and column names must be all lowercase.
+- Source catalog for default GDC tables is `awsdatacatalog`.
+- Add `WHERE` filters to migrate subsets or batch large migrations.
+
+#### Path B: Glue ETL (for large tables or complex transforms)
+
+Use when CTAS would time out, when transforms are complex, or when the migration needs to be scheduled/repeatable.
+
+1. **Create PySpark script** that reads from source and writes to S3 Table
+2. **Create Glue 5.1 or higher job** with `--datalake-formats iceberg` and `--conf` catalog config
+3. **Run and monitor** the job
+
+See [glue-etl-migration.md](glue-etl-migration.md) for job configuration, PySpark script template, and catalog setup.
+
+### Phase 4: Validate the Migration
+
+Run all of these checks -- do not skip any:
+
+1. **Row count comparison**:
+
+   ```sql
+   SELECT 'source' AS tbl, COUNT(*) AS cnt FROM "<source_catalog>"."<source_db>"."<source_table>"
+   UNION ALL
+   SELECT 'target' AS tbl, COUNT(*) AS cnt FROM "s3tablescatalog/<bucket>"."<namespace>"."<new_table>"
+   ```
+
+2. **Schema comparison**: Verify column names, types, and order match expectations. Minor type promotions (e.g., `int` to `bigint`) are acceptable.
+
+3. **Spot-check data**: Compare a sample of rows between source and target, focusing on:
+   - Boundary values (min/max of numeric and date columns)
+   - Null counts per column
+   - Distinct counts on key columns
+
+4. **Partition verification** (if partitioned):
+
+   ```sql
+   SELECT <partition_column>, COUNT(*) FROM "s3tablescatalog/<bucket>"."<namespace>"."<new_table>"
+   GROUP BY 1 ORDER BY 1
+   ```
+
+See [migration-validation.md](migration-validation.md) for the full checklist.
+
+### Phase 5: Post-Migration Guidance
+
+After validation passes:
+
+1. **Update downstream consumers**: Provide the new table path for queries, dashboards, and ETL jobs.
+2. **Recommend keeping the source table** temporarily as a rollback option. Suggest a retention period (e.g., 30 days).
+3. **Do NOT drop the source table**. Warn the user and let them decide when to clean up.
+4. **Evaluate table lineage**: If the source table has lineage present, use it to recommend next-steps for producers and consumers.
+
+## Gotchas
+
+- Athena CTAS has a 100-partition limit per statement. For sources with more than 100 partitions, either migrate in batches with `WHERE` filters or use Glue ETL (Path B).
+- CTAS creates a new table -- it does not do an in-place conversion. The source table remains unchanged.
+- Column names with uppercase letters will cause the target table to be invisible to analytics services. Always lowercase column names in the SELECT: `SELECT upper_Col AS upper_col`.
+- Self-managed Iceberg tables may have schema evolution history (added/renamed columns). CTAS captures the current schema only -- historical evolution is not preserved.
+- Hive tables with complex SerDe configurations (custom delimiters, regex SerDe) should be tested with a small CTAS first to verify Athena can read them correctly. Glue will often read things Athena cannot. Try Glue if Athena fails.
+- Time travel on the source Iceberg table is lost after migration. The S3 Table starts fresh with its own snapshot history.
+
+## Troubleshooting
+
+See [migration-troubleshooting.md](migration-troubleshooting.md) for common errors and fixes covering CTAS failures, validation mismatches, visibility issues, and partition problems.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/ctas-patterns.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/ctas-patterns.md
@@ -1,0 +1,91 @@
+# Athena CTAS Patterns for S3 Tables Migration
+
+## Basic Migration (no partitions)
+
+```sql
+CREATE TABLE "s3tablescatalog/my-bucket"."my_namespace"."customers"
+WITH (format = 'PARQUET') AS
+SELECT * FROM "awsdatacatalog"."legacy_db"."customers"
+```
+
+## Migration with Iceberg Partition Transforms
+
+Convert Hive-style explicit partitions to Iceberg hidden partitions:
+
+```sql
+-- Source has explicit year/month/day columns from Hive partitioning
+-- Target uses Iceberg day() transform on the timestamp column
+CREATE TABLE "s3tablescatalog/my-bucket"."analytics"."events"
+WITH (
+    format = 'PARQUET',
+    partitioning = ARRAY['day(event_timestamp)']
+) AS
+SELECT
+    event_id,
+    user_id,
+    event_type,
+    event_timestamp,
+    payload
+FROM "awsdatacatalog"."raw_db"."events_hive"
+```
+
+## Available Partition Transforms
+
+| Transform | Example | Use when |
+|-----------|---------|----------|
+| `year(col)` | `ARRAY['year(created_at)']` | Multi-year data, infrequent queries |
+| `month(col)` | `ARRAY['month(created_at)']` | Monthly reporting, medium cardinality |
+| `day(col)` | `ARRAY['day(event_time)']` | Daily data, time-series workloads |
+| `hour(col)` | `ARRAY['hour(event_time)']` | High-volume streaming data |
+| `bucket(col, N)` | `ARRAY['bucket(user_id, 16)']` | High-cardinality columns, even distribution |
+| Multiple | `ARRAY['month(ts)', 'bucket(id, 8)']` | Compound partitioning |
+
+## Batched Migration (over 100 partitions)
+
+Athena CTAS has a 100-partition limit per statement. Migrate in batches:
+
+```sql
+-- Batch 1: 2023 data
+CREATE TABLE "s3tablescatalog/my-bucket"."ns"."orders"
+WITH (format = 'PARQUET', partitioning = ARRAY['month(order_date)']) AS
+SELECT * FROM "awsdatacatalog"."sales"."orders"
+WHERE order_date >= DATE '2023-01-01' AND order_date < DATE '2024-01-01'
+
+-- Batch 2+: INSERT INTO for subsequent years
+INSERT INTO "s3tablescatalog/my-bucket"."ns"."orders"
+SELECT * FROM "awsdatacatalog"."sales"."orders"
+WHERE order_date >= DATE '2024-01-01' AND order_date < DATE '2025-01-01'
+```
+
+## Migration with Column Transformations
+
+```sql
+CREATE TABLE "s3tablescatalog/my-bucket"."clean"."users"
+WITH (format = 'PARQUET') AS
+SELECT
+    user_id,
+    LOWER(email) AS email,
+    COALESCE(display_name, username) AS name,
+    CAST(created_at AS timestamp) AS created_at,
+    CASE WHEN status = 'A' THEN 'active' ELSE 'inactive' END AS status
+FROM "awsdatacatalog"."legacy"."users_raw"
+```
+
+## Cross-Catalog Migration (self-managed Iceberg)
+
+```sql
+CREATE TABLE "s3tablescatalog/my-bucket"."analytics"."transactions"
+WITH (
+    format = 'PARQUET',
+    partitioning = ARRAY['day(transaction_date)']
+) AS
+SELECT * FROM "awsdatacatalog"."iceberg_db"."transactions_selfmanaged"
+```
+
+## Format Options
+
+| Format | Best for | Notes |
+|--------|----------|-------|
+| `PARQUET` (default) | Most analytical workloads | Columnar, good compression, wide tool support |
+| `AVRO` | Write-heavy, schema evolution | Row-based, fast writes |
+| `ORC` | Hive ecosystem compatibility | Columnar, good for Hive migrations |

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/data-quality-validation.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/data-quality-validation.md
@@ -1,0 +1,436 @@
+# Data Quality and Validation
+
+Complete guide for validating data quality during and after import into S3 Tables.
+
+## Overview
+
+Data quality validation ensures that loaded data meets expected standards for completeness, accuracy, and consistency. This reference covers:
+
+- Glue Data Quality rules integration
+- Basic post-load validation queries
+- Common validation patterns
+- Troubleshooting quality issues
+
+## Glue Data Quality Rules
+
+Integrate Glue Data Quality rules directly into your ETL jobs for automated validation during the load.
+
+### Basic Integration
+
+Add to your Glue job PySpark script:
+
+```python
+from awsglue.data_quality import DataQualityEvaluationOptions, DataQualityEvaluator
+from awsglue.dynamicframe import DynamicFrame
+
+# Define data quality rules
+rules = """
+    Rules = [
+        RowCount > 0,
+        ColumnCount == <expected_count>,
+        ColumnValues "<column_name>" Completeness > 0.95,
+        ColumnValues "<numeric_column>" between <min> and <max>,
+        IsPrimaryKey "<id_column>",
+        Uniqueness "<id_column>" > 0.99
+    ]
+"""
+
+# Evaluate data quality
+evaluator = DataQualityEvaluator(
+    glueContext,
+    rules,
+    DynamicFrame.fromDF(transformed_df, glueContext, "check")
+)
+result = evaluator.evaluate()
+
+# Fail job if quality checks don't pass
+if result.overallResult != "PASS":
+    raise Exception(f"Data quality check failed: {result}")
+```
+
+### Available Data Quality Rules
+
+| Rule Type | Example | Description |
+|-----------|---------|-------------|
+| **RowCount** | `RowCount > 1000` | Minimum or maximum row count |
+| **ColumnCount** | `ColumnCount == 10` | Expected number of columns |
+| **Completeness** | `ColumnValues "email" Completeness > 0.95` | Non-null percentage |
+| **Uniqueness** | `Uniqueness "user_id" > 0.99` | Unique value percentage |
+| **IsPrimaryKey** | `IsPrimaryKey "order_id"` | Column has unique non-null values |
+| **IsComplete** | `IsComplete "required_field"` | Column has no nulls |
+| **ColumnValues** | `ColumnValues "age" between 0 and 120` | Value range checks |
+| **DistinctValuesCount** | `DistinctValuesCount "status" in [3,5]` | Number of unique values |
+| **Mean** | `Mean "price" between 10.0 and 100.0` | Average value range |
+| **StandardDeviation** | `StandardDeviation "amount" < 50.0` | Variability check |
+
+### Complete Example with Multiple Rules
+
+```python
+from awsglue.data_quality import DataQualityEvaluationOptions, DataQualityEvaluator
+from awsglue.dynamicframe import DynamicFrame
+
+# Define comprehensive data quality rules
+rules = """
+    Rules = [
+        # Basic structure checks
+        RowCount > 100,
+        ColumnCount == 8,
+
+        # Completeness checks
+        IsComplete "customer_id",
+        IsComplete "order_date",
+        ColumnValues "email" Completeness > 0.90,
+
+        # Uniqueness checks
+        IsPrimaryKey "order_id",
+        Uniqueness "customer_id" > 0.80,
+
+        # Value range checks
+        ColumnValues "quantity" between 1 and 1000,
+        ColumnValues "price" between 0.01 and 10000.00,
+        ColumnValues "order_date" >= "2023-01-01",
+
+        # Statistical checks
+        Mean "price" between 10.0 and 500.0,
+        StandardDeviation "quantity" < 100.0,
+
+        # Categorical checks
+        ColumnValues "status" in ["pending", "completed", "cancelled"],
+        DistinctValuesCount "status" == 3
+    ]
+"""
+
+# Convert DataFrame to DynamicFrame for evaluation
+dynamic_frame = DynamicFrame.fromDF(transformed_df, glueContext, "quality_check")
+
+# Create evaluation options
+eval_options = DataQualityEvaluationOptions(
+    publishCloudWatchMetrics=True,
+    publishResultsToCloudWatch=True
+)
+
+# Evaluate data quality
+evaluator = DataQualityEvaluator(glueContext, rules, dynamic_frame, eval_options)
+result = evaluator.evaluate()
+
+# Check results
+if result.overallResult != "PASS":
+    # Log failed rules
+    for rule_result in result.ruleResults:
+        if rule_result.result == "FAIL":
+            print(f"Failed rule: {rule_result.rule}")
+            print(f"Failure reason: {rule_result.failureReason}")
+
+    # Fail the job
+    raise Exception(f"Data quality check failed: {result.overallResult}")
+else:
+    print("All data quality checks passed!")
+```
+
+### Conditional Quality Checks
+
+Only fail on critical issues:
+
+```python
+# Define critical vs warning rules
+critical_rules = """
+    Rules = [
+        IsPrimaryKey "order_id",
+        IsComplete "customer_id",
+        RowCount > 0
+    ]
+"""
+
+warning_rules = """
+    Rules = [
+        ColumnValues "email" Completeness > 0.90,
+        Mean "price" between 10.0 and 500.0
+    ]
+"""
+
+# Evaluate critical rules (fail on failure)
+critical_result = DataQualityEvaluator(glueContext, critical_rules, dynamic_frame).evaluate()
+if critical_result.overallResult != "PASS":
+    raise Exception(f"Critical data quality check failed")
+
+# Evaluate warning rules (log but don't fail)
+warning_result = DataQualityEvaluator(glueContext, warning_rules, dynamic_frame).evaluate()
+if warning_result.overallResult != "PASS":
+    print(f"Warning: Non-critical data quality issues detected")
+    for rule_result in warning_result.ruleResults:
+        if rule_result.result == "FAIL":
+            print(f"  - {rule_result.rule}: {rule_result.failureReason}")
+```
+
+## Basic Validation Without Glue Data Quality
+
+Even without Glue Data Quality, perform basic checks using Athena queries after the load.
+
+### 1. Row Count Validation
+
+Verify data was loaded:
+
+```sql
+-- Count rows in target table
+SELECT COUNT(*) as row_count
+FROM "<catalog>"."<namespace>"."<table>"
+```
+
+Compare with source row count (if available).
+
+### 2. Null Checks
+
+Verify critical columns aren't mostly null:
+
+```sql
+-- Check null percentages for critical columns
+SELECT
+    COUNT(*) as total_rows,
+    SUM(CASE WHEN customer_id IS NULL THEN 1 ELSE 0 END) as null_customer_id,
+    SUM(CASE WHEN order_date IS NULL THEN 1 ELSE 0 END) as null_order_date,
+    SUM(CASE WHEN amount IS NULL THEN 1 ELSE 0 END) as null_amount,
+    -- Calculate percentages
+    CAST(SUM(CASE WHEN customer_id IS NULL THEN 1 ELSE 0 END) AS DOUBLE) / COUNT(*) * 100 as pct_null_customer_id,
+    CAST(SUM(CASE WHEN order_date IS NULL THEN 1 ELSE 0 END) AS DOUBLE) / COUNT(*) * 100 as pct_null_order_date,
+    CAST(SUM(CASE WHEN amount IS NULL THEN 1 ELSE 0 END) AS DOUBLE) / COUNT(*) * 100 as pct_null_amount
+FROM "<catalog>"."<namespace>"."<table>"
+```
+
+### 3. Type Validation
+
+Sample check that types converted correctly:
+
+```sql
+-- Sample data to verify types
+SELECT *
+FROM "<catalog>"."<namespace>"."<table>"
+LIMIT 100
+```
+
+Look for:
+
+- Dates that look like strings (e.g., "2024-01-15" instead of DATE)
+- Numbers that are actually strings
+- Truncated decimals
+- Unexpected null values
+
+### 4. Duplicate Detection
+
+Check for unexpected duplicates on key columns:
+
+```sql
+-- Find duplicate order_ids
+SELECT
+    order_id,
+    COUNT(*) as duplicate_count
+FROM "<catalog>"."<namespace>"."<table>"
+GROUP BY order_id
+HAVING COUNT(*) > 1
+ORDER BY duplicate_count DESC
+LIMIT 100
+```
+
+### 5. Value Range Checks
+
+Verify values are within expected ranges:
+
+```sql
+-- Check value ranges
+SELECT
+    MIN(order_date) as min_date,
+    MAX(order_date) as max_date,
+    MIN(amount) as min_amount,
+    MAX(amount) as max_amount,
+    MIN(quantity) as min_quantity,
+    MAX(quantity) as max_quantity
+FROM "<catalog>"."<namespace>"."<table>"
+```
+
+### 6. Categorical Value Checks
+
+Verify categorical columns have expected values:
+
+```sql
+-- Check distinct values in status column
+SELECT
+    status,
+    COUNT(*) as count
+FROM "<catalog>"."<namespace>"."<table>"
+GROUP BY status
+ORDER BY count DESC
+```
+
+Expected values should match source data categories.
+
+### 7. Statistical Checks
+
+Get basic statistics:
+
+```sql
+-- Calculate basic statistics
+SELECT
+    COUNT(*) as total_rows,
+    AVG(amount) as avg_amount,
+    STDDEV(amount) as stddev_amount,
+    APPROX_PERCENTILE(amount, 0.5) as median_amount,
+    APPROX_PERCENTILE(amount, 0.95) as p95_amount
+FROM "<catalog>"."<namespace>"."<table>"
+```
+
+## Validation Reporting
+
+### Present Results to User
+
+After running validation queries, present results clearly:
+
+```
+Data Load Validation Report:
+✓ Row count: 1,234,567 rows loaded
+✓ Null checks:
+  - customer_id: 0% null (expected: 0%)
+  - order_date: 0.1% null (acceptable)
+  - amount: 2.3% null (within threshold)
+✓ Duplicates: No duplicate order_ids found
+✓ Value ranges:
+  - order_date: 2023-01-01 to 2024-12-31 (expected)
+  - amount: $0.01 to $9,999.99 (valid range)
+  - quantity: 1 to 500 (valid range)
+✓ Categorical values:
+  - status: pending (45%), completed (50%), cancelled (5%)
+⚠ Warning: email column has 10% null values (target: < 5%)
+
+Overall: PASS with warnings
+```
+
+### Handle Failures
+
+When validation fails:
+
+```python
+# In Glue job script
+if result.overallResult != "PASS":
+    failure_summary = []
+    for rule_result in result.ruleResults:
+        if rule_result.result == "FAIL":
+            failure_summary.append(f"  - {rule_result.rule}: {rule_result.failureReason}")
+
+    error_message = "Data quality validation failed:\n" + "\n".join(failure_summary)
+    print(error_message)
+
+    # Optionally send notification or write to error table
+    # Then fail the job
+    raise Exception(error_message)
+```
+
+## Common Validation Patterns
+
+### Pre-Load Validation
+
+Before loading, validate source data:
+
+```python
+# Sample source data
+sample_df = spark.read.format("csv").option("header", "true").load(source_path).limit(1000)
+
+# Check structure
+print(f"Row count: {sample_df.count()}")
+print(f"Column count: {len(sample_df.columns)}")
+print(f"Columns: {sample_df.columns}")
+print(f"Schema: {sample_df.printSchema()}")
+
+# Check for issues
+null_counts = sample_df.select([
+    (col(c).isNull().cast("int")).alias(c) for c in sample_df.columns
+]).groupBy().sum()
+
+print("Null counts in sample:")
+null_counts.show()
+```
+
+### Post-Load Reconciliation
+
+Compare source and target row counts:
+
+```python
+# Count source rows
+source_count = spark.read.format("csv").option("header", "true").load(source_path).count()
+
+# Count target rows
+target_count = spark.sql(f"SELECT COUNT(*) FROM {target_table}").collect()[0][0]
+
+# Verify match
+if source_count != target_count:
+    print(f"Row count mismatch: source={source_count}, target={target_count}")
+    raise Exception("Row count mismatch detected")
+else:
+    print(f"Row count validation passed: {target_count} rows")
+```
+
+## Troubleshooting Quality Issues
+
+### Issue: High Null Percentage
+
+**Symptoms**: More nulls than expected in columns
+**Possible causes**:
+
+- Source data quality issues
+- Type conversion failures (strings that can't be parsed as numbers)
+- Column mapping errors
+
+**Solutions**:
+
+1. Check source data for null values
+2. Verify type conversions are correct
+3. Add explicit null handling in transformation
+
+### Issue: Duplicate Keys
+
+**Symptoms**: Primary key column has duplicates
+**Possible causes**:
+
+- Source data has duplicates
+- Multiple loads without deduplication
+- Partition keys included in data
+
+**Solutions**:
+
+1. Add deduplication logic to Glue job
+2. Use window functions to keep only latest record
+3. Investigate source data quality
+
+### Issue: Value Range Violations
+
+**Symptoms**: Values outside expected ranges
+**Possible causes**:
+
+- Source data contains outliers
+- Type conversion errors
+- Unit mismatches (e.g., dollars vs cents)
+
+**Solutions**:
+
+1. Add filtering or capping in transformation
+2. Verify unit conversions
+3. Add validation rules to reject bad data
+
+## Best Practices
+
+1. **Start with basic checks**: Row count and null checks catch most issues
+2. **Add rules incrementally**: Begin with critical rules, expand over time
+3. **Use sampling for large datasets**: Validate sample before full load
+4. **Publish metrics to CloudWatch**: Enable monitoring and alerting
+5. **Document thresholds**: Make quality expectations explicit
+6. **Handle warnings separately from errors**: Not all issues should fail the job
+7. **Test quality rules**: Ensure rules actually catch bad data
+
+## Summary
+
+Data quality validation workflow:
+
+1. **Pre-load validation**: Sample and inspect source data
+2. **In-load validation**: Use Glue Data Quality rules during ETL
+3. **Post-load validation**: Run Athena queries to verify results
+4. **Reconciliation**: Compare source and target row counts
+5. **Reporting**: Present clear validation results to user
+
+With comprehensive validation, you can ensure data loaded into S3 Tables meets quality standards.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/dynamodb-ingest.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/dynamodb-ingest.md
@@ -1,0 +1,234 @@
+# DynamoDB Ingest
+
+Import DynamoDB tables into the data lake. DynamoDB is unique among sources: no Glue connection needed, schemaless items, and no natural watermark column.
+
+## Contents
+
+- [Method Selection](#method-selection)
+- [Native Export (Path A)](#native-export-path-a)
+- [Glue Direct Read (Path B)](#glue-direct-read-path-b)
+- [Schema Flattening](#schema-flattening)
+- [Incremental Strategies](#incremental-strategies)
+- [Throughput Guidance](#throughput-guidance)
+- [Gotchas](#gotchas)
+
+## Method Selection
+
+Assess the table:
+
+```bash
+aws dynamodb describe-table --table-name <TABLE>
+```
+
+Note item count, table size, billing mode, and PITR status.
+
+| Table size | Method | Why |
+|---|---|---|
+| Small (<10K items, <1 GB) | Glue direct read | Simple, low throughput impact |
+| Medium (10K-100M items, 1-100 GB) | Native export | No read capacity consumed |
+| Large (>100M items, >100 GB) | Native export | Glue direct read would throttle production |
+
+## Native Export (Path A)
+
+Recommended for medium/large tables. Uses no read capacity.
+
+### Export Command
+
+```bash
+aws dynamodb export-table-to-point-in-time \
+  --table-arn arn:aws:dynamodb:<REGION>:<ACCOUNT>:table/<TABLE> \
+  --s3-bucket <EXPORT_BUCKET> \
+  --s3-prefix exports/<TABLE>/ \
+  --export-format DYNAMODB_JSON \
+  --export-type FULL_EXPORT
+```
+
+Export formats:
+
+- `DYNAMODB_JSON` (default) -- each item as JSON with type descriptors like `{"S": "value"}`
+- `ION` -- Amazon Ion, more compact, handles binary natively
+
+### Monitoring
+
+```bash
+aws dynamodb describe-export --export-arn <EXPORT_ARN>
+```
+
+States: `IN_PROGRESS`, `COMPLETED`, `FAILED`. Large tables take minutes to hours.
+
+### Output Structure
+
+```
+s3://<bucket>/exports/<table>/AWSDynamoDB/<export-id>/
+  manifest-summary.json
+  manifest-files.json
+  data/                    (gzipped JSON or Ion)
+```
+
+### Read Export in Glue
+
+```python
+export_df = spark.read.json("s3://<bucket>/exports/<table>/AWSDynamoDB/<export-id>/data/")
+# Items are nested in type descriptors -- flatten per Schema Flattening below
+```
+
+Native export items are wrapped in DynamoDB type descriptors (`{"S": "value"}`, `{"N": "123"}`). Unwrap before flattening:
+
+```python
+# Native export items are wrapped in type descriptors -- unwrap before flattening:
+flat_df = export_df.select(
+    col("Item.pk.S").alias("partition_key"),
+    col("Item.name.S").alias("name"),
+    col("Item.age.N").cast("bigint").alias("age")
+)
+```
+
+### Incremental Export
+
+Requires PITR enabled on the source table.
+
+```bash
+aws dynamodb export-table-to-point-in-time \
+  --table-arn <arn> \
+  --s3-bucket <bucket> \
+  --export-type INCREMENTAL_EXPORT \
+  --incremental-export-specification '{"ExportFromTime":"<last>","ExportToTime":"<now>","ExportViewType":"NEW_AND_OLD_IMAGES"}'
+```
+
+## Glue Direct Read (Path B)
+
+For small tables. No connection needed -- Glue reads DynamoDB via AWS APIs with the Glue job role's permissions.
+
+```python
+dynamodb_df = glueContext.create_dynamic_frame.from_options(
+    connection_type="dynamodb",
+    connection_options={
+        "dynamodb.input.tableName": "<TABLE>",
+        "dynamodb.throughput.read.percent": "0.5"
+    }
+).toDF()
+
+# After flattening, write to target (see iceberg-catalog-config-and-usage.md for path syntax)
+flat_df.writeTo("s3tablescatalog.<namespace>.<table>").append()
+```
+
+Options:
+
+| Option | Default | Purpose |
+|---|---|---|
+| `dynamodb.throughput.read.percent` | 0.5 | Fraction of RCUs to consume (0.1-1.0) |
+| `dynamodb.splits` | auto | Parallel scan segments |
+| `dynamodb.input.tableName` | required | Table name |
+
+## Schema Flattening
+
+Applies to Glue direct-read (Path B) output. For native export (Path A) output, use the type-descriptor unwrapping pattern shown above.
+
+DynamoDB type to Iceberg:
+
+| DDB | Iceberg | Notes |
+|---|---|---|
+| `S` | STRING | |
+| `N` | BIGINT, DOUBLE, or DECIMAL | Inspect values |
+| `BOOL` | BOOLEAN | |
+| `B` | BINARY | Rarely useful |
+| `M` | STRUCT or flatten to columns | |
+| `L` | ARRAY or JSON STRING | |
+| `SS` / `NS` | ARRAY&lt;STRING&gt; / ARRAY&lt;DOUBLE&gt; | |
+
+### Strategy options
+
+**Top-level only (simplest):**
+
+```python
+flat_df = dynamodb_df.select(
+    col("pk").alias("partition_key"),
+    col("name").cast("string"),
+    col("created_at").cast("timestamp")
+)
+```
+
+**Flatten one level:**
+
+```python
+flat_df = dynamodb_df.select(
+    col("pk").alias("user_id"),
+    col("profile.first_name").alias("first_name"),
+    col("address.city").alias("city")
+)
+```
+
+**Preserve as STRUCT:**
+
+```python
+flat_df = dynamodb_df.select(col("pk"), col("profile"), col("tags"))
+```
+
+**Serialize complex types to JSON:**
+
+```python
+from pyspark.sql.functions import to_json
+flat_df = dynamodb_df.select(col("pk"), to_json(col("metadata")).alias("metadata_json"))
+```
+
+### Sample items for schema inference
+
+```bash
+aws dynamodb scan --table-name <TABLE> --limit 10 --output json
+```
+
+Or in Spark:
+
+```python
+sample = dynamodb_df.limit(100).toPandas()
+all_columns = set()
+for _, row in sample.iterrows():
+    all_columns.update(row.dropna().index.tolist())
+```
+
+### Missing attributes
+
+```python
+from pyspark.sql.functions import coalesce, lit
+flat_df = dynamodb_df.select(
+    col("pk"),
+    coalesce(col("email"), lit("")).alias("email"),
+    coalesce(col("status"), lit("unknown")).alias("status")
+)
+```
+
+## Incremental Strategies
+
+| Strategy | Latency | Read impact | Best for |
+|---|---|---|---|
+| Scheduled full export | Hours | None | Large tables, daily freshness |
+| Incremental export | Minutes-hours | None | Medium tables with PITR |
+| DynamoDB Streams + Lambda | Seconds | None | Near-real-time |
+| Application watermark | Minutes | Some | Tables with `last_modified` attribute |
+| Full refresh via Glue | Minutes | High | Small tables (<10K items) |
+
+**Scheduled full export:** EventBridge rule triggers Lambda that runs `export-table-to-point-in-time` then a Glue job. Simple, captures deletes.
+
+**DynamoDB Streams:** Enable with `--stream-specification StreamEnabled=true,StreamViewType=NEW_AND_OLD_IMAGES`. Lambda consumes stream, writes to S3 or target. 24-hour stream retention -- Lambda must keep up.
+
+**Application watermark:** If items have `last_modified` attribute, filter in Glue: `dynamodb_df.filter(f"last_modified > '{last_watermark}'")`. Requires app cooperation and consumes read capacity.
+
+**Full refresh:** For small tables, `dynamodb_df.writeTo(target).using("iceberg").createOrReplace()`. Do NOT use `overwritePartitions()` -- it only replaces partitions present in the DataFrame, leaving deleted items as stale data.
+
+## Throughput Guidance
+
+| Billing mode | Recommendation |
+|---|---|
+| On-demand | `read.percent` = 0.5 or lower |
+| Provisioned | `read.percent` = 0.25-0.5; avoid peak hours |
+| Large table (any mode) | Use native export instead |
+
+## Gotchas
+
+- Native export consumes no read capacity -- always prefer for tables over 1 GB
+- Glue direct reads with high `read.percent` can throttle production traffic
+- DynamoDB Number is arbitrary precision -- decide BIGINT vs DECIMAL based on actual values
+- Binary (`B`) attributes rarely useful in analytics -- exclude unless required
+- DynamoDB Streams retention is 24 hours -- if the consumer falls behind, data is lost
+- Incremental export requires PITR enabled
+- `overwritePartitions()` does NOT delete partitions missing from the source DataFrame

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/error-handling.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/error-handling.md
@@ -1,0 +1,399 @@
+# Error Handling and Troubleshooting
+
+Complete guide for handling common errors and issues during data import into S3 Tables.
+
+## Overview
+
+This reference covers errors encountered during the data import workflow. Errors are organized by workflow phase and severity.
+
+**Connection errors are out of scope for this skill.** JDBC/Snowflake/BigQuery connection failures (timeouts, auth failures, driver not found, SSL errors) belong to `connect-to-data-source`. When a Glue job fails with a connection-level error, delegate to that skill's troubleshooting rather than debugging here.
+
+## Common Issues by Category
+
+### Schema Mismatch Errors
+
+**Symptoms**:
+
+- Type conversion failures during load
+- Column count mismatches between source and target
+- Data truncation warnings
+- Null values where not expected
+
+**Root Causes**:
+
+- Source data types don't match target Iceberg types
+- New columns in source not present in target table
+- Missing columns in source that exist in target
+- Incompatible type conversions (e.g., string → int with non-numeric values)
+
+**Solutions**:
+
+1. **Type mismatch - can cast safely**:
+   - Present conflict to user with example values
+   - Offer to add explicit CAST in transformation
+   - See [type-transformations.md](type-transformations.md) for casting patterns
+
+2. **Type mismatch - cannot cast**:
+   - Show sample problematic values
+   - Options:
+     - Filter out invalid rows
+     - Store as STRING and convert later
+     - Fix source data and re-import
+   - Let user decide based on data importance
+
+3. **New columns in source**:
+   - Suggest schema evolution via ALTER TABLE ADD COLUMNS
+   - Show proposed schema change
+   - Execute evolution if user approves
+   - See [schema-evolution.md](schema-evolution.md)
+
+4. **Missing columns in source**:
+   - Ask user how to handle:
+     - Default values (e.g., NULL, 0, empty string)
+     - Skip these columns (if nullable)
+     - Fail the load (if columns are critical)
+
+**Example Error Message to Present**:
+
+```
+Schema Mismatch Detected:
+- Column "age": Source type STRING, Target type INT
+  Sample values: "25", "thirty", "42", "unknown"
+  Issue: Values "thirty" and "unknown" cannot convert to INT
+
+Options:
+1. Filter out rows with non-numeric ages (loses ~5% of data)
+2. Store age as STRING in target table (requires schema change)
+3. Replace non-numeric values with NULL (preserves all rows)
+
+Which approach would you prefer?
+```
+
+### Permission Errors
+
+**Symptoms**:
+
+- Access Denied errors from AWS services
+- IAM role assumption failures
+- S3 bucket access errors
+- Glue job fails with permission errors
+
+**Root Causes**:
+
+- Missing IAM policies on Glue service role
+- S3 bucket policies blocking access
+- S3 Tables permissions not configured
+- Cross-account access issues
+
+**Solutions**:
+
+1. **Glue service role missing policies**:
+   - Check if role has AWSGlueServiceRole managed policy
+   - Check if role has S3 read/write permissions
+   - Check if role has S3 Tables inline policy
+   - See [iam-role-management.md](iam-role-management.md) for complete setup
+
+2. **S3 bucket access denied**:
+   - Verify IAM role has s3:GetObject, s3:ListBucket on source bucket
+   - Verify IAM role has s3:PutObject on script/results buckets
+   - Check S3 bucket policies don't block the role
+   - For cross-account: verify bucket policy allows role ARN
+
+3. **S3 Tables access denied**:
+   - Verify inline policy includes:
+     - s3tables:PutTableData
+     - s3tables:GetTableMetadataLocation
+     - s3tables:GetTable
+     - s3tables:UpdateTableMetadataLocation
+   - Verify resource ARN matches table bucket structure
+   - See [iam-role-management.md](iam-role-management.md#s3-tables-inline-policy)
+
+4. **Athena query execution errors**:
+   - Verify workgroup has output location configured
+   - Verify IAM has athena:StartQueryExecution
+   - Verify IAM has s3:PutObject on results bucket
+
+**Example Error Message to Present**:
+
+```
+Permission Error Detected:
+Glue job failed with: "Access Denied" when writing to table
+
+Root cause: IAM role "GlueServiceRole-import" is missing S3 Tables permissions
+
+Required actions:
+1. Add inline policy to role with s3tables:PutTableData permission
+2. Resource ARN should be: arn:aws:s3tables:us-east-1:123456789012:bucket/my-table-bucket/namespace/my-namespace/table/*
+
+Would you like me to add this policy to the role?
+```
+
+### Data Quality Failures
+
+**Symptoms**:
+
+- Glue Data Quality rules fail
+- Row counts don't match expected
+- High null percentages in critical columns
+- Duplicate primary keys detected
+
+**Root Causes**:
+
+- Source data quality issues
+- Incorrect transformation logic
+- Schema inference errors
+- Data quality rules too strict
+
+**Solutions**:
+
+1. **Row count mismatch**:
+   - Compare source row count vs target row count
+   - Check Glue job logs for filtering or errors
+   - Verify no duplicate writes occurred
+   - Check if partitioned data was partially loaded
+
+2. **High null percentage**:
+   - Show which columns have unexpected nulls
+   - Check if type conversion failures resulted in nulls
+   - Ask user if nulls are acceptable or if source needs fixing
+   - Adjust data quality thresholds if appropriate
+
+3. **Duplicate keys**:
+   - Show sample duplicate values
+   - Options:
+     - Add deduplication logic (keep latest/first)
+     - Investigate source for duplicates
+     - Fail load and fix source
+   - Add DISTINCT or window function to transformation
+
+4. **Data quality rule failures**:
+   - Show which rules failed and why
+   - Distinguish critical vs warning rules
+   - Options:
+     - Adjust rule thresholds (if too strict)
+     - Fix source data (if data is actually bad)
+     - Proceed with warnings (if non-critical)
+   - See [data-quality-validation.md](data-quality-validation.md)
+
+**Example Error Message to Present**:
+
+```
+Data Quality Check Failed:
+- Rule: IsPrimaryKey "order_id"
+- Failure: Found 127 duplicate order_ids (0.5% of total rows)
+- Sample duplicates: [10234, 10567, 10892, ...]
+
+This could indicate:
+1. Source data has duplicates (check data generation process)
+2. Multiple loads without deduplication
+3. Partition key included in order_id
+
+Options:
+1. Add deduplication keeping the latest record by timestamp
+2. Investigate source system for root cause
+3. Proceed with warning (not recommended for primary key)
+
+How would you like to proceed?
+```
+
+### Large Dataset Timeouts (Athena)
+
+**Symptoms**:
+
+- Athena query exceeds 30-minute timeout
+- Query runs out of memory
+- S3 read throttling errors
+
+**Root Causes**:
+
+- Dataset too large for single Athena query
+- Insufficient Athena engine size
+- Too many small files causing S3 throttling
+- Complex transformations in single query
+
+**Solutions**:
+
+1. **Break into batches**:
+   - Split by date range or partition
+   - Load in multiple INSERT queries
+   - Example: Load one month at a time
+
+2. **Switch to Glue ETL**:
+   - Glue can handle larger datasets with multiple workers
+   - Better for datasets > 1GB or millions of rows
+   - Provides better monitoring and retry logic
+   - See [format-specific-loading.md](format-specific-loading.md) for Glue examples
+
+3. **Increase Athena capacity**:
+   - Use Athena v3 engine
+   - Increase DPU allocation in workgroup settings
+   - Consider Athena provisioned capacity for repeated large queries
+
+4. **Optimize file structure**:
+   - Consolidate many small files (use Glue ETL)
+   - Use columnar formats (Parquet, ORC)
+   - Partition large datasets by date/region
+
+**Example Error Message to Present**:
+
+```
+Athena Query Timeout:
+Query exceeded 30-minute limit loading 5.2GB of data
+
+Recommendations:
+1. Switch to Glue ETL (recommended for datasets > 1GB)
+   - Can handle 5.2GB with 5 G.1X workers in ~15 minutes
+   - Better error handling and monitoring
+
+2. Batch the load by date partition
+   - Load 2024-01 through 2024-06 separately (6 queries)
+   - Each query would handle ~850MB
+
+Would you like me to:
+A) Create a Glue ETL job for this load (recommended)
+B) Set up batched Athena queries by month
+```
+
+### Format-Specific Issues
+
+#### CSV Parsing Errors
+
+**Symptoms**:
+
+- Columns shifted or misaligned
+- Quoted values not parsed correctly
+- Extra or missing columns
+
+**Solutions**:
+
+- Verify delimiter matches file (comma, tab, pipe)
+- Set `.option("quote", "\"")` for quoted fields
+- Set `.option("escape", "\\")` for escaped characters
+- Use `.option("mode", "DROPMALFORMED")` to skip bad rows
+- See [format-specific-loading.md](format-specific-loading.md#csv-issues)
+
+#### JSON Parsing Errors
+
+**Symptoms**:
+
+- Multi-line JSON not parsing
+- Nested structures flattened incorrectly
+- Malformed JSON records causing failures
+
+**Solutions**:
+
+- Set `.option("multiLine", "true")` for multi-line objects
+- Use `.option("mode", "PERMISSIVE")` to handle malformed records
+- Check JSON schema matches expected structure
+- Verify one JSON object per line for JSONL
+- See [format-specific-loading.md](format-specific-loading.md#json-issues)
+
+#### Parquet Partition Issues
+
+**Symptoms**:
+
+- Partition columns not detected
+- Schema evolution errors
+- Missing partitions in results
+
+**Solutions**:
+
+- Verify Hive-style partitioning (key=value/)
+- Use `.option("mergeSchema", "true")` for schema evolution
+- Check partition column names match across files
+- List S3 paths to confirm partition structure
+- See [format-specific-loading.md](format-specific-loading.md#parquet-issues)
+
+#### Avro Library Errors
+
+**Symptoms**:
+
+- "Avro library not found" error
+- Complex union types failing
+- Schema registry connection errors
+
+**Solutions**:
+
+- Add `--datalake-formats: iceberg,avro` to Glue job arguments
+- Or provide spark-avro JAR via `--extra-jars`
+- Convert complex unions to STRING or handle with conditional logic
+- See [format-specific-loading.md](format-specific-loading.md#avro-issues)
+
+## Error Severity Levels
+
+### Critical (Fail Immediately)
+
+These errors should stop the workflow:
+
+- IAM role doesn't exist or can't be assumed
+- Source S3 path doesn't exist or is empty
+- Target table exists with incompatible schema (cannot evolve)
+- Primary key violations in data quality checks
+
+**Action**: Present error clearly, provide remediation steps, wait for user action
+
+### Warnings (Proceed with Caution)
+
+These issues should be flagged but allow continuation:
+
+- High null percentage in optional columns
+- Data quality warnings (not critical rules)
+- Schema evolution needed (user approval required)
+- Source files have malformed records (but most are valid)
+
+**Action**: Show warning with details, ask user if they want to proceed
+
+### Informational
+
+These are expected and don't require action:
+
+- Using CLI fallback because MCP unavailable
+- Sampling large files for schema inference
+- Automatically inferring schema from source
+- Creating IAM role because none exists
+
+**Action**: Log for user visibility, proceed automatically
+
+## Troubleshooting Workflow
+
+When encountering an error:
+
+1. **Identify the phase**: Which workflow phase failed?
+2. **Read the error**: Get full error message from CloudWatch/Athena
+3. **Check permissions**: Verify IAM role has required policies
+4. **Validate data**: Sample source data to check format/quality
+5. **Review configuration**: Check Glue job args, Athena settings
+6. **Consult logs**: Check CloudWatch logs for detailed stack traces
+7. **Search references**: Check relevant reference doc for issue type
+
+## Getting Help
+
+When presenting errors to users:
+
+1. **Be specific**: Show exact error message and where it occurred
+2. **Provide context**: What was being attempted when error happened
+3. **Offer solutions**: Present 2-3 actionable options
+4. **Show impact**: Explain what happens if user chooses each option
+5. **Ask clearly**: Make the choice or next action explicit
+
+## Best Practices
+
+1. **Validate early**: Check permissions and schema before starting load
+2. **Sample first**: Test with small subset before full load
+3. **Monitor actively**: Watch CloudWatch logs during execution
+4. **Handle gracefully**: Don't let jobs fail silently - surface errors
+5. **Document issues**: Keep track of common errors and solutions
+6. **Test transformations**: Verify type casts and filters on sample data
+
+## Summary
+
+Error handling workflow:
+
+1. **Detect error** - Identify error type and severity
+2. **Diagnose root cause** - Check logs, permissions, data
+3. **Present clearly** - Show error and context to user
+4. **Offer solutions** - Provide 2-3 actionable options
+5. **Execute fix** - Apply chosen solution and retry
+6. **Validate resolution** - Confirm error is resolved
+
+With comprehensive error handling, the skill can guide users through issues confidently and get data loaded successfully.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/format-specific-loading.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/format-specific-loading.md
@@ -1,0 +1,482 @@
+# Format-Specific Data Loading
+
+Complete guide for reading and processing different file formats in Glue ETL jobs.
+
+## Overview
+
+This reference covers format-specific configuration and code examples for loading data from various file formats into S3 Tables:
+
+- CSV/TSV (delimited text files)
+- JSON/JSONL (JavaScript Object Notation)
+- Parquet (columnar format with embedded schema)
+- Avro (row-based format with embedded schema)
+- ORC (Optimized Row Columnar)
+
+## CSV and TSV Files
+
+### Basic CSV Reading
+
+```python
+# CSV with custom delimiter
+source_df = spark.read.format("csv") \
+    .option("header", "true") \
+    .option("delimiter", ",") \
+    .option("inferSchema", "true") \
+    .load(args['source_path'])
+```
+
+### TSV (Tab-Separated Values)
+
+```python
+# TSV (tab-separated)
+source_df = spark.read.format("csv") \
+    .option("header", "true") \
+    .option("delimiter", "\t") \
+    .load(args['source_path'])
+```
+
+### CSV Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `header` | `true`/`false` | First row contains column names |
+| `delimiter` | `,`, `\t`, `\|`, etc. | Field separator character |
+| `inferSchema` | `true`/`false` | Automatically detect column types |
+| `quote` | `"` (default) | Character for quoting fields |
+| `escape` | `\` (default) | Escape character |
+| `nullValue` | `NULL`, empty, etc. | String representing null values |
+| `dateFormat` | `yyyy-MM-dd` | Date parsing format |
+| `timestampFormat` | `yyyy-MM-dd HH:mm:ss` | Timestamp parsing format |
+
+### Advanced CSV Example
+
+```python
+# CSV with custom options
+source_df = spark.read.format("csv") \
+    .option("header", "true") \
+    .option("delimiter", ",") \
+    .option("quote", "\"") \
+    .option("escape", "\\") \
+    .option("nullValue", "NULL") \
+    .option("dateFormat", "yyyy-MM-dd") \
+    .option("timestampFormat", "yyyy-MM-dd HH:mm:ss") \
+    .option("mode", "DROPMALFORMED") \
+    .load(args['source_path'])
+```
+
+## JSON and JSONL Files
+
+### JSON Lines (JSONL)
+
+One JSON object per line (most common):
+
+```python
+# JSON Lines (one JSON object per line)
+source_df = spark.read.format("json").load(args['source_path'])
+```
+
+### Nested JSON Handling
+
+#### Option A: Flatten Nested Structures
+
+```python
+from pyspark.sql.functions import col
+
+# Flatten nested JSON
+flattened_df = source_df.select(
+    col("customer.customer_id").alias("customer_id"),
+    col("customer.name").alias("customer_name"),
+    col("customer.email").alias("email"),
+    col("order_id"),
+    col("order_date"),
+    col("amount")
+)
+```
+
+#### Option B: Preserve as STRUCT
+
+No transformation needed - Iceberg supports STRUCT types:
+
+```python
+# Preserve nested structure (no transformation)
+# Schema becomes:
+# - order_id: BIGINT
+# - customer: STRUCT<customer_id:BIGINT, name:STRING, email:STRING>
+# - order_date: DATE
+# - amount: DECIMAL
+```
+
+### JSON Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `multiLine` | `true`/`false` | Parse multi-line JSON objects |
+| `mode` | `PERMISSIVE`, `DROPMALFORMED`, `FAILFAST` | How to handle malformed records |
+| `dateFormat` | `yyyy-MM-dd` | Date parsing format |
+| `timestampFormat` | `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` | Timestamp format |
+
+### Array Handling
+
+```python
+# Explode array into separate rows
+from pyspark.sql.functions import explode
+
+df_with_items = source_df.select(
+    col("order_id"),
+    explode(col("items")).alias("item")
+).select(
+    col("order_id"),
+    col("item.product_id"),
+    col("item.quantity"),
+    col("item.price")
+)
+
+# Or preserve as ARRAY type in Iceberg
+# Schema: items ARRAY<STRUCT<product_id:STRING, quantity:INT, price:DECIMAL>>
+```
+
+## Parquet Files
+
+### Basic Parquet Reading
+
+```python
+# Parquet (direct read, schema preserved)
+source_df = spark.read.format("parquet").load(args['source_path'])
+```
+
+### Partitioned Parquet
+
+Spark automatically detects Hive-style partitions:
+
+```python
+# Partitioned Parquet (Spark auto-detects partitions)
+source_df = spark.read.format("parquet").load("s3://bucket/events/")
+# Partitions like year=2024/month=01/ are automatically handled
+```
+
+### Detect Partition Structure
+
+For partitioned data with Hive-style partitioning (e.g., `year=2024/month=01/day=15/`):
+
+**Using Python regex**:
+
+```python
+import re
+
+# Example S3 path: s3://bucket/events/year=2024/month=01/day=15/part-0000.parquet
+sample_s3_path = "s3://bucket/events/year=2024/month=01/day=15/part-0000.parquet"
+
+# Extract partition key-value pairs
+path_pattern = r'(\w+)=([^/]+)'
+partitions = re.findall(path_pattern, sample_s3_path)
+# Result: [('year', '2024'), ('month', '01'), ('day', '15')]
+
+partition_columns = [col for col, _ in partitions]
+print(f"Detected partition columns: {partition_columns}")
+# Output: ['year', 'month', 'day']
+```
+
+**Using AWS CLI**:
+
+```bash
+# List S3 paths to identify partition patterns
+aws s3 ls s3://bucket/events/ --recursive | head -20
+
+# Look for patterns like:
+# year=2024/month=01/day=01/
+# year=2024/month=01/day=02/
+```
+
+### Partition Column Inference
+
+- Partition columns should typically be: `INT`, `STRING`, or `DATE` types
+- Common partition patterns: `year`, `month`, `day`, `region`, `category`
+- **Important**: Partition columns will NOT appear in the data files themselves (they're in the path)
+
+### Present Partition Info to User
+
+```
+Detected partitioned data structure:
+- Partition columns: year (INT), month (INT), day (INT)
+- Data columns: event_id, event_type, timestamp, user_id, properties
+- Sample partition: year=2024/month=01/day=15
+- Estimated partitions: ~90 (covering 3 months)
+```
+
+## Avro Files
+
+### Basic Avro Reading
+
+```python
+# Avro format
+source_df = spark.read.format("avro").load(args['source_path'])
+```
+
+### Avro Schema Extraction
+
+Avro files contain embedded schemas. Extract and display:
+
+**Using Python avro library**:
+
+```python
+import avro.datafile
+import avro.io
+import json
+
+# Read Avro file and extract schema
+with open('downloaded-sample.avro', 'rb') as f:
+    reader = avro.datafile.DataFileReader(f, avro.io.DatumReader())
+    schema_json = reader.meta.get('avro.schema').decode('utf-8')
+    schema = json.loads(schema_json)
+
+    print("Avro Schema:")
+    print(json.dumps(schema, indent=2))
+
+    # Extract field names and types
+    for field in schema['fields']:
+        print(f"  {field['name']}: {field['type']}")
+```
+
+**Using fastavro**:
+
+```python
+import fastavro
+
+with open('downloaded-sample.avro', 'rb') as f:
+    reader = fastavro.reader(f)
+    schema = reader.writer_schema
+    for field in schema['fields']:
+        print(f"  {field['name']}: {field['type']}")
+```
+
+### Avro to Iceberg Type Mapping
+
+| Avro Type | Iceberg Type | Notes |
+|-----------|--------------|-------|
+| `int` | `INTEGER` | 32-bit signed integer |
+| `long` | `BIGINT` | 64-bit signed integer |
+| `float` | `FLOAT` | 32-bit floating point |
+| `double` | `DOUBLE` | 64-bit floating point |
+| `boolean` | `BOOLEAN` | Direct mapping |
+| `string` | `STRING` | Direct mapping |
+| `bytes` | `BINARY` | Direct mapping |
+| `fixed` | `BINARY` | Fixed-length byte array |
+| `enum` | `STRING` | Store enum values as strings |
+| `array<T>` | `ARRAY<T>` | Direct mapping with recursive type |
+| `map<string, T>` | `MAP<STRING, T>` | Direct mapping |
+| `record` | `STRUCT` | Nested structure |
+| `union [null, T]` | Nullable `T` | Avro nullable pattern |
+| `union [T1, T2, ...]` | `STRING` | Multiple types → JSON string |
+
+### Handling Avro Union Types
+
+Avro uses unions for nullable fields:
+
+```json
+// Avro schema with nullable field
+{
+  "name": "age",
+  "type": ["null", "int"]
+}
+```
+
+Maps to Iceberg:
+
+```sql
+age INT  -- Nullable by default in Iceberg
+```
+
+**For complex unions** (non-nullable):
+
+```python
+from pyspark.sql.functions import col, when
+
+# Example: Handle union of int and string
+df_with_union = source_df.withColumn(
+    "age_clean",
+    when(col("age").cast("int").isNotNull(), col("age").cast("int"))
+    .otherwise(None)
+)
+```
+
+**Options for complex unions**:
+
+- **Option A**: Convert to JSON string and store as STRING
+- **Option B**: Flatten union types into separate columns (age_int, age_string)
+- **Option C**: Fail and ask user how to handle
+
+### Present Avro Schema to User
+
+```
+Detected Avro schema with 15 fields:
+- user_id (long) → BIGINT
+- username (string) → STRING
+- age (union[null, int]) → INT (nullable)
+- status (enum: active, inactive) → STRING
+- metadata (map<string, string>) → MAP<STRING, STRING>
+- preferences (record) → STRUCT
+```
+
+### Glue Job Configuration for Avro
+
+**Option A: Use `--datalake-formats`** (spark-avro built-in in Glue 5.1 or higher):
+
+```python
+# In job DefaultArguments
+'--datalake-formats': 'iceberg,delta,hudi,avro'
+```
+
+**Option B: Provide spark-avro JAR**:
+
+```bash
+# In create-job command
+--default-arguments '{
+  "--extra-jars": "s3://my-bucket/jars/spark-avro_2.12-3.4.0.jar"
+}'
+```
+
+## ORC Files
+
+### Basic ORC Reading
+
+```python
+# ORC format
+source_df = spark.read.format("orc").load(args['source_path'])
+```
+
+ORC files include embedded schema similar to Parquet. No special configuration needed.
+
+## Sampling Source Data
+
+Before loading, sample source files to understand structure:
+
+### CSV Sampling
+
+```bash
+# Download and inspect first 10 lines
+aws s3 cp s3://<bucket>/<key> - | head -10
+```
+
+### Parquet Schema Inspection
+
+```python
+import pyarrow.parquet as pq
+
+# Read Parquet schema
+table = pq.read_table('s3://<bucket>/<key>')
+print(table.schema)
+
+# Sample first 10 rows
+df = table.to_pandas()
+print(df.head(10))
+```
+
+### JSON Sampling
+
+```bash
+# Download and inspect first 5 JSON objects
+aws s3 cp s3://<bucket>/<key> - | head -5
+```
+
+## Complete Glue ETL Script Template
+
+```python
+import sys
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+
+args = getResolvedOptions(sys.argv, ['JOB_NAME', 'source_path', 'target_table', 'source_format'])
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+# Read source data based on format
+if args['source_format'] == 'csv':
+    source_df = spark.read.format("csv") \
+        .option("header", "true") \
+        .option("inferSchema", "true") \
+        .load(args['source_path'])
+elif args['source_format'] == 'json':
+    source_df = spark.read.format("json").load(args['source_path'])
+elif args['source_format'] == 'parquet':
+    source_df = spark.read.format("parquet").load(args['source_path'])
+elif args['source_format'] == 'avro':
+    source_df = spark.read.format("avro").load(args['source_path'])
+elif args['source_format'] == 'orc':
+    source_df = spark.read.format("orc").load(args['source_path'])
+else:
+    raise ValueError(f"Unsupported format: {args['source_format']}")
+
+# Apply transformations as needed
+transformed_df = source_df.select(
+    # Column transformations here
+)
+
+# Write to Iceberg table
+transformed_df.writeTo(args['target_table']).append()
+
+job.commit()
+```
+
+## Format-Specific Common Issues
+
+### CSV Issues
+
+**Issue**: Column type inference incorrect
+**Solution**: Explicitly specify schema or cast columns after reading
+
+**Issue**: Quoted fields not parsed correctly
+**Solution**: Set `.option("quote", "\"")` and `.option("escape", "\\")`
+
+### JSON Issues
+
+**Issue**: Multi-line JSON not parsing
+**Solution**: Set `.option("multiLine", "true")`
+
+**Issue**: Malformed JSON records
+**Solution**: Set `.option("mode", "DROPMALFORMED")` or `"PERMISSIVE"`
+
+### Parquet Issues
+
+**Issue**: Partition columns not detected
+**Solution**: Verify path follows Hive-style partitioning (`key=value/`)
+
+**Issue**: Schema evolution errors
+**Solution**: Use `.option("mergeSchema", "true")` when reading
+
+### Avro Issues
+
+**Issue**: Avro library not found
+**Solution**: Add `--datalake-formats: iceberg,avro` to job arguments
+
+**Issue**: Complex union types failing
+**Solution**: Convert to STRING or handle with conditional logic
+
+## Best Practices
+
+1. **Always sample data first**: Understand structure before loading
+2. **Validate schema mapping**: Ensure source types map correctly to Iceberg
+3. **Handle malformed records**: Use appropriate error handling mode
+4. **Test with small dataset**: Verify transformations work before full load
+5. **Monitor CloudWatch logs**: Check for parsing errors or warnings
+6. **Document format-specific options**: Keep track of delimiter, quote char, etc.
+7. **Use schema evolution carefully**: Understand impact on existing data
+
+## Summary
+
+Different file formats require different reading configurations:
+
+| Format | Key Considerations | Primary Options |
+|--------|-------------------|-----------------|
+| CSV/TSV | Delimiter, header, quotes | `delimiter`, `header`, `quote` |
+| JSON | Nested structures, arrays | `multiLine`, flatten vs preserve |
+| Parquet | Partition detection | Auto-detected, `mergeSchema` |
+| Avro | Union types, embedded schema | `--datalake-formats: avro` |
+| ORC | Similar to Parquet | Auto-schema, minimal config |
+
+With format-specific configuration, Glue ETL can successfully load data from any supported format into S3 Tables.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/glue-etl-migration.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/glue-etl-migration.md
@@ -1,0 +1,129 @@
+# Glue ETL Migration for Large Tables
+
+Use Glue ETL (Path B) when Athena CTAS would time out, when transforms are complex, or when the migration needs to be scheduled/repeatable.
+
+## When to Use
+
+- Source table over ~100 GB
+- Complex column transformations that benefit from PySpark
+- Migration needs to be scheduled or repeatable
+- Source has more than 100 target partitions and batching is impractical
+
+## Job Setup
+
+### Requirements
+
+- Glue 5.1 or higher (Spark 3.5.6, Iceberg 1.10.0)
+- `--datalake-formats iceberg` job argument
+- Catalog config in `--conf` job argument (not `spark.conf.set()`). See [iceberg-catalog-config-and-usage.md](iceberg-catalog-config-and-usage.md) for the exact keys.
+- IAM role with S3 Tables, Glue, and S3 permissions
+
+### Job Configuration (JSON)
+
+Use `--cli-input-json` to avoid shell escaping issues:
+
+> **Glue --conf format**: In Glue `DefaultArguments`, multiple Spark configs must be passed as a single `--conf` value with space-separated `--conf key=value` pairs. Do not split them into separate JSON keys — Glue only reads one `--conf` key.
+
+```json
+{
+    "Name": "migrate-to-s3tables",
+    "Role": "arn:aws:iam::<account-id>:role/<glue-role>",
+    "Command": {
+        "Name": "glueetl",
+        "ScriptLocation": "s3://<scripts-bucket>/scripts/migrate.py",
+        "PythonVersion": "3"
+    },
+    "DefaultArguments": {
+        "--datalake-formats": "iceberg",
+        "--enable-glue-datacatalog": "true",
+        "--conf": "<see iceberg-catalog-config-and-usage.md for S3 Tables Analytics Integration or REST config>"
+    },
+    "GlueVersion": "5.1",
+    "NumberOfWorkers": 10,
+    "WorkerType": "G.1X"
+}
+```
+
+```bash
+aws glue create-job --cli-input-json file://job-config.json --region <region>
+```
+
+Scale `NumberOfWorkers` based on source size: ~2 workers per 50 GB as a starting point.
+
+## PySpark Migration Script
+
+```python
+import sys
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+
+args = getResolvedOptions(sys.argv, [
+    'JOB_NAME', 'source_database', 'source_table',
+    'target_namespace', 'target_table'
+])
+
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+# Read from source (Glue Data Catalog)
+source_df = spark.read.table(
+    f"glue_catalog.{args['source_database']}.{args['source_table']}"
+)
+
+# Apply transforms (customize as needed)
+# Example: lowercase column names for S3 Tables compatibility
+for col_name in source_df.columns:
+    if col_name != col_name.lower():
+        source_df = source_df.withColumnRenamed(col_name, col_name.lower())
+
+# Write to S3 Table
+target_table = f"s3tablescatalog.{args['target_namespace']}.{args['target_table']}"
+
+source_df.writeTo(target_table) \
+    .tableProperty("format-version", "2") \
+    .createOrReplace()
+
+# Verify row count
+source_count = spark.read.table(
+    f"glue_catalog.{args['source_database']}.{args['source_table']}"
+).count()
+target_count = spark.read.table(target_table).count()
+print(f"Source rows: {source_count}, Target rows: {target_count}")
+
+job.commit()
+```
+
+## Key Points
+
+- All catalog config goes in `--conf` job argument, never in `spark.conf.set()`. See [iceberg-catalog-config-and-usage.md](iceberg-catalog-config-and-usage.md) for the exact keys.
+- No `LOCATION` clause -- S3 Tables manages storage
+- Column names must be all lowercase for Athena visibility
+- `createOrReplace()` handles both cases: creates the table if absent, replaces it if present (safe for re-runs)
+- For partitioned writes, add `.partitionedBy()` before `.createOrReplace()`
+
+## Running and Monitoring
+
+```bash
+# Start the job
+JOB_RUN_ID=$(aws glue start-job-run \
+  --job-name "migrate-to-s3tables" \
+  --arguments '{"--source_database":"legacy_db","--source_table":"orders","--target_namespace":"analytics","--target_table":"orders"}' \
+  --query 'JobRunId' --output text)
+
+# Check status
+aws glue get-job-run --job-name "migrate-to-s3tables" --run-id "$JOB_RUN_ID"
+```
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| "Cannot modify static config" | Catalog config in `spark.conf.set()` | Move all catalog config to `--conf` job argument |
+| "Access Denied" on S3 Tables | Missing IAM permissions | Add `AmazonS3TablesFullAccess` to Glue role |
+| Job runs out of memory | Too few workers for data size | Increase `NumberOfWorkers` or use `G.2X` worker type |
+| Table not visible in Athena after Glue job | Used REST endpoint instead of analytics integration | Use the GlueCatalog method with `glue.id` config |

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/glue-job-config.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/glue-job-config.md
@@ -1,0 +1,316 @@
+# Glue Job Configuration Guide
+
+Guide for creating Glue jobs, configuring workers, advanced PySpark patterns, and monitoring for external data import pipelines.
+
+## Creating the Glue Job
+
+Once you have the PySpark script saved to S3 (e.g., `s3://<scripts-bucket>/glue-jobs/external-import-<table-name>.py`), create the Glue job.
+
+### AWS CLI
+
+```bash
+aws glue create-job \
+  --name "external-import-<source>-<table>" \
+  --role "<glue-role-arn>" \
+  --command "Name=glueetl,ScriptLocation=s3://<scripts-bucket>/glue-jobs/external-import-<table>.py,PythonVersion=3" \
+  --connections "Connections=<glue-connection-name>" \
+  --default-arguments '{
+    "--datalake-formats": "iceberg",
+    "--connection_name": "<glue-connection-name>",
+    "--source_table": "<schema>.<table>",
+    "--target_table": "<catalog>.<namespace>.<s3-table>",
+    "--watermark_column": "<timestamp-column>",
+    "--watermark_bucket": "<bucket>",
+    "--watermark_key": "watermarks/<table-name>.txt",
+    "--conf": "<see iceberg-catalog-config-and-usage.md for S3 Tables or standard Iceberg catalog config>",
+    "--enable-glue-datacatalog": "true",
+    "--enable-metrics": "true",
+    "--enable-continuous-cloudwatch-log": "true"
+  }' \
+  --glue-version "5.1" \
+  --number-of-workers 5 \
+  --worker-type "G.1X" \
+  --timeout 60 \
+  --max-retries 1 \
+  --region <region>
+```
+
+## Job Configuration Parameters
+
+### Worker Types and Sizing
+
+Choose worker type based on workload characteristics:
+
+| Worker Type | vCPUs | Memory | Use Case |
+|-------------|-------|--------|----------|
+| G.1X | 4 | 16 GB | Standard ETL, small to medium data volumes |
+| G.2X | 8 | 32 GB | Large data volumes, memory-intensive transforms |
+| G.4X | 16 | 64 GB | Very large data volumes, complex joins |
+| G.8X | 32 | 128 GB | Massive data volumes, high parallelism |
+
+**Number of workers guidance:**
+
+- **Small tables** (<1M rows, <1 GB): 2-5 workers, G.1X
+- **Medium tables** (1M-10M rows, 1-10 GB): 5-10 workers, G.1X or G.2X
+- **Large tables** (10M-100M rows, 10-100 GB): 10-20 workers, G.2X
+- **Very large tables** (>100M rows, >100 GB): 20-50 workers, G.2X or G.4X
+
+Start conservative and scale up based on job duration and throughput.
+
+### Timeout Configuration
+
+Set timeout based on expected job duration:
+
+- **Small incremental loads**: 15-30 minutes
+- **Medium incremental loads**: 30-60 minutes
+- **Large incremental loads**: 60-120 minutes
+- **Full refresh of large tables**: 120-480 minutes
+
+Add buffer for source database query time and network latency.
+
+### Retry Configuration
+
+Configure retries for transient failures:
+
+```python
+'MaxRetries': 1  # Retry once on failure
+```
+
+For production pipelines, consider:
+
+- Setting `MaxRetries` to 1-2 for transient network issues
+- Using Glue job bookmarks to avoid duplicate processing
+- Implementing idempotent logic (upsert instead of append)
+
+### Important Job Arguments
+
+**Required arguments:**
+
+- `--datalake-formats iceberg`: Required for S3 Tables and standard Iceberg targets
+- `--enable-glue-datacatalog`: Enable Glue Data Catalog integration for Iceberg
+- `--conf`: Spark catalog configuration. See [iceberg-catalog-config-and-usage.md](iceberg-catalog-config-and-usage.md) for the exact keys per target type.
+- `--enable-metrics`: Publish CloudWatch metrics
+- `--enable-continuous-cloudwatch-log`: Stream logs to CloudWatch
+
+**Optional arguments:**
+
+- `--enable-spark-ui`: Enable Spark UI for debugging (requires S3 bucket)
+- `--spark-event-logs-path`: Where to store Spark UI logs
+- `--conf spark.sql.adaptive.enabled=true`: Enable adaptive query execution
+- `--conf spark.sql.adaptive.coalescePartitions.enabled=true`: Optimize partition count
+
+### Network Configuration
+
+If the source database is in a VPC, ensure the Glue job has network access:
+
+```python
+'Connections': {
+    'Connections': ['<glue-connection-name>']
+}
+```
+
+The connection specifies:
+
+- VPC
+- Subnet
+- Security groups
+- Availability zone
+
+Glue provisions ENIs in the specified subnet to access the database.
+
+## Advanced PySpark Patterns
+
+### Parallel Reads with Partitioning
+
+For large tables, read data in parallel using Spark partitioning:
+
+```python
+# Read with parallel partitions
+source_df = spark.read.format("jdbc").options(
+    url=jdbc_url,
+    dbtable="large_table",
+    numPartitions=10,  # Read with 10 parallel connections
+    partitionColumn="id",  # Partition on this column
+    lowerBound=1,  # Min value
+    upperBound=10000000  # Max value
+).load()
+```
+
+This creates 10 parallel queries:
+
+- Partition 1: `WHERE id >= 1 AND id < 1000000`
+- Partition 2: `WHERE id >= 1000000 AND id < 2000000`
+- ...
+- Partition 10: `WHERE id >= 9000000 AND id <= 10000000`
+
+**Best practices:**
+
+- Use a numeric column with even distribution
+- Set `numPartitions` = number of workers × cores per worker
+- Choose `lowerBound` and `upperBound` based on actual data range
+
+### Deduplication Logic
+
+If there's risk of duplicate records (job retries, late arrivals):
+
+```python
+from pyspark.sql.window import Window
+from pyspark.sql.functions import row_number
+
+# Deduplicate by primary key, keeping latest by watermark
+window = Window.partitionBy("primary_key").orderBy(col(watermark_column).desc())
+deduplicated_df = source_df.withColumn("row_num", row_number().over(window)) \
+    .filter(col("row_num") == 1) \
+    .drop("row_num")
+```
+
+### Type Conversion and Validation
+
+Add data quality checks and type conversions:
+
+```python
+from pyspark.sql.functions import col, when
+
+transformed_df = source_df.select(
+    # Safe type casting with null handling
+    when(col("amount").cast("double").isNotNull(), col("amount").cast("double"))
+        .otherwise(0.0).alias("amount"),
+
+    # String trimming and validation
+    when(col("email").rlike(r"^[\w\.-]+@[\w\.-]+\.\w+$"), col("email"))
+        .otherwise(None).alias("email"),
+
+    # Date parsing with fallback
+    when(col("order_date").isNotNull(),
+         to_date(col("order_date"), "yyyy-MM-dd"))
+        .otherwise(None).alias("order_date")
+)
+```
+
+### Watermark with Buffer for Late Arrivals
+
+If source data can arrive late (event timestamp < updated timestamp):
+
+```python
+from datetime import timedelta
+
+# Load data from 1 day before last watermark to catch late arrivals
+buffer_watermark = (datetime.strptime(last_watermark, '%Y-%m-%d %H:%M:%S')
+                    - timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
+
+filtered_df = source_df.filter(
+    f"{args['watermark_column']} > '{buffer_watermark}'"
+)
+
+# Then use upsert to avoid duplicates
+```
+
+## Monitoring and Observability
+
+### CloudWatch Logs
+
+Glue streams job logs to CloudWatch Logs under:
+
+- Log group: `/aws-glue/jobs/output`
+- Log stream: `<job-name>-<job-run-id>`
+
+**Key log patterns to monitor:**
+
+- `Last watermark: <value>` - Starting point for incremental load
+- `Loading X new/updated records` - How many records found
+- `Updated watermark to: <value>` - New watermark after load
+- `ERROR` - Any errors during execution
+
+### CloudWatch Metrics
+
+With `--enable-metrics`, Glue publishes:
+
+- `glue.driver.aggregate.numCompletedTasks` - Tasks completed
+- `glue.driver.aggregate.elapsedTime` - Job duration
+- `glue.driver.aggregate.recordsRead` - Records read from source
+- `glue.driver.aggregate.bytesRead` - Bytes read from source
+
+Set up CloudWatch alarms for:
+
+- Job failures (state = FAILED)
+- Long-running jobs (duration > threshold)
+- No records loaded (might indicate source issue)
+
+### Spark UI
+
+Enable Spark UI for detailed execution metrics:
+
+```python
+'DefaultArguments': {
+    '--enable-spark-ui': 'true',
+    '--spark-event-logs-path': 's3://<logs-bucket>/spark-logs/'
+}
+```
+
+Access via Glue console → Job runs → View Spark UI
+
+Use Spark UI to:
+
+- Identify slow stages (data skew, shuffle issues)
+- Analyze task distribution across workers
+- Debug memory issues (GC time, spills to disk)
+
+## Script Storage and Versioning
+
+**Best practices for script management:**
+
+1. **Store scripts in S3**: `s3://<scripts-bucket>/glue-jobs/<job-name>.py`
+2. **Version scripts**: Use S3 versioning or include version in filename
+3. **Separate environments**: Different buckets for dev/staging/prod
+4. **Use Git**: Maintain scripts in Git, deploy to S3 via CI/CD
+
+**Example structure:**
+
+```
+s3://my-glue-scripts/
+  prod/
+    external-import-customers.py
+    external-import-orders.py
+  dev/
+    external-import-customers.py
+    external-import-orders.py
+```
+
+## Testing Scripts Locally
+
+Test PySpark scripts locally before deploying to Glue:
+
+```bash
+# Install dependencies
+pip install pyspark boto3
+
+# Run script locally (modify to use local Spark)
+python external-import-customers.py \
+  --JOB_NAME test-run \
+  --connection_name test-connection \
+  --source_table customers \
+  --target_table local.test.customers \
+  --watermark_column updated_at \
+  --watermark_bucket test-bucket \
+  --watermark_key watermarks/customers.txt
+```
+
+For full local testing, use AWS Glue Docker images:
+
+```bash
+docker pull amazon/aws-glue-libs:glue_libs_5.0.0_image_01
+```
+
+## Summary
+
+Glue ETL job creation workflow:
+
+1. **Choose template** - Append, Upsert, Custom SQL, or Full Refresh
+2. **Customize script** - Add transformations, validation, error handling
+3. **Save to S3** - Store script in versioned S3 location
+4. **Create job** - Use MCP or CLI with appropriate configuration
+5. **Size workers** - Choose worker type and count based on data volume
+6. **Configure monitoring** - Enable CloudWatch logs and metrics
+7. **Test locally** - Validate logic before deploying (optional)
+
+With a well-configured Glue job, external database data flows continuously into S3 Tables with minimal operational overhead.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/glue-job-scripts.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/glue-job-scripts.md
@@ -1,0 +1,341 @@
+# Glue ETL Job Creation Guide
+
+Complete guide for creating AWS Glue ETL jobs that import data from external databases into S3 Tables.
+
+## Overview
+
+Glue ETL jobs use PySpark to connect to external databases via connections, read data incrementally using watermark columns, apply transformations, and write to Iceberg tables in S3 Tables.
+
+## PySpark Script Structure
+
+### Basic Incremental Append Template
+
+For immutable data (transactions, events, logs) where you only need to append new records:
+
+```python
+import sys
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from awsglue.dynamicframe import DynamicFrame
+import boto3
+from datetime import datetime
+from pyspark.sql.functions import lit
+
+# Parse job arguments
+args = getResolvedOptions(sys.argv, [
+    'JOB_NAME',
+    'connection_name',
+    'source_table',
+    'target_table',
+    'watermark_column',
+    'watermark_bucket',
+    'watermark_key'
+])
+
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+# Read last watermark from S3
+s3 = boto3.client('s3')
+try:
+    obj = s3.get_object(Bucket=args['watermark_bucket'], Key=args['watermark_key'])
+    last_watermark = obj['Body'].read().decode('utf-8').strip()
+    print(f"Last watermark: {last_watermark}")
+except s3.exceptions.NoSuchKey:
+    last_watermark = '1970-01-01 00:00:00'  # Default for timestamp
+    # OR last_watermark = '0'  # Default for ID column
+    print("No previous watermark found, starting from beginning")
+
+# Read from external database using Glue connection
+source_df = glueContext.create_dynamic_frame.from_catalog(
+    database="<temp-catalog-db>",
+    table_name="<source-table>",
+    transformation_ctx="source_df",
+    additional_options={
+        "connectionName": args['connection_name']
+    }
+).toDF()
+
+# Apply incremental filter
+filtered_df = source_df.filter(
+    f"{args['watermark_column']} > '{last_watermark}'"
+)
+
+row_count = filtered_df.count()
+print(f"Loading {row_count} new/updated records")
+
+if row_count > 0:
+    # Apply transformations (type casting, column mapping, etc.)
+    transformed_df = filtered_df.select(
+        # Map source columns to target schema
+        filtered_df["source_col1"].cast("int").alias("target_col1"),
+        filtered_df["source_col2"].alias("target_col2"),
+        filtered_df["source_col3"].cast("double").alias("target_col3"),
+        # Add load metadata
+        lit(datetime.now()).alias("load_timestamp")
+    )
+
+    # Write to Iceberg table (append mode)
+    transformed_df.writeTo(args['target_table']).append()
+
+    # Update watermark in S3
+    new_watermark = filtered_df.agg({args['watermark_column']: "max"}).collect()[0][0]
+    s3.put_object(
+        Bucket=args['watermark_bucket'],
+        Key=args['watermark_key'],
+        Body=str(new_watermark)
+    )
+    print(f"Updated watermark to: {new_watermark}")
+    print(f"Successfully loaded {row_count} records")
+else:
+    print("No new records to load")
+
+job.commit()
+```
+
+### Incremental Upsert Template
+
+For mutable data (customer profiles, product catalog) where records can be updated:
+
+```python
+import sys
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from pyspark.sql.functions import col, lit
+import boto3
+from datetime import datetime
+
+# Parse job arguments
+args = getResolvedOptions(sys.argv, [
+    'JOB_NAME',
+    'connection_name',
+    'source_table',
+    'target_table',
+    'watermark_column',
+    'primary_key',  # Column used for merging
+    'watermark_bucket',
+    'watermark_key'
+])
+
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+# Read last watermark
+s3 = boto3.client('s3')
+try:
+    obj = s3.get_object(Bucket=args['watermark_bucket'], Key=args['watermark_key'])
+    last_watermark = obj['Body'].read().decode('utf-8').strip()
+    print(f"Last watermark: {last_watermark}")
+except s3.exceptions.NoSuchKey:
+    last_watermark = '1970-01-01 00:00:00'
+    print("No previous watermark found, starting from beginning")
+
+# Read from external database
+source_df = glueContext.create_dynamic_frame.from_catalog(
+    database="<temp-catalog-db>",
+    table_name="<source-table>",
+    transformation_ctx="source_df",
+    additional_options={
+        "connectionName": args['connection_name']
+    }
+).toDF()
+
+# Get new/updated records
+changed_records_df = source_df.filter(
+    f"{args['watermark_column']} > '{last_watermark}'"
+)
+
+row_count = changed_records_df.count()
+print(f"Found {row_count} new/updated records")
+
+if row_count > 0:
+    # Apply transformations
+    transformed_df = changed_records_df.select(
+        changed_records_df["customer_id"].cast("int").alias("customer_id"),
+        changed_records_df["customer_name"].alias("name"),
+        changed_records_df["email"].alias("email"),
+        changed_records_df["status"].alias("status"),
+        changed_records_df["updated_at"].alias("updated_at"),
+        lit(datetime.now()).alias("load_timestamp")
+    )
+
+    # Create temporary view for MERGE operation
+    transformed_df.createOrReplaceTempView("source_view")
+
+    # Execute MERGE INTO (upsert)
+    spark.sql(f"""
+    MERGE INTO {args['target_table']} AS target
+    USING source_view AS source
+    ON target.{args['primary_key']} = source.{args['primary_key']}
+    WHEN MATCHED THEN UPDATE SET *
+    WHEN NOT MATCHED THEN INSERT *
+    """)
+
+    # Update watermark
+    new_watermark = changed_records_df.agg({args['watermark_column']: "max"}).collect()[0][0]
+    s3.put_object(
+        Bucket=args['watermark_bucket'],
+        Key=args['watermark_key'],
+        Body=str(new_watermark)
+    )
+    print(f"Updated watermark to: {new_watermark}")
+    print(f"Upserted {row_count} records")
+else:
+    print("No new records to process")
+
+job.commit()
+```
+
+### Custom SQL Query Template
+
+When users want to filter or transform at source with custom SQL:
+
+```python
+import sys
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from pyspark.sql.functions import lit
+import boto3
+from datetime import datetime
+
+# Parse job arguments
+args = getResolvedOptions(sys.argv, [
+    'JOB_NAME',
+    'connection_name',
+    'source_query',  # SQL query to execute
+    'target_table',
+    'watermark_column',
+    'watermark_bucket',
+    'watermark_key',
+    'jdbc_driver'
+])
+
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+# Retrieve JDBC credentials from Glue connection
+jdbc_conf = glueContext.extract_jdbc_conf(args['connection_name'])
+
+# Read last watermark
+s3 = boto3.client('s3')
+try:
+    obj = s3.get_object(Bucket=args['watermark_bucket'], Key=args['watermark_key'])
+    last_watermark = obj['Body'].read().decode('utf-8').strip()
+    print(f"Last watermark: {last_watermark}")
+except s3.exceptions.NoSuchKey:
+    last_watermark = '1970-01-01 00:00:00'
+    print("Starting from beginning")
+
+# Build query with watermark filter
+query = f"""
+SELECT * FROM ({args['source_query']}) AS base_query
+WHERE {args['watermark_column']} > '{last_watermark}'
+"""
+
+print(f"Executing query: {query}")
+
+# Read using JDBC with custom query
+source_df = spark.read.format("jdbc").options(
+    url=jdbc_conf['url'],
+    dbtable=f"({query}) AS subquery",
+    user=jdbc_conf['user'],
+    password=jdbc_conf['password'],
+    driver=args['jdbc_driver']  # e.g., "oracle.jdbc.OracleDriver"
+).load()
+
+row_count = source_df.count()
+print(f"Query returned {row_count} records")
+
+if row_count > 0:
+    # Add load metadata
+    transformed_df = source_df.withColumn("load_timestamp", lit(datetime.now()))
+
+    # Write to Iceberg table
+    transformed_df.writeTo(args['target_table']).append()
+
+    # Update watermark
+    new_watermark = source_df.agg({args['watermark_column']: "max"}).collect()[0][0]
+    s3.put_object(
+        Bucket=args['watermark_bucket'],
+        Key=args['watermark_key'],
+        Body=str(new_watermark)
+    )
+    print(f"Updated watermark to: {new_watermark}")
+else:
+    print("No new records")
+
+job.commit()
+```
+
+### Full Refresh Template
+
+For small dimension tables or when source doesn't support watermarks:
+
+```python
+import sys
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from pyspark.sql.functions import lit
+from datetime import datetime
+
+# Parse job arguments
+args = getResolvedOptions(sys.argv, [
+    'JOB_NAME',
+    'connection_name',
+    'source_table',
+    'target_table'
+])
+
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+# Read all records from source
+source_df = glueContext.create_dynamic_frame.from_catalog(
+    database="<temp-catalog-db>",
+    table_name="<source-table>",
+    transformation_ctx="source_df",
+    additional_options={
+        "connectionName": args['connection_name']
+    }
+).toDF()
+
+row_count = source_df.count()
+print(f"Loading {row_count} records (full refresh)")
+
+# Apply transformations
+transformed_df = source_df.select(
+    source_df["col1"].alias("col1"),
+    source_df["col2"].alias("col2"),
+    lit(datetime.now()).alias("load_timestamp")
+)
+
+# Overwrite target table
+transformed_df.writeTo(args['target_table']).overwritePartitions()
+
+print(f"Full refresh completed: {row_count} records loaded")
+
+job.commit()
+```

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/iceberg-catalog-config-and-usage.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/iceberg-catalog-config-and-usage.md
@@ -1,0 +1,179 @@
+# Iceberg Catalog Config and Engine Access Patterns
+
+How to configure Spark catalog settings, select a target format, and address tables from each engine.
+
+## S3 Tables (Default)
+
+Managed Iceberg tables with automatic compaction, snapshot management, and multi-engine access.
+
+- Catalog path: The table bucket is configured in `--conf` via `glue.id`, so the write path is 3-part: `s3tablescatalog.<namespace>.<table>`
+- No LOCATION clause in CREATE TABLE
+- Table and column names must be lowercase
+- Requires Glue 5.1 or higher and `--datalake-formats iceberg` job argument
+- All `spark.sql.catalog.*` config goes in `--conf` job arguments, never in `spark.conf.set()` (Glue 5.x static config restriction)
+- Delegate table creation to [create-data-lake-table](../../create-data-lake-table/SKILL.md)
+
+Two access methods exist. Use Analytics Integration when the table needs to be visible to Athena, Redshift, or EMR. Use REST Endpoint when only Glue Spark jobs access the table.
+
+**Analytics Integration (recommended for multi-engine access):**
+
+```
+spark.sql.catalog.s3tablescatalog=org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.s3tablescatalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog
+spark.sql.catalog.s3tablescatalog.glue.id=<account-id>:s3tablescatalog/<table-bucket-name>
+spark.sql.catalog.s3tablescatalog.warehouse=<table-bucket-arn>
+```
+
+The `warehouse` parameter is required. Without it Spark fails with "Cannot derive default warehouse location".
+
+**REST Endpoint (Glue-only access):**
+
+```
+spark.sql.catalog.s3tables=org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.s3tables.type=rest
+spark.sql.catalog.s3tables.uri=https://s3tables.<region>.amazonaws.com/iceberg
+spark.sql.catalog.s3tables.warehouse=<table-bucket-arn>
+spark.sql.catalog.s3tables.rest.sigv4-enabled=true
+spark.sql.catalog.s3tables.rest.signing-name=s3tables
+spark.sql.catalog.s3tables.rest.signing-region=<region>
+spark.sql.catalog.s3tables.io-impl=org.apache.iceberg.aws.s3.S3FileIO
+```
+
+Tables created via REST are NOT visible in Athena or Redshift.
+
+**`--conf` format in Glue DefaultArguments:** Pass as a single string. First pair has no `--conf` prefix; subsequent pairs are space-separated with `--conf` prefix:
+
+```json
+"--conf": "spark.sql.catalog.s3tablescatalog=org.apache.iceberg.spark.SparkCatalog --conf spark.sql.catalog.s3tablescatalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog --conf spark.sql.catalog.s3tablescatalog.glue.id=<account-id>:s3tablescatalog/<table-bucket-name> --conf spark.sql.catalog.s3tablescatalog.warehouse=<table-bucket-arn>"
+```
+
+Use `--cli-input-json file://config.json` to avoid shell escaping issues.
+
+**Write path (PySpark):**
+
+```python
+df.writeTo("s3tablescatalog.<namespace>.<table>").append()
+```
+
+## Standard Iceberg on General Purpose Bucket
+
+Self-managed Iceberg tables on regular S3 buckets. User handles compaction and snapshot cleanup.
+
+- Catalog path: `glue_catalog.<database>.<table>` (via Glue Data Catalog)
+- LOCATION clause IS required: `LOCATION 's3://<bucket>/<prefix>/'`
+- Registered in Glue Data Catalog as normal
+- Works with Glue 5.1 or higher and `--datalake-formats iceberg` job argument
+- All `spark.sql.catalog.*` config goes in `--conf` job arguments, never in `spark.conf.set()`
+
+**Glue job catalog config:**
+
+```
+spark.sql.catalog.glue_catalog=org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.glue_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog
+spark.sql.catalog.glue_catalog.warehouse=s3://<bucket>/<warehouse-prefix>/
+```
+
+The `warehouse` parameter sets the default base path for new tables.
+
+**Write path (PySpark):**
+
+```python
+df.writeTo("glue_catalog.<database>.<table>").append()
+```
+
+**Athena DDL:**
+
+```sql
+CREATE TABLE <database>.<table> (
+  col1 STRING,
+  col2 INT
+)
+LOCATION 's3://<bucket>/<prefix>/'
+TBLPROPERTIES ('table_type' = 'ICEBERG')
+```
+
+## Parquet / ORC / CSV on S3
+
+Raw files written to S3 with no Iceberg table metadata. Queryable via external tables in Athena.
+
+- No table management (no compaction, no snapshots, no schema evolution)
+- User must create an external table in Glue catalog to query with Athena
+- Suitable when the user explicitly wants raw files, not a managed table
+
+**Write path (PySpark):**
+
+```python
+# Parquet
+df.write.format("parquet").mode("overwrite").save("s3://<bucket>/<prefix>/")
+
+# ORC
+df.write.format("orc").mode("overwrite").save("s3://<bucket>/<prefix>/")
+
+# CSV
+df.write.format("csv").option("header", "true").mode("overwrite").save("s3://<bucket>/<prefix>/")
+```
+
+**External table for querying:**
+
+```sql
+CREATE EXTERNAL TABLE <database>.<table> (
+  col1 STRING,
+  col2 INT
+)
+STORED AS PARQUET
+LOCATION 's3://<bucket>/<prefix>/'
+```
+
+## Gotchas
+
+- S3 Tables CREATE TABLE must NOT include a LOCATION clause. Standard Iceberg MUST include one.
+- The `s3tablescatalog` federated catalog uses slash-separated paths in Athena: `"s3tablescatalog/<bucket>"."<namespace>"."<table>"`. Spark uses dot-separated: `s3tablescatalog.<namespace>.<table>` (the bucket is configured in `--conf` via `glue.id`).
+- Parquet/ORC/CSV targets do not create Iceberg metadata -- they are raw files only. No schema evolution, time travel, or ACID transactions.
+- Discover available MCP tools by keyword search -- do not hardcode tool names.
+
+## Engine Access Patterns
+
+How each engine reads and writes to each target format. Use this when building jobs that read from one format and write to another, or when validating ingested data.
+
+### S3 Tables
+
+| Engine | Read | Write | Table reference |
+|--------|------|-------|-----------------|
+| Athena | `SELECT * FROM "s3tablescatalog/<bucket>"."<ns>"."<table>"` | INSERT INTO, CTAS | 4-level, slash-separated catalog |
+| Redshift | `SELECT * FROM s3tablescatalog.<bucket>.<ns>.<table>` | INSERT (via external schema) | 4-level, dot-separated |
+| Spark (Analytics Integration) | `spark.table("s3tablescatalog.<bucket>.<ns>.<table>")` | `df.writeTo("s3tablescatalog.<bucket>.<ns>.<table>")` | 4-level, bucket explicit |
+| Spark (REST Endpoint) | `spark.table("<catalog>.<ns>.<table>")` | `df.writeTo("<catalog>.<ns>.<table>")` | 3-level, bucket in `--conf` warehouse |
+
+Spark with Analytics Integration and Athena both use 4 levels, but Athena uses slash-separated catalog paths while Spark uses dots. Spark with REST uses 3 levels because the table bucket is embedded in the `--conf` warehouse ARN.
+
+### Standard Iceberg
+
+| Engine | Read | Write | Table reference |
+|--------|------|-------|-----------------|
+| Athena | `SELECT * FROM <database>.<table>` | INSERT INTO, CTAS | 2-level (default catalog) |
+| Redshift | `SELECT * FROM awsdatacatalog.<database>.<table>` | INSERT (via external schema) | 3-level with catalog |
+| Spark | `spark.table("glue_catalog.<database>.<table>")` | `df.writeTo("glue_catalog.<database>.<table>")` | 2-level under configured catalog name |
+
+Standard Iceberg tables are registered in the default Glue Data Catalog. Athena queries them without a catalog prefix. Spark requires the catalog name from `--conf` (e.g., `glue_catalog`).
+
+### Parquet / ORC / CSV
+
+| Engine | Read | Write |
+|--------|------|-------|
+| Athena | `SELECT * FROM <database>.<external_table>` (requires external table in Glue catalog) | Not applicable (raw files) |
+| Spark | `spark.read.format("parquet").load("s3://...")` | `df.write.format("parquet").save("s3://...")` |
+
+No catalog registration needed for Spark reads — point directly at the S3 path. Athena requires an external table definition in the Glue catalog.
+
+## Decision Guide
+
+| Factor | S3 Tables | Standard Iceberg | Raw files |
+|--------|-----------|-----------------|-----------|
+| Automatic compaction | Yes | No (manual) | N/A |
+| Snapshot management | Yes | No (manual) | N/A |
+| Schema evolution | Yes | Yes | No |
+| Time travel | Yes | Yes | No |
+| ACID transactions | Yes | Yes | No |
+| Multi-engine access | Athena, EMR, Redshift, Spark | Athena, EMR, Spark | Athena (external table) |
+| Setup complexity | Low | Medium | Lowest |
+| Ongoing maintenance | None | High | None |

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/incremental-loading.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/incremental-loading.md
@@ -1,0 +1,500 @@
+# Incremental Loading Strategies
+
+Complete guide for configuring incremental data loading from external databases.
+
+## Overview
+
+Incremental loading imports only new or changed records instead of the entire dataset on each run. This is essential for recurring pipelines to minimize data transfer and processing time.
+
+## Identify Watermark Column
+
+A watermark column tracks which records have been loaded. The Glue job queries for records where watermark > last_loaded_value.
+
+### Common Watermark Patterns
+
+**Timestamp column** (preferred):
+
+- `updated_at`, `modified_date`, `last_changed`, `etl_timestamp`
+- Query: `WHERE timestamp_col > '2024-03-12 10:30:00'`
+- Best for: Mutable data that gets updated
+
+**Monotonic ID column**:
+
+- `id`, `order_id`, `transaction_id` (auto-incrementing)
+- Query: `WHERE id > 1234567`
+- Best for: Immutable data with sequential IDs
+
+**Both timestamp and ID**:
+
+- Use timestamp for recent changes, ID as fallback for historical data
+- Query: `WHERE timestamp_col > '...' OR (timestamp_col IS NULL AND id > ...)`
+
+### Ask the User
+
+Present candidates from the source schema:
+
+```
+I found these potential watermark columns:
+1. CREATED_DATE (TIMESTAMP) - Never changes once set
+2. UPDATED_AT (TIMESTAMP) - Updates when record changes (recommended)
+3. ID (NUMBER) - Auto-incrementing primary key
+
+Which should I use to track new/updated records?
+```
+
+**Recommendation logic**:
+
+- If `updated_at` or `modified_date` exists → Recommend this (captures updates)
+- Else if timestamp column exists → Use creation timestamp
+- Else if auto-incrementing ID → Use ID
+- Else → Recommend full refresh
+
+## Determine Load Strategy
+
+### Incremental Append (New Records Only)
+
+**Best for**: Immutable data
+
+- Transaction logs
+- Event streams
+- Historical orders
+- Audit trails
+
+**How it works**:
+
+1. Query source for records where `watermark > last_watermark`
+2. Append new records to target table
+3. Update watermark to max value from current batch
+
+**Pros**: Simple, fast, no deduplication needed
+**Cons**: Doesn't capture updates to existing records
+
+**PySpark example**:
+
+```python
+# Filter for new records
+new_records_df = source_df.filter(
+    f"{watermark_column} > '{last_watermark}'"
+)
+
+# Append to target
+new_records_df.writeTo(target_table).append()
+```
+
+### Incremental Upsert (New + Updated Records)
+
+**Best for**: Mutable data
+
+- Customer profiles
+- Product catalogs
+- Employee records
+- Account balances
+
+**How it works**:
+
+1. Query source for records where `watermark > last_watermark`
+2. Merge into target table using primary key
+3. Update existing records, insert new ones
+4. Update watermark
+
+**Pros**: Captures both new records and updates
+**Cons**: More complex, requires MERGE operation
+
+**PySpark example**:
+
+```python
+# Get new/updated records
+changed_records_df = source_df.filter(
+    f"{watermark_column} > '{last_watermark}'"
+)
+
+# Merge into target (upsert)
+spark.sql(f"""
+MERGE INTO {target_table} AS target
+USING changed_records AS source
+ON target.{primary_key} = source.{primary_key}
+WHEN MATCHED THEN UPDATE SET *
+WHEN NOT MATCHED THEN INSERT *
+""")
+```
+
+### Full Refresh
+
+**Best for**:
+
+- Small dimension tables (< 10K rows)
+- Data without watermark columns
+- When source doesn't support incremental queries
+
+**How it works**:
+
+1. Truncate or drop target table
+2. Load all records from source
+3. No watermark needed
+
+**Pros**: Simple, guarantees data consistency
+**Cons**: Inefficient for large tables, higher data transfer costs
+
+**PySpark example**:
+
+```python
+# Read all records
+all_records_df = source_df.select("*")
+
+# Overwrite target table
+all_records_df.writeTo(target_table).overwritePartitions()
+```
+
+## Watermark Storage Options
+
+The Glue job needs to persist the last loaded watermark value between runs.
+
+### Option A: S3 File (Simple)
+
+Store watermark in a text file in S3.
+
+**Advantages**:
+
+- Simple to implement
+- No additional AWS services
+- Easy to inspect and debug
+
+**Implementation**:
+
+```python
+import boto3
+
+s3 = boto3.client('s3')
+watermark_bucket = args['watermark_bucket']
+watermark_key = args['watermark_key']
+
+# Read last watermark
+try:
+    obj = s3.get_object(Bucket=watermark_bucket, Key=watermark_key)
+    last_watermark = obj['Body'].read().decode('utf-8').strip()
+    print(f"Last watermark: {last_watermark}")
+except s3.exceptions.NoSuchKey:
+    last_watermark = '1970-01-01 00:00:00'  # Default for timestamp
+    # OR last_watermark = '0'  # Default for ID
+    print("No previous watermark found, starting from beginning")
+
+# After loading, update watermark
+new_watermark = filtered_df.agg({watermark_column: "max"}).collect()[0][0]
+s3.put_object(
+    Bucket=watermark_bucket,
+    Key=watermark_key,
+    Body=str(new_watermark)
+)
+print(f"Updated watermark to: {new_watermark}")
+```
+
+**S3 path structure**:
+
+```
+s3://my-glue-watermarks/
+  customers.txt          → "2024-03-12 14:30:00"
+  orders.txt             → "2024-03-12 14:25:00"
+  products.txt           → "2024-03-10 08:00:00"
+```
+
+### Option B: DynamoDB Table (Robust)
+
+Store watermarks in a DynamoDB table with one item per job.
+
+**Advantages**:
+
+- Atomic updates
+- Query watermarks programmatically
+- Can store additional metadata (last run time, row count, etc.)
+
+**Create table**:
+
+```bash
+aws dynamodb create-table \
+  --table-name glue-job-watermarks \
+  --attribute-definitions \
+    AttributeName=job_name,AttributeType=S \
+  --key-schema \
+    AttributeName=job_name,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region <region>
+```
+
+**Implementation**:
+
+```python
+import boto3
+from datetime import datetime
+
+dynamodb = boto3.resource('dynamodb')
+table = dynamodb.Table('glue-job-watermarks')
+job_name = args['JOB_NAME']
+
+# Read last watermark
+try:
+    response = table.get_item(Key={'job_name': job_name})
+    item = response['Item']
+    last_watermark = item['watermark']
+    print(f"Last watermark for {job_name}: {last_watermark}")
+except KeyError:
+    last_watermark = '1970-01-01 00:00:00'
+    print("No previous watermark found, starting from beginning")
+
+# After loading, update watermark
+new_watermark = filtered_df.agg({watermark_column: "max"}).collect()[0][0]
+table.put_item(Item={
+    'job_name': job_name,
+    'watermark': str(new_watermark),
+    'last_run_time': datetime.now().isoformat(),
+    'rows_loaded': row_count
+})
+print(f"Updated watermark to: {new_watermark}")
+```
+
+### Option C: Query Target Table (Advanced)
+
+Query the target S3 Table to determine the max watermark value.
+
+**Advantages**:
+
+- No external storage needed
+- Watermark always matches actual data
+
+**Disadvantages**:
+
+- Requires target table scan (can be slow)
+- Doesn't work for first run (empty table)
+
+**Implementation**:
+
+```python
+# Query target table for max watermark
+try:
+    max_watermark_df = spark.sql(f"""
+        SELECT MAX({watermark_column}) as max_value
+        FROM {target_table}
+    """)
+    last_watermark = max_watermark_df.collect()[0]['max_value']
+    if last_watermark is None:
+        last_watermark = '1970-01-01 00:00:00'
+    print(f"Max watermark in target: {last_watermark}")
+except:
+    last_watermark = '1970-01-01 00:00:00'
+    print("Target table empty or doesn't exist, starting from beginning")
+```
+
+**Recommendation**: Use **Option A (S3 file)** for simplicity unless you have specific requirements for DynamoDB's features.
+
+## Handling Edge Cases
+
+### Timezone Considerations
+
+**Problem**: Source database uses one timezone, target uses another
+**Solution**: Normalize all timestamps to UTC
+
+```python
+from pyspark.sql.functions import to_utc_timestamp
+
+# Convert source timestamp to UTC
+df_utc = source_df.withColumn(
+    "timestamp_utc",
+    to_utc_timestamp(col("source_timestamp"), "America/New_York")
+)
+```
+
+### Backfill Historical Data
+
+**Scenario**: Need to load historical data before starting incremental loads
+
+**Approach**:
+
+1. Set watermark to earliest desired date: `1900-01-01 00:00:00`
+2. Run job once to load all historical data
+3. Subsequent runs will be incremental from that point forward
+
+**OR** load in batches:
+
+```python
+# Batch 1: Load 2020 data
+WHERE timestamp >= '2020-01-01' AND timestamp < '2021-01-01'
+
+# Batch 2: Load 2021 data
+WHERE timestamp >= '2021-01-01' AND timestamp < '2022-01-01'
+
+# Batch 3: Load 2022+ data
+WHERE timestamp >= '2022-01-01'
+
+# Then switch to incremental
+```
+
+### Late-Arriving Data
+
+**Problem**: Records arrive after their timestamp (e.g., event from yesterday arrives today)
+
+**Solution 1**: Add buffer window
+
+```python
+# Load data from 1 day before last watermark to catch late arrivals
+buffer_watermark = last_watermark - timedelta(days=1)
+WHERE timestamp > buffer_watermark
+```
+
+**Solution 2**: Use separate updated_at column
+
+```python
+# Use updated_at instead of event_timestamp
+WHERE updated_at > last_watermark
+```
+
+### Deleted Records
+
+**Problem**: Source deletes records, but incremental load doesn't capture deletions
+
+**Solutions**:
+
+**Option 1**: Periodic full refresh
+
+- Run incremental loads daily
+- Run full refresh weekly to remove deleted records
+
+**Option 2**: Soft deletes
+
+- Source system marks records as deleted instead of removing them
+- Filter: `WHERE updated_at > last_watermark OR deleted_at > last_watermark`
+
+**Option 3**: Compare and prune
+
+- Periodically query source for all IDs
+- Find IDs in target that don't exist in source
+- Delete those records from target
+
+### Duplicate Records
+
+**Problem**: Same record loaded multiple times due to job retries or watermark issues
+
+**Prevention**:
+
+1. Use upsert instead of append for mutable data
+2. Add deduplication logic:
+
+```python
+from pyspark.sql.window import Window
+from pyspark.sql.functions import row_number
+
+# Deduplicate by primary key, keeping latest by watermark
+window = Window.partitionBy("primary_key").orderBy(col(watermark_column).desc())
+deduplicated_df = df.withColumn("row_num", row_number().over(window)) \
+    .filter(col("row_num") == 1) \
+    .drop("row_num")
+```
+
+## Performance Optimization
+
+### Index Watermark Column
+
+Ensure the watermark column has an index in the source database:
+
+```sql
+-- Oracle
+CREATE INDEX idx_customers_updated_at ON CUSTOMERS(UPDATED_AT);
+
+-- SQL Server
+CREATE INDEX idx_customers_updated_at ON CUSTOMERS(UPDATED_AT);
+
+-- PostgreSQL
+CREATE INDEX idx_customers_updated_at ON customers(updated_at);
+```
+
+Without an index, source database will do full table scans.
+
+### Batch Size Tuning
+
+For high-volume tables, load data in smaller batches:
+
+```python
+# Load 1 hour of data at a time
+batch_size = timedelta(hours=1)
+current_watermark = last_watermark
+
+while current_watermark < datetime.now():
+    next_watermark = current_watermark + batch_size
+
+    batch_df = source_df.filter(
+        (col(watermark_column) > current_watermark) &
+        (col(watermark_column) <= next_watermark)
+    )
+
+    batch_df.writeTo(target_table).append()
+
+    current_watermark = next_watermark
+```
+
+### Parallel Reads
+
+Use Spark's partitioning for parallel reads from source:
+
+```python
+source_df = spark.read.format("jdbc").options(
+    url=jdbc_url,
+    dbtable=table_name,
+    numPartitions=10,  # Read in parallel with 10 partitions
+    partitionColumn=watermark_column,
+    lowerBound=last_watermark,
+    upperBound=current_time
+).load()
+```
+
+## Monitoring and Alerting
+
+Track these metrics for each incremental load:
+
+- **Rows loaded**: Number of new/updated records
+- **Watermark advancement**: How much watermark advanced
+- **Load duration**: Time taken for the job
+- **Data lag**: Difference between source max watermark and loaded watermark
+
+```python
+# Log metrics
+print(f"Job metrics:")
+print(f"  Rows loaded: {row_count}")
+print(f"  Previous watermark: {last_watermark}")
+print(f"  New watermark: {new_watermark}")
+print(f"  Watermark advancement: {new_watermark - last_watermark}")
+print(f"  Load duration: {load_duration} seconds")
+
+# Publish to CloudWatch (optional)
+cloudwatch = boto3.client('cloudwatch')
+cloudwatch.put_metric_data(
+    Namespace='GlueJobs',
+    MetricData=[{
+        'MetricName': 'RowsLoaded',
+        'Value': row_count,
+        'Unit': 'Count',
+        'Dimensions': [{'Name': 'JobName', 'Value': job_name}]
+    }]
+)
+```
+
+## Best Practices
+
+1. **Choose the right watermark column**: Prefer `updated_at` over `created_at` for mutable data
+2. **Test with small batches first**: Verify logic before full-scale loads
+3. **Add buffer for late arrivals**: Consider loading data from 1 day before watermark
+4. **Monitor watermark advancement**: Alert if watermark stops advancing
+5. **Handle timezones consistently**: Convert all timestamps to UTC
+6. **Index watermark column in source**: Dramatically improves query performance
+7. **Use upsert for mutable data**: Prevents duplicates and captures updates
+8. **Store watermark reliably**: S3 file is simple and sufficient for most cases
+
+## Summary
+
+Incremental loading workflow:
+
+1. **Identify watermark column** - Timestamp or auto-incrementing ID
+2. **Choose load strategy** - Append (immutable) vs Upsert (mutable) vs Full Refresh
+3. **Store watermark** - S3 file, DynamoDB, or query target table
+4. **Handle edge cases** - Timezones, late arrivals, deletions, duplicates
+5. **Optimize performance** - Index watermark, batch loading, parallel reads
+6. **Monitor** - Track rows loaded, watermark advancement, data lag
+
+With proper incremental loading, recurring pipelines efficiently sync only changed data from external databases.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/jdbc-ingest.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/jdbc-ingest.md
@@ -1,0 +1,174 @@
+# JDBC Database Ingest
+
+Move data from a JDBC source (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora, Redshift) into the data lake. Assumes a Glue connection exists. If it doesn't, delegate to the `connect-to-data-source` skill first.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Workflow](#workflow)
+- [Parallel Reads](#parallel-reads)
+- [Type Mapping](#type-mapping)
+- [Connection Errors](#connection-errors)
+
+## Prerequisites
+
+- A tested Glue connection (created via `connect-to-data-source` skill)
+- Source table name, schema, and optional filter SQL
+- Target table (existing or to be created via `create-data-lake-table` skill)
+- Target format decided (default S3 Tables; see [iceberg-catalog-config-and-usage.md](iceberg-catalog-config-and-usage.md))
+
+## Workflow
+
+### 1. Confirm connection exists
+
+```bash
+aws glue get-connection --name <CONNECTION_NAME> --region <REGION>
+```
+
+If the connection does not exist, stop and delegate to `connect-to-data-source`.
+
+### 2. Identify source scope
+
+Ask the user which tables, views, or custom SQL query. See [jdbc-schema-discovery.md](jdbc-schema-discovery.md) for crawler-based discovery, direct schema inspection, and custom SQL patterns.
+
+### 3. Decide load strategy
+
+| Intent | Strategy | Reference |
+|---|---|---|
+| One-time full load | Full scan, write once | [glue-job-scripts.md](glue-job-scripts.md) full-refresh template |
+| Recurring, append-only (events, logs) | Incremental append with watermark | [incremental-loading.md](incremental-loading.md) |
+| Recurring, mutable (customers, products) | Incremental upsert with MERGE | [incremental-loading.md](incremental-loading.md) |
+| Small dimension | Full refresh via `createOrReplace()` | [glue-job-scripts.md](glue-job-scripts.md) |
+
+### 4. Create target table if needed
+
+If the target table doesn't exist, delegate to `create-data-lake-table`. Never create it inline.
+
+### 5. Build the Glue 5.1 or higher job
+
+Use the PySpark templates in [glue-job-scripts.md](glue-job-scripts.md) and the job config guidance in [glue-job-config.md](glue-job-config.md).
+
+Reference the Glue connection via job `Connections` property:
+
+```json
+"Connections": {"Connections": ["<CONNECTION_NAME>"]}
+```
+
+In the script, read via connection name -- no credentials in code:
+
+```python
+source_df = glueContext.create_dynamic_frame.from_options(
+    connection_type="jdbc",
+    connection_options={
+        "useConnectionProperties": "true",
+        "connectionName": args['connection_name'],
+        "dbtable": args['source_table']
+    }
+).toDF()
+```
+
+### 6. Test, validate, schedule
+
+- Run the job manually once
+- Validate per [data-quality-validation.md](data-quality-validation.md): row counts, null checks on critical columns, spot-check samples
+- For recurring pipelines, create a Glue Trigger per [testing-and-scheduling.md](testing-and-scheduling.md)
+
+## Parallel Reads
+
+For large tables, read in parallel via Spark partitioning on a numeric column:
+
+```python
+jdbc_conf = glueContext.extract_jdbc_conf(args['connection_name'])
+
+source_df = spark.read.format("jdbc").options(
+    url=jdbc_conf["url"],
+    user=jdbc_conf["user"],
+    password=jdbc_conf["password"],
+    dbtable="<SCHEMA>.<TABLE>",
+    numPartitions=10,
+    partitionColumn="<numeric_column>",
+    lowerBound=1,
+    upperBound="<max_value>"
+).load()
+```
+
+Best practices:
+
+- Use a numeric column with even distribution for `partitionColumn`
+- Set `numPartitions` = number of Glue workers × 2
+- Ensure `lowerBound`/`upperBound` cover actual data range
+- Source database must handle concurrent connections
+
+Retrieve credentials from the connection at runtime rather than hardcoding. See [connect-to-data-source credential-security.md](../../connect-to-data-source/references/credential-security.md) for IAM DB auth and Secrets Manager patterns.
+
+## Type Mapping
+
+Source-to-Iceberg type mappings for ingest. Apply via `.cast()` or column aliases in the Glue script.
+
+### Oracle
+
+| Oracle | Iceberg | Notes |
+|---|---|---|
+| VARCHAR2, CHAR | STRING | |
+| NUMBER(p,s) | DECIMAL(p,s) | |
+| NUMBER (no scale) | BIGINT | For integer values |
+| DATE | TIMESTAMP | Oracle DATE includes time |
+| TIMESTAMP | TIMESTAMP | |
+| CLOB | STRING | |
+| BLOB | BINARY | |
+
+### SQL Server
+
+| SQL Server | Iceberg | Notes |
+|---|---|---|
+| VARCHAR, NVARCHAR, CHAR | STRING | |
+| INT, SMALLINT | INTEGER | |
+| BIGINT | BIGINT | |
+| DECIMAL, NUMERIC | DECIMAL(p,s) | |
+| FLOAT, REAL | DOUBLE | |
+| BIT | BOOLEAN | |
+| DATE | DATE | |
+| DATETIME, DATETIME2 | TIMESTAMP | |
+
+### PostgreSQL
+
+| PostgreSQL | Iceberg | Notes |
+|---|---|---|
+| VARCHAR, TEXT | STRING | |
+| INTEGER, SMALLINT | INTEGER | |
+| BIGINT | BIGINT | |
+| NUMERIC, DECIMAL | DECIMAL(p,s) | |
+| REAL | FLOAT | |
+| DOUBLE PRECISION | DOUBLE | |
+| BOOLEAN | BOOLEAN | |
+| DATE | DATE | |
+| TIMESTAMP, TIMESTAMPTZ | TIMESTAMP | |
+| JSON, JSONB | STRING | Parse in Spark if needed |
+| UUID | STRING | |
+
+### MySQL
+
+| MySQL | Iceberg | Notes |
+|---|---|---|
+| VARCHAR, CHAR, TEXT | STRING | |
+| INT, SMALLINT, TINYINT | INTEGER | TINYINT(1) is BOOLEAN |
+| BIGINT | BIGINT | |
+| DECIMAL | DECIMAL(p,s) | |
+| FLOAT | FLOAT | |
+| DOUBLE | DOUBLE | |
+| DATE | DATE | |
+| DATETIME, TIMESTAMP | TIMESTAMP | |
+| JSON | STRING | |
+
+### Redshift
+
+Same as PostgreSQL mappings. Redshift-specific additions:
+
+- `SUPER` -> STRING (serialize) or STRUCT (parse)
+- `GEOMETRY` / `GEOGRAPHY` -> BINARY or STRING
+
+## Connection Errors
+
+If the Glue job fails with a connection-related error (timeout, auth failure, driver not found, SSL handshake), delegate to `connect-to-data-source` for troubleshooting. Do not attempt network or credential fixes in this skill.
+
+See [connect-to-data-source troubleshooting.md](../../connect-to-data-source/references/troubleshooting.md).

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/jdbc-performance.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/jdbc-performance.md
@@ -1,0 +1,444 @@
+# Performance and Troubleshooting Guide
+
+Guide for diagnosing and resolving performance issues, incremental loading problems, IAM/permissions errors, and monitoring for external data import pipelines.
+
+## Table of Contents
+
+- [Performance Issues](#performance-issues) — Slow queries, job timeouts
+- [Incremental Loading Issues](#incremental-loading-issues) — Watermark not advancing, duplicates
+- [IAM and Permissions Errors](#iam-and-permissions-errors) — S3 access denied, Glue catalog access
+- [Monitoring and Alerting](#monitoring-and-alerting) — CloudWatch alarms, key metrics
+- [Troubleshooting Checklist](#troubleshooting-checklist) — Systematic diagnosis steps
+
+## Performance Issues
+
+### Slow Query Execution
+
+**Symptom:**
+
+- Job runs for hours
+- CloudWatch logs show: "Executing query..." but no progress
+
+**Root causes:**
+
+1. **Missing indexes** - Source query does full table scan
+2. **Too much data** - Loading entire table instead of incremental
+3. **Network bandwidth** - Limited throughput between database and Glue
+4. **Source database load** - Database under heavy load
+
+**Troubleshooting:**
+
+1. **Check query execution plan in source database:**
+
+   ```sql
+   -- Oracle
+   EXPLAIN PLAN FOR
+   SELECT * FROM large_table WHERE updated_at > '2024-01-01';
+   SELECT * FROM TABLE(DBMS_XPLAN.DISPLAY);
+
+   -- SQL Server
+   SET SHOWPLAN_TEXT ON;
+   SELECT * FROM large_table WHERE updated_at > '2024-01-01';
+
+   -- PostgreSQL
+   EXPLAIN ANALYZE
+   SELECT * FROM large_table WHERE updated_at > '2024-01-01';
+
+   -- MySQL
+   EXPLAIN
+   SELECT * FROM large_table WHERE updated_at > '2024-01-01';
+   ```
+
+2. **Monitor source database load:**
+   - Check CPU, memory, I/O utilization
+   - Review slow query logs
+   - Identify concurrent queries
+
+3. **Measure network throughput:**
+   - Check data transfer rate in CloudWatch metrics
+   - Look for bandwidth bottlenecks
+
+**Solutions:**
+
+1. **Add index on watermark column:**
+
+   ```sql
+   -- Oracle
+   CREATE INDEX idx_updated_at ON large_table(updated_at);
+
+   -- SQL Server
+   CREATE INDEX idx_updated_at ON large_table(updated_at);
+
+   -- PostgreSQL
+   CREATE INDEX idx_updated_at ON large_table(updated_at);
+
+   -- MySQL
+   CREATE INDEX idx_updated_at ON large_table(updated_at);
+   ```
+
+2. **Use parallel reads:**
+
+   ```python
+   source_df = spark.read.format("jdbc").options(
+       url=jdbc_url,
+       dbtable="large_table",
+       numPartitions=10,  # Read in parallel
+       partitionColumn="id",
+       lowerBound=1,
+       upperBound=10000000
+   ).load()
+   ```
+
+3. **Reduce batch size:**
+
+   ```python
+   # Load 1 day at a time instead of full month
+   WHERE updated_at >= '2024-01-01' AND updated_at < '2024-01-02'
+   ```
+
+4. **Increase Glue workers:**
+
+   ```python
+   'NumberOfWorkers': 20,  # Up from 5
+   'WorkerType': 'G.2X'    # Larger workers
+   ```
+
+### Job Timeout
+
+**Symptom:**
+
+```
+ERROR: Job exceeded timeout of 60 minutes
+JobRunState: TIMEOUT
+```
+
+**Root causes:**
+
+1. **Timeout too short** - Data volume requires more time
+2. **Performance issues** - See "Slow Query Execution" above
+
+**Solution:**
+
+Increase job timeout:
+
+```bash
+aws glue update-job \
+  --job-name external-import-customers \
+  --job-update Timeout=180
+```
+
+## Incremental Loading Issues
+
+### Watermark Not Advancing
+
+**Symptom:**
+
+- Job runs successfully but loads 0 records every time
+- Watermark file contains same value after each run
+
+**Root causes:**
+
+1. **No new data in source** - Actually no changes
+2. **Timezone mismatch** - Source uses local time, watermark uses UTC
+3. **Watermark filter logic incorrect** - Using `>=` instead of `>`
+
+**Troubleshooting:**
+
+1. **Check source for new data:**
+
+   ```sql
+   SELECT COUNT(*) FROM table WHERE updated_at > '<last-watermark>';
+   ```
+
+2. **Check timezone:**
+
+   ```python
+   print(f"Last watermark: {last_watermark}")
+   print(f"Last watermark timezone: {last_watermark_tz}")
+
+   # Convert to UTC
+   from datetime import datetime
+   import pytz
+
+   utc_watermark = pytz.timezone('America/New_York').localize(
+       datetime.strptime(last_watermark, '%Y-%m-%d %H:%M:%S')
+   ).astimezone(pytz.utc)
+   ```
+
+3. **Check filter logic:**
+
+   ```python
+   # Correct: > (strictly greater than)
+   filtered_df = source_df.filter(f"{watermark_column} > '{last_watermark}'")
+
+   # Incorrect: >= (will reload last batch every time)
+   # filtered_df = source_df.filter(f"{watermark_column} >= '{last_watermark}'")
+   ```
+
+**Solution:**
+
+Normalize all timestamps to UTC:
+
+```python
+from pyspark.sql.functions import to_utc_timestamp
+
+# Convert source timestamp to UTC
+df_utc = source_df.withColumn(
+    "updated_at_utc",
+    to_utc_timestamp(col("updated_at"), "America/New_York")
+)
+
+# Filter using UTC timestamps
+filtered_df = df_utc.filter(f"updated_at_utc > '{last_watermark_utc}'")
+```
+
+### Duplicate Records
+
+**Symptom:**
+
+- Target table contains duplicate records (same primary key multiple times)
+
+**Root causes:**
+
+1. **Using append instead of upsert** - For mutable data
+2. **Job retry** - Job failed mid-run, reran from same watermark
+3. **Late-arriving data** - Records arrive after their event timestamp
+
+**Solution:**
+
+1. **Use upsert for mutable data:**
+
+   ```python
+   # MERGE INTO instead of append
+   spark.sql(f"""
+   MERGE INTO {target_table} AS target
+   USING source_view AS source
+   ON target.customer_id = source.customer_id
+   WHEN MATCHED THEN UPDATE SET *
+   WHEN NOT MATCHED THEN INSERT *
+   """)
+   ```
+
+2. **Add deduplication logic:**
+
+   ```python
+   from pyspark.sql.window import Window
+   from pyspark.sql.functions import row_number
+
+   window = Window.partitionBy("customer_id").orderBy(col("updated_at").desc())
+   deduplicated_df = source_df.withColumn("row_num", row_number().over(window)) \
+       .filter(col("row_num") == 1) \
+       .drop("row_num")
+   ```
+
+3. **Handle late arrivals with buffer:**
+
+   ```python
+   # Load from 1 day before watermark
+   buffer_watermark = last_watermark - timedelta(days=1)
+   filtered_df = source_df.filter(f"{watermark_column} > '{buffer_watermark}'")
+
+   # Then upsert to avoid duplicates
+   ```
+
+## IAM and Permissions Errors
+
+### S3 Access Denied
+
+**Symptom:**
+
+```
+ERROR: Access Denied (Service: Amazon S3; Status Code: 403)
+```
+
+**Root cause:**
+Glue job IAM role lacks S3 permissions
+
+**Solution:**
+
+Add S3 permissions to Glue role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<scripts-bucket>/*",
+        "arn:aws:s3:::<watermark-bucket>/*",
+        "arn:aws:s3:::<data-bucket>/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": [
+        "arn:aws:s3:::<scripts-bucket>",
+        "arn:aws:s3:::<watermark-bucket>",
+        "arn:aws:s3:::<data-bucket>"
+      ]
+    }
+  ]
+}
+```
+
+### Glue Data Catalog Access Denied
+
+**Symptom:**
+
+```
+ERROR: User is not authorized to perform glue:GetTable
+```
+
+**Root cause:**
+Glue job role lacks Glue Data Catalog permissions
+
+**Solution:**
+
+Add Glue permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetDatabase",
+        "glue:GetTable",
+        "glue:GetPartitions",
+        "glue:CreateTable",
+        "glue:UpdateTable",
+        "glue:DeleteTable"
+      ],
+      "Resource": [
+        "arn:aws:glue:region:account:catalog",
+        "arn:aws:glue:region:account:database/*",
+        "arn:aws:glue:region:account:table/*/*"
+      ]
+    }
+  ]
+}
+```
+
+## Monitoring and Alerting
+
+### Set Up CloudWatch Alarms
+
+**Job failure alarm:**
+
+```bash
+aws cloudwatch put-metric-alarm \
+  --alarm-name "glue-job-failure-customers" \
+  --metric-name JobFailure \
+  --namespace AWS/Glue \
+  --statistic Sum \
+  --period 300 \
+  --threshold 1 \
+  --comparison-operator GreaterThanOrEqualToThreshold \
+  --dimensions Name=JobName,Value="external-import-customers" \
+  --evaluation-periods 1 \
+  --alarm-actions <sns-topic-arn>
+```
+
+**Long-running job alarm:**
+
+```bash
+aws cloudwatch put-metric-alarm \
+  --alarm-name "glue-job-long-running-customers" \
+  --metric-name glue.driver.aggregate.elapsedTime \
+  --namespace Glue \
+  --statistic Maximum \
+  --period 300 \
+  --threshold 3600000 \
+  --comparison-operator GreaterThanThreshold \
+  --dimensions Name=JobName,Value="external-import-customers" \
+  --evaluation-periods 1 \
+  --alarm-actions <sns-topic-arn>
+```
+
+### Key Metrics to Track
+
+- `glue.driver.aggregate.recordsRead` - Records read from source
+- `glue.driver.aggregate.bytesRead` - Bytes read from source
+- `glue.driver.aggregate.elapsedTime` - Job duration
+- `glue.driver.aggregate.numCompletedTasks` - Tasks completed
+- Job run state (SUCCEEDED, FAILED, TIMEOUT)
+
+## Troubleshooting Checklist
+
+When a job fails, follow this systematic approach:
+
+### 1. Check Job Run Status
+
+```bash
+aws glue get-job-run \
+  --job-name <job-name> \
+  --run-id <run-id> \
+  --query 'JobRun.[JobRunState,ErrorMessage]'
+```
+
+### 2. Review CloudWatch Logs
+
+```bash
+aws logs tail /aws-glue/jobs/output --follow \
+  --log-stream-names "<job-name>-<run-id>"
+```
+
+Look for:
+
+- `ERROR` messages
+- Exception stack traces
+- Last successful log message before failure
+
+### 3. Test Connection
+
+```bash
+# Test Glue connection
+aws glue get-connection --name <connection-name>
+
+# Test from EC2 in same subnet
+telnet <db-host> <db-port>
+```
+
+### 4. Verify Permissions
+
+```bash
+# Check IAM role policies
+aws iam get-role --role-name <glue-role-name>
+aws iam list-attached-role-policies --role-name <glue-role-name>
+```
+
+### 5. Validate Source Data
+
+```sql
+-- Run query in source database
+SELECT COUNT(*) FROM table WHERE updated_at > '<watermark>';
+```
+
+### 6. Check Watermark
+
+```bash
+# Read watermark file
+aws s3 cp s3://<bucket>/watermarks/<table>.txt -
+```
+
+## Summary
+
+Error resolution workflow:
+
+1. **Identify error category** - Connection, schema, performance, incremental, or permissions
+2. **Check CloudWatch logs** - Read error messages and stack traces
+3. **Test connectivity** - Verify network, security groups, credentials
+4. **Validate source data** - Query source database directly
+5. **Review job configuration** - Check worker count, timeout, arguments
+6. **Monitor metrics** - Set up CloudWatch alarms for proactive detection
+7. **Document resolution** - Keep runbook of common issues and fixes
+
+With systematic troubleshooting and proper monitoring, external data import pipelines run reliably with minimal intervention.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/jdbc-schema-discovery.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/jdbc-schema-discovery.md
@@ -1,0 +1,469 @@
+# Schema Discovery for External Databases
+
+Complete guide for discovering schemas in external database systems and inferring target S3 Table schemas.
+
+## Overview
+
+Schema discovery identifies what data is available in the source system and maps it to Iceberg-compatible types for the target S3 Table.
+
+## Identifying Source Data
+
+### Ask the User
+
+Gather information about what to import:
+
+**Which table(s) or view(s)** to import:
+
+- Single table: `CUSTOMERS`, `SALES_ORDERS`, `INVENTORY`
+- Multiple tables: List of tables to import
+- Views: Database views are treated like tables
+
+**Schema/database name** (if system supports multiple databases):
+
+- Oracle: Schema name (e.g., `SALES_SCHEMA`)
+- SQL Server: Database and schema (e.g., `SalesDB.dbo`)
+- PostgreSQL: Schema within database (e.g., `public`, `analytics`)
+- MySQL: Database name (e.g., `sales_db`)
+
+**Custom SQL query** (optional):
+
+- If user wants to filter or transform at source
+- Useful for reducing data volume before transfer
+- Example: `SELECT * FROM CUSTOMERS WHERE status = 'ACTIVE' AND created_date >= CURRENT_DATE - 90`
+
+## Auto-Discovering Available Tables
+
+Use Glue crawlers to discover available tables in the source database.
+
+### Create Temporary Crawler
+
+```bash
+# Create crawler
+aws glue create-crawler \
+  --name "temp-discovery-crawler" \
+  --role "<glue-service-role-arn>" \
+  --database-name "temp_discovery_db" \
+  --targets '{
+    "JdbcTargets": [{
+      "ConnectionName": "<connection-name>",
+      "Path": "<database>/%"
+    }]
+  }' \
+  --region <region>
+```
+
+### Path Patterns for Different Databases
+
+| Database | Path Pattern | Example |
+|----------|--------------|---------|
+| Oracle | `<schema>/%` | `SALES_SCHEMA/%` |
+| SQL Server | `<database>/<schema>/%` | `SalesDB/dbo/%` |
+| PostgreSQL | `<database>/<schema>/%` | `analytics/public/%` |
+| MySQL | `<database>/%` | `sales_db/%` |
+
+### Run the Crawler
+
+```bash
+# Start crawler
+aws glue start-crawler --name "temp-discovery-crawler" --region <region>
+
+# Check status (wait until State is READY)
+aws glue get-crawler --name "temp-discovery-crawler" --region <region> \
+  --query 'Crawler.State' --output text
+```
+
+Crawler states: `READY` (not running), `RUNNING`, `STOPPING`
+
+### List Discovered Tables
+
+After the crawler completes:
+
+```bash
+aws glue get-tables --database-name "temp_discovery_db" --region <region>
+```
+
+Present the list to the user:
+
+```
+I found these tables in your database:
+1. CUSTOMERS (45 columns, ~1.2M rows)
+2. ORDERS (32 columns, ~5.8M rows)
+3. PRODUCTS (18 columns, ~15K rows)
+4. INVENTORY (12 columns, ~250K rows)
+
+Which one(s) should I import?
+```
+
+### Clean Up
+
+After user selects table(s), clean up the temporary crawler and database:
+
+```bash
+# Delete crawler
+aws glue delete-crawler --name "temp-discovery-crawler" --region <region>
+
+# Delete temp database (optional - tables still useful for reference)
+aws glue delete-database --name "temp_discovery_db" --region <region>
+```
+
+## Inspecting Table Schema
+
+Once the user identifies the source table, retrieve its detailed schema.
+
+### Using Glue Data Catalog (after crawling)
+
+```bash
+aws glue get-table \
+  --database-name "temp_discovery_db" \
+  --name "<table-name>" \
+  --region <region>
+```
+
+This returns:
+
+- Column names and data types
+- Table statistics (row count estimate, data size)
+- Partition information (if partitioned)
+
+### Directly Querying the Database
+
+Alternative: Query the source database directly to get schema.
+
+**For SQL databases** (via test Glue job):
+
+```python
+# test-schema.py
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.getOrCreate()
+
+# Read just the schema (LIMIT 0)
+df = spark.read.format("jdbc").options(
+    url="<jdbc-url>",
+    dbtable="(SELECT * FROM <table> WHERE 1=0) AS schema_query",
+    user="<username>",
+    password="<password>"
+).load()
+
+# Print schema
+df.printSchema()
+```
+
+**Using Athena Federated Query** (if connector installed):
+
+```sql
+-- Query external database via Athena connector
+SELECT * FROM "<athena-connector>"."<schema>"."<table>" LIMIT 0
+```
+
+Shows schema without transferring data.
+
+## Custom SQL Queries
+
+If the user wants to filter or transform at source, support custom SQL:
+
+### Benefits of Source-Side Filtering
+
+1. **Reduces data transfer**: Only move needed data
+2. **Improves performance**: Database does the filtering
+3. **Enables complex transformations**: Use database-specific functions
+
+### Example Queries
+
+**Filter by date**:
+
+```sql
+SELECT *
+FROM CUSTOMERS
+WHERE created_date >= CURRENT_DATE - 90
+```
+
+**Filter by status**:
+
+```sql
+SELECT *
+FROM ORDERS
+WHERE status IN ('COMPLETED', 'SHIPPED')
+```
+
+**Join multiple tables**:
+
+```sql
+SELECT
+  o.order_id,
+  o.order_date,
+  c.customer_name,
+  c.email,
+  SUM(oi.quantity * oi.price) as total_amount
+FROM ORDERS o
+JOIN CUSTOMERS c ON o.customer_id = c.customer_id
+JOIN ORDER_ITEMS oi ON o.order_id = oi.order_id
+WHERE o.order_date >= CURRENT_DATE - 30
+GROUP BY o.order_id, o.order_date, c.customer_name, c.email
+```
+
+**Select specific columns**:
+
+```sql
+SELECT
+  customer_id,
+  customer_name,
+  email,
+  phone,
+  created_date,
+  last_purchase_date
+FROM CUSTOMERS
+WHERE status = 'ACTIVE'
+```
+
+### Storing Custom Queries
+
+Store the query for use in the Glue ETL script:
+
+**Option 1: As job parameter**:
+
+```python
+'--source_query': 'SELECT * FROM CUSTOMERS WHERE status = \'ACTIVE\''
+```
+
+**Option 2: In S3 file**:
+
+```python
+# Read query from S3
+import boto3
+s3 = boto3.client('s3')
+obj = s3.get_object(Bucket='<bucket>', Key='queries/customer-import.sql')
+source_query = obj['Body'].read().decode('utf-8')
+```
+
+## Type Mapping: Source Database → Iceberg
+
+Map source database types to Iceberg types for the target S3 Table.
+
+### Common Type Mappings
+
+| Source Type | Iceberg Type | Notes |
+|-------------|--------------|-------|
+| VARCHAR, CHAR, TEXT, STRING | STRING | Variable-length text |
+| INTEGER, INT, SMALLINT | INTEGER | 32-bit signed integer |
+| BIGINT, NUMBER(19) | BIGINT | 64-bit signed integer |
+| DECIMAL, NUMERIC | DECIMAL(p,s) | Preserve precision/scale |
+| FLOAT, REAL | FLOAT | 32-bit floating point |
+| DOUBLE PRECISION, BINARY_DOUBLE | DOUBLE | 64-bit floating point |
+| BOOLEAN, BIT | BOOLEAN | True/false |
+| DATE | DATE | Date without time |
+| TIMESTAMP, DATETIME, DATETIME2 | TIMESTAMP | Date and time |
+| TIME | STRING | Convert to string (Iceberg has no TIME type) |
+| BLOB, BYTEA, VARBINARY, BINARY | BINARY | Binary data |
+| CLOB, TEXT | STRING | Large text |
+| UUID | STRING | Store as string |
+| JSON, JSONB | STRING | Store as JSON string |
+| ARRAY | ARRAY\<T\> | If database supports arrays |
+| MAP, HSTORE | MAP\<K,V\> | If database supports maps |
+
+### Oracle-Specific Types
+
+| Oracle Type | Iceberg Type | Notes |
+|-------------|--------------|-------|
+| NUMBER | DECIMAL or BIGINT | Use DECIMAL for precision, BIGINT if no scale |
+| NUMBER(p,s) | DECIMAL(p,s) | Preserve precision and scale |
+| VARCHAR2, NVARCHAR2 | STRING | Variable-length string |
+| CHAR, NCHAR | STRING | Fixed-length string |
+| DATE | TIMESTAMP | Oracle DATE includes time |
+| TIMESTAMP | TIMESTAMP | Direct mapping |
+| CLOB, NCLOB | STRING | Large text |
+| BLOB | BINARY | Binary data |
+| RAW | BINARY | Raw binary |
+
+### SQL Server-Specific Types
+
+| SQL Server Type | Iceberg Type | Notes |
+|-----------------|--------------|-------|
+| NVARCHAR, VARCHAR | STRING | Unicode or ASCII string |
+| INT | INTEGER | 32-bit integer |
+| BIGINT | BIGINT | 64-bit integer |
+| SMALLINT | INTEGER | 16-bit → 32-bit |
+| TINYINT | INTEGER | 8-bit → 32-bit |
+| DECIMAL, NUMERIC | DECIMAL(p,s) | Preserve precision |
+| MONEY, SMALLMONEY | DECIMAL(19,4) | Currency |
+| DATETIME, DATETIME2 | TIMESTAMP | Date and time |
+| DATE | DATE | Date only |
+| TIME | STRING | Convert to string |
+| BIT | BOOLEAN | True/false |
+| UNIQUEIDENTIFIER | STRING | GUID as string |
+
+### PostgreSQL-Specific Types
+
+| PostgreSQL Type | Iceberg Type | Notes |
+|-----------------|--------------|-------|
+| INTEGER | INTEGER | 32-bit integer |
+| BIGINT | BIGINT | 64-bit integer |
+| SMALLINT | INTEGER | 16-bit → 32-bit |
+| NUMERIC | DECIMAL(p,s) | Arbitrary precision |
+| REAL | FLOAT | 32-bit floating |
+| DOUBLE PRECISION | DOUBLE | 64-bit floating |
+| TEXT, VARCHAR | STRING | Variable-length text |
+| BOOLEAN | BOOLEAN | True/false |
+| DATE | DATE | Date only |
+| TIMESTAMP | TIMESTAMP | Date and time |
+| TIMESTAMPTZ | TIMESTAMP | Timestamp with timezone |
+| JSON, JSONB | STRING | Store as JSON string |
+| UUID | STRING | UUID as string |
+| BYTEA | BINARY | Binary data |
+| ARRAY | ARRAY\<T\> | PostgreSQL arrays supported |
+
+### MySQL-Specific Types
+
+| MySQL Type | Iceberg Type | Notes |
+|------------|--------------|-------|
+| INT, INTEGER | INTEGER | 32-bit integer |
+| BIGINT | BIGINT | 64-bit integer |
+| SMALLINT | INTEGER | 16-bit → 32-bit |
+| TINYINT | INTEGER | 8-bit → 32-bit (or BOOLEAN if TINYINT(1)) |
+| DECIMAL, NUMERIC | DECIMAL(p,s) | Preserve precision |
+| FLOAT | FLOAT | 32-bit floating |
+| DOUBLE | DOUBLE | 64-bit floating |
+| VARCHAR, CHAR, TEXT | STRING | Variable/fixed-length text |
+| DATE | DATE | Date only |
+| DATETIME, TIMESTAMP | TIMESTAMP | Date and time |
+| TIME | STRING | Convert to string |
+| BOOLEAN | BOOLEAN | True/false |
+| BLOB, BINARY, VARBINARY | BINARY | Binary data |
+| JSON | STRING | Store as JSON string |
+
+## Proposing Target Schema
+
+Based on the source schema, propose the target S3 Table schema to the user.
+
+### Example Schema Proposal
+
+**Source table**: `CUSTOMERS` in Oracle database
+
+- CUSTOMER_ID: NUMBER(10) → BIGINT
+- CUSTOMER_NAME: VARCHAR2(200) → STRING
+- EMAIL: VARCHAR2(255) → STRING
+- PHONE: VARCHAR2(20) → STRING
+- STATUS: VARCHAR2(20) → STRING
+- CREDIT_LIMIT: NUMBER(10,2) → DECIMAL(10,2)
+- CREATED_DATE: DATE → TIMESTAMP
+- LAST_PURCHASE_DATE: DATE → TIMESTAMP
+
+**Proposed S3 Table schema**:
+
+```sql
+CREATE TABLE "glue_catalog"."sales"."customers" (
+  customer_id BIGINT,
+  customer_name STRING,
+  email STRING,
+  phone STRING,
+  status STRING,
+  credit_limit DECIMAL(10,2),
+  created_date TIMESTAMP,
+  last_purchase_date TIMESTAMP,
+  load_timestamp TIMESTAMP,  -- Added: track when record was loaded
+  load_date DATE             -- Partition column for efficient queries
+)
+PARTITIONED BY (load_date)
+TBLPROPERTIES ('table_type' = 'ICEBERG')
+```
+
+**Present to user**:
+
+```
+I've mapped the Oracle CUSTOMERS table to this Iceberg schema:
+
+Source (Oracle)                  → Target (Iceberg)
+CUSTOMER_ID (NUMBER(10))         → customer_id (BIGINT)
+CUSTOMER_NAME (VARCHAR2(200))    → customer_name (STRING)
+EMAIL (VARCHAR2(255))            → email (STRING)
+PHONE (VARCHAR2(20))             → phone (STRING)
+STATUS (VARCHAR2(20))            → status (STRING)
+CREDIT_LIMIT (NUMBER(10,2))      → credit_limit (DECIMAL(10,2))
+CREATED_DATE (DATE)              → created_date (TIMESTAMP)
+LAST_PURCHASE_DATE (DATE)        → last_purchase_date (TIMESTAMP)
+
+Added columns:
+- load_timestamp (TIMESTAMP): Tracks when record was loaded
+- load_date (DATE): Partition column for efficient queries
+
+Does this look correct? Any adjustments needed?
+```
+
+## Handling Complex Types
+
+### JSON Columns
+
+**Option 1**: Store as STRING (simplest)
+
+```sql
+json_data STRING
+```
+
+**Option 2**: Parse and flatten to STRUCT
+
+```sql
+metadata STRUCT<
+  key1: STRING,
+  key2: INT,
+  key3: ARRAY<STRING>
+>
+```
+
+Recommend Option 1 unless user specifically wants to query nested fields.
+
+### Array/List Columns
+
+If source database supports arrays (PostgreSQL, Oracle VARRAY):
+
+**Option 1**: Keep as ARRAY
+
+```sql
+tags ARRAY<STRING>
+```
+
+**Option 2**: Convert to STRING (comma-separated)
+
+```sql
+tags STRING  -- "tag1,tag2,tag3"
+```
+
+**Option 3**: Explode to separate table (normalized)
+
+### Binary/BLOB Columns
+
+**Recommendation**: Only import if truly needed (increases storage costs)
+
+If importing:
+
+```sql
+document BINARY
+```
+
+Consider storing large binaries in S3 and storing S3 key in table instead:
+
+```sql
+document_s3_key STRING  -- "s3://docs-bucket/doc123.pdf"
+```
+
+## Best Practices
+
+1. **Ask user to confirm schema**: Don't assume type mappings are correct
+2. **Add metadata columns**: `load_timestamp`, `load_date`, `source_system`
+3. **Consider partitioning**: Partition by load date for incremental loads
+4. **Handle nullability**: Make most columns nullable unless user specifies otherwise
+5. **Document type conversions**: Note any lossy conversions (e.g., TIME → STRING)
+6. **Test with sample data**: Load a small batch to verify types work correctly
+
+## Summary
+
+Schema discovery workflow:
+
+1. **Identify source data** - Ask user for table/query
+2. **Auto-discover tables** - Use Glue crawler if user unsure
+3. **Inspect schema** - Get column names and types
+4. **Support custom SQL** - Allow source-side filtering
+5. **Map types** - Convert source types to Iceberg types
+6. **Propose target schema** - Present to user for confirmation
+7. **Add metadata columns** - load_timestamp, load_date, etc.
+
+With proper schema discovery, data from external databases maps cleanly to S3 Tables with Iceberg types.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/local-upload.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/local-upload.md
@@ -1,0 +1,127 @@
+# Local File Upload
+
+Upload files from the local filesystem to S3, with optional ingestion into a table.
+
+## Workflow
+
+### 1. Determine Intent
+
+**First, check the source path.** If the user provides an S3 URI (e.g., `s3://...`) as the source, stop and use [s3-files.md](s3-files.md) instead. This workflow is for local files only.
+
+Parse the user's request to route:
+
+- **Upload only?** ("put this in S3", "upload my file", "move to AWS") -> Path A
+- **Upload + make queryable?** ("load this into a table", "ingest this CSV", "make it queryable") -> Path B
+
+If ambiguous and the file is structured (CSV, JSON, Parquet, TSV, Avro, ORC), ask: "Do you want this queryable as a table, or just stored in S3?"
+
+### 2. Discover Local Data
+
+1. **Validate path**: Confirm the file or directory exists and is readable
+2. **Detect format**: Infer from extension (.csv, .json, .parquet, .tsv, .avro, .orc) or ask
+3. **Check size**: `ls -lh` for files, `du -sh` for directories
+4. **For structured files, peek at content**:
+   - CSV/TSV: `head -5` to check headers, delimiter, encoding
+   - JSON: `head -20` to check structure (records vs. arrays)
+   - Parquet/Avro/ORC: note format, skip content peek
+
+**Encoding check** (CSV/TSV/JSON only):
+
+```bash
+file --mime-encoding <path>
+```
+
+If not UTF-8 or ASCII, warn the user before upload. Non-UTF-8 files can cause downstream parsing failures.
+
+### 3. Choose S3 Destination
+
+1. **Ask for target bucket** or list available buckets:
+
+   ```bash
+   aws s3 ls
+   ```
+
+2. **Suggest prefix structure**: `s3://<bucket>/<domain>/<dataset>/<filename>`
+3. **Confirm with user** before uploading
+
+Default: preserve original filename. Override: user specifies a different key.
+
+### 4. Upload
+
+**Single file -- check for existing objects** before uploading (`aws s3 cp` silently overwrites):
+
+```bash
+aws s3 ls s3://<bucket>/<prefix>/<filename>
+```
+
+If the object exists, warn the user and get explicit confirmation before proceeding.
+
+**Directory -- check for existing objects** before syncing. Use a bounded existence check to avoid enumerating every object under the prefix (which can be very slow on large prefixes):
+
+```bash
+aws s3api list-objects-v2 --bucket <bucket> --prefix <prefix>/ --max-items 1
+```
+
+If the result contains any `Contents`, objects exist and the user should be warned before proceeding. `aws s3 sync` skips unchanged files but overwrites modified ones without prompting.
+
+**Single file upload**:
+
+```bash
+aws s3 cp <local-path> s3://<bucket>/<prefix>/<filename>
+```
+
+**Directory upload**:
+
+```bash
+aws s3 sync <local-dir> s3://<bucket>/<prefix>/
+```
+
+For files over 8 MB, `aws s3 cp` uses multipart upload automatically. No special flags needed.
+
+**Verify upload**:
+
+```bash
+aws s3 ls s3://<bucket>/<prefix>/<filename>
+```
+
+### 5. Route Based on Intent
+
+#### Path A: Upload Only
+
+Report results and stop:
+
+- S3 URI of uploaded file(s)
+- File size and format
+- Example command to download: `aws s3 cp s3://... .`
+
+#### Path B: Upload + Table Ingestion
+
+After upload completes, continue with the [s3-files.md](s3-files.md) workflow using:
+
+- S3 path where data was uploaded
+- Detected file format
+- Row/size estimate
+- Encoding (if checked)
+
+Do not reimplement schema inference or table creation -- follow the S3 files workflow for those steps.
+
+## Gotchas
+
+- `aws s3 cp` silently overwrites existing S3 objects. Always check first.
+- `aws s3 sync` skips unchanged files but overwrites modified ones without prompting. Check destination before syncing directories.
+- CSV files with mixed encodings (e.g., Latin-1 headers, UTF-8 body) upload fine but break downstream parsing. Always check encoding for text formats.
+- Large uploads on slow connections can time out. For files over 5 GB, suggest running the upload in a `screen` or `tmux` session.
+- Compressed files (.gz, .zip): upload as-is for Path A. For Path B, note the compression so the S3 files workflow can handle decompression.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `upload failed: ... An error occurred (AccessDenied)` | No write permission to target bucket | Check IAM policy or bucket policy allows `s3:PutObject` |
+| `The user-provided path ... does not exist` | Typo in local path | Verify path with `ls` |
+| `fatal error: An error occurred (NoSuchBucket)` | Bucket does not exist | List buckets with `aws s3 ls` and pick an existing one |
+| Upload hangs or is very slow | Large file on slow connection | Check file size, suggest `tmux`/`screen`, verify network |
+
+## References
+
+- [upload-options.md](upload-options.md) -- Compression, multipart thresholds, sync vs cp tradeoffs

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/migration-troubleshooting.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/migration-troubleshooting.md
@@ -1,0 +1,42 @@
+# Migration Troubleshooting
+
+Common issues when migrating Glue Data Catalog tables to S3 Tables.
+
+## CTAS Errors
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `GENERIC_INTERNAL_ERROR: Invalid table or column names` | Uppercase in table or column names | Lowercase all names in the CTAS SELECT and table name |
+| CTAS times out | Table too large for single Athena query | Use Glue ETL (Path B) or migrate in partitioned batches |
+| `LOCATION is not supported` | Included LOCATION clause in CTAS | Remove LOCATION -- S3 Tables manages storage automatically |
+| `SYNTAX_ERROR: line X:Y: mismatched input` | Malformed partition transform or missing quotes | Check `partitioning = ARRAY[...]` syntax and quote the catalog path |
+| `TABLE_NOT_FOUND` on source | Wrong catalog prefix for source table | Use `awsdatacatalog` as the source catalog for standard Glue tables |
+
+## Validation Failures
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Row count mismatch | WHERE filter excluded rows, or source has duplicates | Check filter clause; run dedup analysis on source |
+| Schema mismatch (extra/missing columns) | SELECT * picked up partition columns or metadata | Explicitly list columns in SELECT |
+| Null count differs | Type coercion converted empty strings to nulls | Check source data for empty strings vs actual nulls |
+| Boundary values differ | Timezone or precision differences | Compare with explicit CAST to same type |
+
+## Visibility Issues
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Target table not visible in Athena | Analytics integration not enabled | Create `s3tablescatalog` federated catalog. See [ctas-patterns.md](ctas-patterns.md) for catalog path syntax. |
+| Table visible but returns no data | CTAS succeeded but wrote zero rows | Check WHERE filter; verify source table has data |
+| Table visible but columns show as `_col0`, `_col1` | Used SELECT * with incompatible source format | Explicitly name columns with aliases |
+
+## Partition Issues
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| CTAS fails with too many partitions | Over 100 target partitions in single CTAS | Batch with WHERE filters or use coarser partition transform (e.g., `month()` instead of `day()`) |
+| Partition column missing in target | Iceberg hidden partitions derive from source column | The source column must be in the SELECT; the transform is in `partitioning` |
+| Uneven partition sizes | Poor transform choice for data distribution | Consider `bucket()` for high-cardinality columns |
+
+## Glue ETL Issues
+
+See [glue-etl-migration.md](glue-etl-migration.md#troubleshooting) for Glue-specific errors.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/migration-validation.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/migration-validation.md
@@ -1,0 +1,103 @@
+# Migration Validation Checklist
+
+Run all checks after migration. Do not skip any.
+
+## 1. Row Count Match
+
+```sql
+SELECT 'source' AS tbl, COUNT(*) AS cnt
+FROM "<source_catalog>"."<source_db>"."<source_table>"
+UNION ALL
+SELECT 'target' AS tbl, COUNT(*) AS cnt
+FROM "s3tablescatalog/<bucket>"."<namespace>"."<target_table>"
+```
+
+Counts must match exactly unless a WHERE filter was applied during migration. If filtered, document the expected difference.
+
+## 2. Schema Comparison
+
+```sql
+-- Source schema
+DESCRIBE "<source_catalog>"."<source_db>"."<source_table>"
+
+-- Target schema
+DESCRIBE "s3tablescatalog/<bucket>"."<namespace>"."<target_table>"
+```
+
+Check:
+
+- All expected columns are present
+- Column order matches (or is acceptable if reordered)
+- Types are compatible (minor promotions like int->bigint are OK)
+- No unexpected columns added or dropped
+
+## 3. Null Count Comparison
+
+```sql
+-- Run for each column, or generate dynamically
+SELECT
+    COUNT(*) - COUNT(col1) AS col1_nulls,
+    COUNT(*) - COUNT(col2) AS col2_nulls
+FROM "s3tablescatalog/<bucket>"."<namespace>"."<target_table>"
+```
+
+Compare against the same query on the source. Null counts should match.
+
+## 4. Boundary Value Check
+
+```sql
+SELECT
+    MIN(numeric_col) AS min_val,
+    MAX(numeric_col) AS max_val,
+    MIN(date_col) AS min_date,
+    MAX(date_col) AS max_date
+FROM "s3tablescatalog/<bucket>"."<namespace>"."<target_table>"
+```
+
+Compare against source. Min/max values should match (accounting for any WHERE filters).
+
+## 5. Distinct Count Check
+
+```sql
+SELECT
+    COUNT(DISTINCT key_col) AS distinct_keys
+FROM "s3tablescatalog/<bucket>"."<namespace>"."<target_table>"
+```
+
+Compare against source. Mismatches indicate duplicates introduced or rows lost.
+
+## 6. Partition Verification (if partitioned)
+
+```sql
+SELECT <partition_expression>, COUNT(*) AS row_count
+FROM "s3tablescatalog/<bucket>"."<namespace>"."<target_table>"
+GROUP BY 1
+ORDER BY 1
+```
+
+Verify partition distribution is reasonable and no partitions are missing.
+
+## 7. Sample Row Comparison
+
+```sql
+-- Pick a specific key value and compare full rows
+SELECT * FROM "<source_catalog>"."<source_db>"."<source_table>"
+WHERE key_col = '<known_value>'
+
+SELECT * FROM "s3tablescatalog/<bucket>"."<namespace>"."<target_table>"
+WHERE key_col = '<known_value>'
+```
+
+Spot-check 3-5 specific rows. All column values should match.
+
+## Pass Criteria
+
+| Check | Pass condition |
+|-------|---------------|
+| Row count | Exact match (or documented delta if filtered) |
+| Schema | All columns present with compatible types |
+| Null counts | Match within tolerance (0 difference expected) |
+| Boundary values | Match exactly |
+| Distinct counts | Match exactly |
+| Partitions | All expected partitions present |
+| Sample rows | All values match |

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/s3-files.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/s3-files.md
@@ -1,0 +1,119 @@
+# S3 File Import
+
+Import structured data files (CSV, TSV, JSON, Parquet, Avro, ORC) from S3 into tables.
+
+## Workflow
+
+### Phase 0: Understand Intent and Check Tools
+
+1. **Detect load pattern**: One-time ("load this file") vs recurring ("set up a pipeline", "keep updated")
+2. **Choose approach**: Glue ETL (default, can be scheduled) vs Athena (fallback for simple loads)
+3. **Require Glue 5.1 or higher** for all Iceberg targets (S3 Tables and standard Iceberg).
+4. **Discover available MCP tools**: Search for S3 Tables MCP, Data Processing MCP, IAM MCP by keyword -- do not hardcode tool names.
+
+Use MCP tools when available. Fall back to AWS CLI only when MCP tool discovery finds no matching tools.
+
+### Phase 1: Discover Source Data
+
+1. **Identify source**: Ask user for S3 path and file format (CSV, JSON, Parquet, Avro, ORC)
+2. **Sample files**: List and download samples to understand structure
+3. **Detect partitions**: For Parquet/ORC, look for Hive-style partitioning (`year=2024/month=01/`)
+
+Format-specific guidance: See [format-specific-loading.md](format-specific-loading.md)
+
+### Phase 2: Infer and Validate Schema
+
+1. **Build schema**: CSV (headers + sample values), JSON (type mapping), Parquet/Avro/ORC (embedded schema)
+2. **Map types**: Source types to target types (STRING to INT/DATE/TIMESTAMP based on content). See [type-transformations.md](type-transformations.md).
+3. **Handle conflicts**: New columns (schema evolution via ALTER TABLE), type mismatches (cast/skip/fail), missing columns (ask user: use NULL or fail)
+4. **Nested JSON/arrays** (if detected): Ask the user which approach they prefer before proceeding:
+   - **Flatten** -- Expand structs into separate columns, explode arrays into rows
+   - **Preserve** -- Keep as STRUCT/ARRAY types
+   - Do not proceed until the user has chosen.
+
+Schema evolution and nested data: See [schema-evolution.md](schema-evolution.md)
+
+### Phase 3: Set Up or Verify Target Table
+
+1. **Check if table exists** using MCP or CLI
+2. **Create table if needed**: Delegate to [create-data-lake-table](../../create-data-lake-table/SKILL.md) for all target types. Pass the target format (S3 Tables, standard Iceberg, or raw files) and schema. See [iceberg-catalog-config-and-usage.md](iceberg-catalog-config-and-usage.md) for target-specific catalog configuration used in the subsequent Glue job.
+3. **Evolve schema if needed**: Compare schemas, generate ALTER TABLE ADD COLUMNS, execute via Athena
+
+### Phase 3.5: Verify or Create IAM Role for Glue
+
+1. **Check for existing role**: Look for `AWSGlueServiceRole-*` or `GlueServiceRole-*`
+2. **Verify permissions**: AWSGlueServiceRole managed policy, S3 access, S3 Tables inline policy (if S3 Tables target)
+3. **Create role if needed**: Trust policy for `glue.amazonaws.com`, attach policies, capture role ARN
+
+Complete IAM setup: Handled by [create-data-lake-table](../../create-data-lake-table/SKILL.md).
+
+### Phase 4: Execute Data Load
+
+#### Path A: Glue ETL (Primary)
+
+Create PySpark script, create Glue job with catalog config from [iceberg-catalog-config-and-usage.md](iceberg-catalog-config-and-usage.md), test job, schedule if recurring.
+
+**When to use**: Default for most loads. Required for recurring/scheduled imports, complex transformations, large datasets (millions+ rows).
+
+Guides: [format-specific-loading.md](format-specific-loading.md), [glue-job-config.md](glue-job-config.md), [glue-job-scripts.md](glue-job-scripts.md)
+
+#### Path B: Athena (Fallback)
+
+Create external table, build INSERT INTO query with transformations, execute and monitor, clean up.
+
+**When to use**: Simple one-time loads only. Small to medium datasets. SQL transformations sufficient.
+
+Guide: [athena-loading.md](athena-loading.md)
+
+### Phase 5: Validate Data Load
+
+1. Row count validation
+2. Null checks on critical columns
+3. Type validation via sample check
+4. Spot-check data
+
+See [data-quality-validation.md](data-quality-validation.md)
+
+### Phase 6: Report Results
+
+Present summary: what was loaded, how to query, any issues, next steps.
+
+## Decision Trees
+
+### Glue ETL vs Athena
+
+**Use Glue ETL** when: recurring loads, complex transforms, large datasets, format-specific handling, data quality validation.
+
+**Use Athena** when: simple one-time load, small/medium dataset, SQL transforms sufficient, Glue unavailable.
+
+### Glue Triggers vs MWAA
+
+**Use Glue Triggers** (most cases): single job, simple schedule, no complex dependencies.
+
+**Use MWAA/Airflow** (advanced): multiple sources with coordinated loading, complex dependencies, branching logic.
+
+## Argument Routing
+
+- **S3 path only**: Infer one-time load, proceed with discovery
+- **S3 path + table name**: Check if table exists, infer schema, execute load
+- **"--recurring" or "--pipeline"**: Force recurring pipeline via Glue
+- **No args**: Walk through workflow interactively
+
+## Gotchas
+
+- S3 Tables requires Glue 5.1 or higher. Standard Iceberg also requires Glue 5.1 or higher for proper Iceberg compatibility.
+- S3 Tables CREATE TABLE must NOT include a LOCATION clause. Standard Iceberg MUST include one.
+- When creating tables for S3 Tables import, use the Spark DDL path (Path B) in create-data-lake-table to ensure the Glue catalog is configured.
+- Target-specific catalog configuration and Glue version requirements are defined in [iceberg-catalog-config-and-usage.md](iceberg-catalog-config-and-usage.md).
+
+## References
+
+- [format-specific-loading.md](format-specific-loading.md)
+- [type-transformations.md](type-transformations.md)
+- [schema-evolution.md](schema-evolution.md)
+- [data-quality-validation.md](data-quality-validation.md)
+- [athena-loading.md](athena-loading.md)
+- [error-handling.md](error-handling.md)
+- [iceberg-catalog-config-and-usage.md](iceberg-catalog-config-and-usage.md)
+- [glue-job-config.md](glue-job-config.md)
+- [glue-job-scripts.md](glue-job-scripts.md)

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/schema-evolution.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/schema-evolution.md
@@ -1,0 +1,400 @@
+# Schema Evolution and Nested Structure Handling Reference
+
+This document describes expected approaches for handling schema evolution and nested JSON/struct data during imports.
+
+## Schema Evolution
+
+### What is Schema Evolution?
+
+Schema evolution occurs when source data has columns that don't exist in the target table. This is common when:
+
+- Source data schema changes over time (new fields added)
+- Importing from multiple sources with different schemas
+- Business requirements evolve and new data points are captured
+
+### Types of Schema Changes
+
+| Change Type | Example | Handling |
+|-------------|---------|----------|
+| New columns | Source has `phone_number`, table doesn't | ALTER TABLE ADD COLUMNS |
+| Missing columns | Table has `country`, source doesn't | Use NULL or default value |
+| Type changes | Source `price` is STRING, was INT | Type conflict resolution (see type-transformations.md) |
+| Column rename | Source has `customer_name`, table has `name` | Manual mapping or user decision |
+
+## Schema Evolution Workflow
+
+### 1. Detect Schema Differences
+
+```python
+# Get current table schema from Glue Catalog
+import boto3
+glue = boto3.client('glue')
+
+response = glue.get_table(
+    DatabaseName='my_database',
+    Name='my_table'
+)
+
+existing_columns = {col['Name']: col['Type'] for col in response['Table']['StorageDescriptor']['Columns']}
+
+# Compare with source schema
+source_columns = {'customer_id': 'int', 'name': 'string', 'email': 'string', 'phone': 'string'}  # Inferred
+
+new_columns = set(source_columns.keys()) - set(existing_columns.keys())
+missing_columns = set(existing_columns.keys()) - set(source_columns.keys())
+```
+
+Expected output to user:
+
+```
+Schema Comparison:
+
+Existing table columns: customer_id, name, email
+Source data columns: customer_id, name, email, phone
+
+New columns in source (will be added): phone
+Missing columns in source (will be NULL): None
+
+Schema evolution will automatically add new columns to the table.
+```
+
+### 2. Add New Columns via ALTER TABLE
+
+**With AWS CLI**:
+
+```bash
+aws athena start-query-execution \
+  --query-string "ALTER TABLE \"catalog\".\"namespace\".\"table\" ADD COLUMNS (phone STRING)" \
+  --query-execution-context Database=namespace \
+  --result-configuration OutputLocation=s3://bucket/results/ \
+  --region us-east-1
+```
+
+### 3. Handle Missing Columns
+
+If source is missing columns that exist in the target table, two approaches:
+
+**Option 1: Use NULL for missing columns** (recommended) — New rows will have NULL in these columns. Existing rows keep their values.
+
+**Option 2: Fail the import** — Ensures data completeness. Requires source to have all columns.
+
+## Nested JSON Handling
+
+### Flatten vs Preserve Decision
+
+When source data has nested structures:
+
+```json
+{
+  "order_id": 12345,
+  "customer": {
+    "customer_id": 789,
+    "name": "John Doe",
+    "email": "john@example.com"
+  },
+  "items": [
+    {"product_id": 456, "quantity": 2, "price": 29.99}
+  ]
+}
+```
+
+### Flattening Implementation
+
+**PySpark - Flatten Struct**:
+
+```python
+from pyspark.sql.functions import col
+
+flattened_df = source_df.select(
+    col("order_id"),
+    col("customer.customer_id").alias("customer_id"),
+    col("customer.name").alias("customer_name"),
+    col("customer.email").alias("customer_email"),
+    col("order_date"),
+    col("total")
+)
+```
+
+**PySpark - Explode Array**:
+
+```python
+from pyspark.sql.functions import explode, col
+
+# One row per item
+exploded_df = source_df.select(
+    col("order_id"),
+    col("customer.customer_id").alias("customer_id"),
+    explode(col("items")).alias("item")
+).select(
+    "order_id",
+    "customer_id",
+    col("item.product_id"),
+    col("item.quantity"),
+    col("item.price")
+)
+```
+
+**Athena SQL - Flatten with UNNEST**:
+
+```sql
+-- Create external table with nested types
+CREATE EXTERNAL TABLE orders_nested (
+  order_id BIGINT,
+  customer STRUCT<customer_id: BIGINT, name: STRING, email: STRING>,
+  items ARRAY<STRUCT<product_id: BIGINT, quantity: INT, price: DECIMAL(10,2)>>,
+  order_date DATE,
+  total DECIMAL(10,2)
+)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+LOCATION 's3://bucket/orders/';
+
+-- Flatten and insert
+INSERT INTO "catalog"."namespace"."orders_flat"
+SELECT
+  order_id,
+  customer.customer_id,
+  customer.name AS customer_name,
+  customer.email AS customer_email,
+  item.product_id,
+  item.quantity,
+  item.price,
+  order_date
+FROM orders_nested
+CROSS JOIN UNNEST(items) AS t(item);
+```
+
+### Preserving Nested Structures
+
+**S3 Tables DDL with Nested Types**:
+
+```sql
+CREATE TABLE "catalog"."namespace"."orders_nested" (
+  order_id BIGINT,
+  customer STRUCT<
+    customer_id: BIGINT,
+    name: STRING,
+    email: STRING
+  >,
+  items ARRAY<STRUCT<
+    product_id: BIGINT,
+    quantity: INT,
+    price: DECIMAL(10,2)
+  >>,
+  order_date DATE,
+  total DECIMAL(10,2)
+)
+USING ICEBERG
+```
+
+**Querying Nested Data**:
+
+```sql
+-- Access struct fields
+SELECT
+  order_id,
+  customer.name,
+  customer.email,
+  order_date
+FROM "catalog"."namespace"."orders_nested"
+WHERE customer.customer_id = 789;
+
+-- Explode array in queries
+SELECT
+  order_id,
+  item.product_id,
+  item.quantity,
+  item.price
+FROM "catalog"."namespace"."orders_nested"
+CROSS JOIN UNNEST(items) AS t(item);
+```
+
+**PySpark - Write with Nested Types**:
+
+```python
+# Preserve nested structure
+source_df.writeTo(args['target_table']).append()
+
+# No flattening needed - PySpark DataFrame schema maps directly to Iceberg
+```
+
+## Array Handling Options
+
+Implementation examples for each array handling approach:
+
+### Option 1: Keep as Array
+
+Store as `ARRAY<STRUCT<...>>` in S3 Table. Query with UNNEST when needed. Preserves one-to-many relationships efficiently.
+
+### Option 2: Explode to Separate Rows
+
+Each array element becomes its own row. Simple flat table structure. May create many duplicate rows if arrays are large.
+
+### Option 3: Create Separate Related Table
+
+Store items in separate table (e.g., `order_items`). Link via foreign key. Normalized database design.
+
+## Complete Examples
+
+### Example 1: Schema Evolution
+
+**Before** (existing table):
+
+```sql
+CREATE TABLE customers (
+  customer_id INT,
+  name STRING,
+  email STRING
+)
+```
+
+**New Source Data** adds columns: `phone STRING`, `address STRING`
+
+**After Evolution**:
+
+```sql
+ALTER TABLE customers ADD COLUMNS (
+  phone STRING,
+  address STRING
+);
+```
+
+**Result**:
+
+- Existing rows: `customer_id=1, name="Alice", email="alice@example.com", phone=NULL, address=NULL`
+- New rows: `customer_id=2, name="Bob", email="bob@example.com", phone="555-1234", address="123 Main St"`
+
+### Example 2: Nested JSON with Flattening
+
+**Source JSON**:
+
+```json
+{
+  "user_id": 100,
+  "profile": {
+    "age": 30,
+    "city": "Seattle"
+  },
+  "purchases": [
+    {"item": "book", "amount": 20},
+    {"item": "laptop", "amount": 1200}
+  ]
+}
+```
+
+**Flattened Table**:
+
+```
+user_id | age | city    | item   | amount
+--------|-----|---------|--------|-------
+100     | 30  | Seattle | book   | 20
+100     | 30  | Seattle | laptop | 1200
+```
+
+**PySpark Code**:
+
+```python
+from pyspark.sql.functions import explode, col
+
+df = spark.read.json("s3://bucket/data.json")
+
+flattened = df.select(
+    col("user_id"),
+    col("profile.age"),
+    col("profile.city"),
+    explode(col("purchases")).alias("purchase")
+).select(
+    "user_id",
+    "age",
+    "city",
+    col("purchase.item"),
+    col("purchase.amount")
+)
+```
+
+### Example 3: Nested JSON Preserved
+
+**Same Source**, but preserved as nested:
+
+**Table Schema**:
+
+```sql
+CREATE TABLE user_purchases (
+  user_id BIGINT,
+  profile STRUCT<age: INT, city: STRING>,
+  purchases ARRAY<STRUCT<item: STRING, amount: DECIMAL(10,2)>>
+)
+```
+
+**Query Example**:
+
+```sql
+-- Get users from Seattle who bought laptops
+SELECT
+  user_id,
+  profile.age,
+  purchase.item,
+  purchase.amount
+FROM user_purchases
+CROSS JOIN UNNEST(purchases) AS t(purchase)
+WHERE profile.city = 'Seattle'
+  AND purchase.item = 'laptop';
+```
+
+## Evaluation Criteria
+
+### Schema Evolution
+
+**Detection**:
+
+- Compares source schema to existing table schema
+- Identifies new, missing, and changed columns
+- Reports differences clearly to user
+
+**Automatic Handling**:
+
+- New columns: Automatically executes ALTER TABLE ADD COLUMNS
+- Missing columns: Uses NULL or asks user
+- Type changes: Routes to type conflict resolution
+
+**Execution**:
+
+- ALTER TABLE commands are syntactically correct
+- Uses appropriate Iceberg/S3 Tables syntax
+- Verifies changes applied successfully
+
+### Nested JSON
+
+**Detection**:
+
+- Identifies STRUCT and ARRAY types in source
+- Determines nesting depth
+- Lists all nested fields clearly
+
+**User Choice**:
+
+- Presents flatten vs preserve options
+- Explains pros/cons of each approach
+- Waits for user decision
+
+**Implementation**:
+
+- Flatten: Provides complete PySpark/SQL with explode for arrays
+- Preserve: Creates correct DDL with nested types
+- Validates nested schema is correct
+
+**Query Examples**:
+
+- Shows how to query nested data
+- Demonstrates struct field access (e.g., `customer.name`)
+- Shows UNNEST/explode for arrays
+
+## Common Mistakes to Avoid
+
+Recreating entire table when only ALTER TABLE ADD COLUMNS is needed
+Silently using NULL for missing columns without informing user
+Not asking user how to handle nested structures (flatten vs preserve)
+Incomplete flattening code (missing some nested fields)
+Incorrect DDL for nested types (wrong syntax)
+Not validating that ALTER TABLE succeeded
+Exploding arrays without explaining it creates multiple rows
+Not providing query examples for nested data access

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/snowflake-ingest.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/snowflake-ingest.md
@@ -1,0 +1,106 @@
+# Snowflake Ingest
+
+Move data from Snowflake into the data lake. Assumes a Glue `SNOWFLAKE` connection exists. If not, delegate to `connect-to-data-source`.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Read Pattern](#read-pattern)
+- [Incremental Loading](#incremental-loading)
+- [Partition Pruning](#partition-pruning)
+- [Type Mapping](#type-mapping)
+- [Further Reading](#further-reading)
+
+## Prerequisites
+
+- Glue connection of type `SNOWFLAKE` (not JDBC)
+- Source database, schema, table, and optional query
+- Target table in data lake
+- Warehouse sized for the read workload (larger warehouse = faster read, more cost)
+
+## Read Pattern
+
+The Glue Snowflake connector reads via Snowflake's COPY INTO mechanism under the hood -- efficient for large extracts.
+
+```python
+snowflake_df = glueContext.create_dynamic_frame.from_options(
+    connection_type="snowflake",
+    connection_options={
+        "connectionName": args['connection_name'],
+        "sfDatabase": args['database'],
+        "sfSchema": args['schema'],
+        "dbtable": args['table']
+    }
+).toDF()
+```
+
+For custom SQL, use `query` instead of `dbtable`:
+
+```python
+connection_options={
+    "connectionName": args['connection_name'],
+    "query": "SELECT id, name, updated_at FROM SALES.ORDERS WHERE status = 'CLOSED'"
+}
+```
+
+## Incremental Loading
+
+Snowflake has reliable timestamps on most tables. Common watermark columns:
+
+- Application-maintained `updated_at` / `modified_at`
+- Snowflake-maintained `_FIVETRAN_SYNCED` if sourced via Fivetran
+- `INFORMATION_SCHEMA.TABLES.LAST_ALTERED` for schema-level freshness (not row-level)
+
+For tables without an `updated_at`, options:
+
+- Query `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY` or `TABLE_STORAGE_METRICS` to identify changed tables for full refresh scheduling
+- Use Snowflake Streams to capture CDC (advanced; requires Snowflake-side setup -- see [Snowflake Streams docs](https://docs.snowflake.com/en/user-guide/streams-intro))
+
+Standard watermark filter in the custom query:
+
+```python
+connection_options={
+    "connectionName": args['connection_name'],
+    "query": f"SELECT * FROM {source_table} WHERE updated_at > '{last_watermark}'"
+}
+```
+
+See [incremental-loading.md](incremental-loading.md) for watermark storage and the broader incremental pattern.
+
+## Partition Pruning
+
+Snowflake tables are automatically micro-partitioned. Push down filters via the `query` option -- do not pull full tables and filter in Spark.
+
+Clustered tables benefit most from filter push-down. Check cluster keys:
+
+```sql
+SHOW TABLES LIKE '<table>' IN SCHEMA <db>.<schema>;
+-- Look at CLUSTER_BY column
+```
+
+If the source table is clustered on `created_date` and you filter on `created_date >= '2026-01-01'`, Snowflake prunes micro-partitions and returns only relevant data.
+
+## Type Mapping
+
+| Snowflake | Iceberg | Notes |
+|---|---|---|
+| VARCHAR, STRING, TEXT | STRING | |
+| NUMBER(p,s) | DECIMAL(p,s) | |
+| NUMBER (no scale) | BIGINT | |
+| FLOAT, DOUBLE | DOUBLE | |
+| BOOLEAN | BOOLEAN | |
+| DATE | DATE | |
+| TIME | STRING | Iceberg has no TIME type |
+| TIMESTAMP_NTZ | TIMESTAMP | Naive timestamp |
+| TIMESTAMP_LTZ, TIMESTAMP_TZ | TIMESTAMPTZ | Timezone-aware |
+| VARIANT | STRING | Serialize as JSON |
+| OBJECT | STRUCT or STRING | Flatten or serialize |
+| ARRAY | ARRAY or STRING | |
+| BINARY | BINARY | |
+| GEOGRAPHY, GEOMETRY | STRING | GeoJSON or WKT |
+
+## Further Reading
+
+- [AWS Glue: Snowflake connections (programming)](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-connect-snowflake-home.html)
+- [Snowflake Streams for CDC](https://docs.snowflake.com/en/user-guide/streams-intro)
+- [Snowflake query profile and clustering](https://docs.snowflake.com/en/user-guide/ui-query-profile)

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/testing-and-scheduling.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/testing-and-scheduling.md
@@ -1,0 +1,524 @@
+# Testing and Scheduling Guide
+
+Complete guide for testing Glue ETL jobs, validating data loads, and setting up recurring schedules for external data import pipelines.
+
+## Overview
+
+After creating a Glue ETL job, you must:
+
+1. **Test the job** - Run manually to verify it works
+2. **Validate data** - Confirm data loaded correctly into target table
+3. **Schedule the job** - Set up recurring execution (for ongoing pipelines)
+4. **Monitor execution** - Track job runs and handle failures
+
+## Testing the Job
+
+### Run the Job Manually
+
+Before scheduling, run the job once to validate the entire workflow.
+
+```bash
+JOB_RUN_ID=$(aws glue start-job-run \
+  --job-name "external-import-<source>-<table>" \
+  --region <region> \
+  --query 'JobRunId' --output text)
+
+echo "Job run started: $JOB_RUN_ID"
+```
+
+### Monitor Job Execution
+
+Check job status and logs:
+
+```bash
+# Get job run status
+aws glue get-job-run \
+  --job-name "external-import-<source>-<table>" \
+  --run-id "$JOB_RUN_ID" \
+  --region <region>
+
+# Check if job succeeded
+STATUS=$(aws glue get-job-run \
+  --job-name "external-import-<source>-<table>" \
+  --run-id "$JOB_RUN_ID" \
+  --query 'JobRun.JobRunState' \
+  --output text)
+
+echo "Job status: $STATUS"
+```
+
+**Job states:**
+
+- `STARTING` - Job is initializing
+- `RUNNING` - Job is executing
+- `SUCCEEDED` - Job completed successfully
+- `FAILED` - Job failed (check logs for errors)
+- `TIMEOUT` - Job exceeded timeout limit
+- `STOPPED` - Job was manually stopped
+
+### View CloudWatch Logs
+
+Glue streams logs to CloudWatch Logs:
+
+```bash
+# Get log stream name
+LOG_STREAM=$(aws glue get-job-run \
+  --job-name "external-import-<source>-<table>" \
+  --run-id "$JOB_RUN_ID" \
+  --query 'JobRun.LogGroupName' \
+  --output text)
+
+# Tail logs
+aws logs tail /aws-glue/jobs/output --follow \
+  --log-stream-names "<job-name>-<run-id>" \
+  --region <region>
+```
+
+**Key log messages to look for:**
+
+- `Last watermark: <value>` - Starting point for incremental load
+- `Loading X new/updated records` - Number of records found
+- `Updated watermark to: <value>` - New watermark after successful load
+- `Successfully loaded X records` - Confirmation of append/upsert
+- `ERROR` or `Exception` - Errors that caused failure
+
+### Common Issues During Testing
+
+#### Connection Timeouts
+
+**Symptom**: Job fails with "Connection timeout" or "Unable to connect to database"
+
+**Causes:**
+
+- VPC/subnet configuration incorrect
+- Security groups blocking traffic
+- Database firewall rules
+- Network ACLs blocking Glue's IP ranges
+
+**Solution:**
+
+1. Test connection in Glue console: Connections → Select connection → Test
+2. Verify security groups allow inbound from Glue's security group
+3. Check database firewall allows connections from Glue subnet CIDR
+4. Ensure NAT gateway/internet gateway for outbound connectivity (if needed)
+
+#### Authentication Failures
+
+**Symptom**: "Access denied" or "Invalid username/password"
+
+**Causes:**
+
+- Incorrect credentials in connection
+- Password expired
+- Database user lacks required permissions
+- IP-based restrictions on database user
+
+**Solution:**
+
+1. Verify credentials by connecting manually (e.g., via SQL client)
+2. Check database user has SELECT permission on source tables
+3. Ensure user is allowed from Glue's IP/subnet
+4. For AWS Secrets Manager: verify secret ARN and IAM permissions
+
+#### Schema Mismatches
+
+**Symptom**: "Type mismatch" or "Cannot cast X to Y"
+
+**Causes:**
+
+- Source column type incompatible with target schema
+- Source column is NULL but target doesn't allow NULL
+- Decimal precision/scale mismatch
+
+**Solution:**
+
+1. Add explicit type casting in PySpark script
+2. Use `.cast("string")` as fallback for problematic columns
+3. Add NULL handling: `when(col("x").isNotNull(), col("x")).otherwise(default_value)`
+4. Update target schema to match source types more closely
+
+#### Performance Issues
+
+**Symptom**: Job runs slowly or times out
+
+**Causes:**
+
+- Source database query is slow (no indexes, full table scan)
+- Too few Glue workers
+- Network bandwidth limitations
+- Reading too much data in single batch
+
+**Solution:**
+
+1. Add indexes on watermark column in source database
+2. Increase number of Glue workers
+3. Use parallel reads with `numPartitions` option
+4. Reduce batch size by using smaller date ranges
+5. Optimize source query (add WHERE clauses, select only needed columns)
+
+#### Watermark Not Advancing
+
+**Symptom**: Job runs but no new records loaded, watermark stays same
+
+**Causes:**
+
+- No new data in source
+- Watermark column comparison incorrect (timezone issue)
+- Watermark file not updating due to S3 permissions
+- Filter logic incorrect
+
+**Solution:**
+
+1. Verify new data exists in source: Query source directly
+2. Check timezone handling: Convert all timestamps to UTC
+3. Verify Glue job role has S3 write permissions for watermark bucket
+4. Add debug logging: Print watermark values and filter query
+
+## Validating Data Load
+
+After the job completes successfully, verify data was loaded correctly.
+
+### Check Row Count
+
+Query the target S3 Table to confirm records were written:
+
+```sql
+-- Count total rows
+SELECT COUNT(*) FROM "<catalog>"."<namespace>"."<table>";
+```
+
+Compare with expected count from job logs (e.g., "Successfully loaded X records").
+
+### Inspect Latest Records
+
+View the most recently loaded records:
+
+```sql
+-- Get latest records by watermark column
+SELECT *
+FROM "<catalog>"."<namespace>"."<table>"
+ORDER BY <watermark-column> DESC
+LIMIT 10;
+```
+
+Verify:
+
+- Columns match expected schema
+- Data types are correct
+- Values look reasonable
+- Timestamps are in expected timezone
+
+### Verify Watermark Updated
+
+Check that the watermark file was updated:
+
+```bash
+# Read watermark file from S3
+aws s3 cp s3://<bucket>/watermarks/<table-name>.txt -
+
+# Should show the new watermark value matching the job logs
+```
+
+### Compare Source and Target
+
+For critical tables, compare aggregations between source and target:
+
+**Source (via Glue connection):**
+
+```sql
+SELECT COUNT(*), SUM(amount), MAX(updated_at)
+FROM <schema>.<table>
+WHERE updated_at > '<last-watermark>';
+```
+
+**Target (S3 Table):**
+
+```sql
+SELECT COUNT(*), SUM(amount), MAX(load_timestamp)
+FROM "<catalog>"."<namespace>"."<table>"
+WHERE load_timestamp >= '<job-start-time>';
+```
+
+Counts and sums should match.
+
+### Validate Data Quality
+
+Run basic data quality checks:
+
+```sql
+-- Check for NULL values in key columns
+SELECT COUNT(*) FROM "<catalog>"."<namespace>"."<table>"
+WHERE customer_id IS NULL OR email IS NULL;
+
+-- Check for duplicates (if using append instead of upsert)
+SELECT customer_id, COUNT(*)
+FROM "<catalog>"."<namespace>"."<table>"
+GROUP BY customer_id
+HAVING COUNT(*) > 1;
+
+-- Check date range
+SELECT MIN(order_date), MAX(order_date)
+FROM "<catalog>"."<namespace>"."<table>";
+```
+
+For production pipelines, consider using AWS Glue Data Quality rules to automate validation.
+
+## Scheduling Recurring Pipelines
+
+Once testing is complete, set up scheduling for ongoing data syncs.
+
+### Determine Schedule Frequency
+
+Choose schedule based on data freshness requirements:
+
+**Real-time (<1 minute latency):**
+
+- Don't use Glue batch jobs - use AWS DMS, Glue Streaming, or Kinesis instead
+
+**Near real-time (5-15 minute latency):**
+
+- Schedule: Every 15 minutes: `cron(0/15 * * * ? *)`
+- Consider costs - Glue jobs have minimum 1-minute billing
+
+**Hourly:**
+
+- Schedule: Top of each hour: `cron(0 * * * ? *)`
+- Good for: Transaction logs, event streams
+
+**Every 6 hours:**
+
+- Schedule: `cron(0 */6 * * ? *)`
+- Good for: Slowly changing data, reporting tables
+
+**Daily:**
+
+- Schedule: 2 AM UTC: `cron(0 2 * * ? *)`
+- Good for: Dimension tables, reference data
+- Choose off-peak hours to avoid source database load
+
+**Weekly:**
+
+- Schedule: Monday at 2 AM: `cron(0 2 ? * MON *)`
+- Good for: Historical archives, full refreshes
+
+**Coordinate with source system:**
+
+- Avoid peak hours when source database is under load
+- Schedule after batch processes complete (if applicable)
+- Consider maintenance windows
+
+### Create Glue Trigger
+
+Glue Triggers schedule job execution.
+
+```bash
+aws glue create-trigger \
+  --name "external-import-<table>-schedule" \
+  --type SCHEDULED \
+  --schedule "cron(0 */6 * * ? *)" \
+  --actions JobName="external-import-<source>-<table>" \
+  --description "Scheduled sync from <source> to S3 Tables" \
+  --start-on-creation \
+  --region <region>
+```
+
+**Cron expression format:**
+
+```
+cron(Minutes Hours Day-of-month Month Day-of-week Year)
+```
+
+**Examples:**
+
+- Every 15 minutes: `cron(0/15 * * * ? *)`
+- Hourly: `cron(0 * * * ? *)`
+- Every 6 hours: `cron(0 */6 * * ? *)`
+- Daily at 2 AM UTC: `cron(0 2 * * ? *)`
+- Weekdays at 6 AM UTC: `cron(0 6 ? * MON-FRI *)`
+- First day of month at midnight: `cron(0 0 1 * ? *)`
+
+### Start/Stop Triggers
+
+**Start a trigger** (enable scheduling):
+
+```bash
+aws glue start-trigger \
+  --name "external-import-<table>-schedule" \
+  --region <region>
+```
+
+**Stop a trigger** (disable scheduling):
+
+```bash
+aws glue stop-trigger \
+  --name "external-import-<table>-schedule" \
+  --region <region>
+```
+
+### View Trigger Status
+
+Check trigger details and recent runs:
+
+```bash
+aws glue get-trigger \
+  --name "external-import-<table>-schedule" \
+  --region <region>
+```
+
+## Monitoring Scheduled Jobs
+
+### CloudWatch Alarms
+
+Set up CloudWatch alarms for job failures:
+
+```bash
+# Create alarm for job failures
+aws cloudwatch put-metric-alarm \
+  --alarm-name "glue-job-failure-<table>" \
+  --alarm-description "Alert when Glue job fails" \
+  --metric-name JobFailure \
+  --namespace AWS/Glue \
+  --statistic Sum \
+  --period 300 \
+  --threshold 1 \
+  --comparison-operator GreaterThanOrEqualToThreshold \
+  --dimensions Name=JobName,Value="external-import-<source>-<table>" \
+  --evaluation-periods 1 \
+  --alarm-actions <sns-topic-arn>
+```
+
+**Metrics to monitor:**
+
+- `glue.driver.aggregate.recordsRead` - Records read from source
+- `glue.driver.aggregate.elapsedTime` - Job duration
+- Job state (SUCCEEDED, FAILED, TIMEOUT)
+
+### View Recent Job Runs
+
+List recent executions of a job:
+
+```bash
+aws glue get-job-runs \
+  --job-name "external-import-<source>-<table>" \
+  --region <region> \
+  --max-results 10
+```
+
+### Track Watermark Progression
+
+Monitor how watermark advances over time:
+
+```bash
+# List watermark history (if versioning enabled on S3 bucket)
+aws s3api list-object-versions \
+  --bucket <bucket> \
+  --prefix watermarks/<table-name>.txt \
+  --query 'Versions[*].[LastModified,VersionId]' \
+  --output table
+```
+
+Create a Lambda function to log watermark values to CloudWatch Logs after each job run for historical tracking.
+
+## Advanced Scheduling Patterns
+
+### Conditional Triggers
+
+Run a job only after another job succeeds:
+
+```bash
+aws glue create-trigger \
+  --name "external-import-orders-after-customers" \
+  --type CONDITIONAL \
+  --actions JobName="external-import-orders" \
+  --predicate '{
+    "Conditions": [{
+      "LogicalOperator": "EQUALS",
+      "JobName": "external-import-customers",
+      "State": "SUCCEEDED"
+    }]
+  }' \
+  --start-on-creation
+```
+
+Use for:
+
+- Loading dimension tables before fact tables
+- Ensuring dependencies load in correct order
+- Chaining transformations
+
+### Event-Driven Triggers
+
+Trigger job based on EventBridge events:
+
+```bash
+# Create EventBridge rule to trigger Glue job
+aws events put-rule \
+  --name "trigger-glue-on-event" \
+  --event-pattern '{
+    "source": ["aws.s3"],
+    "detail-type": ["Object Created"],
+    "detail": {
+      "bucket": {
+        "name": ["source-data-bucket"]
+      }
+    }
+  }'
+
+aws events put-targets \
+  --rule "trigger-glue-on-event" \
+  --targets "Id=1,Arn=arn:aws:glue:region:account:job/external-import-job"
+```
+
+### On-Demand Triggers
+
+Allow users to trigger jobs manually via API/console without scheduling:
+
+```bash
+# Don't create a trigger, just run the job when needed
+aws glue start-job-run \
+  --job-name "external-import-<source>-<table>"
+```
+
+## Best Practices
+
+### Testing
+
+1. **Test connection first** - Use Glue console's "Test connection" before creating job
+2. **Start small** - Test with small data subset or short time window first
+3. **Validate thoroughly** - Check row counts, data quality, watermark progression
+4. **Test failure scenarios** - Kill job mid-run to verify watermark isn't corrupted
+
+### Scheduling
+
+1. **Start conservatively** - Begin with less frequent schedule, increase if needed
+2. **Avoid peak hours** - Schedule during off-peak times for source database
+3. **Set appropriate timeouts** - Allow buffer for larger-than-expected data volumes
+4. **Use conditional triggers** - For dependent jobs, use conditional triggers instead of fixed time delays
+
+### Monitoring
+
+1. **Set up CloudWatch alarms** - Alert on failures, long durations, no records loaded
+2. **Track watermark progression** - Ensure watermark advances on each run
+3. **Monitor source lag** - Compare source max timestamp vs loaded max timestamp
+4. **Review logs regularly** - Check for warnings, performance issues
+
+### Maintenance
+
+1. **Review and adjust schedules** - As data volumes change, adjust frequency or worker count
+2. **Update scripts in Git** - Version control all job scripts
+3. **Test script changes in dev** - Before deploying to production
+4. **Archive old watermarks** - Keep historical watermark values for debugging
+
+## Summary
+
+Testing and scheduling workflow:
+
+1. **Run job manually** - Start job and monitor execution
+2. **Check CloudWatch logs** - Verify no errors, watermark advanced
+3. **Validate data load** - Query target table, check row counts, inspect data
+4. **Verify watermark** - Confirm watermark file updated correctly
+5. **Create trigger** - Set up scheduled execution with appropriate frequency
+6. **Set up monitoring** - CloudWatch alarms for failures, duration, data lag
+7. **Monitor initial runs** - Watch first few scheduled executions closely
+
+With proper testing and monitoring, scheduled Glue jobs provide reliable, automated data pipelines from external databases to S3 Tables.

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/type-transformations.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/type-transformations.md
@@ -1,0 +1,325 @@
+# Type Transformation and Conflict Resolution Reference
+
+This document describes expected approaches for handling type conflicts and transformations during data import.
+
+## Type Conflict Detection
+
+### What is a Type Conflict?
+
+A type conflict occurs when:
+
+1. **Target table exists** with a defined schema
+2. **Source data** has a column with a **different type**
+3. **Direct load would fail** without transformation
+
+### Common Type Conflicts
+
+| Source Type | Target Type | Example Conflict |
+|-------------|-------------|------------------|
+| STRING | INT/DECIMAL | "$29.99" → 29.99 |
+| STRING | DATE/TIMESTAMP | "2024-01-15" → DATE |
+| INT | STRING | 12345 → "12345" |
+| STRING | BOOLEAN | "true"/"false" → TRUE/FALSE |
+| DECIMAL | INT | 29.99 → 29 (loses precision) |
+
+## Expected User Interaction
+
+When a type conflict is detected, the skill should:
+
+### 1. Clearly Identify the Conflict
+
+```
+[!] Type Conflict Detected:
+
+Column: price
+Source Type: STRING (contains values like "$29.99", "$149.50")
+Target Type: DECIMAL(10,2)
+
+This conflict must be resolved before import can proceed.
+```
+
+### 2. Present Clear Options
+
+```
+How would you like to handle this?
+
+Option 1: Transform/Cast - Remove $ symbol and cast STRING to DECIMAL
+  - Pros: Preserves all valid data
+  - Cons: Invalid values may cause import to fail
+  - Example: "$29.99" → 29.99
+
+Option 2: Skip Invalid Rows - Skip rows where transformation fails
+  - Pros: Import continues even with bad data
+  - Cons: May lose some rows
+  - Example: "$29.99" → 29.99, "N/A" → skipped
+
+Option 3: Fail Import - Stop if any invalid values found
+  - Pros: Ensures data quality
+  - Cons: Requires fixing source data first
+  - Example: Stops immediately on first invalid value
+
+Which option do you prefer?
+```
+
+### 3. Wait for User Decision
+
+Do NOT silently apply a transformation without user confirmation.
+
+## Transformation Patterns
+
+### STRING → Numeric (INT/DECIMAL)
+
+**PySpark**:
+
+```python
+from pyspark.sql.functions import regexp_replace, col
+
+# Remove non-numeric characters except decimal point
+transformed_df = source_df.withColumn(
+    "price",
+    regexp_replace(col("price"), "[^0-9.]", "").cast("decimal(10,2)")
+)
+
+# With validation (skip invalid)
+from pyspark.sql.functions import when
+
+transformed_df = source_df.withColumn(
+    "price",
+    when(
+        regexp_replace(col("price"), "[^0-9.]", "").rlike("^[0-9.]+$"),
+        regexp_replace(col("price"), "[^0-9.]", "").cast("decimal(10,2)")
+    ).otherwise(None)
+).filter(col("price").isNotNull())
+```
+
+**Athena SQL**:
+
+```sql
+SELECT
+  CAST(regexp_replace(price, '[^0-9.]', '') AS DECIMAL(10,2)) AS price
+FROM source_table
+WHERE regexp_replace(price, '[^0-9.]', '') <> ''
+```
+
+### STRING → DATE/TIMESTAMP
+
+**PySpark**:
+
+```python
+from pyspark.sql.functions import to_date, to_timestamp
+
+# Simple date parsing
+transformed_df = source_df.withColumn(
+    "signup_date",
+    to_date(col("signup_date"), "yyyy-MM-dd")
+)
+
+# Timestamp with timezone
+transformed_df = source_df.withColumn(
+    "event_timestamp",
+    to_timestamp(col("event_timestamp"), "yyyy-MM-dd HH:mm:ss")
+)
+
+# Multiple format attempts
+from pyspark.sql.functions import coalesce
+
+transformed_df = source_df.withColumn(
+    "date_field",
+    coalesce(
+        to_date(col("date_field"), "yyyy-MM-dd"),
+        to_date(col("date_field"), "MM/dd/yyyy"),
+        to_date(col("date_field"), "dd-MMM-yyyy")
+    )
+)
+```
+
+**Athena SQL**:
+
+```sql
+SELECT
+  DATE_PARSE(date_string, '%Y-%m-%d') AS parsed_date,
+  FROM_ISO8601_TIMESTAMP(timestamp_string) AS parsed_timestamp
+FROM source_table
+```
+
+### STRING → BOOLEAN
+
+**PySpark**:
+
+```python
+from pyspark.sql.functions import when, upper
+
+transformed_df = source_df.withColumn(
+    "is_active",
+    when(upper(col("is_active")).isin("TRUE", "T", "YES", "Y", "1"), True)
+    .when(upper(col("is_active")).isin("FALSE", "F", "NO", "N", "0"), False)
+    .otherwise(None)
+)
+```
+
+**Athena SQL**:
+
+```sql
+SELECT
+  CASE
+    WHEN UPPER(is_active) IN ('TRUE', 'T', 'YES', 'Y', '1') THEN TRUE
+    WHEN UPPER(is_active) IN ('FALSE', 'F', 'NO', 'N', '0') THEN FALSE
+    ELSE NULL
+  END AS is_active
+FROM source_table
+```
+
+### Numeric → STRING
+
+**PySpark**:
+
+```python
+# Simple cast
+transformed_df = source_df.withColumn(
+    "id_as_string",
+    col("id").cast("string")
+)
+
+# With formatting
+from pyspark.sql.functions import format_string
+
+transformed_df = source_df.withColumn(
+    "price_formatted",
+    format_string("$%.2f", col("price"))
+)
+```
+
+### Handling NULL Values
+
+**PySpark**:
+
+```python
+from pyspark.sql.functions import coalesce, lit
+
+# Provide default for nulls
+transformed_df = source_df.withColumn(
+    "quantity",
+    coalesce(col("quantity"), lit(0))
+)
+
+# Filter out nulls in critical columns
+transformed_df = source_df.filter(
+    col("customer_id").isNotNull() &
+    col("order_date").isNotNull()
+)
+```
+
+## Complete Transformation Example
+
+### Scenario
+Source CSV has:
+
+- `price` as STRING with "$" prefix
+- `signup_date` as STRING "YYYY-MM-DD"
+- `is_active` as STRING "true"/"false"
+
+Target table expects:
+
+- `price` as DECIMAL(10,2)
+- `signup_date` as DATE
+- `is_active` as BOOLEAN
+
+### Glue ETL Script
+
+```python
+import sys
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from pyspark.sql.functions import regexp_replace, to_date, when, upper, col
+
+args = getResolvedOptions(sys.argv, ['JOB_NAME', 'source_path', 'target_table'])
+sc = SparkContext()
+glueContext = GlueContext(sc)
+spark = glueContext.spark_session
+job = Job(glueContext)
+job.init(args['JOB_NAME'], args)
+
+# Read source CSV
+source_df = spark.read.format("csv") \
+    .option("header", "true") \
+    .load(args['source_path'])
+
+# Apply transformations
+transformed_df = source_df \
+    .withColumn(
+        "price",
+        regexp_replace(col("price"), "[^0-9.]", "").cast("decimal(10,2)")
+    ) \
+    .withColumn(
+        "signup_date",
+        to_date(col("signup_date"), "yyyy-MM-dd")
+    ) \
+    .withColumn(
+        "is_active",
+        when(upper(col("is_active")) == "TRUE", True)
+        .when(upper(col("is_active")) == "FALSE", False)
+        .otherwise(None)
+    )
+
+# Filter out rows with failed transformations
+clean_df = transformed_df.filter(
+    col("price").isNotNull() &
+    col("signup_date").isNotNull() &
+    col("is_active").isNotNull()
+)
+
+# Log filtered count
+original_count = source_df.count()
+clean_count = clean_df.count()
+print(f"Original rows: {original_count}")
+print(f"Clean rows: {clean_count}")
+print(f"Filtered out: {original_count - clean_count}")
+
+# Write to Iceberg table
+clean_df.writeTo(args['target_table']).append()
+
+job.commit()
+```
+
+## Evaluation Criteria
+
+When evaluating type conflict resolution:
+
+**Detection**:
+
+- Skill compares source schema to target schema
+- Identifies specific columns with type mismatches
+- Clearly communicates the conflict to user
+
+**User Interaction**:
+
+- Presents at least 2-3 options for handling the conflict
+- Explains pros/cons of each option
+- Waits for user decision before proceeding
+- Does NOT silently transform without confirmation
+
+**Transformation Code**:
+
+- Provides complete PySpark or SQL code for transformation
+- Handles edge cases (null values, invalid formats)
+- Includes data quality filters if "skip invalid" chosen
+- Logs row counts (original vs transformed)
+
+**Validation**:
+
+- Tests transformation on sample data first
+- Validates that transformed types match target schema
+- Reports success/failure clearly
+
+## Common Mistakes to Avoid
+
+Silently applying transformations without user consent
+Not detecting type conflicts before attempting import
+Incomplete transformation code (missing null handling)
+Not logging how many rows were filtered out
+Assuming all source data is valid without validation
+Not providing fallback for invalid values
+Generic "cast to type" without cleaning data first (e.g., "$29.99" → cast fails)

--- a/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/upload-options.md
+++ b/plugins/aws-data-analytics/skills/ingest-into-data-lake/references/upload-options.md
@@ -1,0 +1,40 @@
+# Upload Options Reference
+
+## cp vs sync
+
+| Command | Use when |
+|---------|----------|
+| `aws s3 cp` | Single file, or directory with `--recursive` |
+| `aws s3 sync` | Directory upload, skips unchanged files on re-run |
+
+`sync` is idempotent — safe to re-run after interruption. Prefer `sync` for directories.
+
+## Multipart Upload
+
+`aws s3 cp` automatically uses multipart for files over 8 MB (default threshold). No flags needed. To tune:
+
+```bash
+aws configure set default.s3.multipart_threshold 64MB
+aws configure set default.s3.multipart_chunksize 64MB
+```
+
+## Compression Before Upload
+
+Compressing locally saves transfer time and storage cost. Downstream tools (Athena, Glue) read gzip natively.
+
+```bash
+gzip file.csv
+aws s3 cp file.csv.gz s3://<bucket>/<prefix>/
+```
+
+Do NOT compress Parquet, Avro, or ORC — they have built-in compression.
+
+## Overwrite Protection
+
+Check if target exists before uploading:
+
+```bash
+aws s3 ls s3://<bucket>/<prefix>/<filename>
+```
+
+If it exists, warn the user. `aws s3 cp` overwrites without confirmation.

--- a/plugins/aws-data-analytics/skills/query-data-lake/SKILL.md
+++ b/plugins/aws-data-analytics/skills/query-data-lake/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: query-data-lake
+description: "Execute and manage Athena SQL queries across default and federated catalogs (Glue, S3 Tables, Redshift). Triggers on phrases like: query data, run SQL, athena query, analyze table, SQL query, workgroup status, profile table, query Redshift catalog, query S3 Tables. Do NOT use for finding specific data assets (use find-data-lake-assets), full catalog audits (use exploring-data-catalog), importing data (use ingest-into-data-lake)."
+argument-hint: "[SQL-query|query-name|workgroup-name|catalog-name|'profile TABLE_NAME']"
+owner_team: AWS Analytics
+owner_cti: AWS/Analytics/Agent Skills
+stages: [preprod]
+version: 1
+metadata:
+  service: [athena, glue, s3tables, redshift]
+  task: [debug, audit]
+  persona: [developer, data-engineer, architect]
+  workload: [data-analytics]
+---
+
+# Query Data Lake
+
+Execute SQL queries on Amazon Athena across default and federated catalogs (Glue, S3 Tables, Redshift) with workgroup selection, statement classification, and error recovery.
+
+## Overview
+
+Executes and manages Athena SQL queries across default and federated catalogs. Selects a workgroup, resolves target assets (delegating fuzzy references to `find-data-lake-assets`), classifies statements for safety, and reports cost and data scanned. Use the AWS MCP server for sandboxed execution and audit logging; the same AWS CLI commands work directly when the MCP server is not available.
+
+**Constraints for parameter acquisition:**
+
+- You MUST accept a single optional argument: SQL text, a named-query name, a workgroup name, a catalog name, or `profile TABLE_NAME`
+- You MUST accept the argument as direct text or a pointer to a file containing SQL
+- You MUST ask the user for the target AWS region if not already set
+- You MUST confirm the output S3 location before executing any non-trivial query
+- You MUST respect the user's decision to abort at any step
+
+## Common Tasks
+
+### 1. Verify Dependencies
+
+Check for required tools and AWS access before running queries.
+
+**Constraints:**
+
+- You MUST verify AWS MCP server tools are available (`aws___call_aws`) and run queries through them when present; fall back to AWS CLI only if the MCP server is unavailable
+- You MUST NOT fall back to shell or Bash for query execution — results must be captured via the MCP tool or `aws athena` CLI so output location and cost are tracked
+- You MUST confirm credentials with `aws sts get-caller-identity` and inform the user about any missing tools
+
+### 2. Resolve Workgroup
+
+Check caller identity, list workgroups, auto-select the best one (see [workgroup-selection.md](references/workgroup-selection.md)).
+
+**Constraints:**
+
+- You MUST select a workgroup before submitting any query (prevents output-location errors)
+- You MUST present the selected workgroup and its output location to the user
+- You MUST NOT auto-escalate to a different workgroup on failure without user confirmation
+
+### 3. Resolve the Target Asset
+
+If the user refers to a table by name, by business concept ("our quarterly report", "the sales data"), by S3 path, or by catalog without specifying the table, delegate to `find-data-lake-assets` to return the concrete `database.table` (and catalog if non-default).
+
+**Constraints:**
+
+- You MUST NOT attempt to resolve fuzzy asset references with `athena list-data-catalogs` or by iterating `get-tables` — those miss federated catalogs and waste tokens
+- You SHOULD skip this step only when the user provides a fully-qualified reference (exact `database.table`) or raw SQL they want executed as-is
+- You MUST state the resolved asset explicitly before building the query: "Found [table] in [catalog]. Using this for the query."
+- You SHOULD default to the default Glue catalog unless the user mentions "federated", "Redshift", "S3 Tables", or `find-data-lake-assets` returns a different catalog
+
+### 4. Discover Schema
+
+For analytical queries, You SHOULD profile the target table before building the final query. You MUST show sample rows (`SELECT ... LIMIT 5`) as part of profiling.
+
+### 5. Build Query
+
+Table addressing depends on catalog type:
+
+- Default Glue catalog: `database.table` (omit the catalog prefix for single-catalog queries). In cross-catalog queries, qualify default-catalog tables with `"awsdatacatalog".database.table`.
+- Registered data source: `datasource.database.table`
+- Unregistered Glue catalog: `"catalog/subcatalog".database.table`
+
+### 6. Classify and Execute
+
+Classify the SQL statement before executing:
+
+| Statement | Behavior |
+|---|---|
+| `SELECT`, `SHOW`, `DESCRIBE`, `EXPLAIN` | Safe — execute |
+| `INSERT`, `UPDATE`, `DELETE`, `DROP`, `ALTER`, `CREATE`, `TRUNCATE`, `MERGE` | Destructive — warn the user and require explicit confirmation |
+| Unsure | Treat as destructive; confirm |
+
+Example tool call (via AWS MCP server):
+
+```
+aws___call_aws(command="aws athena start-query-execution --work-group <WORKGROUP_NAME> --query-string '<sql>' --query-execution-context Database=<db>")
+```
+
+For federated or S3 Tables catalogs, also set `Catalog=<CATALOG_PATH>` in the execution context (e.g. `Catalog=s3tablescatalog/<BUCKET_NAME>`).
+
+**Constraints:**
+
+- You MUST warn the user before executing when the target is Redshift-federated ("No partition pruning — every query scans the full table")
+- You MUST warn the user before executing a cross-catalog join ("Cross-catalog joins incur network overhead and may be slow")
+- You MUST confirm the output S3 location before executing
+- You MUST explain which tool is being called before executing
+- You MUST respect the user's decision to abort
+
+### 7. Present and Recover
+
+Present results with cost, data scanned, duration, and actionable insights. On failure, list available workgroups and let the user choose which to retry with.
+
+### Argument Routing
+
+Resolve in this order; stop at the first match:
+
+1. Contains SQL keywords (`SELECT`, `SHOW`, `DESCRIBE`, `INSERT`, etc.) — SQL text, execute directly
+2. `profile TABLE_NAME` — run comprehensive table profiling (see [query-patterns.md](references/query-patterns.md))
+3. Matches a known named query — look up and execute
+4. Matches a known workgroup — show workgroup status and recent queries
+5. Matches a known catalog — delegate to `exploring-data-catalog` to enumerate databases and tables
+6. No args — show recent query activity and available tables
+
+### Principles
+
+- Always select workgroup before executing (prevents output-location errors)
+- Profile unfamiliar tables before running analytical queries
+- Present cost alongside results so users build cost awareness
+- Suggest `LIMIT` for exploratory queries on large tables
+- Never ask domain questions with obvious answers, but always confirm security-relevant actions (workgroup switches, output location changes, non-SELECT statements)
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| Redshift identifier error with mixed case | Redshift-federated names are lowercase only | Lowercase the identifier |
+| `CatalogId` validation failure | ARN passed instead of catalog name | Pass the catalog name, not the ARN |
+| Cross-catalog `information_schema` returns nothing | Missing catalog qualifier | Use catalog-qualified path: `"catalog".information_schema.tables` |
+| Query fails with output-location error | Workgroup has no output location configured | Select a different workgroup with an output location, or configure one |
+| Destructive statement executed without confirmation | Statement classification skipped | Always classify `INSERT`/`UPDATE`/`DELETE`/`DROP`/`ALTER`/`CREATE`/`TRUNCATE`/`MERGE` and confirm with the user |
+
+## Additional Resources
+
+- [Workgroup selection logic](references/workgroup-selection.md)
+- [Common query patterns](references/query-patterns.md)
+- [Athena best practices](https://docs.aws.amazon.com/athena/latest/ug/performance-tuning.html)
+- [Athena federated query](https://docs.aws.amazon.com/athena/latest/ug/connect-to-a-data-source.html)

--- a/plugins/aws-data-analytics/skills/query-data-lake/references/query-patterns.md
+++ b/plugins/aws-data-analytics/skills/query-data-lake/references/query-patterns.md
@@ -1,0 +1,186 @@
+# Common Query Patterns (Presto/Athena SQL)
+
+## Table Profiling
+
+```sql
+-- Schema discovery
+SELECT column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = '<database>' AND table_name = '<table>';
+
+-- Quick row count and date range
+SELECT COUNT(*) as total_rows,
+       MIN(created_at) as earliest,
+       MAX(created_at) as latest
+FROM <table>;
+
+-- Sample data (always do this before analytical queries)
+SELECT * FROM <table> LIMIT 5;
+
+-- Null analysis
+SELECT
+    '<column>' as field,
+    COUNT(*) - COUNT(<column>) as null_count,
+    ROUND((COUNT(*) - COUNT(<column>)) * 100.0 / COUNT(*), 2) as null_pct
+FROM <table>;
+```
+
+## Cohort Retention
+
+```sql
+WITH cohorts AS (
+    SELECT
+        user_id,
+        DATE_TRUNC('month', first_activity_date) as cohort_month
+    FROM users
+),
+activity AS (
+    SELECT
+        user_id,
+        DATE_TRUNC('month', activity_date) as activity_month
+    FROM user_activity
+)
+SELECT
+    c.cohort_month,
+    COUNT(DISTINCT c.user_id) as cohort_size,
+    COUNT(DISTINCT CASE
+        WHEN a.activity_month = c.cohort_month THEN a.user_id
+    END) as month_0,
+    COUNT(DISTINCT CASE
+        WHEN a.activity_month = DATE_ADD('month', 1, c.cohort_month) THEN a.user_id
+    END) as month_1,
+    COUNT(DISTINCT CASE
+        WHEN a.activity_month = DATE_ADD('month', 3, c.cohort_month) THEN a.user_id
+    END) as month_3,
+    COUNT(DISTINCT CASE
+        WHEN a.activity_month = DATE_ADD('month', 6, c.cohort_month) THEN a.user_id
+    END) as month_6
+FROM cohorts c
+LEFT JOIN activity a ON c.user_id = a.user_id
+GROUP BY c.cohort_month
+ORDER BY c.cohort_month;
+```
+
+## Funnel Analysis
+
+```sql
+WITH funnel AS (
+    SELECT
+        user_id,
+        MAX(CASE WHEN event = 'page_view' THEN 1 ELSE 0 END) as step_1_view,
+        MAX(CASE WHEN event = 'signup_start' THEN 1 ELSE 0 END) as step_2_start,
+        MAX(CASE WHEN event = 'signup_complete' THEN 1 ELSE 0 END) as step_3_complete,
+        MAX(CASE WHEN event = 'first_purchase' THEN 1 ELSE 0 END) as step_4_purchase
+    FROM events
+    WHERE event_date >= DATE_ADD('day', -30, CURRENT_DATE)
+    GROUP BY user_id
+)
+SELECT
+    COUNT(*) as total_users,
+    SUM(step_1_view) as viewed,
+    SUM(step_2_start) as started_signup,
+    SUM(step_3_complete) as completed_signup,
+    SUM(step_4_purchase) as purchased,
+    ROUND(100.0 * SUM(step_2_start) / NULLIF(SUM(step_1_view), 0), 1) as view_to_start_pct,
+    ROUND(100.0 * SUM(step_3_complete) / NULLIF(SUM(step_2_start), 0), 1) as start_to_complete_pct,
+    ROUND(100.0 * SUM(step_4_purchase) / NULLIF(SUM(step_3_complete), 0), 1) as complete_to_purchase_pct
+FROM funnel;
+```
+
+## Deduplication
+
+```sql
+-- Keep the most recent record per key (Presto/Athena syntax)
+WITH ranked AS (
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY entity_id
+            ORDER BY updated_at DESC
+        ) as rn
+    FROM source_table
+)
+SELECT * FROM ranked WHERE rn = 1;
+```
+
+## Window Functions
+
+```sql
+-- Running total
+SUM(revenue) OVER (ORDER BY event_date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as running_total
+
+-- 7-day moving average
+AVG(revenue) OVER (ORDER BY event_date ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) as moving_avg_7d
+
+-- Period-over-period comparison
+LAG(value, 1) OVER (PARTITION BY entity ORDER BY event_date) as prev_value
+
+-- Percent of total
+revenue / SUM(revenue) OVER () as pct_of_total
+revenue / SUM(revenue) OVER (PARTITION BY category) as pct_of_category
+
+-- Ranking
+ROW_NUMBER() OVER (PARTITION BY category ORDER BY revenue DESC) as rank_in_category
+```
+
+## Period Comparison / Growth
+
+When the user asks for "growth", "change", or "comparison" between periods, compute the delta — not raw totals.
+
+```sql
+WITH quarterly AS (
+    SELECT
+        category,
+        QUARTER(order_date) as q,
+        SUM(amount) as revenue
+    FROM orders
+    WHERE YEAR(order_date) = 2025
+    GROUP BY category, QUARTER(order_date)
+)
+SELECT
+    curr.category,
+    prev.revenue as prev_period,
+    curr.revenue as curr_period,
+    ROUND((curr.revenue - prev.revenue) / prev.revenue * 100, 1) as growth_pct
+FROM quarterly curr
+JOIN quarterly prev ON curr.category = prev.category AND curr.q = prev.q + 1
+ORDER BY growth_pct DESC;
+```
+
+## Performance-Aware Patterns
+
+```sql
+-- Always filter on partition keys to reduce scan cost
+SELECT region, COUNT(*)
+FROM sales
+WHERE year = '2024' AND month = '02'
+GROUP BY region;
+
+-- Use LIMIT for exploratory queries
+SELECT * FROM large_table LIMIT 100;
+
+-- Use approximate functions for large-scale cardinality
+SELECT APPROX_DISTINCT(user_id) as approx_unique_users
+FROM events;
+```
+
+## Data Quality Checks
+
+```sql
+-- Distinct value counts per column
+SELECT
+    COUNT(DISTINCT col1) as col1_unique,
+    COUNT(DISTINCT col2) as col2_unique
+FROM <table>;
+
+-- Detect unexpected values
+SELECT column_name, COUNT(*) as cnt
+FROM <table>
+GROUP BY column_name
+ORDER BY cnt DESC
+LIMIT 20;
+
+-- Check for join explosion
+SELECT COUNT(*) as pre_join FROM table_a;
+SELECT COUNT(*) as post_join FROM table_a a JOIN table_b b ON a.id = b.a_id;
+```

--- a/plugins/aws-data-analytics/skills/query-data-lake/references/workgroup-selection.md
+++ b/plugins/aws-data-analytics/skills/query-data-lake/references/workgroup-selection.md
@@ -1,0 +1,90 @@
+# Workgroup Selection
+
+Always list workgroups first before executing any query.
+
+## Detect Execution Context
+
+Before selecting a workgroup, determine the current IAM identity:
+
+```bash
+aws sts get-caller-identity --query Arn --output text
+```
+
+The ARN pattern reveals the execution context:
+
+| ARN Pattern | Context | Workgroup Strategy |
+|---|---|---|
+| `arn:aws:sts::*:assumed-role/AmazonDataZone-<project-id>-<suffix>/<session>` | SageMaker Unified Studio project role | Use the project-scoped workgroup (see below) |
+| `arn:aws:sts::*:assumed-role/SageMakerUnifiedStudio-<project-id>-<suffix>/<session>` | SageMaker Unified Studio project role | Use the project-scoped workgroup (see below) |
+| `arn:aws:sts::*:assumed-role/AmazonSageMaker-ExecutionRole-*` | SageMaker notebook/studio role | Prefer `sagemaker-studio-workgroup-*` |
+| Anything else | Standard IAM user/role | Follow general priority order |
+
+## SageMaker Project Role Selection
+
+When running as a SageMaker project role (`AmazonDataZone-*` or `SageMakerUnifiedStudio-*`):
+
+1. List all workgroups the role can access:
+
+   ```bash
+   aws athena list-work-groups --query 'WorkGroups[].Name' --output json
+   ```
+
+2. Extract the project ID from the role ARN. Split the role name on `-`.
+
+   The first segment is the prefix (e.g., `AmazonDataZone`), the second
+   segment is the project ID (e.g., `abc123def`), and subsequent segments
+   form the suffix (e.g., `DataLakeAccess`). Take the second segment.
+   The project ID is an **alphanumeric string (no hyphens)**.
+   Known suffixes that follow the project ID: `DataLakeAccess`, `SparkAccess`,
+   `QueryAccess`, `IngestionAccess`. Example:
+
+   ```
+   arn:aws:sts::123456789012:assumed-role/AmazonDataZone-abc123def-DataLakeAccess/session
+                                                         ^^^^^^^^^
+                                                         project ID = abc123def
+   ```
+
+3. Match the workgroup to the project. Project workgroups follow the pattern
+
+   `sagemaker-studio-workgroup-<project-id>` or contain the project ID.
+
+4. If exactly one `sagemaker-studio-workgroup-*` exists, verify its suffix
+
+   contains the project ID extracted in step 2. If it matches, use it.
+   If it does not match, fall through to step 6.
+
+5. If multiple exist, pick the one whose suffix matches the project ID
+
+   extracted from the role ARN. Optionally check environment variables
+   `SAGEMAKER_PROJECT_ID` or `SAGEMAKER_PROJECT_NAME` if the ARN extraction
+   is ambiguous.
+
+6. If no `sagemaker-studio-workgroup-*` exists, **do not fall back** to other
+
+   workgroups. Inform the user that no project-scoped workgroup was found and
+   ask them to verify their project configuration or IAM permissions.
+
+Project roles typically have IAM permissions scoped to their own workgroup.
+Attempting to use `primary` or another project's workgroup will fail with
+AccessDeniedException. Do not retry with `primary` in this context.
+
+## General Priority Order (Non-Project Roles)
+
+1. `sagemaker-studio-workgroup-*` workgroups -- most reliable, always have output locations configured
+2. Workgroups with explicitly configured output locations
+3. `primary` workgroup (use with caution, may lack output location)
+
+## Error Recovery
+
+| Error | Context | Action |
+|---|---|---|
+| No output location | Any | Retry with the next workgroup in priority order |
+| AccessDeniedException on workgroup | Project role | Do not retry with other workgroups. Inform the user their project role lacks access. |
+| AccessDeniedException on workgroup | Standard role | Retry with the next workgroup in priority order |
+| No workgroups found | Any | Ask the user to configure a workgroup or check IAM permissions |
+
+## Anti-patterns
+
+- Never default to `primary` workgroup without checking others first
+- Never hardcode a workgroup name across sessions
+- Never retry with `primary` when running as a SageMaker project role -- it will fail with AccessDeniedException

--- a/plugins/aws-data-analytics/skills/store-and-query-vectors/SKILL.md
+++ b/plugins/aws-data-analytics/skills/store-and-query-vectors/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: store-and-query-vectors
+description: >
+  Store and query vector embeddings using Amazon S3 Vectors,
+  a cost-effective long-term vector storage service with its own
+  API namespace (s3vectors). Triggers on: create S3 vector bucket, vector index,
+  store embeddings, semantic search, RAG vector storage, similarity search,
+  vector database, migrate from other vector databases. Do NOT use for: querying
+  tabular data (use query-data-lake), S3 object storage, or
+  hundreds/thousands of sustained QPS (use OpenSearch).
+owner_team: Amazon S3
+owner_cti: AWS/S3/Vector
+stages: [preprod, prod]
+version: 1
+metadata:
+  service: [s3vectors, bedrock]
+  task: [deploy, debug, migrate]
+  persona: [developer, architect]
+  workload: [data-analytics]
+---
+
+# Store and Query Vectors with Amazon S3 Vectors
+
+## Overview
+
+Amazon S3 Vectors is a cost-effective AWS service for storing and querying vector embeddings at scale. Optimized for long-term storage with subsecond latency for cold queries, as low as 100ms for warm queries.
+
+## Decision Guide
+
+- **Hundreds/thousands of sustained queries per second (QPS)**: Wrong tool. Recommend OpenSearch.
+- **Hybrid search, aggregations, faceted search**: Recommend OpenSearch with S3 Vectors as storage engine. For OpenSearch integration, search AWS docs for `"Using S3 Vectors with OpenSearch Service"`.
+- **Tiered (bulk + hot)**: S3 Vectors for storage + OpenSearch Serverless for real-time. See `references/limits-and-patterns.md`.
+- **Cost-effective storage, infrequent queries, RAG**: S3 Vectors is the right fit. Proceed.
+
+For latest guidance, search AWS docs for `"S3 Vectors best practices"`.
+
+## Common Tasks
+
+Classify the request before starting:
+
+- **Simple query**: Existing index, skip to Step 6
+- **Standard**: You MUST list existing indexes first and suggest reusing if relevant. Else, new index + store vectors, follow Steps 2-6
+- **Migration or multi-tenant**: Read `references/limits-and-patterns.md` first, then Steps 2-6
+
+You MUST execute commands using AWS MCP server tools when connected. Fall back to AWS CLI only if AWS MCP is unavailable. You MUST explain each step to the user before executing.
+
+### 1. Verify Dependencies
+
+**Constraints:**
+
+- You MUST check whether AWS MCP tools or AWS CLI is available and inform user if missing
+- You MUST confirm target AWS region
+
+### 2. Create a Vector Bucket
+
+You MUST confirm bucket name with user. Names: 3-63 chars, lowercase letters, numbers, hyphens only. Encryption (SSE-S3 default or SSE-KMS for compliance) is immutable after creation.
+
+```bash
+aws s3vectors create-vector-bucket \
+  --vector-bucket-name <BUCKET_NAME>
+```
+
+**Constraints:**
+
+- You MUST explain encryption cannot be changed after creation
+- For SSE-KMS, KMS key policy MUST grant `kms:GenerateDataKey` and `kms:Decrypt` to the S3 Vectors service principal `indexing.s3vectors.amazonaws.com`. You MUST use full KMS key ARN (not alias). See `references/limits-and-patterns.md` for command example.
+
+### 3. Create a Vector Index
+
+Every parameter is **immutable after creation**.
+
+**Pre-flight checklist (confirm ALL with user):**
+
+1. **Dimension** (required, integer 1-4096) -- MUST match embedding model output
+2. **Distance metric** (required) -- `cosine` or `euclidean`. Use embedding model's recommended metric;
+3. **Non-filterable metadata keys** (optional, max 10, 1-63 chars) -- Declare at creation or lose forever. For Bedrock Knowledge Bases integration, search AWS docs for `"S3 Vectors Bedrock Knowledge Bases prerequisites"` to get the required key names.
+4. **Encryption** (optional) -- Inherits from bucket. Override per-index if needed.
+
+```bash
+aws s3vectors create-index \
+  --vector-bucket-name <BUCKET_NAME> \
+  --index-name <INDEX_NAME> \
+  --dimension <DIM> \
+  --distance-metric <cosine|euclidean> \
+  --data-type float32 \
+  --metadata-configuration '{"nonFilterableMetadataKeys":["<KEY1>","<KEY2>"]}'
+```
+
+Omit `--metadata-configuration` if no non-filterable keys are needed.
+
+Index names: 3-63 chars, lowercase, numbers, hyphens, dots. Unique within bucket. Filterable metadata: 2 KB limit. Total metadata (filterable + non-filterable combined): 40 KB. See `references/metadata-filtering.md`.
+
+### 4. Generate Embeddings (if needed)
+
+Skip to Step 5 (store) or Step 6 (query) if user already has embeddings.
+
+**Constraints:**
+
+- You MUST ask which embedding model to use if not specified
+- You MUST NOT assume a default model
+- Dimension MUST match Step 3
+- You MUST use the same model for both storing and querying
+
+Generate embeddings with Bedrock invoke-model:
+
+```bash
+aws bedrock-runtime invoke-model \
+  --model-id <MODEL_ID> \
+  --content-type application/json \
+  --cli-binary-format raw-in-base64-out \
+  --body '{"inputText": "your text"}' \
+  invoke-model-output.json
+```
+
+You MUST use `--cli-binary-format raw-in-base64-out` for CLI v2. Output file is required for CLI. The response key is model-dependent (e.g., embedding for Titan, embeddings for Cohere). For Titan, parse with `json.load(open('invoke-model-output.json'))['embedding']`. Use `embedding` array as `float32` in put-vectors or query-vectors. For batch embedding generation, use AWS SDK or CLI.
+
+### 5. Put Vectors
+
+```bash
+aws s3vectors put-vectors \
+  --vector-bucket-name <BUCKET_NAME> \
+  --index-name <INDEX_NAME> \
+  --vectors '[{"key":"<ID>","data":{"float32":[<EMBEDDING>]},"metadata":{"topic":"science"}}]'
+```
+
+**Constraints:**
+
+- You MUST NOT exceed 500 vectors per call
+- You SHOULD batch vectors for cost optimization
+- For bulk operations, You SHOULD use an SDK instead of CLI -- vector payloads may be too large for shell arguments
+- You MUST implement retry with backoff on `429 TooManyRequestsException`
+- See `references/limits-and-patterns.md` for batch patterns
+
+### 6. Query Vectors
+
+Generate embedding if needed (Step 4), then query:
+
+```bash
+aws s3vectors query-vectors \
+  --vector-bucket-name <BUCKET_NAME> \
+  --index-name <INDEX_NAME> \
+  --query-vector '{"float32":[<EMBEDDING>]}' \
+  --top-k 10 \
+  --return-distance
+```
+
+Optional: add `--return-metadata` and/or `--filter '{"topic":{"$eq":"science"}}'` (both require GetVectors permission). See `references/metadata-filtering.md`.
+
+Example response body: `{"vectors": [{"key": "id1", "distance": 0.45, "metadata": {"topic": "science"}}, ...], "distanceMetric": "cosine"}`
+
+**Constraints:**
+
+- Using `--filter` or `--return-metadata` requires both `s3vectors:QueryVectors` AND `s3vectors:GetVectors` IAM permissions. Without GetVectors, these options return 403.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `DimensionMismatch` | Dims don't match index | Use matching model, or delete/recreate index (confirm with user -- destroys all vectors). |
+| `403 Forbidden` with `--filter` or `--return-metadata` | Missing `s3vectors:GetVectors` | Add `s3vectors:GetVectors` to IAM policy. |
+| Fewer results than `--top-k` | Few vectors match filter | Expected -- filtering is inline. Broaden filter. |
+| `429 TooManyRequestsException` | Exceeded per-index rate limits | Retry with backoff. Shard across indexes for sustained throughput. Search AWS docs for `"S3 Vectors limitations and restrictions"` for current limits. |
+| `AccessDeniedException` | Missing `s3vectors:*` IAM actions | S3 Vectors uses `s3vectors:*` namespace, not `s3:*`. Update IAM policy. |
+| `RequestTimeoutException` or service unavailable | Request timeout or region not supported | Retry request. For regional availability, search AWS docs for `"S3 Vectors limitations and restrictions"`. |
+
+## Additional Resources
+
+- [limits-and-patterns.md](references/limits-and-patterns.md) -- Multi-tenant patterns, batch ingestion, SSE-KMS, migration
+- [metadata-filtering.md](references/metadata-filtering.md) -- Filter operators, non-filterable metadata, Bedrock KB keys

--- a/plugins/aws-data-analytics/skills/store-and-query-vectors/references/limits-and-patterns.md
+++ b/plugins/aws-data-analytics/skills/store-and-query-vectors/references/limits-and-patterns.md
@@ -1,0 +1,68 @@
+# Patterns for S3 Vectors at Scale
+
+For current limits: search AWS docs for `"S3 Vectors limitations and restrictions"`
+
+## When to Use S3 Vectors
+
+Use S3 Vectors for large, long-term vector data that doesn't require the
+high-throughput performance of in-memory vector databases. S3 Vectors provides a
+cost-optimized data foundation with query performance optimized for long-term
+storage and infrequent access of data. You also benefit from a storage
+architecture with strong consistency guarantees, ensuring subsequent queries
+always include your most recently added data.
+
+S3 Vectors delivers subsecond latency for infrequent queries and as low as 100ms
+for more frequent queries.
+
+## Multi-Tenant Patterns
+
+**Per-tenant index** (recommended for isolation):
+
+- Each tenant gets their own index within a shared vector bucket
+- Queries naturally scoped to one tenant
+- Easy to delete a tenant's data (delete the index)
+- Use when: tenants need strict isolation, different schemas, or independent scaling
+
+**Single index with metadata filtering** (simpler):
+
+- All tenants share one index, filter by `tenant_id` metadata
+- Simpler to manage, single query endpoint
+- Use when: tenants have identical schemas and moderate scale
+- Risk: noisy neighbor if one tenant dominates the index
+
+## Batch Ingestion Pattern
+
+For large-scale ingestion (millions of vectors):
+
+1. Batch vectors into groups of up to 500 per PutVectors call
+2. Use parallel workers with backoff on `ServiceUnavailableException`
+3. For sustained throughput beyond per-index limits, shard across multiple indexes
+4. Search AWS docs for `"S3 Vectors limitations and restrictions"` for current per-call and per-second limits
+
+## SSE-KMS Encryption
+
+To create a vector bucket with SSE-KMS:
+
+```bash
+aws s3vectors create-vector-bucket \
+  --vector-bucket-name <BUCKET_NAME> \
+  --encryption-configuration '{"sseType":"aws:kms","kmsKeyArn":"arn:aws:kms:<REGION>:<ACCOUNT>:key/<KEY_ID>"}'
+```
+
+You MUST use the full KMS key ARN (not alias or key ID). The KMS key policy MUST grant
+`kms:GenerateDataKey` and `kms:Decrypt` to the S3 Vectors service principal `indexing.s3vectors.amazonaws.com`.
+Encryption cannot be changed after bucket or index creation.
+
+For full KMS policy examples, search AWS docs for `"S3 Vectors data encryption KMS"`.
+
+## Migration Pattern
+
+When migrating from another vector DB (pgVector, AOSS, etc.):
+
+1. Create vector bucket and index matching source dimensions + distance metric
+2. Export vectors from source (with metadata)
+3. Batch PutVectors into S3 Vectors
+4. Verify with QueryVectors using known test vectors
+5. S3 Vectors only supports `cosine` and `euclidean` — if source used dotProduct,
+
+   use `cosine` on normalized vectors as equivalent

--- a/plugins/aws-data-analytics/skills/store-and-query-vectors/references/metadata-filtering.md
+++ b/plugins/aws-data-analytics/skills/store-and-query-vectors/references/metadata-filtering.md
@@ -1,0 +1,71 @@
+# Metadata Filtering
+
+For full docs: search AWS docs for `"S3 Vectors metadata filtering"`
+
+## Filterable vs Non-filterable
+
+- **Filterable** (default): All metadata is filterable unless explicitly declared otherwise.
+
+  Can be used in query `--filter` expressions. Limited to 2 KB per vector.
+
+- **Non-filterable**: Declared at index creation via `--metadata-configuration`. Search AWS docs for `"S3 Vectors non-filterable metadata"` for JSON syntax.
+
+  Cannot be used in filters but can store larger data. Total metadata per vector
+  (filterable + non-filterable combined) is limited to 40 KB. Ideal for text
+  chunks, descriptions, raw content. Immutable — cannot change after index
+  creation. Max 10 non-filterable keys per index.
+
+## Filter Operators
+
+| Operator | Input types | Description |
+|----------|------------|-------------|
+| `$eq` | string, number, boolean | Exact match (default when no operator specified) |
+| `$ne` | string, number, boolean | Not equal |
+| `$gt` | number | Greater than |
+| `$gte` | number | Greater than or equal |
+| `$lt` | number | Less than |
+| `$lte` | number | Less than or equal |
+| `$in` | array of primitives | Match any value in array |
+| `$nin` | array of primitives | Match none of the values |
+| `$exists` | boolean | Check if field exists |
+| `$and` | array of filters | Logical AND |
+| `$or` | array of filters | Logical OR |
+
+## Filter Examples
+
+Simple equality (implicit `$eq`):
+
+```json
+{"genre": "documentary"}
+```
+
+Numeric range:
+
+```json
+{"year": {"$gte": 2020, "$lte": 2024}}
+```
+
+Array match:
+
+```json
+{"category": {"$in": ["science", "technology"]}}
+```
+
+Compound filter:
+
+```json
+{"$and": [{"genre": {"$eq": "drama"}}, {"year": {"$gte": 2020}}]}
+```
+
+Existence check:
+
+```json
+{"genre": {"$exists": true}}
+```
+
+## Key Rules
+
+- `$eq` is implicit — `{"genre": "drama"}` equals `{"genre": {"$eq": "drama"}}`
+- `$eq` on array metadata matches if input matches ANY element in the array
+- Filtering is applied during search (not post-filter). All returned results satisfy the filter, but fewer than top-K may be returned when few vectors match
+- Query with filter requires both `s3vectors:QueryVectors` AND `s3vectors:GetVectors`


### PR DESCRIPTION
Add documentation and skills for the AWS Data Analytics plugin:
- connect-to-data-source: JDBC, Snowflake, BigQuery connections
- create-data-lake-table: S3 Tables and Iceberg table creation
- exploring-data-catalog: Glue Data Catalog navigation
- find-data-lake-assets: Cross-catalog asset search
- ingest-into-data-lake: Multi-source data ingestion
- query-data-lake: Athena SQL query execution
- store-and-query-vectors: S3 Vectors operations

Each skill includes SKILL.md and reference documentation.

## Description

<!-- Describe the changes in this PR -->

## Type of Change

- [X] New plugin
- [X] New skill
- [ ] Bug fix
- [X] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [X] My changes pass `python3 tools/validate.py`
- [X] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
