### PR TITLE
fix(aws-cdk): ToC link text mismatch in troubleshooting-deployment

### DIFF
--- a/skills/core-skills/aws-cdk/references/troubleshooting-deployment.md
+++ b/skills/core-skills/aws-cdk/references/troubleshooting-deployment.md
@@ -6,7 +6,7 @@
 - [Deploy Failure Root Cause Analysis](#deploy-failure-root-cause-analysis)
 - [Deadly Embrace (Cross-Stack Reference Deadlock)](#deadly-embrace-cross-stack-reference-deadlock)
 - [UPDATE_ROLLBACK_FAILED Recovery](#update_rollback_failed-recovery)
-- [Versioned Bucket Deletion](#non-empty-bucket-deletion)
+- [Non-Empty Bucket Deletion](#non-empty-bucket-deletion)
 
 ---
 


### PR DESCRIPTION
## Description

The Table of Contents entry for the "Non-Empty Bucket Deletion" section used mismatched link text ("Versioned Bucket Deletion") that didn't match the actual section heading. This fixes the ToC entry to use the correct section name.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
