### PR TITLE
feat(aws-cdk): improve skill content with latest CDK guidance

### DIFF
--- a/skills/core-skills/aws-cdk/SKILL.md
+++ b/skills/core-skills/aws-cdk/SKILL.md
@@ -14,7 +14,7 @@ Domain expertise for CDK construct authoring, deployment workflows, compliance, 
 
 ## Critical Warnings
 
-**Deadly embrace**: Removing a cross-stack reference deadlocks deployment. Two-deploy fix required: (1) remove consumer import + add `this.exportValue()` on producer, deploy; (2) remove `exportValue()`, deploy again. See [troubleshooting-deployment](references/troubleshooting-deployment.md).
+**Deadly embrace**: Removing a cross-stack reference deadlocks deployment (`Export ... cannot be deleted as it is in use by ...`). Preferred fix: weaken the reference first — `CrossStackReferences.of($RESOURCE).produce(ReferenceStrength.BOTH)` then `WEAK`, then remove (three deploys). Legacy fallback: two-deploy `this.exportValue()` recipe. See [troubleshooting-deployment](references/troubleshooting-deployment.md).
 
 **Construct ID changes cause replacement**: Renaming/moving a construct changes its logical ID → CloudFormation replaces the resource (data loss for stateful resources). Always `cdk diff` before deploy. See [refactor-and-prevent-replacement](references/refactor-and-prevent-replacement.md).
 
@@ -39,7 +39,7 @@ Domain expertise for CDK construct authoring, deployment workflows, compliance, 
 
 | Error | Cause → Fix |
 |-------|------------|
-| **DeployFailed / DeploymentError** | CDK error is not root cause. Check CFN events: `aws cloudformation describe-stack-events --stack-name $STACK --query "StackEvents[?contains(ResourceStatus,'FAILED')]"`. [Details](references/troubleshooting-deployment.md) |
+| **DeployFailed / DeploymentError** | CDK error isn't the root cause. `cdk deploy $STACK --verbose`, then `cdk --unstable=diagnose diagnose $STACK` (CLI ≥ 2.1120.0); else `aws cloudformation describe-events --stack-name $STACK --filters FailedEvents=true` — the first `_FAILED` event is the cause. [Details](references/troubleshooting-deployment.md) |
 | **NoCredentials / ExpiredToken / AssumeRoleFailed** | `aws sts get-caller-identity` + `cdk doctor`. Expired SSO, missing `env`, missing `sts:AssumeRole`. [Details](references/troubleshooting-credentials.md) |
 | **Asset errors** (CannotFindAsset, FailedToBundleAsset, AssetBuildFailed, AssetPublishFailed) | Path wrong, Docker not running, or bootstrap bucket perms. Use `path.join(__dirname, ...)`. [Details](references/troubleshooting-synth.md) |
 | **AppRequired** | Add `"app": "npx tsx bin/my-app.ts"` to `cdk.json`. [Details](references/troubleshooting-synth.md) |

