### PR TITLE
feat: add secret safety hook and skill for AI agent credential protec…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 .vscode/
 .env
 .claude/settings.local.json
+__pycache__/

--- a/plugins/aws-core/hooks/hooks.json
+++ b/plugins/aws-core/hooks/hooks.json
@@ -1,0 +1,65 @@
+{
+  "description": "Prevents AI agents from directly fetching secret values via AWS Secrets Manager API calls",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(aws secretsmanager get-secret-value*)",
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "if": "Bash(aws secretsmanager batch-get-secret-value*)",
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "if": "Bash(curl*localhost:2773/secretsmanager/get*)",
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "if": "Bash(curl*127.0.0.1:2773/secretsmanager/get*)",
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "if": "Bash(*get_secret_value*)",
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "if": "Bash(*batch_get_secret_value*)",
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "use_aws|mcp__aws.*|mcp__plugin_*aws-mcp*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/aws-core/hooks/secret-safety.py
+++ b/plugins/aws-core/hooks/secret-safety.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block direct secret fetching from AWS Secrets Manager.
+
+Reads JSON from stdin, checks tool_name and tool_input, and returns
+a deny decision if the call would fetch secret values directly.
+
+Use {{resolve:secretsmanager:secret-id:SecretString:key}} with asm-exec instead.
+"""
+
+import json
+import re
+import sys
+
+DENY_MSG = (
+    "Direct secret fetching is blocked. "
+    "Use {{resolve:secretsmanager:secret-id:SecretString:key}} with asm-exec instead. "
+    "Run /aws-secrets-manager for details."
+)
+
+SMA_PATTERN = re.compile(
+    r'(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1):2773/secretsmanager/get'
+)
+
+# Match the operation regardless of casing/separators:
+# GetSecretValue, get_secret_value, get-secret-value, BatchGetSecretValue, ...
+GSV_PATTERN = re.compile(r'(batch[-_]?)?get[-_]?secret[-_]?value', re.I)
+
+# Structured operation names normalized to lowercase, no separators.
+GSV_OPERATIONS = ("getsecretvalue", "batchgetsecretvalue")
+
+
+def _normalize_op(operation):
+    """Collapse casing and -/_ separators so GetSecretValue == get-secret-value."""
+    return operation.lower().replace("-", "").replace("_", "")
+
+
+def deny():
+    json.dump({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": DENY_MSG
+        }
+    }, sys.stdout)
+    sys.exit(0)
+
+
+def allow():
+    sys.exit(0)
+
+
+def main():
+    data = json.load(sys.stdin)
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+
+    # Check structured AWS tool calls (use_aws or MCP AWS tools)
+    if tool_name == "use_aws" or tool_name.startswith("mcp__"):
+        service = (tool_input.get("service_name") or tool_input.get("service") or tool_input.get("serviceName") or "").lower()
+        operation = tool_input.get("operation_name") or tool_input.get("operation") or tool_input.get("operationName") or ""
+        if service == "secretsmanager" and _normalize_op(operation) in GSV_OPERATIONS:
+            deny()
+        # Fallback: search all string values for secret-fetching patterns
+        if GSV_PATTERN.search(json.dumps(tool_input)):
+            if "secretsmanager" in json.dumps(tool_input).lower():
+                deny()
+        # Check run_script tools for secret fetching in code
+        if "run_script" in tool_name:
+            for key, val in tool_input.items():
+                if isinstance(val, str) and GSV_PATTERN.search(val):
+                    deny()
+            if GSV_PATTERN.search(json.dumps(tool_input)):
+                deny()
+        allow()
+
+    # Check Bash commands
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        # AWS CLI secret fetching
+        if re.search(r'aws\s+secretsmanager\s+(get-secret-value|batch-get-secret-value)', command, re.I):
+            deny()
+        # Direct SMA access
+        if SMA_PATTERN.search(command):
+            deny()
+        # boto3/SDK secret fetching in scripts
+        if GSV_PATTERN.search(command):
+            deny()
+
+    allow()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/aws-core/skills/aws-secrets-manager/SKILL.md
+++ b/plugins/aws-core/skills/aws-secrets-manager/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: aws-secrets-manager
+description: >
+  Secret safety for AWS Secrets Manager, secret management, credentials, API keys,
+  tokens, and passwords. Prevents AI agents from directly fetching secret values
+  and teaches runtime dynamic references with asm-exec so plaintext never enters
+  the LLM context window.
+version: 1
+---
+
+# Using Secrets Safely with Agents
+
+## Overview
+
+When AI agents handle secrets, credentials, API keys, tokens, or passwords with
+shell or AWS API access, they can call `aws secretsmanager get-secret-value`
+and receive plaintext values in their context window. This creates risk:
+secrets may leak into logs, conversation history, or downstream tool calls.
+
+This skill teaches a safer pattern: **dynamic references** resolved at runtime
+by a wrapper script (`asm-exec`), so the agent never sees the secret value.
+
+> **Best-effort defense, not a security boundary.** This prevents the most common
+> leakage path but cannot stop all evasion vectors. Combine with IAM
+> least-privilege, CloudTrail monitoring, and VPC endpoint policies.
+
+## Rules
+
+You MUST follow these rules when working with secrets:
+
+1. **MUST NOT call `get-secret-value` or `batch-get-secret-value`** -- not via AWS
+   CLI, SDK, MCP tools, curl, or any other mechanism.
+2. **MUST NOT attempt to read secret values** from the Secrets Manager Agent (SMA)
+   daemon directly (localhost:2773 or any loopback variant).
+3. **MUST use `{{resolve:secretsmanager:...}}` references** -- these are
+   resolved at runtime by `asm-exec` without exposing values to you.
+
+## The `{{resolve:...}}` Syntax
+
+```
+{{resolve:secretsmanager:<secret-id>:<field-type>:<json-key>:<version-stage>}}
+```
+
+| Component | Required | Default | Example |
+|-----------|----------|---------|---------|
+| `secret-id` | Yes | -- | `prod/db-creds` or full ARN |
+| `field-type` | No | `SecretString` | `SecretString` |
+| `json-key` | No | (full value) | `password` |
+| `version-stage` | No | `AWSCURRENT` | `AWSPENDING` |
+
+## Using `asm-exec`
+
+`asm-exec` is a wrapper that resolves `{{resolve:...}}` references in command
+arguments and environment variables, then `exec`s the target command. The secret
+value exists only in the child process -- never in the agent's context.
+
+### Usage
+
+```bash
+# Pass a database password to psql without exposing it
+asm-exec -- psql \
+  "host=mydb.example.com \
+   user={{resolve:secretsmanager:prod/db-creds:SecretString:username}} \
+   password={{resolve:secretsmanager:prod/db-creds:SecretString:password}}" \
+  -c "SELECT * FROM users LIMIT 10"
+
+# Use default field-type (SecretString) and full value (no json-key)
+asm-exec -- curl -H "Authorization: Bearer {{resolve:secretsmanager:prod/api-token}}" \
+  https://api.example.com/data
+
+# Multiple secrets in one command
+asm-exec -- mysql \
+  -h {{resolve:secretsmanager:prod/mysql:SecretString:host}} \
+  -u {{resolve:secretsmanager:prod/mysql:SecretString:username}} \
+  -p{{resolve:secretsmanager:prod/mysql:SecretString:password}} \
+  -e "SHOW TABLES"
+```
+
+### How It Works
+
+1. Scans all command arguments for `{{resolve:...}}` patterns
+2. Resolves each reference through the first available backend, in order:
+   1. **AWS Secrets Manager Agent (SMA)** on localhost:2773 (zero-latency, cached)
+   2. **AWS MCP endpoint** (`https://aws-mcp.us-east-1.api.aws/mcp`), calling the
+      `aws___call_aws` tool over a SigV4-signed request
+   3. Determines the secret's region from an ARN's region segment, or from
+      `AWS_REGION` / `AWS_DEFAULT_REGION`, and passes it to the resolver
+3. Substitutes resolved values using `re.sub` with a callable (single-pass --
+   prevents re-scan injection if a secret value contains `{{resolve:...}}`)
+4. Runs the target command via `subprocess.run` -- secret values exist only in the
+   asm-exec process, never in the agent's context window
+
+> **No local AWS CLI fallback for resolution.** `asm-exec` does not shell out to
+> `aws secretsmanager get-secret-value` to resolve references. Resolution happens
+> only through SMA or the MCP endpoint, so the plaintext value is never written to
+> a local process's stdout where it could be captured.
+
+### SigV4 signing
+
+The MCP endpoint authenticates every tool call with AWS SigV4. `asm-exec` signs
+requests itself using only the Python standard library (`hashlib`/`hmac`) -- it
+does **not** depend on botocore or spin up the `mcp-proxy-for-aws` proxy, keeping
+the wrapper a lightweight ephemeral process. The signing service and region are
+inferred from the endpoint hostname (e.g. `aws-mcp.us-east-1.api.aws` ->
+service `aws-mcp`, region `us-east-1`); this signing region is independent of the
+secret's own region, which is passed as `--region` to the server-side CLI command.
+
+Credentials for signing are resolved in order: environment variables
+(`AWS_ACCESS_KEY_ID` etc.), `aws configure export-credentials` (AWS CLI v2), then
+`aws configure get` (AWS CLI v1).
+
+### Prerequisites
+
+Either backend must be reachable, with credentials that have
+`secretsmanager:GetSecretValue` permission:
+
+- **AWS Secrets Manager Agent (SMA)** running on localhost:2773, OR
+- **AWS credentials** resolvable for SigV4 signing of the MCP endpoint (see above).
+  For cross-region secrets, set `AWS_REGION` (or use a full ARN) so the correct
+  region is targeted.
+
+See [SMA setup guide](https://docs.aws.amazon.com/secretsmanager/latest/userguide/secrets-manager-agent.html).
+
+## Common Patterns
+
+### Database connections
+
+```bash
+asm-exec -- psql "postgresql://{{resolve:secretsmanager:prod/db:SecretString:username}}:{{resolve:secretsmanager:prod/db:SecretString:password}}@db.example.com:5432/mydb"
+```
+
+### Docker with secrets
+
+```bash
+asm-exec -- docker run -e "DB_PASSWORD={{resolve:secretsmanager:prod/db:SecretString:password}}" myapp:latest
+```
+
+### Configuration file templating
+
+```bash
+# Generate config with resolved secrets, write to file
+asm-exec -- sh -c 'echo "password={{resolve:secretsmanager:app/db:SecretString:password}}" > /tmp/app.conf'
+```
+
+## Structural Enforcement (Plugin Hook)
+
+When the `aws-core` plugin is enabled, a `PreToolUse` hook automatically blocks
+any attempt to call `get-secret-value` or `batch-get-secret-value` -- via AWS CLI,
+MCP tools, or direct SMA access. No manual configuration needed.
+
+The hook is defined at `plugins/aws-core/hooks/hooks.json` and activates
+automatically when the plugin is installed.
+
+## Troubleshooting
+
+### "Secret not found" errors
+
+Verify the secret exists and your IAM role has `secretsmanager:GetSecretValue`
+permission. Check the secret name matches exactly (case-sensitive).
+
+### SMA connection refused
+
+The Secrets Manager Agent may not be running. This is non-fatal: `asm-exec`
+falls through to the SigV4-signed MCP endpoint. Ensure AWS credentials are
+resolvable (see SigV4 signing above) so that backend can authenticate.
+
+### "Failed to resolve" errors
+
+Both backends were unreachable or returned no value. Check that either SMA is
+running or AWS credentials are valid (`aws sts get-caller-identity`), that the
+secret's region is correct (set `AWS_REGION` or use a full ARN), and that your
+identity has `secretsmanager:GetSecretValue` on the secret. A `401` from the MCP
+endpoint indicates a SigV4 signing or credential problem, not a missing secret.
+
+### Resolution produces empty string
+
+The JSON key may not exist in the secret value. Verify the secret structure
+in the AWS Console or ask the secret owner to confirm the available keys.

--- a/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
+++ b/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""asm-exec: Resolve {{resolve:secretsmanager:...}} references and run the command.
+
+Usage: asm-exec <command> [args...]
+
+Resolves dynamic references in arguments and exported environment variables,
+then runs the command. Secret values never return to the calling agent.
+
+Resolution order:
+  1. AWS Secrets Manager Agent (SMA) on localhost:2773 (zero-latency, cached)
+  2. Streamable HTTP MCP endpoint (requires AWS credentials)
+
+Security: Uses re.sub with callable for single-pass substitution (resolved
+values are never re-scanned). SecretBinary is not supported.
+"""
+
+import datetime
+import hashlib
+import hmac
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def _shell_quote(value):
+    """Quote a value for safe inclusion in the cli_command string."""
+    return shlex.quote(value)
+
+PATTERN = re.compile(r'\{\{resolve:secretsmanager:([^}]+)\}\}')
+SMA_ENDPOINT = os.environ.get('AWS_SECRETS_MANAGER_AGENT_ENDPOINT', 'http://localhost:2773')
+SSRF_TOKEN = os.environ.get('AWS_SESSION_TOKEN', os.environ.get('AWS_TOKEN', ''))
+MCP_ENDPOINT = os.environ.get('ASM_EXEC_MCP_ENDPOINT', 'https://aws-mcp.us-east-1.api.aws/mcp')
+
+_sma_available = None
+
+
+def _check_sma():
+    global _sma_available
+    if _sma_available is None:
+        try:
+            req = urllib.request.Request(f'{SMA_ENDPOINT}/ping', method='GET')
+            urllib.request.urlopen(req, timeout=1)
+            _sma_available = True
+        except (urllib.error.URLError, OSError):
+            _sma_available = False
+    return _sma_available
+
+
+def _get_aws_credentials():
+    """Resolve AWS credentials for SigV4 signing.
+
+    Order: environment variables, then `aws configure export-credentials`
+    (AWS CLI v2), then `aws configure get` (AWS CLI v1, which lacks
+    export-credentials). Returns a dict with access_key/secret_key/token or None.
+    """
+    if os.environ.get('AWS_ACCESS_KEY_ID'):
+        return {
+            'access_key': os.environ['AWS_ACCESS_KEY_ID'],
+            'secret_key': os.environ.get('AWS_SECRET_ACCESS_KEY', ''),
+            'token': os.environ.get('AWS_SESSION_TOKEN', ''),
+        }
+    # AWS CLI v2: export-credentials emits resolved (possibly assumed-role) creds.
+    try:
+        result = subprocess.run(
+            ['aws', 'configure', 'export-credentials', '--format', 'env'],
+            capture_output=True, text=True, check=True, timeout=5
+        )
+        creds = {}
+        for line in result.stdout.splitlines():
+            if '=' in line:
+                line = line.removeprefix('export ')
+                k, v = line.split('=', 1)
+                if k == 'AWS_ACCESS_KEY_ID':
+                    creds['access_key'] = v
+                elif k == 'AWS_SECRET_ACCESS_KEY':
+                    creds['secret_key'] = v
+                elif k == 'AWS_SESSION_TOKEN':
+                    creds['token'] = v
+        if creds.get('access_key'):
+            return creds
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    # AWS CLI v1 fallback: read static creds from the configured profile.
+    try:
+        def _cfg(key):
+            r = subprocess.run(['aws', 'configure', 'get', key],
+                               capture_output=True, text=True, timeout=5)
+            return r.stdout.strip() if r.returncode == 0 else ''
+        access_key = _cfg('aws_access_key_id')
+        if access_key:
+            return {
+                'access_key': access_key,
+                'secret_key': _cfg('aws_secret_access_key'),
+                'token': _cfg('aws_session_token'),
+            }
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _signing_service_region(endpoint):
+    """Derive (service, region) for SigV4 from an AWS MCP endpoint hostname.
+
+    Mirrors mcp-proxy-for-aws: 'service.region.api.aws' -> (service, region);
+    'bedrock-agentcore' style is handled as a special case. The signing region
+    is the endpoint's own region, independent of any secret's region.
+    """
+    host = urllib.parse.urlparse(endpoint).hostname or ''
+    parts = host.split('.')
+    if len(parts) >= 5 and parts[-4] == 'bedrock-agentcore' and parts[-2:] == ['amazonaws', 'com']:
+        return 'bedrock-agentcore', parts[-3]
+    if len(parts) == 4 and parts[2:] == ['api', 'aws']:
+        return parts[0], parts[1]
+    # Fallback: first segment as service, region from environment.
+    region = os.environ.get('AWS_REGION') or os.environ.get('AWS_DEFAULT_REGION') or 'us-east-1'
+    return (parts[0] if parts else 'aws-mcp'), region
+
+
+def _sign_v4(method, path, body, creds, service, region, now):
+    """Compute SigV4 headers (stdlib only) for a request. Returns a header dict.
+
+    botocore is not available in asm-exec's runtime, so signing is implemented
+    directly with hashlib/hmac following the AWS SigV4 spec.
+    """
+    host = urllib.parse.urlparse(MCP_ENDPOINT).hostname or ''
+    amzdate = now.strftime('%Y%m%dT%H%M%SZ')
+    datestamp = now.strftime('%Y%m%d')
+    payload_hash = hashlib.sha256(body).hexdigest()
+
+    headers = {
+        'host': host,
+        'x-amz-date': amzdate,
+        'x-amz-content-sha256': payload_hash,
+    }
+    if creds.get('token'):
+        headers['x-amz-security-token'] = creds['token']
+
+    signed_keys = sorted(headers)
+    canonical_headers = ''.join(f'{k}:{headers[k].strip()}\n' for k in signed_keys)
+    signed_headers_str = ';'.join(signed_keys)
+    canonical_request = (f'{method}\n{path}\n\n{canonical_headers}\n'
+                         f'{signed_headers_str}\n{payload_hash}')
+
+    scope = f'{datestamp}/{region}/{service}/aws4_request'
+    string_to_sign = (f'AWS4-HMAC-SHA256\n{amzdate}\n{scope}\n'
+                      f'{hashlib.sha256(canonical_request.encode()).hexdigest()}')
+
+    def _hmac(key, msg):
+        return hmac.new(key, msg.encode('utf-8'), hashlib.sha256).digest()
+
+    k_date = _hmac(('AWS4' + creds['secret_key']).encode('utf-8'), datestamp)
+    k_region = _hmac(k_date, region)
+    k_service = _hmac(k_region, service)
+    k_signing = _hmac(k_service, 'aws4_request')
+    signature = hmac.new(k_signing, string_to_sign.encode('utf-8'),
+                         hashlib.sha256).hexdigest()
+
+    headers['Authorization'] = (
+        f'AWS4-HMAC-SHA256 Credential={creds["access_key"]}/{scope}, '
+        f'SignedHeaders={signed_headers_str}, Signature={signature}'
+    )
+    return headers
+
+
+def _mcp_post(payload, session_id=None):
+    """POST a SigV4-signed JSON-RPC request to the AWS MCP endpoint.
+
+    Returns (parsed_response, session_id_from_response). The caller passes the
+    session id returned by 'initialize' back into subsequent calls.
+    """
+    creds = _get_aws_credentials()
+    if not creds or not creds.get('access_key'):
+        raise RuntimeError('no AWS credentials available for MCP signing')
+
+    body = json.dumps(payload).encode()
+    service, region = _signing_service_region(MCP_ENDPOINT)
+    path = urllib.parse.urlparse(MCP_ENDPOINT).path or '/'
+    now = datetime.datetime.utcnow()
+
+    sig_headers = _sign_v4('POST', path, body, creds, service, region, now)
+    req = urllib.request.Request(MCP_ENDPOINT, data=body, method='POST')
+    req.add_header('Content-Type', 'application/json')
+    req.add_header('Accept', 'application/json, text/event-stream')
+    req.add_header('User-Agent', 'ASMExecWrapper/1.0.0')
+    if session_id:
+        req.add_header('Mcp-Session-Id', session_id)
+    for k, v in sig_headers.items():
+        req.add_header(k, v)
+
+    resp = urllib.request.urlopen(req, timeout=10)
+    session_out = resp.headers.get('Mcp-Session-Id')
+    raw = resp.read()
+    parsed = json.loads(raw) if raw else {}
+    return parsed, session_out
+
+
+def _extract_secret_string(payload):
+    """Pull SecretString out of a parsed get-secret-value response dict."""
+    if isinstance(payload, dict):
+        if "SecretString" in payload:
+            return payload["SecretString"]
+        # call_aws may nest the CLI output under a results/output key
+        for key in ("result", "results", "output", "stdout"):
+            if key in payload:
+                nested = payload[key]
+                if isinstance(nested, str):
+                    try:
+                        nested = json.loads(nested)
+                    except json.JSONDecodeError:
+                        continue
+                found = _extract_secret_string(nested)
+                if found:
+                    return found
+    return None
+
+
+def _resolve_via_mcp(secret_name, label, region):
+    """Resolve a secret via the SigV4-authenticated AWS MCP endpoint.
+
+    The server exposes 'aws___call_aws', which runs a full AWS CLI command
+    (passed as the 'cli_command' string) server-side and returns its output.
+    The SecretString returns into this process and never reaches the agent.
+    Returns the value or None.
+    """
+    try:
+        # Initialize and capture the session id for subsequent calls.
+        _, session_id = _mcp_post(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize",
+             "params": {"protocolVersion": "2024-11-05",
+                        "clientInfo": {"name": "asm-exec", "version": "1.0.0"},
+                        "capabilities": {}}})
+        # Notify initialized
+        _mcp_post({"jsonrpc": "2.0", "method": "notifications/initialized"},
+                  session_id)
+        # Build the CLI command string the MCP server will execute. Include
+        # --region so cross-region secrets resolve regardless of the endpoint's
+        # home region. The secret id is quoted to tolerate ARNs and shell metachars.
+        cmd_parts = ["aws", "secretsmanager", "get-secret-value",
+                     "--secret-id", _shell_quote(secret_name),
+                     "--version-stage", _shell_quote(label),
+                     "--output", "json"]
+        if region:
+            cmd_parts += ["--region", region]
+        cli_command = " ".join(cmd_parts)
+        # Call tool
+        resp, _ = _mcp_post(
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+             "params": {"name": "aws___call_aws",
+                        "arguments": {"cli_command": cli_command}}},
+            session_id)
+        result = resp.get("result", {})
+        # tools/call returns a content array of text items
+        if isinstance(result, dict) and "content" in result:
+            for item in result["content"]:
+                if item.get("type") == "text":
+                    try:
+                        data = json.loads(item["text"])
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    found = _extract_secret_string(data)
+                    if found:
+                        return found
+        if isinstance(result, dict):
+            return _extract_secret_string(result)
+    except (urllib.error.URLError, OSError, json.JSONDecodeError,
+            KeyError, TypeError, RuntimeError):
+        pass
+    return None
+
+
+def resolve_one(ref):
+    """Resolve secret-id[:field-type[:json-key[:version-stage]]].
+
+    Secret-id may be an ARN (contains colons) or a plain name.
+    ARN format: arn:aws:secretsmanager:<Region>:<AccountId>:secret:<SecretName>-<6RandomChars>
+    """
+    # ARN-aware split: if ref starts with 'arn:', treat everything up to
+    # the 7th colon as the secret-id (6 colons in a standard ARN)
+    if ref.startswith('arn:'):
+        arn_parts = ref.split(':')
+        # Standard ARN has 7 segments (indices 0-6): arn:partition:service:region:account:resource-type:resource-id
+        if len(arn_parts) >= 7:
+            secret_name = ':'.join(arn_parts[:7])
+            remainder = arn_parts[7:]
+        else:
+            secret_name = ref
+            remainder = []
+        field_type = remainder[0] if len(remainder) > 0 else 'SecretString'
+        json_key = remainder[1] if len(remainder) > 1 else None
+        label = remainder[2] if len(remainder) > 2 else 'AWSCURRENT'
+    else:
+        parts = ref.split(':', 3)
+        secret_name = parts[0]
+        field_type = parts[1] if len(parts) > 1 else 'SecretString'
+        json_key = parts[2] if len(parts) > 2 else None
+        label = parts[3] if len(parts) > 3 else 'AWSCURRENT'
+
+    if field_type != 'SecretString':
+        print(f'asm-exec: ERROR: Only SecretString is supported, got: {field_type}', file=sys.stderr)
+        sys.exit(1)
+
+    value = None
+
+    # Region for cross-region secrets: honor an ARN's region segment first,
+    # then fall back to the ambient AWS_REGION / AWS_DEFAULT_REGION.
+    region = None
+    if secret_name.startswith('arn:'):
+        arn_segments = secret_name.split(':')
+        if len(arn_segments) >= 4 and arn_segments[3]:
+            region = arn_segments[3]
+    if not region:
+        region = os.environ.get('AWS_REGION') or os.environ.get('AWS_DEFAULT_REGION')
+
+    # 1. Try SMA daemon
+    if _check_sma():
+        url = f'{SMA_ENDPOINT}/secretsmanager/get?secretId={urllib.parse.quote(secret_name, safe="")}&versionStage={label}'
+        req = urllib.request.Request(url, method='GET')
+        if SSRF_TOKEN:
+            req.add_header('X-Aws-Parameters-Secrets-Token', SSRF_TOKEN)
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                data = json.loads(resp.read())
+                value = data.get('SecretString')
+        except (urllib.error.URLError, OSError, json.JSONDecodeError):
+            pass
+
+    # 2. Resolve via Streamable HTTP MCP
+    if not value:
+        value = _resolve_via_mcp(secret_name, label, region)
+
+    if not value:
+        print(f'asm-exec: ERROR: Failed to resolve: {ref}', file=sys.stderr)
+        sys.exit(1)
+
+    if json_key:
+        try:
+            obj = json.loads(value)
+            value = obj[json_key]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            print(f"asm-exec: ERROR: JSON key '{json_key}' not found in: {secret_name}", file=sys.stderr)
+            sys.exit(1)
+        if not isinstance(value, str):
+            value = json.dumps(value)
+
+    return value
+
+
+def resolve_string(s):
+    """Single-pass substitution — resolved values are never re-scanned."""
+    return PATTERN.sub(lambda m: resolve_one(m.group(1)), s)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: asm-exec <command> [args...]', file=sys.stderr)
+        sys.exit(1)
+
+    cmd_args = sys.argv[1:]
+    # Strip optional -- separator (convention: asm-exec -- command)
+    if cmd_args and cmd_args[0] == '--':
+        cmd_args = cmd_args[1:]
+    if not cmd_args:
+        print('Usage: asm-exec <command> [args...]', file=sys.stderr)
+        sys.exit(1)
+
+    args = [resolve_string(a) if PATTERN.search(a) else a for a in cmd_args]
+
+    result = subprocess.run(args)
+    sys.exit(result.returncode)
+
+
+if __name__ == '__main__':
+    main()

