### PR TITLE
docs: Add guidance to update the marketplace index when the plugin is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ For `aws-core` that covers service selection, CDK/CloudFormation, serverless, co
 /plugin install aws-core@claude-plugins-official
 ```
 
+> **Tip:** If you get `Plugin not found`, update your local marketplace index first:
+>
+> ```
+> /plugin marketplace update claude-plugins-official
+> ```
+
 For `aws-agents` that covers building AI agents on AWS with Amazon Bedrock and AgentCore:
 
 ```


### PR DESCRIPTION
## Description

As per the documentation:
```
If Claude Code reports that the plugin is not found in any marketplace, your marketplace is either missing or outdated. Run /plugin marketplace update claude-plugins-official to refresh it, or /plugin marketplace add anthropics/claude-plugins-official if you haven’t added it before. Then retry the install.
```

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [X] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [X] My changes pass `python3 tools/validate.py`
- [X] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
