### PR TITLE
fix(aws-data-analytics): Update README skill names and links to match…

### DIFF
--- a/plugins/aws-data-analytics/README.md
+++ b/plugins/aws-data-analytics/README.md
@@ -13,13 +13,13 @@ This plugin brings AWS data engineering expertise directly into your coding assi
 
 | # | Skill | Description | Documentation |
 | -- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
-| 1 | `create-data-lake-table` | Create managed Iceberg tables using Amazon S3 Tables with automatic compaction, AWS Glue catalog registration, and partitioning | [SKILL.md](skills/create-data-lake-table/SKILL.md) |
-| 2 | `ingest-into-data-lake` | Import data from S3 files, JDBC databases, Snowflake, BigQuery, DynamoDB, or existing AWS Glue catalog tables into S3 Tables or standard Iceberg | [SKILL.md](skills/ingest-into-data-lake/SKILL.md) |
-| 3 | `query-data-lake` | Execute and manage Athena SQL queries across default and federated catalogs (AWS Glue, S3 Tables, Amazon Redshift) | [SKILL.md](skills/query-data-lake/SKILL.md) |
-| 4 | `find-data-lake-assets` | Resolve data lake asset references across AWS Glue Data Catalog, S3, S3 Tables, and Amazon Redshift by name, keyword, column, or S3 path | [SKILL.md](skills/find-data-lake-assets/SKILL.md) |
+| 1 | `creating-data-lake-table` | Create managed Iceberg tables using Amazon S3 Tables with automatic compaction, AWS Glue catalog registration, and partitioning | [SKILL.md](skills/creating-data-lake-table/SKILL.md) |
+| 2 | `ingesting-into-data-lake` | Import data from S3 files, JDBC databases, Snowflake, BigQuery, DynamoDB, or existing AWS Glue catalog tables into S3 Tables or standard Iceberg | [SKILL.md](skills/ingesting-into-data-lake/SKILL.md) |
+| 3 | `querying-data-lake` | Execute and manage Athena SQL queries across default and federated catalogs (AWS Glue, S3 Tables, Amazon Redshift) | [SKILL.md](skills/querying-data-lake/SKILL.md) |
+| 4 | `finding-data-lake-assets` | Resolve data lake asset references across AWS Glue Data Catalog, S3, S3 Tables, and Amazon Redshift by name, keyword, column, or S3 path | [SKILL.md](skills/finding-data-lake-assets/SKILL.md) |
 | 5 | `exploring-data-catalog` | Full inventory and audit of AWS Glue Data Catalog assets across S3 Tables, Amazon Redshift-federated, and remote Iceberg catalogs | [SKILL.md](skills/exploring-data-catalog/SKILL.md) |
-| 6 | `store-and-query-vectors` | Store and query vector embeddings using Amazon S3 Vectors for semantic search and RAG workloads | [SKILL.md](skills/store-and-query-vectors/SKILL.md) |
-| 7 | `connect-to-data-source` | Create and troubleshoot AWS Glue connections to JDBC databases, Amazon Redshift, Snowflake, and BigQuery | [SKILL.md](skills/connect-to-data-source/SKILL.md) |
+| 6 | `storing-and-querying-vectors` | Store and query vector embeddings using Amazon S3 Vectors for semantic search and RAG workloads | [SKILL.md](skills/storing-and-querying-vectors/SKILL.md) |
+| 7 | `connecting-to-data-source` | Create and troubleshoot AWS Glue connections to JDBC databases, Amazon Redshift, Snowflake, and BigQuery | [SKILL.md](skills/connecting-to-data-source/SKILL.md) |
 
 ## MCP Servers
 
@@ -37,9 +37,9 @@ The data lake skills cover the jobs-to-be-done for building and operating a data
 
 ### How It Works
 
-- **Create tables** — The `create-data-lake-table` skill sets up managed Iceberg tables on Amazon S3 Tables with automatic compaction, snapshot management, AWS Glue catalog registration, partitioning, and IAM access control.
-- **Ingest data** — The `ingest-into-data-lake` skill moves data from local files, S3, JDBC databases (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora, Amazon Redshift), Snowflake, BigQuery, DynamoDB, or existing AWS Glue catalog tables into your data lake. Supports one-time loads, recurring pipelines, and migrations.
-- **Query data** — The `query-data-lake` skill executes Athena SQL queries across default and federated catalogs, with workgroup selection, statement classification, cost tracking, and error recovery.
+- **Create tables** — The `creating-data-lake-table` skill sets up managed Iceberg tables on Amazon S3 Tables with automatic compaction, snapshot management, AWS Glue catalog registration, partitioning, and IAM access control.
+- **Ingest data** — The `ingesting-into-data-lake` skill moves data from local files, S3, JDBC databases (Oracle, SQL Server, PostgreSQL, MySQL, RDS, Aurora, Amazon Redshift), Snowflake, BigQuery, DynamoDB, or existing AWS Glue catalog tables into your data lake. Supports one-time loads, recurring pipelines, and migrations.
+- **Query data** — The `querying-data-lake` skill executes Athena SQL queries across default and federated catalogs, with workgroup selection, statement classification, cost tracking, and error recovery.
 
 ### Examples
 
@@ -53,7 +53,7 @@ The data lake skills cover the jobs-to-be-done for building and operating a data
 The discovery skills help you understand what data exists in your AWS account and find specific assets quickly.
 
 - **`exploring-data-catalog`** — Full inventory and audit across AWS Glue Data Catalog, S3 Tables, Amazon Redshift-federated, and remote Iceberg catalogs. Maps your data landscape, flags stale tables, and suggests improvements.
-- **`find-data-lake-assets`** — Resolves fuzzy data references ("our orders table", "the sales dataset") to concrete catalog entries using layered search across AWS Glue, S3, S3 Tables, and Amazon Redshift.
+- **`finding-data-lake-assets`** — Resolves fuzzy data references ("our orders table", "the sales dataset") to concrete catalog entries using layered search across AWS Glue, S3, S3 Tables, and Amazon Redshift.
 
 ### Examples
 
@@ -64,7 +64,7 @@ The discovery skills help you understand what data exists in your AWS account an
 
 ## Vector Storage
 
-The `store-and-query-vectors` skill provides cost-effective vector embedding storage and retrieval using Amazon S3 Vectors, optimized for long-term storage with subsecond query latency.
+The `storing-and-querying-vectors` skill provides cost-effective vector embedding storage and retrieval using Amazon S3 Vectors, optimized for long-term storage with subsecond query latency.
 
 ### Examples
 
@@ -74,7 +74,7 @@ The `store-and-query-vectors` skill provides cost-effective vector embedding sto
 
 ## External Connectivity
 
-The `connect-to-data-source` skill creates and troubleshoots AWS Glue connections to external databases. It discovers existing connections and candidate sources in your account, registers credentials securely via Secrets Manager or IAM DB auth, configures VPC networking, and tests end-to-end connectivity.
+The `connecting-to-data-source` skill creates and troubleshoots AWS Glue connections to external databases. It discovers existing connections and candidate sources in your account, registers credentials securely via Secrets Manager or IAM DB auth, configures VPC networking, and tests end-to-end connectivity.
 
 ### Examples
 


### PR DESCRIPTION
… directory names

Skill directories use gerund names (creating-data-lake-table, etc.) but the README referenced imperative names (create-data-lake-table, etc.), causing 6 broken SKILL.md links.

## Description

<!-- Describe the changes in this PR -->

## Type of Change

- [ ] New plugin
- [ ] New skill
- [X] Bug fix
- [X] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [X] My changes pass `python3 tools/validate.py`
- [X] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
