### PR TITLE
docs: Update aws-core to pin the version of MCP Proxy for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add the AWS MCP Server to your Kiro MCP configuration (`.kiro/settings/mcp.json`
 }
 ```
 
-> **Note:** It is recommended to pin to a specific version (e.g., `@1.6.0`) to ensure reproducible behavior. Using `@latest` may pull in breaking changes. Check [PyPI](https://pypi.org/project/mcp-proxy-for-aws/) for the latest stable version.
+> **Note:** It is recommended to pin to a specific version (e.g., `@1.6.0`) to ensure reproducible behavior and protect against supply chain risks. We recommend regularly checking [PyPI](https://pypi.org/project/mcp-proxy-for-aws/) for new stable versions and updating accordingly.
 
 Then install skills from this repository:
 

--- a/plugins/aws-core/.mcp.json
+++ b/plugins/aws-core/.mcp.json
@@ -3,7 +3,7 @@
     "aws-mcp": {
       "command": "uvx",
       "args": [
-        "mcp-proxy-for-aws@latest",
+        "mcp-proxy-for-aws@1.6.0",
         "https://aws-mcp.us-east-1.api.aws/mcp"
       ]
     }

--- a/plugins/aws-data-analytics/.mcp.json
+++ b/plugins/aws-data-analytics/.mcp.json
@@ -3,7 +3,7 @@
     "aws-mcp": {
       "command": "uvx",
       "args": [
-        "mcp-proxy-for-aws@latest",
+        "mcp-proxy-for-aws@1.6.0",
         "https://aws-mcp.us-east-1.api.aws/mcp"
       ]
     }


### PR DESCRIPTION
## Description

Pin mcp-proxy-for-aws to @1.6.0 in the `aws-core` plugin, and update the version pinning guidance in the README.

Previously, plugins referenced `@latest` which exposes customers to potential supply chain risks and breaking changes from unreleased versions. Pinning to a known-good version aligns with the shared responsibility model — customers control what runs on their machine — while the updated note recommends regularly checking for new stable releases.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [x] Documentation update
- [ ] CI/CD change
- [x] Other

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [X] My changes pass `python3 tools/validate.py`
- [X] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
