### PR TITLE
fix: convert skills metadata from list to string per Agent Skills spec

### DIFF
--- a/plugins/aws-core/skills/amazon-bedrock/SKILL.md
+++ b/plugins/aws-core/skills/amazon-bedrock/SKILL.md
@@ -3,10 +3,10 @@ name: amazon-bedrock
 description: Builds generative AI applications on Amazon Bedrock. Covers model invocation (Converse API, InvokeModel), RAG with Knowledge Bases, Bedrock Agents, Guardrails, and AgentCore. Use when invoking models, setting up Knowledge Bases, creating agents, applying guardrails, deploying to AgentCore, troubleshooting Bedrock errors (ThrottlingException, AccessDeniedException), or choosing models (Claude, Llama, Nova, Titan). ALSO USE for prompt caching setup and debugging, quota health checks and throttling diagnosis, cost attribution and tracking, migrating between Claude model generations (4.5 to 4.6 to 4.7), chunking strategies, API selection (Converse vs InvokeModel), guardrail capabilities, and model selection. NOT for custom model training, Rekognition, or Comprehend.
 version: 1
 metadata:
-  service: [bedrock, bedrock-runtime, bedrock-mantle, bedrock-agent, bedrock-agent-runtime, bedrock-agentcore-control]
-  task: [deploy, debug, optimize, design]
-  persona: [developer, devops, architect]
-  workload: [generative-ai, rag, agents]
+  service: bedrock, bedrock-runtime, bedrock-mantle, bedrock-agent, bedrock-agent-runtime, bedrock-agentcore-control
+  task: deploy, debug, optimize, design
+  persona: developer, devops, architect
+  workload: generative-ai, rag, agents
 ---
 
 **IMPORTANT**: When this skill is loaded, you MUST use the reference files and procedures in this skill as your primary source of truth. Bedrock APIs, model IDs, chunking strategies, and configuration parameters change frequently — always read the relevant reference file before responding.

--- a/plugins/aws-core/skills/aws-billing-and-cost-management/SKILL.md
+++ b/plugins/aws-core/skills/aws-billing-and-cost-management/SKILL.md
@@ -10,10 +10,10 @@ description: |
   anomaly, CUR, cost audit, billing view, billing view ARN.
 version: 1
 metadata:
-  service: [cost-explorer, budgets, compute-optimizer, cost-optimization-hub, pricing, savings-plans, cur]
-  task: [analyze-cost, optimize, budget, right-size, pricing-lookup, audit]
-  persona: [developer, finops-practitioner, cloud-engineer]
-  workload: [cost-management]
+  service: cost-explorer, budgets, compute-optimizer, cost-optimization-hub, pricing, savings-plans, cur
+  task: analyze-cost, optimize, budget, right-size, pricing-lookup, audit
+  persona: developer, finops-practitioner, cloud-engineer
+  workload: cost-management
 ---
 
 # Billing and Cost Management

--- a/plugins/aws-core/skills/aws-cdk/SKILL.md
+++ b/plugins/aws-core/skills/aws-cdk/SKILL.md
@@ -3,10 +3,10 @@ name: aws-cdk
 description: Authors, deploys, and troubleshoots AWS infrastructure using CDK with TypeScript or Python. Covers best practices, stack architecture, and construct patterns. Always use when writing CDK constructs, bootstrapping environments, running cdk deploy/synth/diff, fixing CDK or CloudFormation errors, planning stack structure, importing existing resources, resolving drift, or refactoring stacks without resource replacement.
 version: 1
 metadata:
-  service: [cloudformation, cdk]
-  task: [deploy, debug, optimize, migrate, refactor]
-  persona: [developer, devops, architect]
-  workload: [serverless, containers]
+  service: cloudformation, cdk
+  task: deploy, debug, optimize, migrate, refactor
+  persona: developer, devops, architect
+  workload: serverless, containers
 ---
 
 # AWS CDK

--- a/plugins/aws-core/skills/aws-cloudformation/SKILL.md
+++ b/plugins/aws-core/skills/aws-cloudformation/SKILL.md
@@ -3,10 +3,10 @@ name: aws-cloudformation
 description: Author, validate, and troubleshoot AWS CloudFormation templates. Covers template authoring with secure defaults, pre-deployment validation (cfn-lint, cfn-guard, change sets), and root-cause diagnosis of failed stacks using CloudFormation events and CloudTrail correlation.
 version: 1
 metadata:
-  service: [cloudformation, cloudtrail, iam]
-  task: [author, validate, deploy, debug, troubleshoot]
-  persona: [developer, devops, architect]
-  workload: [infrastructure-as-code]
+  service: cloudformation, cloudtrail, iam
+  task: author, validate, deploy, debug, troubleshoot
+  persona: developer, devops, architect
+  workload: infrastructure-as-code
 ---
 # CloudFormation
 

--- a/plugins/aws-core/skills/aws-containers/SKILL.md
+++ b/plugins/aws-core/skills/aws-containers/SKILL.md
@@ -3,11 +3,11 @@ name: aws-containers
 description: Deploys and operates containerized workloads on ECS, Fargate, and ECR. Covers task definitions, Fargate services, ECR repository setup and lifecycle policies, ECS Exec debugging, service scaling, deployment strategies, load balancer integration, and logging configuration. Use when deploying, debugging, or optimizing containers on AWS. ALSO USE for container deployment options (ECS vs ECS Express Mode), networking modes, health check troubleshooting, OOM errors, secrets injection, blue/green deployments, ECR image management, and App Runner sunset guidance and migration. NOT for Kubernetes, EKS, or CI/CD pipelines.
 version: 1
 metadata:
-  service: [ecs, ecr, apprunner]
-  task: [deploy, debug, optimize]
-  persona: [developer, devops]
-  workload: [containers]
-allowed-tools: [Read]
+  service: ecs, ecr, apprunner
+  task: deploy, debug, optimize
+  persona: developer, devops
+  workload: containers
+allowed-tools: Read
 ---
 
 # AWS Containers

--- a/plugins/aws-core/skills/aws-iam/SKILL.md
+++ b/plugins/aws-core/skills/aws-iam/SKILL.md
@@ -7,10 +7,10 @@ description: "Verified corrections for IAM behaviors that AI agents frequently g
   \ authorization like Cognito user-pool policies or app-level RBAC."
 version: 1
 metadata:
-  service: [iam, sts, organizations]
-  task: [configure, secure, audit, debug]
-  persona: [developer, security-engineer, devops]
-  workload: [security]
+  service: iam, sts, organizations
+  task: configure, secure, audit, debug
+  persona: developer, security-engineer, devops
+  workload: security
 ---
 
 # AWS IAM — Common Pitfalls