--- a/skills/core-skills/aws-cdk/references/bootstrap-and-project-setup.md
+++ b/skills/core-skills/aws-cdk/references/bootstrap-and-project-setup.md
@@ -26,14 +26,15 @@
     - [Virtual Environment](#virtual-environment)
     - [Common Commands](#common-commands-1)
   - [Version Management Best Practices](#version-management-best-practices)
+    - [CLI and Library Are Separate Release Tracks](#cli-and-library-are-separate-release-tracks)
+    - [Feature Flags](#feature-flags)
 
 ---
 
 ## Overview
 
 Every CDK deployment target (account + region pair) MUST be bootstrapped before the first
-deployment. Projects MUST be initialized with pinned dependencies and strict tooling to
-ensure reproducible builds.
+deployment. Projects MUST commit a lockfile and SHOULD use strict tooling to ensure reproducible builds.
 
 ---
 
@@ -193,7 +194,7 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Dependencies SHOULD be pinned to exact versions in `requirements.txt`.
+Dependencies SHOULD be captured in `requirements.txt` (or `poetry.lock` / `Pipfile.lock`) and committed for reproducible builds. See [Version Management Best Practices](#version-management-best-practices).
 
 ### Common Commands
 
@@ -208,29 +209,49 @@ cdk doctor          # Check for potential problems
 
 ## Version Management Best Practices
 
-- `aws-cdk-lib` and `constructs` MUST be pinned to exact versions in
-  `package.json` (or `requirements.txt` for Python).
-- The CDK CLI MUST be installed as a pinned dev dependency and invoked via
-  `npx cdk` — MUST NOT be installed globally.
-- `@latest` MUST NOT be used for any CDK package.
-- Teams SHOULD automate weekly dependency upgrades (e.g., Dependabot, Renovate)
-  to stay current without manual drift.
+- **Commit lockfiles** (`package-lock.json` / `poetry.lock` / `Pipfile.lock`). Unlocked builds drift and lose determinism.
+- **For CDK applications**, use **caret (`^`) ranges** for `aws-cdk-lib` and `constructs` in `dependencies` — this is the officially recommended approach. The lockfile provides reproducibility; the caret range lets `npm update` pull compatible fixes and features.
+
+  ```json
+  {
+    "dependencies": {
+      "aws-cdk-lib": "^2.170.0",
+      "constructs": "^10.5.0"
+    }
+  }
+  ```
+
+  Teams that prefer exact pinning for stricter reproducibility SHOULD pair it with automated upgrade tooling (Dependabot, Renovate) to avoid falling behind.
+- **For construct libraries**, declare `aws-cdk-lib` and `constructs` as `peerDependencies` (caret, widest compatible) and as `devDependencies` at the oldest supported exact version.
+- **Experimental / alpha modules** (e.g. `@aws-cdk/aws-*-alpha`) SHOULD use exact versions — their APIs can change between releases without SemVer guarantees.
+- **Automate upgrades**: a weekly job that bumps `aws-cdk-lib`, runs `cdk synth` to catch breaking changes, deploys to a test environment, and opens a PR on success.
+
+### CLI and Library Are Separate Release Tracks
+
+The CDK CLI (`aws-cdk`) and the library (`aws-cdk-lib`) are **independent packages on different release tracks — their version numbers do NOT align**. A CLI at `2.1001.x` paired with a library at `2.200.x` is normal. The compatibility contract is one-way: a newer CLI can read assemblies produced by older libraries, but an older CLI CANNOT read assemblies produced by newer libraries. The mismatch surfaces as:
+
+```
+This CDK CLI is not compatible with the CDK library used by your application.
+(Cloud assembly schema version mismatch)
+```
+
+The fix is to upgrade the CLI to a specific newer version. You MUST install `aws-cdk` as a dev dependency at an **exact** version and invoke it via `npx cdk`; you MUST NOT use `aws-cdk@latest` anywhere — it is non-deterministic, so a broken release can reach your pipeline instantly.
 
 ```json
 {
   "devDependencies": {
-    "aws-cdk": "$EXACT_VERSION"
-  },
-  "dependencies": {
-    "aws-cdk-lib": "$EXACT_VERSION",
-    "constructs": "$EXACT_VERSION"
+    "aws-cdk": "2.1010.0"
   }
 }
 ```
-
-Invoke the CLI through the pinned version:
 
 ```bash
 npx cdk synth
 npx cdk deploy $STACK_NAME
 ```
+
+Bump the pinned CLI version regularly (Dependabot / Renovate), on the same cadence as `aws-cdk-lib`.
+
+### Feature Flags
+
+`cdk.json`'s `context` object carries CDK feature flags — per-release opt-ins to behaviour changes. When upgrading `aws-cdk-lib`, review new flags and adopt them incrementally (inspect via `cdk flags --unstable=flags`). Do not flip everything to recommended in one commit.

--- a/skills/core-skills/aws-cdk/references/compliance-and-drift.md
+++ b/skills/core-skills/aws-cdk/references/compliance-and-drift.md
@@ -126,10 +126,10 @@ preference):
    with the CDK-defined state. This is the simplest resolution.
 
 2. **Adopt the change** — If the out-of-band change is desired, update the CDK
-   code to match the live state using `Cfn``<Resource>``PropsMixin` to adopt the drifted
+   code to match the live state using `Cfn<Resource>PropsMixin` to adopt the drifted
    property values.
 
-3. **Fallback overrides** — If `Cfn``<Resource>``PropsMixin` is not available for the
+3. **Fallback overrides** — If `Cfn<Resource>PropsMixin` is not available for the
    resource type, use `addPropertyOverride` or `node.defaultChild` to set the
    property at the L1 level.
 

--- a/skills/core-skills/aws-cdk/references/construct-patterns.md
+++ b/skills/core-skills/aws-cdk/references/construct-patterns.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Scope and Construct IDs](#scope-and-construct-ids)
 - [Choosing Construct Levels](#choosing-construct-levels)
 - [Mixing L1 and L2](#mixing-l1-and-l2)
 - [Cross-Stack References](#cross-stack-references)
@@ -14,6 +15,44 @@
 ## Overview
 
 This reference covers construct selection, composition, cross-stack wiring, and testing patterns. It provides decision frameworks for choosing construct levels, mixing them safely, passing references across stacks, building custom constructs, and verifying infrastructure with assertions.
+
+---
+
+## Scope and Construct IDs
+
+Every construct is created with `new SomeConstruct(scope, id, props?)`. The first two arguments are not interchangeable boilerplate — misusing them is a common review finding.
+
+### Scope (first argument)
+
+Inside a construct's `constructor`, you MUST pass `this` as the scope of child constructs — NOT the incoming `scope` argument:
+
+```typescript
+// ❌ INCORRECT — child parented to the wrong node
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    new ChildConstruct(scope, 'Child');   // wrong: uses 'scope'
+  }
+}
+
+// ✅ CORRECT
+export class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    new ChildConstruct(this, 'Child');     // 'this' is the parent
+  }
+}
+```
+
+Passing `this` makes the child a child of the current construct, which is almost always the intent. A scope other than `this` is legitimate only when it comes from a function parameter or a local variable used to group constructs (e.g. in `App` or helper/test stacks).
+
+### Construct ID (second argument)
+
+The construct ID is the locally unique identifier within a scope. The IDs between a CloudFormation resource and its containing `Stack` are concatenated into the resource's **logical ID** — and changing a logical ID replaces the resource.
+
+- Construct IDs SHOULD be short and to the point.
+- You SHOULD NOT interpolate variables into a construct ID: if the variable's value changes, the logical ID changes and the resource is replaced. Legitimate exceptions (constructs created in a loop; an intentional, conditional replacement) MUST be annotated with a comment explaining why.
+- Construct IDs only need to be unique within their scope. They SHOULD NOT repeat project, region, or stage names already present higher in the construct tree.
 
 ---
 
@@ -32,7 +71,7 @@ You SHOULD prefer L2 constructs as the default choice. They provide sensible def
 
 ### When L1 is viable
 
-L1 (`Cfn*`) constructs are acceptable when no L2 exists or when you need a property the L2 does not expose. You SHOULD combine L1 with Mixins, Facades, or `I``<Resource>``Ref` interfaces to retain type safety and grant support.
+L1 (`Cfn*`) constructs are acceptable when no L2 exists or when you need a property the L2 does not expose. You SHOULD combine L1 with Mixins, Facades, or `I<Resource>Ref` interfaces to retain type safety and grant support.
 
 ### When using L3
 
@@ -42,7 +81,7 @@ L3 constructs provision multiple resources behind a single API. You MUST read wh
 
 Use this escalation ladder — prefer the first option that works:
 
-1. **Cfn``<Resource>``PropsMixin** (preferred) — type-safe, applied via `.with()`:
+1. **Cfn<Resource>PropsMixin** (preferred) — type-safe, applied via `.with()`:
 
    ```typescript
    import { CfnBucketPropsMixin } from '@aws-cdk/cfn-property-mixins/aws-s3';
@@ -62,11 +101,11 @@ Use this escalation ladder — prefer the first option that works:
 
 ## Mixing L1 and L2
 
-When a stack contains both L1 and L2 constructs, you MUST use `I``<Resource>``Ref` interfaces and Facades to bridge them — do not pass L1 property types to L2 props or vice versa, as their types are not interchangeable.
+When a stack contains both L1 and L2 constructs, you MUST use `I<Resource>Ref` interfaces and Facades to bridge them — do not pass L1 property types to L2 props or vice versa, as their types are not interchangeable.
 
-### I``<Resource>``Ref interfaces (e.g. IBucketRef)
+### I<Resource>Ref interfaces (e.g. IBucketRef)
 
-Both L1 and L2 constructs implement `I``<Resource>``Ref`-style interfaces (e.g., `IBucketRef`, `IFunctionRef`). Use these interfaces as prop types to accept either level:
+Both L1 and L2 constructs implement `I<Resource>Ref`-style interfaces (e.g., `IBucketRef`, `IFunctionRef`). Use these interfaces as prop types to accept either level:
 
 ```typescript
 interface MyProps {
@@ -76,7 +115,7 @@ interface MyProps {
 
 ### Facades for L1 grants
 
-L1 constructs lack `grant*()` methods. You SHOULD wrap them with `fromCfn``<Resource>``()` or `from``<Resource>``Attributes()` to get an L2 interface:
+L1 constructs lack `grant*()` methods. You SHOULD wrap them with `fromCfn<Resource>()` or `from<Resource>Attributes()` to get an L2 interface:
 
 ```typescript
 const cfnTable = new dynamodb.CfnTable(this, 'Table', { /* ... */ });
@@ -90,7 +129,7 @@ When you need to customize a resource, follow this order (least invasive first):
 
 1. L2 prop — use the built-in property if available.
 2. Mixin — add behavior via a helper function.
-3. `Cfn``<Resource>``PropsMixin` — type-safe L1 prop injection.
+3. `Cfn<Resource>PropsMixin` — type-safe L1 prop injection.
 4. `node.defaultChild` — access the underlying L1 construct.
 5. `addPropertyOverride` — override arbitrary CloudFormation properties.
 

--- a/skills/core-skills/aws-cdk/references/troubleshooting-deployment.md
+++ b/skills/core-skills/aws-cdk/references/troubleshooting-deployment.md
@@ -26,59 +26,150 @@ Three error categories exist:
 
 ## Deploy Failure Root Cause Analysis
 
-The CDK CLI surfaces a summary, but you MUST check CloudFormation stack events for the real error.
+The CDK CLI surfaces only a terse summary; the real cause is in the failed deployment, not the CLI output. You MUST work through these steps in order.
 
-### Step 1: Query failed events
-
-```bash
-aws cloudformation describe-stack-events \
-  --stack-name $STACK \
-  --query "StackEvents[?contains(ResourceStatus,'FAILED')]"
-```
-
-### Step 2: Enable verbose output
-
-Re-run the deploy with verbose logging to capture the full CLI-to-CloudFormation interaction:
+### Step 1: Re-run with `--verbose`
 
 ```bash
 cdk deploy $STACK --verbose
 ```
 
-### Diagnosis checklist
+Prints every AWS API call, the change-set diff, and a fuller stack trace (`-vv` / `-vvv` for more).
 
-You MUST work through these in order:
+### Step 2: `cdk diagnose` (preferred, CDK CLI ≥ 2.1120.0)
 
-1. Read the `ResourceStatusReason` from the failed CloudFormation event.
-2. Identify the logical resource ID and map it back to your CDK construct.
-3. Classify the error into one of the three categories above.
-4. For `DeployFailed`: fix the resource configuration or IAM permissions.
-5. For `DeploymentError`: check asset paths, Docker availability, and the CDK publishing role.
-6. For `EarlyValidationFailure`: check bootstrap version, environment configuration, or CLI version.
+```bash
+cdk --unstable=diagnose diagnose $STACK
+```
+
+Inspects the failed deployment and prints the root cause with pointers back to the CDK source that caused it. It runs after the fact, so it also works for diagnosing CI/CD pipeline failures. Requires the `--unstable=diagnose` flag.
+
+### Step 3: CloudFormation events (fallback)
+
+If `cdk diagnose` is unavailable (older CLI) or you need the raw stream:
+
+```bash
+aws cloudformation describe-events --stack-name $STACK --filters FailedEvents=true
+```
+
+`describe-events` groups events by operation ID and surfaces validation, provisioning, and hook-invocation errors — it supersedes `describe-stack-events`. The FIRST event in the output is the real root cause; later failures are rollback cascade.
+
+### Step 4: Read the `ResourceStatusReason`
+
+| Reason | Likely cause → fix |
+|---|---|
+| `... already exists` | Physical-name collision — remove `bucketName`/`tableName`/`roleName` and let CDK auto-generate. |
+| `resource creation cancelled` | Not the root — another resource failed first; find that event. |
+| `... in the WAITING state for approximately ... seconds` | Stabilization timeout (RDS, ASG signals, long-running Lambda). |
+| `Export X cannot be deleted as it is in use by Stack Y` | Cross-stack deadlock — see [Deadly Embrace](#deadly-embrace-cross-stack-reference-deadlock). |
+| `is not authorized to perform ...` | The default CDK bootstrap grants AdministratorAccess to the execution role — this error means you're using a customized bootstrap with a restricted execution role, a permissions boundary, or an SCP. Check which specific action/resource is denied, then add only that permission to your custom execution role or permissions boundary. Do NOT widen to `*` — grant the minimum action on the minimum resource ARN. |
+
+### Step 5: Service logs for Lambda / API Gateway / custom resources
+
+CloudFormation only reports *that* a resource failed. The actual reason (e.g. a custom-resource Lambda threw) is in CloudWatch Logs:
+
+- Lambda: `/aws/lambda/<function-name>`
+- CodeBuild-in-pipeline: `/aws/codebuild/<project>`
+- CloudFormation custom resources: the backing Lambda's log group.
+
+### `EarlyValidationFailure` specifically
+
+Fails BEFORE the change set is submitted — a construct's `validate()` returned errors, a synth-time assertion tripped, or an `addError` annotation fired. The message names the exact property and constraint; fix it before redeploying.
+
+> If you have the awslabs `aws-iac-mcp-server`, its `troubleshoot_cloudformation_deployment` tool matches the failure event stream against 30+ known patterns and returns CloudTrail deep links — use it to shortcut Steps 2–4.
 
 ---
 
 ## Deadly Embrace (Cross-Stack Reference Deadlock)
 
-A deadly embrace occurs when Stack A exports a value that Stack B imports. CloudFormation MUST NOT delete an export while any other stack imports it. Attempting to remove the export or the resource behind it fails with:
+A deadly embrace occurs when Stack A exports a value that Stack B imports, and you then try to remove the export (or the resource behind it). CloudFormation refuses:
 
-> Export cannot be deleted while it is in use by another stack.
+> Export Stack1:ExportsOutputFnGetAtt-XXXX cannot be deleted as it is in use by Stack2
 
-### Two-deploy fix
+The deadlock is structural: a safe removal needs B deployed first (so it stops importing), but CDK orders A before B because of the dependency.
 
-This MUST be done in exactly two deployments:
+Every cross-stack reference has a **strength**:
 
-**Deploy 1 — Decouple the consumer:**
+- **Strong** (default) — uses `Fn::ImportValue`. CloudFormation blocks the producer from removing the export while any consumer still imports it.
+- **Weak** — uses `Fn::GetStackOutput`. No coupling; the producer can be changed or deleted independently.
+- **Both** — transitional state for migrating strong → weak.
 
-1. In the consuming stack (Stack B), remove the `Fn.importValue` / cross-stack reference. Replace it with a hardcoded value, SSM lookup, or other mechanism.
-2. In the producing stack (Stack A), add `this.exportValue(resource.resourceArn)` (or the relevant attribute) to keep the export alive during transition.
-3. Deploy both stacks.
+Cross-account references are always weak (strong is unsupported cross-account).
 
-**Deploy 2 — Remove the export:**
+### Fix — reference strength (recommended)
 
-1. In the producing stack (Stack A), remove the `this.exportValue()` call.
+CDK supports weakening the reference before removing the resource, with no manual `exportValue` hacks. You MUST do this as a **three-deploy migration**.
+
+**Weaken all references to a resource** — `CrossStackReferences.of(resource).produce()`:
+
+```typescript
+import { CrossStackReferences, ReferenceStrength } from 'aws-cdk-lib';
+
+// Deploy 1 — consumers move to Fn::GetStackOutput; the strong export stays
+CrossStackReferences.of(bucket).produce(ReferenceStrength.BOTH);
+
+// Deploy 2 — drop the strong export now that no consumer uses Fn::ImportValue
+CrossStackReferences.of(bucket).produce(ReferenceStrength.WEAK);
+
+// Deploy 3 — remove the resource or the reference entirely
+```
+
+**Weaken a single reference** — `Stack.consumeReference()`:
+
+```typescript
+import { Stack, ReferenceStrength } from 'aws-cdk-lib';
+
+// Deploy 1 — wrap with consumeReference (defaults to BOTH)
+new CfnOutput(consumer, 'BucketArn', { value: Stack.consumeReference(bucket.bucketArn) });
+
+// Deploy 2 — switch to WEAK
+new CfnOutput(consumer, 'BucketArn', {
+  value: Stack.consumeReference(bucket.bucketArn, ReferenceStrength.WEAK),
+});
+
+// Deploy 3 — remove the resource or reference
+```
+
+(Use `Stack.consumeListReference()` for string-list references.)
+
+### Fix — legacy two-deploy (`exportValue`)
+
+Use this only on CDK versions that lack `ReferenceStrength`. It MUST be done in exactly two deployments:
+
+**Deploy 1 — decouple the consumer, keep the export alive:**
+
+1. In consumer Stack B, remove the cross-stack reference (replace with a hardcoded value, SSM lookup, etc.).
+2. In producer Stack A, add `this.exportValue(resource.attribute)` to keep the export alive during the transition.
+3. Deploy both.
+
+**Deploy 2 — remove the export:**
+
+1. In Stack A, remove the `this.exportValue()` call (and the underlying resource if desired).
 2. Deploy again.
 
 You MUST NOT attempt to remove the export and the import in a single deployment.
+
+### Manual deploy ordering (`cdk deploy -e`)
+
+If the consumer already stopped using the value and you control ordering yourself:
+
+```bash
+cdk deploy -e $CONSUMER_STACK   # deploy consumer first (drops the import)
+cdk deploy -e $PRODUCER_STACK   # then producer, removing the export
+```
+
+`-e` / `--exclusively` deploys only the named stack and skips dependency reconciliation.
+
+### Prevention
+
+- Default cross-stack references to **weak** for resources you expect to remove or replace. Set app-wide in `cdk.json`:
+
+  ```json
+  { "context": { "@aws-cdk/core:defaultCrossStackReferences": "weak" } }
+  ```
+
+- Keep stateful, long-lived resources in their own stack, separate from consumers.
+- Use SSM Parameter Store as indirection (producer writes a parameter, consumer reads it) — no CFN export, no embrace.
 
 ---
 

--- a/skills/core-skills/aws-cdk/references/troubleshooting-synth.md
+++ b/skills/core-skills/aws-cdk/references/troubleshooting-synth.md
@@ -49,7 +49,7 @@ The `app` field in `cdk.json` determines the execution mode. The failure causes 
 
 | Cause | Symptom | Fix |
 |-------|---------|-----|
-| Path aliases not resolved by ts-node | `Cannot find module 'lib/MyStack'` | Switch to `tsx`: `"app": "npx tsx bin/my-app.ts"` |
+| Path aliases not resolved by ts-node | `Cannot find module 'lib/MyStack'` | Switch to `tsx` (`"app": "npx tsx bin/my-app.ts"`), or register `tsconfig-paths` with ts-node (`"app": "npx ts-node -r tsconfig-paths/register --prefer-ts-exts bin/my-app.ts"`) |
 | Monorepo — wrong `node_modules` | `Cannot find module 'typescript'` | Verify hoisting: `npm ls typescript`. Point `cdk.json` at correct binary. pnpm: `shamefully-hoist=true`. |
 | `npm link` / symlinked packages | `Cannot find module '@my/shared-constructs'` | Install peer deps explicitly, or `NODE_OPTIONS=--preserve-symlinks`. Long-term: publish to registry. |
 | Wrong working directory | `cdk.json` not found | `cd` to directory containing `cdk.json` |

--- a/skills/core-skills/aws-cdk/references/v1-to-v2-migration.md
+++ b/skills/core-skills/aws-cdk/references/v1-to-v2-migration.md
@@ -111,3 +111,9 @@ If more than one version appears, you have duplicates.
 2. Run `npm dedupe` to collapse duplicates
 3. In monorepos, hoist `aws-cdk-lib` to the root workspace
 4. Verify with `npm ls aws-cdk-lib` — only one copy SHOULD appear
+
+If `npm dedupe` alone does not resolve it, reset the install:
+
+```bash
+rm -rf node_modules && npm ci && npm dedupe
+```


### PR DESCRIPTION
## Description

Improves the `aws-cdk` skill with up-to-date CDK guidance and fixes formatting issues throughout the reference docs.

The version management section previously recommended exact pinning for `aws-cdk-lib` in applications, which conflicts with the official CDK recommendation of caret ranges paired with a committed lockfile. This update aligns the guidance and adds missing context about CLI/library being independent release tracks.

The deadly embrace section now covers the `ReferenceStrength` API (`CrossStackReferences.of().produce()`) as the preferred fix, with the legacy `exportValue` recipe kept as a fallback for older CDK versions.

The deployment troubleshooting workflow now starts with `cdk diagnose` (available since CLI 2.1120.0) and uses the newer `describe-events` API.

Also adds a new section on scope and construct IDs — the most common CDK review finding — and fixes escaped backtick formatting (`Cfn``<Resource>``PropsMixin` → `Cfn<Resource>PropsMixin`) that was rendering incorrectly.

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
