### PR TITLE
docs: Pin the version of the MCP Proxy for AWS to respect best security practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Add the AWS MCP Server to your Kiro MCP configuration (`.kiro/settings/mcp.json`
     "aws": {
       "command": "uvx",
       "args": [
-        "mcp-proxy-for-aws@latest",
+        "mcp-proxy-for-aws@1.6.0",
         "https://aws-mcp.us-east-1.api.aws/mcp",
         "--metadata", "AWS_REGION=us-west-2"
       ]
@@ -67,6 +67,8 @@ Add the AWS MCP Server to your Kiro MCP configuration (`.kiro/settings/mcp.json`
   }
 }
 ```
+
+> **Note:** It is recommended to pin to a specific version (e.g., `@1.6.0`) to ensure reproducible behavior. Using `@latest` may pull in breaking changes. Check [PyPI](https://pypi.org/project/mcp-proxy-for-aws/) for the latest stable version.
 
 Then install skills from this repository:
 


### PR DESCRIPTION
## Description

Pin mcp-proxy-for-aws to version 1.6.0 across all documentation to prevent users from pulling in breaking changes from unreleased versions.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [X] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [X] My changes pass `python3 tools/validate.py`
- [X] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