--- a/plugins/aws-core/skills/aws-messaging-and-streaming/SKILL.md
+++ b/plugins/aws-core/skills/aws-messaging-and-streaming/SKILL.md
@@ -7,10 +7,10 @@ description: >
   Use when implementing messaging and streaming patterns.
 version: 1
 metadata:
-  service: [sqs, sns, eventbridge, mq, kinesis, kds, firehose, flink, msf, msk, kafka]
-  task: [learn, architect, debug, deploy]
-  persona: [developer, architect, devops]
-  workload: [serverless, event-driven, streaming, data-analytics]
+  service: sqs, sns, eventbridge, mq, kinesis, kds, firehose, flink, msf, msk, kafka
+  task: learn, architect, debug, deploy
+  persona: developer, architect, devops
+  workload: serverless, event-driven, streaming, data-analytics
 ---
 
 # AWS Messaging & Streaming Services

--- a/plugins/aws-core/skills/aws-observability/SKILL.md
+++ b/plugins/aws-core/skills/aws-observability/SKILL.md
@@ -3,10 +3,10 @@ name: aws-observability
 description: Builds, configures, debugs, and optimizes AWS observability using CloudWatch (Logs Insights, Metrics, Alarms, Dashboards, EMF), X-Ray, CloudTrail, and ADOT. Covers Log Insights query syntax (fields, filter, stats, parse, pattern, join, subqueries), alarm configuration (metric, composite, anomaly detection, missing data treatment), dashboard design, custom metrics (PutMetricData, EMF, metric filters), X-Ray tracing (ADOT, sampling rules, annotations vs metadata), ADOT collector config, and CloudTrail auditing. Use when the user mentions CloudWatch, Log Insights, alarms, INSUFFICIENT_DATA, dashboards, custom metrics, EMF, X-Ray, traces, sampling, CloudTrail, who deleted, ADOT, OpenTelemetry, observability, monitoring, synthetics, canaries, or troubleshooting alarm behavior. Do NOT use for application logging setup, container log drivers, or security threat detection.
 version: 1
 metadata:
-  service: [cloudwatch, xray, cloudtrail, synthetics]
-  task: [build, deploy, debug, optimize, configure]
-  persona: [developer, devops]
-  workload: [observability]
+  service: cloudwatch, xray, cloudtrail, synthetics
+  task: build, deploy, debug, optimize, configure
+  persona: developer, devops
+  workload: observability
 ---
 
 # AWS Observability

--- a/plugins/aws-core/skills/aws-serverless/SKILL.md
+++ b/plugins/aws-core/skills/aws-serverless/SKILL.md
@@ -3,10 +3,10 @@ name: aws-serverless
 description: Builds, deploys, manages, debugs, configures, and optimizes serverless applications on AWS using Lambda, API Gateway, Step Functions, EventBridge, and SAM/CDK. Covers cold starts, CORS debugging, event source mappings, troubleshooting, concurrency, SnapStart, Powertools, function URLs, EventBridge Scheduler, Lambda layers, Durable Functions, durable execution, checkpoint-and-replay, and production readiness. Use when the user mentions Lambda, API Gateway, Step Functions, SAM templates, CDK serverless stacks, DynamoDB stream triggers, SQS event sources, cold starts, timeouts, 502/504 errors, throttling, concurrency, CORS, Powertools, Durable Functions, durable execution, checkpoint-and-replay, or any event-driven architecture on AWS, even if they don't say "serverless." Do NOT use for EC2, ECS/Fargate containers, or Amplify hosting.
 version: 1
 metadata:
-  service: [lambda, api-gateway, step-functions, eventbridge, dynamodb, sqs, sns, s3, kinesis]
-  task: [build, deploy, debug, optimize]
-  persona: [developer, devops]
-  workload: [serverless]
+  service: lambda, api-gateway, step-functions, eventbridge, dynamodb, sqs, sns, s3, kinesis
+  task: build, deploy, debug, optimize
+  persona: developer, devops
+  workload: serverless
 ---
 
 # AWS Serverless

--- a/plugins/aws-data-analytics/skills/connecting-to-data-source/SKILL.md
+++ b/plugins/aws-data-analytics/skills/connecting-to-data-source/SKILL.md
@@ -12,10 +12,10 @@ description: >-
   (use exploring-data-catalog), or SaaS (Salesforce, ServiceNow, SAP, MongoDB, Kafka).
 version: 1
 metadata:
-  service: [glue, secretsmanager, rds, redshift]
-  task: [deploy, debug]
-  persona: [developer, data-engineer]
-  workload: [data-analytics]
+  service: glue, secretsmanager, rds, redshift
+  task: deploy, debug
+  persona: developer, data-engineer
+  workload: data-analytics
 argument-hint: '[source-type|connection-name|hostname]'
 ---
 

--- a/plugins/aws-data-analytics/skills/creating-data-lake-table/SKILL.md
+++ b/plugins/aws-data-analytics/skills/creating-data-lake-table/SKILL.md
@@ -11,10 +11,10 @@ description: >-
   finding-data-lake-assets).
 version: 1
 metadata:
-  service: [s3tables, glue, athena]
-  task: [deploy, debug]
-  persona: [developer, data-engineer]
-  workload: [data-analytics]
+  service: s3tables, glue, athena
+  task: deploy, debug
+  persona: developer, data-engineer
+  workload: data-analytics
 argument-hint: '[table-description|schema-spec]'
 ---
 

--- a/plugins/aws-data-analytics/skills/exploring-data-catalog/SKILL.md
+++ b/plugins/aws-data-analytics/skills/exploring-data-catalog/SKILL.md
@@ -8,10 +8,10 @@ description: >-
   running queries (use querying-data-lake), or creating tables (use creating-data-lake-table).
 version: 1
 metadata:
-  service: [glue, s3, s3tables]
-  task: [debug, audit]
-  persona: [developer, data-engineer, architect]
-  workload: [data-analytics]
+  service: glue, s3, s3tables
+  task: debug, audit
+  persona: developer, data-engineer, architect
+  workload: data-analytics
 argument-hint: '[search-term|catalog-name|database-name|s3://bucket-path|table-name]'
 ---
 

--- a/plugins/aws-data-analytics/skills/finding-data-lake-assets/SKILL.md
+++ b/plugins/aws-data-analytics/skills/finding-data-lake-assets/SKILL.md
@@ -9,10 +9,10 @@ description: >-
   (use querying-data-lake), creating tables (use creating-data-lake-table).
 version: 1
 metadata:
