### PR TITLE
chore: remove CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-All notable changes to this project are documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-[Unreleased]: https://github.com/aws/agent-toolkit-for-aws/compare/HEAD...HEAD


### PR DESCRIPTION
## Summary

Removes `CHANGELOG.md`. This is a content repository consumed from `main` — there is no versioned artifact whose upgrade path a changelog would help users navigate.

## Why

- **No version to pin.** The plugin marketplace pulls from `main`; users copying skills copy from `main`. There's no installed artifact whose upgrade path needs documenting.
- **Near-duplicative of `git log` / PR titles.** Each change here is already described in its PR title and commit message, with full diff context one click away.
- **Unit of change doesn't match release buckets.** Most PRs add or tweak a single skill/rule independently — they don't cluster into themed releases that fit `Added / Changed / Fixed` under a version header.
- **Per-PR coordination tax that's already eroding.** Typical failure mode for manual changelogs at low cadence.
- **SemVer claim we can't honor.** The file declares SemVer adherence, but "breaking change" doesn't have clear semantics for a skills repo (renaming a skill? removing a rule?).
- **No downstream consumer.** Nothing parses it, links to it, or surfaces it in the marketplace.

If we ever want categorized release notes later, `.github/release.yml` can group PRs by label inside auto-generated GitHub Release notes — no separate file needed.
