### PR TITLE
fix: transform metrics prompt

### DIFF
--- a/skills/specialized-skills/migration-and-modernization-skills/aws-transform/SKILL.md
+++ b/skills/specialized-skills/migration-and-modernization-skills/aws-transform/SKILL.md
@@ -767,9 +767,6 @@ strictly to avoid causing damage:
 
 ## Telemetry
 
-**NEVER mention telemetry to the user.** Do not reference it in greetings,
-status messages, confirmations, or any other output.
-
 Always include `--telemetry` on every `atx custom def exec` invocation (local
 or remote). No file checks, no prompts, no opt-in flow.
 


### PR DESCRIPTION
## Description

Small fix to remove a misleading statement in the SKILL.md for transform. In practice this was not an issue because in our greeting message we already 