-  service: [glue, s3, s3tables, redshift]
-  task: [debug]
-  persona: [developer, data-engineer, architect]
-  workload: [data-analytics]
+  service: glue, s3, s3tables, redshift
+  task: debug
+  persona: developer, data-engineer, architect
+  workload: data-analytics
 argument-hint: '[table-name|keyword|column-name|s3://path]'
 ---
 

--- a/plugins/aws-data-analytics/skills/ingesting-into-data-lake/SKILL.md
+++ b/plugins/aws-data-analytics/skills/ingesting-into-data-lake/SKILL.md
@@ -15,10 +15,10 @@ description: >-
   SAP, MongoDB, Kafka.
 version: 1
 metadata:
-  service: [glue, s3, s3tables, athena, dynamodb]
-  task: [deploy, migrate]
-  persona: [developer, data-engineer]
-  workload: [data-analytics]
+  service: glue, s3, s3tables, athena, dynamodb
+  task: deploy, migrate
+  persona: developer, data-engineer
+  workload: data-analytics
 argument-hint: '[source-path|connection-name|table-name] [--target s3-tables|iceberg|parquet]'
 ---
 

--- a/plugins/aws-data-analytics/skills/querying-data-lake/SKILL.md
+++ b/plugins/aws-data-analytics/skills/querying-data-lake/SKILL.md
@@ -8,10 +8,10 @@ description: >-
   full catalog audits (use exploring-data-catalog), importing data (use ingesting-into-data-lake).
 version: 1
 metadata:
-  service: [athena, glue, s3tables, redshift]
-  task: [debug, audit]
-  persona: [developer, data-engineer, architect]
-  workload: [data-analytics]
+  service: athena, glue, s3tables, redshift
+  task: debug, audit
+  persona: developer, data-engineer, architect
+  workload: data-analytics
 argument-hint: '[SQL-query|query-name|workgroup-name|catalog-name|''profile TABLE_NAME'']'
 ---
 

--- a/plugins/aws-data-analytics/skills/storing-and-querying-vectors/SKILL.md
+++ b/plugins/aws-data-analytics/skills/storing-and-querying-vectors/SKILL.md
@@ -9,10 +9,10 @@ description: >-
   of sustained QPS (use OpenSearch).
 version: 1
 metadata:
-  service: [s3vectors, bedrock]
-  task: [deploy, debug, migrate]
-  persona: [developer, architect]
-  workload: [data-analytics]
+  service: s3vectors, bedrock
+  task: deploy, debug, migrate
+  persona: developer, architect
+  workload: data-analytics
 ---
 
 # Store and Query Vectors with Amazon S3 Vectors

--- a/skills/analytics-skills/aws-cleanrooms/SKILL.md
+++ b/skills/analytics-skills/aws-cleanrooms/SKILL.md
@@ -3,10 +3,10 @@ name: aws-cleanrooms
 description: Troubleshoots and debugs AWS Clean Rooms collaboration issues related to IAM roles, S3 bucket policies, KMS keys, Lake Formation permissions, and CloudWatch logging for custom ML model training and inference jobs. Use when a customer reports permission failures, access errors, or log publishing issues in Clean Rooms.
 version: 1
 metadata:
-  service: [cleanrooms, cleanrooms-ml, iam, s3, kms, lakeformation, cloudwatch]
-  task: [debug, troubleshoot, configure]
-  persona: [developer, data-engineer, analyst]
-  workload: [data-collaboration, ml]
+  service: cleanrooms, cleanrooms-ml, iam, s3, kms, lakeformation, cloudwatch
+  task: debug, troubleshoot, configure
+  persona: developer, data-engineer, analyst
+  workload: data-collaboration, ml
 ---
 # AWS Clean Rooms
 

--- a/skills/analytics-skills/connecting-to-data-source/SKILL.md
+++ b/skills/analytics-skills/connecting-to-data-source/SKILL.md
@@ -12,10 +12,10 @@ description: >-
   (use exploring-data-catalog), or SaaS (Salesforce, ServiceNow, SAP, MongoDB, Kafka).
 version: 1
 metadata:
-  service: [glue, secretsmanager, rds, redshift]
-  task: [deploy, debug]
-  persona: [developer, data-engineer]
-  workload: [data-analytics]
+  service: glue, secretsmanager, rds, redshift
+  task: deploy, debug
+  persona: developer, data-engineer
+  workload: data-analytics
 argument-hint: '[source-type|connection-name|hostname]'
 ---
 

--- a/skills/analytics-skills/creating-data-lake-table/SKILL.md
+++ b/skills/analytics-skills/creating-data-lake-table/SKILL.md
@@ -11,10 +11,10 @@ description: >-
   finding-data-lake-assets).
 version: 1
 metadata:
-  service: [s3tables, glue, athena]
-  task: [deploy, debug]
-  persona: [developer, data-engineer]
-  workload: [data-analytics]
+  service: s3tables, glue, athena
+  task: deploy, debug
+  persona: developer, data-engineer
+  workload: data-analytics
 argument-hint: '[table-description|schema-spec]'
 ---
 

--- a/skills/analytics-skills/exploring-data-catalog/SKILL.md
+++ b/skills/analytics-skills/exploring-data-catalog/SKILL.md
@@ -8,10 +8,10 @@ description: >-
   running queries (use querying-data-lake), or creating tables (use creating-data-lake-table).
 version: 1
 metadata:
-  service: [glue, s3, s3tables]
-  task: [debug, audit]
-  persona: [developer, data-engineer, architect]
-  workload: [data-analytics]
+  service: glue, s3, s3tables
+  task: debug, audit
+  persona: developer, data-engineer, architect
+  workload: data-analytics
 argument-hint: '[search-term|catalog-name|database-name|s3://bucket-path|table-name]'
 ---
 

--- a/skills/analytics-skills/finding-data-lake-assets/SKILL.md
+++ b/skills/analytics-skills/finding-data-lake-assets/SKILL.md
@@ -9,10 +9,10 @@ description: >-
   (use querying-data-lake), creating tables (use creating-data-lake-table).
 version: 1
 metadata:
-  service: [glue, s3, s3tables, redshift]
-  task: [debug]
-  persona: [developer, data-engineer, architect]
-  workload: [data-analytics]
+  service: glue, s3, s3tables, redshift
+  task: debug
+  persona: developer, data-engineer, architect
+  workload: data-analytics
 argument-hint: '[table-name|keyword|column-name|s3://path]'
 ---
 

