### PR TITLE
fix: add aws prefix to messaging skill

### DIFF
--- a/plugins/aws-core/skills/aws-messaging-and-streaming/SKILL.md
+++ b/plugins/aws-core/skills/aws-messaging-and-streaming/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: messaging-and-streaming
+name: aws-messaging-and-streaming
 description: >
   Guides use of AWS messaging and streaming services. Covers Amazon SQS,
   Amazon SNS, Amazon EventBridge, Amazon MQ, Amazon Kinesis Data Streams,


### PR DESCRIPTION
## Description

<!-- Describe the changes in this PR -->

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [x] Other

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] My changes pass `python3 tools/validate.py`
- [ ] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