--- a/rules/aws-agent-rules.md
+++ b/rules/aws-agent-rules.md
@@ -15,3 +15,12 @@
   principles.
 - Do not use em dashes in AWS resource names or descriptions. Use
   hyphens instead.
+
+## Secret Safety
+
+- MUST load the `aws-secrets-manager` skill first for any secret,
+  credential, API key, token, or password task. MUST NOT call
+  `secretsmanager get-secret-value` or `batch-get-secret-value`, and MUST
+  NOT hit the Secrets Manager Agent daemon directly. MUST use
+  `{{resolve:secretsmanager:secret-id:SecretString:json-key}}` with
+  `asm-exec` so the secret resolves at runtime without entering context.


### PR DESCRIPTION
## Description

Adds a secret safety capability to the aws-core plugin that prevents AI agents from directly fetching secret values via AWS Secrets Manager API calls.

**Problem:** AI agents with shell or AWS API access can call `get-secret-value` and receive plaintext secrets in their context window, creating risk of leakage into logs, conversation history, or downstream tool calls.

**Solution:** Three-layer defense:
1. **Plugin hook** (`plugins/aws-core/hooks/`) — `PreToolUse` hook structurally blocks `get-secret-value` and `batch-get-secret-value` before execution (via CLI, MCP tools, or direct SMA access)
2. **Skill** (`using-secrets-safely-with-agents`) — teaches agents the safe alternative: `{{resolve:secretsmanager:secret-id:SecretString:json-key:version-stage}}` dynamic references resolved at runtime by `asm-exec`
3. **Rules** — behavioral constraints added to `aws-agent-rules.md`

The `asm-exec` wrapper resolves references via the Secrets Manager Agent (localhost:2773) or AWS MCP fallback, then runs the target command. Secret values never enter the agent's context. Python 3.8+, stdlib-only, cross-platform (Windows/macOS/Linux).

This is a best-effort defense, not a security boundary — determined adversaries can evade via SDK calls or encoded commands.

## Local Testing

```bash
*Hook DENIES direct secret fetching (even with --dangerously-skip-permissions):*
$ claude -p "Run: aws secretsmanager get-secret-value --secret-id test/secret" \
    --plugin-dir ./plugins/aws-core --dangerously-skip-permissions
> The command was blocked by a hook that prevents direct secret fetching.
> Use {{resolve:secretsmanager:SECRET_NAME}} with asm-exec instead.

*Normal commands pass through unaffected:*
$ claude -p "Run: echo hello world" \
    --plugin-dir ./plugins/aws-core --dangerously-skip-permissions
> hello world
```

Validation: python3 tools/validate.py passes.
## Type of Change
- [ ] New plugin
- [x] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [x] Other
## Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass python3 tools/validate.py
- [x] I have updated relevant documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.