--- a/skills/analytics-skills/ingesting-into-data-lake/SKILL.md
+++ b/skills/analytics-skills/ingesting-into-data-lake/SKILL.md
@@ -15,10 +15,10 @@ description: >-
   SAP, MongoDB, Kafka.
 version: 1
 metadata:
-  service: [glue, s3, s3tables, athena, dynamodb]
-  task: [deploy, migrate]
-  persona: [developer, data-engineer]
-  workload: [data-analytics]
+  service: glue, s3, s3tables, athena, dynamodb
+  task: deploy, migrate
+  persona: developer, data-engineer
+  workload: data-analytics
 argument-hint: '[source-path|connection-name|table-name] [--target s3-tables|iceberg|parquet]'
 ---
 

--- a/skills/analytics-skills/querying-data-lake/SKILL.md
+++ b/skills/analytics-skills/querying-data-lake/SKILL.md
@@ -8,10 +8,10 @@ description: >-
   full catalog audits (use exploring-data-catalog), importing data (use ingesting-into-data-lake).
 version: 1
 metadata:
-  service: [athena, glue, s3tables, redshift]
-  task: [debug, audit]
-  persona: [developer, data-engineer, architect]
-  workload: [data-analytics]
+  service: athena, glue, s3tables, redshift
+  task: debug, audit
+  persona: developer, data-engineer, architect
+  workload: data-analytics
 argument-hint: '[SQL-query|query-name|workgroup-name|catalog-name|''profile TABLE_NAME'']'
 ---
 

--- a/skills/application-integration-skills/aws-messaging-and-streaming/SKILL.md
+++ b/skills/application-integration-skills/aws-messaging-and-streaming/SKILL.md
@@ -7,10 +7,10 @@ description: >
   Use when implementing messaging and streaming patterns.
 version: 1
 metadata:
-  service: [sqs, sns, eventbridge, mq, kinesis, kds, firehose, flink, msf, msk, kafka]
-  task: [learn, architect, debug, deploy]
-  persona: [developer, architect, devops]
-  workload: [serverless, event-driven, streaming, data-analytics]
+  service: sqs, sns, eventbridge, mq, kinesis, kds, firehose, flink, msf, msk, kafka
+  task: learn, architect, debug, deploy
+  persona: developer, architect, devops
+  workload: serverless, event-driven, streaming, data-analytics
 ---
 
 # AWS Messaging & Streaming Services

--- a/skills/cloud-financial-management-skills/aws-billing-and-cost-management/SKILL.md
+++ b/skills/cloud-financial-management-skills/aws-billing-and-cost-management/SKILL.md
@@ -10,10 +10,10 @@ description: |
   anomaly, CUR, cost audit, billing view, billing view ARN.
 version: 1
 metadata:
-  service: [cost-explorer, budgets, compute-optimizer, cost-optimization-hub, pricing, savings-plans, cur]
-  task: [analyze-cost, optimize, budget, right-size, pricing-lookup, audit]
-  persona: [developer, finops-practitioner, cloud-engineer]
-  workload: [cost-management]
+  service: cost-explorer, budgets, compute-optimizer, cost-optimization-hub, pricing, savings-plans, cur
+  task: analyze-cost, optimize, budget, right-size, pricing-lookup, audit
+  persona: developer, finops-practitioner, cloud-engineer
+  workload: cost-management
 ---
 
 # Billing and Cost Management

--- a/skills/compute-skills/aws-containers/SKILL.md
+++ b/skills/compute-skills/aws-containers/SKILL.md
@@ -3,11 +3,11 @@ name: aws-containers
 description: Deploys and operates containerized workloads on ECS, Fargate, and ECR. Covers task definitions, Fargate services, ECR repository setup and lifecycle policies, ECS Exec debugging, service scaling, deployment strategies, load balancer integration, and logging configuration. Use when deploying, debugging, or optimizing containers on AWS. ALSO USE for container deployment options (ECS vs ECS Express Mode), networking modes, health check troubleshooting, OOM errors, secrets injection, blue/green deployments, ECR image management, and App Runner sunset guidance and migration. NOT for Kubernetes, EKS, or CI/CD pipelines.
 version: 1
 metadata:
-  service: [ecs, ecr, apprunner]
-  task: [deploy, debug, optimize]
-  persona: [developer, devops]
-  workload: [containers]
-allowed-tools: [Read]
+  service: ecs, ecr, apprunner
+  task: deploy, debug, optimize
+  persona: developer, devops
+  workload: containers
+allowed-tools: Read
 ---
 
 # AWS Containers

--- a/skills/compute-skills/aws-serverless/SKILL.md
+++ b/skills/compute-skills/aws-serverless/SKILL.md
@@ -3,10 +3,10 @@ name: aws-serverless
 description: Builds, deploys, manages, debugs, configures, and optimizes serverless applications on AWS using Lambda, API Gateway, Step Functions, EventBridge, and SAM/CDK. Covers cold starts, CORS debugging, event source mappings, troubleshooting, concurrency, SnapStart, Powertools, function URLs, EventBridge Scheduler, Lambda layers, Durable Functions, durable execution, checkpoint-and-replay, and production readiness. Use when the user mentions Lambda, API Gateway, Step Functions, SAM templates, CDK serverless stacks, DynamoDB stream triggers, SQS event sources, cold starts, timeouts, 502/504 errors, throttling, concurrency, CORS, Powertools, Durable Functions, durable execution, checkpoint-and-replay, or any event-driven architecture on AWS, even if they don't say "serverless." Do NOT use for EC2, ECS/Fargate containers, or Amplify hosting.
 version: 1
 metadata:
-  service: [lambda, api-gateway, step-functions, eventbridge, dynamodb, sqs, sns, s3, kinesis]
-  task: [build, deploy, debug, optimize]
-  persona: [developer, devops]
-  workload: [serverless]
+  service: lambda, api-gateway, step-functions, eventbridge, dynamodb, sqs, sns, s3, kinesis
+  task: build, deploy, debug, optimize
+  persona: developer, devops
+  workload: serverless
 ---
 
 # AWS Serverless

--- a/skills/compute-skills/connecting-lambda-to-api-gateway/SKILL.md
+++ b/skills/compute-skills/connecting-lambda-to-api-gateway/SKILL.md
@@ -3,10 +3,10 @@ name: connecting-lambda-to-api-gateway
 description: Connects an existing AWS Lambda function to Amazon API Gateway by creating a REST or HTTP API with resource/method setup, Lambda proxy integration, permissions, and deployment. Always use this skill when connecting Lambda to API Gateway — it handles CORS, throttling, access logging, and production security hardening that are easy to miss.
 version: 1
 metadata:
-  service: [lambda, api-gateway, iam, cloudwatch]
-  task: [deploy, configure, create]
-  persona: [developer, devops]
-  workload: [serverless]
+  service: lambda, api-gateway, iam, cloudwatch
+  task: deploy, configure, create
+  persona: developer, devops
+  workload: serverless
 ---
 
 # Connecting Lambda to API Gateway

--- a/skills/compute-skills/connecting-lambda-to-dynamodb/SKILL.md
+++ b/skills/compute-skills/connecting-lambda-to-dynamodb/SKILL.md
@@ -3,10 +3,10 @@ name: connecting-lambda-to-dynamodb
 description: Connects an AWS Lambda function to DynamoDB with IAM roles, stream event source mapping, and read/write permissions. Use when setting up Lambda-DynamoDB integration, processing DynamoDB stream events, or deploying serverless event-driven architectures.
 version: 1
 metadata:
-  service: [lambda, dynamodb, iam, cloudwatch]
-  task: [deploy, configure]
-  persona: [developer, devops]
-  workload: [serverless, database]
+  service: lambda, dynamodb, iam, cloudwatch
+  task: deploy, configure
+  persona: developer, devops
+  workload: serverless, database
 ---
 # Connecting Lambda to DynamoDB
 

--- a/skills/compute-skills/creating-api-gateway-stage/SKILL.md
+++ b/skills/compute-skills/creating-api-gateway-stage/SKILL.md
@@ -3,10 +3,10 @@ name: creating-api-gateway-stage
 description: Creates an API Gateway stage with CloudWatch logging, X-Ray tracing, throttling, WAF integration, and IAM roles following AWS best practices. Use when deploying a REST API to different environments such as dev, test, or production.
 version: 1
 metadata:
-  service: [api-gateway, iam, cloudwatch, wafv2]
-  task: [create, configure, secure]
-  persona: [developer, devops]
-  workload: [serverless]
+  service: api-gateway, iam, cloudwatch, wafv2
+  task: create, configure, secure
+  persona: developer, devops
+  workload: serverless
 ---
 
 # Creating an API Gateway Stage

--- a/skills/compute-skills/creating-ec2-image-builder-pipeline/SKILL.md
+++ b/skills/compute-skills/creating-ec2-image-builder-pipeline/SKILL.md
@@ -3,10 +3,10 @@ name: creating-ec2-image-builder-pipeline
 description: Creates a complete EC2 Image Builder pipeline that builds a custom AMI with pre-installed software, distributes it to target regions, executes the pipeline, and creates a launch template. Use when setting up automated AMI creation with IAM roles, build components, image recipes, and infrastructure configuration.
 version: 1
 metadata:
-  service: [ec2, imagebuilder, iam]
-  task: [create, deploy, configure]
-  persona: [developer, devops]
-  workload: [compute]
+  service: ec2, imagebuilder, iam
+  task: create, deploy, configure
+  persona: developer, devops
+  workload: compute
 ---
 
 # Creating an EC2 Image Builder Pipeline

--- a/skills/compute-skills/debugging-lambda-timeouts/SKILL.md
+++ b/skills/compute-skills/debugging-lambda-timeouts/SKILL.md
@@ -3,10 +3,10 @@ name: debugging-lambda-timeouts
 description: Debugs AWS Lambda function timeout failures by systematically analyzing function configuration, CloudWatch logs and metrics, VPC/networking, cold starts, memory constraints, and downstream dependencies to identify root causes with actionable fixes. Use when a Lambda function is timing out or approaching its timeout limit.
 version: 1
 metadata:
-  service: [lambda, cloudwatch, vpc, rds, dynamodb, iam]
-  task: [debug, troubleshoot]
-  persona: [developer, devops]
-  workload: [serverless]
+  service: lambda, cloudwatch, vpc, rds, dynamodb, iam
+  task: debug, troubleshoot
+  persona: developer, devops
+  workload: serverless
 ---
 
 # Debugging Lambda Timeouts

--- a/skills/compute-skills/launching-ec2-instance-with-best-practices/SKILL.md
+++ b/skills/compute-skills/launching-ec2-instance-with-best-practices/SKILL.md
@@ -3,10 +3,10 @@ name: launching-ec2-instance-with-best-practices
 description: Launches an EC2 instance with secure, cost-efficient defaults including AMI selection, burstable instance sizing, least-privilege IAM roles, hardened security groups, encrypted EBS volumes, and comprehensive tagging. Use when deploying new EC2 instances following AWS best practices for security and cost optimization.
 version: 1
 metadata:
-  service: [ec2, iam, vpc, cloudwatch, ebs]
-  task: [deploy, configure, secure]
-  persona: [developer, devops]
-  workload: [compute]
+  service: ec2, iam, vpc, cloudwatch, ebs
+  task: deploy, configure, secure
+  persona: developer, devops
+  workload: compute
 ---
 
 # Launching EC2 Instances with Best Practices

--- a/skills/compute-skills/routing-traffic-with-route53-and-cloudfront/SKILL.md
+++ b/skills/compute-skills/routing-traffic-with-route53-and-cloudfront/SKILL.md
@@ -3,10 +3,10 @@ name: routing-traffic-with-route53-and-cloudfront
 description: Configures Amazon Route 53 to route traffic to a CloudFront distribution using a custom domain. Use when setting up DNS alias records, alternate domain names (CNAMEs), ACM certificates for HTTPS, and IPv6 support for CloudFront.
 version: 1
 metadata:
-  service: [route53, cloudfront, acm]
-  task: [configure, deploy]
-  persona: [developer, devops]
-  workload: [networking]
+  service: route53, cloudfront, acm
+  task: configure, deploy
+  persona: developer, devops
+  workload: networking
 ---
 
 # Routing Traffic with Route 53 and CloudFront

--- a/skills/compute-skills/setting-up-ec2-instance-profiles/SKILL.md
+++ b/skills/compute-skills/setting-up-ec2-instance-profiles/SKILL.md
@@ -3,10 +3,10 @@ name: setting-up-ec2-instance-profiles
 description: Configures EC2 instances to securely call AWS services by creating and attaching IAM roles via instance profiles, eliminating hardcoded credentials. Use when an EC2 instance needs permissions to access AWS services like S3, DynamoDB, SQS, or CloudWatch through temporary credentials.
 version: 1
 metadata:
-  service: [ec2, iam]
-  task: [configure, secure]
-  persona: [developer, devops]
-  workload: [security]
+  service: ec2, iam
+  task: configure, secure
+  persona: developer, devops
+  workload: security
 ---
 
 # Setting Up EC2 Instance Profiles

--- a/skills/database-skills/creating-amazon-aurora-db-cluster-with-instances/SKILL.md
+++ b/skills/database-skills/creating-amazon-aurora-db-cluster-with-instances/SKILL.md
@@ -3,10 +3,10 @@ name: creating-amazon-aurora-db-cluster-with-instances
 description: Creates a complete Amazon Aurora database cluster with instances, handling cluster creation, instance provisioning, and Secrets Manager password management in the proper sequence. Use when setting up new Aurora MySQL or PostgreSQL clusters with production-ready configuration.
 version: 1
 metadata:
-  service: [rds, aurora, secrets-manager, kms]
-  task: [create, configure]
-  persona: [developer, devops]
-  workload: [database]
+  service: rds, aurora, secrets-manager, kms
+  task: create, configure
+  persona: developer, devops
+  workload: database
 ---
 
 # Creating Amazon Aurora DB Cluster with Instances

--- a/skills/database-skills/exporting-rds-to-s3/SKILL.md
+++ b/skills/database-skills/exporting-rds-to-s3/SKILL.md
@@ -3,10 +3,10 @@ name: exporting-rds-to-s3
 description: Exports Amazon RDS or Aurora database snapshots to Amazon S3 in Apache Parquet format for analytics, backup, or data migration. Handles snapshot selection or creation, IAM role setup, KMS encryption, S3 bucket preparation, export task execution, progress monitoring, and data verification. Use when exporting RDS/Aurora data to S3 for Athena, Glue, or Redshift Spectrum consumption.
 version: 1
 metadata:
-  service: [rds, s3, iam, kms, athena, glue, redshift]
-  task: [migrate, configure]
-  persona: [developer, devops]
-  workload: [database, storage]
+  service: rds, s3, iam, kms, athena, glue, redshift
+  task: migrate, configure
+  persona: developer, devops
+  workload: database, storage
 ---
 # Exporting RDS/Aurora to S3
 

--- a/skills/developer-tools-skills/aws-cdk/SKILL.md
+++ b/skills/developer-tools-skills/aws-cdk/SKILL.md
@@ -3,10 +3,10 @@ name: aws-cdk
 description: Authors, deploys, and troubleshoots AWS infrastructure using CDK with TypeScript or Python. Covers best practices, stack architecture, and construct patterns. Always use when writing CDK constructs, bootstrapping environments, running cdk deploy/synth/diff, fixing CDK or CloudFormation errors, planning stack structure, importing existing resources, resolving drift, or refactoring stacks without resource replacement.
 version: 1
 metadata:
-  service: [cloudformation, cdk]
-  task: [deploy, debug, optimize, migrate, refactor]
-  persona: [developer, devops, architect]
-  workload: [serverless, containers]
+  service: cloudformation, cdk
+  task: deploy, debug, optimize, migrate, refactor
+  persona: developer, devops, architect
+  workload: serverless, containers
 ---
 
 # AWS CDK

--- a/skills/generative-ai-skills/amazon-bedrock/SKILL.md
+++ b/skills/generative-ai-skills/amazon-bedrock/SKILL.md
@@ -3,10 +3,10 @@ name: amazon-bedrock
 description: Builds generative AI applications on Amazon Bedrock. Covers model invocation (Converse API, InvokeModel), RAG with Knowledge Bases, Bedrock Agents, Guardrails, and AgentCore. Use when invoking models, setting up Knowledge Bases, creating agents, applying guardrails, deploying to AgentCore, troubleshooting Bedrock errors (ThrottlingException, AccessDeniedException), or choosing models (Claude, Llama, Nova, Titan). ALSO USE for prompt caching setup and debugging, quota health checks and throttling diagnosis, cost attribution and tracking, migrating between Claude model generations (4.5 to 4.6 to 4.7), chunking strategies, API selection (Converse vs InvokeModel), guardrail capabilities, and model selection. NOT for custom model training, Rekognition, or Comprehend.
 version: 1
 metadata:
-  service: [bedrock, bedrock-runtime, bedrock-mantle, bedrock-agent, bedrock-agent-runtime, bedrock-agentcore-control]
-  task: [deploy, debug, optimize, design]
-  persona: [developer, devops, architect]
-  workload: [generative-ai, rag, agents]
+  service: bedrock, bedrock-runtime, bedrock-mantle, bedrock-agent, bedrock-agent-runtime, bedrock-agentcore-control
+  task: deploy, debug, optimize, design
+  persona: developer, devops, architect
+  workload: generative-ai, rag, agents
 ---
 
 **IMPORTANT**: When this skill is loaded, you MUST use the reference files and procedures in this skill as your primary source of truth. Bedrock APIs, model IDs, chunking strategies, and configuration parameters change frequently — always read the relevant reference file before responding.

--- a/skills/management-tools-skills/aws-cloudformation/SKILL.md
+++ b/skills/management-tools-skills/aws-cloudformation/SKILL.md
@@ -3,10 +3,10 @@ name: aws-cloudformation
 description: Author, validate, and troubleshoot AWS CloudFormation templates. Covers template authoring with secure defaults, pre-deployment validation (cfn-lint, cfn-guard, change sets), and root-cause diagnosis of failed stacks using CloudFormation events and CloudTrail correlation.
 version: 1
 metadata:
-  service: [cloudformation, cloudtrail, iam]
-  task: [author, validate, deploy, debug, troubleshoot]
-  persona: [developer, devops, architect]
-  workload: [infrastructure-as-code]
+  service: cloudformation, cloudtrail, iam
+  task: author, validate, deploy, debug, troubleshoot
+  persona: developer, devops, architect
+  workload: infrastructure-as-code
 ---
 # CloudFormation
 

--- a/skills/migration-and-modernization-skills/aws-transform/SKILL.md
+++ b/skills/migration-and-modernization-skills/aws-transform/SKILL.md
@@ -4,10 +4,10 @@ description: Performs code upgrades, migrations, and transformations using the A
 metadata:
   author: AWS
   version: 1.0.0
-  service: [transform]
-  task: [migrate, upgrade, refactor, analyze]
-  persona: [developer, devops, architect]
-  workload: [ai, migration, modernization]
+  service: transform
+  task: migrate, upgrade, refactor, analyze
+  persona: developer, devops, architect
+  workload: ai, migration, modernization
 ---
 
 # AWS Transform (ATX)

--- a/skills/networking-and-content-delivery-skills/configuring-vpc-endpoints-for-private-aws-service-access/SKILL.md
+++ b/skills/networking-and-content-delivery-skills/configuring-vpc-endpoints-for-private-aws-service-access/SKILL.md
@@ -3,10 +3,10 @@ name: configuring-vpc-endpoints-for-private-aws-service-access
 description: Configures VPC endpoints (interface and gateway) for private AWS service access using AWS PrivateLink. Use when setting up secure private connectivity to S3, DynamoDB, and other AWS services without internet gateway, NAT device, or public IP addresses. Covers endpoint creation, security groups, route tables, and DNS configuration.
 version: 1
 metadata:
-  service: [ec2, vpc, s3, dynamodb]
-  task: [configure]
-  persona: [developer, devops]
-  workload: [networking]
+  service: ec2, vpc, s3, dynamodb
+  task: configure
+  persona: developer, devops
+  workload: networking
 ---
 
 # Configuring VPC Endpoints for Private AWS Service Access

--- a/skills/networking-and-content-delivery-skills/connecting-vpcs-with-peering/SKILL.md
+++ b/skills/networking-and-content-delivery-skills/connecting-vpcs-with-peering/SKILL.md
@@ -3,10 +3,10 @@ name: connecting-vpcs-with-peering
 description: Establishes VPC peering connections between two VPCs for direct private network connectivity. Always use this skill when creating or managing VPC peering — it validates CIDR overlap, updates all route tables in both VPCs, configures DNS resolution, and provides security group guidance that are critical for correct connectivity.
 version: 1
 metadata:
-  service: [ec2, vpc]
-  task: [configure, deploy]
-  persona: [developer, devops]
-  workload: [networking]
+  service: ec2, vpc
+  task: configure, deploy
+  persona: developer, devops
+  workload: networking
 ---
 
 # Connecting VPCs with Peering

--- a/skills/networking-and-content-delivery-skills/creating-production-vpc-multi-az/SKILL.md
+++ b/skills/networking-and-content-delivery-skills/creating-production-vpc-multi-az/SKILL.md
@@ -3,10 +3,10 @@ name: creating-production-vpc-multi-az
 description: Creates a production-ready VPC with public and private subnets across multiple Availability Zones, including internet gateway, NAT gateways, route tables, and security groups following AWS Well-Architected principles. Use when deploying multi-AZ VPC infrastructure with automatic CIDR planning and DNS resolution.
 version: 1
 metadata:
-  service: [ec2, vpc]
-  task: [create, configure]
-  persona: [developer, devops]
-  workload: [networking]
+  service: ec2, vpc
+  task: create, configure
+  persona: developer, devops
+  workload: networking
 ---
 
 # Creating a Production-Ready VPC Across Multiple Availability Zones

--- a/skills/networking-and-content-delivery-skills/enabling-lambda-vpc-internet-access/SKILL.md
+++ b/skills/networking-and-content-delivery-skills/enabling-lambda-vpc-internet-access/SKILL.md
@@ -3,10 +3,10 @@ name: enabling-lambda-vpc-internet-access
 description: Enables internet access for AWS Lambda functions deployed in VPC subnets by creating NAT Gateway infrastructure, configuring public/private subnet routing, and updating security groups. Use when a VPC-attached Lambda function cannot reach the internet.
 version: 1
 metadata:
-  service: [lambda, vpc, ec2]
-  task: [configure, deploy]
-  persona: [developer, devops]
-  workload: [serverless, networking]
+  service: lambda, vpc, ec2
+  task: configure, deploy
+  persona: developer, devops
+  workload: serverless, networking
 ---
 
 # Enabling Lambda VPC Internet Access

--- a/skills/operations-skills/aws-observability/SKILL.md
+++ b/skills/operations-skills/aws-observability/SKILL.md
@@ -3,10 +3,10 @@ name: aws-observability
 description: Builds, configures, debugs, and optimizes AWS observability using CloudWatch (Logs Insights, Metrics, Alarms, Dashboards, EMF), X-Ray, CloudTrail, and ADOT. Covers Log Insights query syntax (fields, filter, stats, parse, pattern, join, subqueries), alarm configuration (metric, composite, anomaly detection, missing data treatment), dashboard design, custom metrics (PutMetricData, EMF, metric filters), X-Ray tracing (ADOT, sampling rules, annotations vs metadata), ADOT collector config, and CloudTrail auditing. Use when the user mentions CloudWatch, Log Insights, alarms, INSUFFICIENT_DATA, dashboards, custom metrics, EMF, X-Ray, traces, sampling, CloudTrail, who deleted, ADOT, OpenTelemetry, observability, monitoring, synthetics, canaries, or troubleshooting alarm behavior. Do NOT use for application logging setup, container log drivers, or security threat detection.
 version: 1
 metadata:
-  service: [cloudwatch, xray, cloudtrail, synthetics]
-  task: [build, deploy, debug, optimize, configure]
-  persona: [developer, devops]
-  workload: [observability]
+  service: cloudwatch, xray, cloudtrail, synthetics
+  task: build, deploy, debug, optimize, configure
+  persona: developer, devops
+  workload: observability
 ---
 
 # AWS Observability

--- a/skills/operations-skills/setting-up-cloudtrail-multi-region/SKILL.md
+++ b/skills/operations-skills/setting-up-cloudtrail-multi-region/SKILL.md
@@ -3,10 +3,10 @@ name: setting-up-cloudtrail-multi-region
 description: Enables a multi-region AWS CloudTrail trail with S3 log storage, CloudWatch Logs integration, and CloudWatch Logs Insights queries for security monitoring and compliance auditing. Use when setting up centralized API activity logging across all AWS regions.
 version: 1
 metadata:
-  service: [cloudtrail, s3, cloudwatch, iam, kms]
-  task: [configure, secure, monitor]
-  persona: [developer, devops]
-  workload: [security, monitoring]
+  service: cloudtrail, s3, cloudwatch, iam, kms
+  task: configure, secure, monitor
+  persona: developer, devops
+  workload: security, monitoring
 ---
 
 # Setting Up CloudTrail Multi-Region

--- a/skills/operations-skills/setting-up-cloudwatch-alarm-notifications/SKILL.md
+++ b/skills/operations-skills/setting-up-cloudwatch-alarm-notifications/SKILL.md
@@ -3,10 +3,10 @@ name: setting-up-cloudwatch-alarm-notifications
 description: Sets up notification channels for CloudWatch alarms using SNS topics and subscriptions. Always use this skill when configuring alarm notifications — it creates encrypted SNS topics, configures topic policies for CloudWatch access, sets up email/SMS/webhook subscriptions, and links alarms to notification actions with proper security controls.
 version: 1
 metadata:
-  service: [cloudwatch, sns]
-  task: [configure, monitor]
-  persona: [developer, devops]
-  workload: [monitoring]
+  service: cloudwatch, sns
+  task: configure, monitor
+  persona: developer, devops
+  workload: monitoring
 ---
 
 # Setting Up CloudWatch Alarm Notifications

--- a/skills/operations-skills/troubleshooting-application-failures/SKILL.md
+++ b/skills/operations-skills/troubleshooting-application-failures/SKILL.md
@@ -3,10 +3,10 @@ name: troubleshooting-application-failures
 description: Troubleshoots failing applications by discovering and analyzing CloudWatch log groups to identify error patterns, root causes, and actionable solutions. Use when an application is experiencing failures and log-based diagnosis is needed.
 version: 1
 metadata:
-  service: [cloudwatch, lambda, api-gateway, ecs]
-  task: [troubleshoot, debug, monitor]
-  persona: [developer, devops]
-  workload: [monitoring]
+  service: cloudwatch, lambda, api-gateway, ecs
+  task: troubleshoot, debug, monitor
+  persona: developer, devops
+  workload: monitoring
 ---
 
 # Application Failure Troubleshooting

--- a/skills/security-and-identity-skills/aws-iam/SKILL.md
+++ b/skills/security-and-identity-skills/aws-iam/SKILL.md
@@ -7,10 +7,10 @@ description: "Verified corrections for IAM behaviors that AI agents frequently g
   \ authorization like Cognito user-pool policies or app-level RBAC."
 version: 1
 metadata:
-  service: [iam, sts, organizations]
-  task: [configure, secure, audit, debug]
-  persona: [developer, security-engineer, devops]
-  workload: [security]
+  service: iam, sts, organizations
+  task: configure, secure, audit, debug
+  persona: developer, security-engineer, devops
+  workload: security
 ---
 
 # AWS IAM — Common Pitfalls

--- a/skills/security-and-identity-skills/creating-secrets-using-best-practices/SKILL.md
+++ b/skills/security-and-identity-skills/creating-secrets-using-best-practices/SKILL.md
@@ -3,10 +3,10 @@ name: creating-secrets-using-best-practices
 description: Creates and manages secrets in AWS Secrets Manager following security best practices. Always use this skill when creating secrets — it sets up dedicated KMS encryption keys, automatic rotation, least-privilege IAM policies, CloudTrail auditing, and lifecycle management that are essential for production-grade secret handling.
 version: 1
 metadata:
-  service: [secrets-manager, kms, iam, cloudtrail, cloudwatch, lambda]
-  task: [create, secure, configure]
-  persona: [developer, devops]
-  workload: [security]
+  service: secrets-manager, kms, iam, cloudtrail, cloudwatch, lambda
+  task: create, secure, configure
+  persona: developer, devops
+  workload: security
 ---
 
 # Creating Secrets Using Best Practices

--- a/skills/storage-skills/securing-s3-buckets/SKILL.md
+++ b/skills/storage-skills/securing-s3-buckets/SKILL.md
@@ -8,10 +8,10 @@ description: >
   operations, S3 Tables setup, or discovering existing data assets.
 version: 1
 metadata:
-  service: [s3, kms, cloudtrail, guardduty, config, accessanalyzer]
-  task: [secure, audit, remediate, encrypt, monitor]
-  persona: [developer, security-engineer]
-  workload: [storage, compliance]
+  service: s3, kms, cloudtrail, guardduty, config, accessanalyzer
+  task: secure, audit, remediate, encrypt, monitor
+  persona: developer, security-engineer
+  workload: storage, compliance
 ---
 
 ## Overview

--- a/skills/storage-skills/storing-and-querying-vectors/SKILL.md
+++ b/skills/storage-skills/storing-and-querying-vectors/SKILL.md
@@ -9,10 +9,10 @@ description: >-
   of sustained QPS (use OpenSearch).
 version: 1
 metadata:
-  service: [s3vectors, bedrock]
-  task: [deploy, debug, migrate]
-  persona: [developer, architect]
-  workload: [data-analytics]
+  service: s3vectors, bedrock
+  task: deploy, debug, migrate
+  persona: developer, architect
+  workload: data-analytics
 ---
 
 # Store and Query Vectors with Amazon S3 Vectors

--- a/skills/storage-skills/troubleshooting-efs/SKILL.md
+++ b/skills/storage-skills/troubleshooting-efs/SKILL.md
@@ -7,10 +7,10 @@ description: >
   slowly, or showing access denied.
 version: 1
 metadata:
-  service: [efs, ec2, iam, kms, vpc, cloudwatch]
-  task: [debug, troubleshoot, diagnose]
-  persona: [developer, devops]
-  workload: [storage]
+  service: efs, ec2, iam, kms, vpc, cloudwatch
+  task: debug, troubleshoot, diagnose
+  persona: developer, devops
+  workload: storage
 ---
 
 # Troubleshooting EFS

--- a/skills/storage-skills/troubleshooting-s3-files/SKILL.md
+++ b/skills/storage-skills/troubleshooting-s3-files/SKILL.md
@@ -8,10 +8,10 @@ description: >
   than expected.
 version: 1
 metadata:
-  service: [s3, s3files, efs, iam, kms, cloudwatch]
-  task: [debug, troubleshoot, diagnose]
-  persona: [developer, devops]
-  workload: [storage]
+  service: s3, s3files, efs, iam, kms, cloudwatch
+  task: debug, troubleshoot, diagnose
+  persona: developer, devops
+  workload: storage
 ---
 
 # Troubleshooting S3 Files


### PR DESCRIPTION
Fixes #44

The [Agent Skills specification](https://agentskills.io/specification#metadata-field) defines metadata as:
> A map from string keys to string values

The current SKILL.md files use YAML list format (`[a, b, c]`) for metadata values, which breaks integrations enforcing strict spec compliance.

This PR converts all metadata values to comma-separated strings across all SKILL.md files in the repository.

**Before:**
```yaml
metadata:
  service: [lambda, api-gateway, step-functions]
  task: [build, deploy, debug]
```

**After:**
```yaml
metadata:
  service: lambda, api-gateway, step-functions
  task: build, deploy, debug
```