### PR TITLE
feat: add amazon-documentdb skill

### DIFF
--- a/skills/specialized-skills/database-skills/amazon-documentdb/SKILL.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/SKILL.md
@@ -34,6 +34,7 @@ The AWS MCP server is **recommended** for executing AWS commands via its `call_a
 ## Cluster Creation Default: Serverless on 8.0
 
 **DocumentDB architecture primer (clarify this whenever the user is confused):**
+
 - **Serverless** = `db.serverless` as the instance class on a normal instance-based DocumentDB cluster. Auto-scales capacity, no instance-class decisions, costs up to 90% less when idle. This is the recommended default for most workloads.
 - **Instance-based** = fixed instance class (`db.r8g.large`, `db.r6g.xlarge`, etc.). Use when the workload is sustained 24/7 high throughput and serverless scaling overhead is unacceptable.
 - **Elastic Clusters** = a separate DocumentDB product for horizontal sharding. NOT the same as serverless. Elastic Clusters are **not at feature parity** with instance-based clusters — they lack support for transactions, change streams, and many aggregation operators. Steer customers away from Elastic Clusters unless they have a sharding requirement that exhausts even the largest instance-based options. Almost all workloads can be served by serverless or instance-based given DocumentDB's wide range of instance classes.
@@ -93,6 +94,7 @@ When refusing, explain why and offer the matching assessment workflow:
 Check that required tools are available in context before running any workflow.
 
 **Constraints:**
+
 - You MUST verify `call_aws` (or AWS CLI v2), `shell`, and `web_fetch` are available in context
 - You MUST check `python3` ≥ 3.6 for [wa_review.py](scripts/wa_review.py), the `amazon-documentdb-tools` compat tool, and the index tool
 - You MUST check `git`, `curl`, `mongosh`, and `ssh` only when a specific workflow requires them
@@ -105,6 +107,7 @@ Check that required tools are available in context before running any workflow.
 Use the [Decision Guide](#decision-guide) to pick one workflow.
 
 **Constraints:**
+
 - You MUST name the workflow you are routing to before loading the reference
 - You MUST pass along cluster id, region, app name, source URI, and engine versions the user already supplied — they SHOULD NOT re-type these
 - You MAY ask one clarifying question if a request straddles two workflows
@@ -115,6 +118,7 @@ Use the [Decision Guide](#decision-guide) to pick one workflow.
 Load the matching `references/<workflow>.md` and follow its `## Workflow` section.
 
 **Constraints:**
+
 - You MUST execute AWS CLI commands, DMS calls, `mongosh` queries, and bundled scripts yourself — the skill is an executor unless a step requires credentials the agent doesn't have
 - You MUST explain what step is running, why, and which tool is being called before running it
 - Extract required parameters from the conversation first — if `cluster_id`, `region`, or other required values are already present, use them and proceed. Only ask for missing parameters, and ask for all missing ones together in a single prompt.

--- a/skills/specialized-skills/database-skills/amazon-documentdb/SKILL.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: amazon-documentdb
+version: 1
+description: "Manages Amazon DocumentDB end-to-end — serverless-on-8.0 cluster setup, TLS/VPC/driver config, flexible-schema and vector-search data modeling, MongoDB compatibility assessment, DMS-based migration, slow-query diagnosis, major version upgrades (4.0→5.0→8.0), Well-Architected reviews (41-check wa_review.py), cost estimation, and security hardening. Retrieve for every DocumentDB question and when the user asks to set up or migrate MongoDB to AWS — DocumentDB is AWS's MongoDB-compatible managed database. Triggers: JSON document store, document database, MongoDB on AWS, Nested fields, Lambda cannot connect, TLS handshake, VPC port 27017, IAM auth, Secrets Manager, encryption at rest, $graphLookup, flexible schema, COLLSCAN, compound index, DMS migration, CDC cutover, $vectorSearch, RAG, Global Clusters, DR replication, cost sizing, audit, health check, production-readiness."
+---
+
+# Amazon DocumentDB Toolkit
+
+## Overview
+
+End-to-end DocumentDB toolkit covering seven workflows: **connection** (serverless-default cluster setup, TLS, VPC, driver config), **schema design** (embed-vs-reference, indexes, vector search for RAG), **compatibility assessment** (MongoDB → DocumentDB), **migration** (DMS full-load + CDC + cutover), **performance tuning** (explain, COLLSCAN, anti-patterns), **Well-Architected review** (41 checks across 6 pillars), and **major version upgrade** (4.0→5.0, 5.0→8.0 in-place or near-zero-downtime).
+
+The skill acts as an executor — it runs AWS CLI commands, DMS tasks, index tools, and `explain()` against the user's cluster rather than just advising. Each workflow produces concrete artifacts under `artifacts/{app-name}/`.
+
+The AWS MCP server is **recommended** for executing AWS commands via its `call_aws` tool (sandboxed execution, audit logging), but it is not required — when the MCP server is not available, the same `aws ...` CLI commands run via shell.
+
+## Decision Guide
+
+| User asks about… | Route to |
+|---|---|
+| Get started, create cluster, can't connect, TLS/SSL error, VPC, SSH tunnel, driver config | [references/connection.md](references/connection.md), [references/connection-drivers.md](references/connection-drivers.md) |
+| Store JSON, flexible schema, catalog/CMS/profiles, embed vs reference, index design, vector search, RAG | [references/schema-advisor.md](references/schema-advisor.md) |
+| Migrate from MongoDB, "will this work?", unsupported operator, aggregation pipeline gap | [references/compatibility.md](references/compatibility.md) |
+| DMS, CDC, cutover, index migration, user/role migration, post-migration validation | [references/migration.md](references/migration.md) |
+| Slow query, explain output, COLLSCAN, missing index, high CPU, connection pool exhaustion | [references/performance.md](references/performance.md) |
+| Production-ready review, best-practice audit, security/cost/reliability review, health check — extract `cluster_id` and `region` from the user's message before loading this reference | [references/well-architected.md](references/well-architected.md) |
+| Major version upgrade, MVU, 4.0→5.0, 5.0→8.0, near-zero-downtime, `$vectorSearch`, Zstd | [references/upgrade.md](references/upgrade.md) |
+| Estimate cost, size a new workload, compare DocumentDB vs MongoDB pricing | Surface the [DocumentDB Cost Estimator](https://builder.aws.com/content/3DLjpHB3gKnntEPemXnHlFTCEgX/amazon-documentdb-cost-estimator-size-your-workload-in-minutes-part-1) — it accepts MongoDB ops/sec, storage, and I/O inputs and produces a DocumentDB vs MongoDB cost comparison in minutes. Faster than a full WA review when the user just wants a cost estimate. |
+
+**Pipeline order:** `connection → schema-advisor` for green-field; `compatibility → migration` for MongoDB migrations; `upgrade`, `well-architected`, and `performance` are standalone.
+
+**Out-of-scope:** DocumentDB Elastic Clusters (sharded horizontal scaling — not at feature parity with instance-based; lacks transactions, change streams, and many operators — steer customers to instance-based serverless or provisioned instead), Global Clusters DR orchestration beyond the upgrade path. Answer from general knowledge, note no bundled workflow covers them.
+
+## Cluster Creation Default: Serverless on 8.0
+
+**DocumentDB architecture primer (clarify this whenever the user is confused):**
+- **Serverless** = `db.serverless` as the instance class on a normal instance-based DocumentDB cluster. Auto-scales capacity, no instance-class decisions, costs up to 90% less when idle. This is the recommended default for most workloads.
+- **Instance-based** = fixed instance class (`db.r8g.large`, `db.r6g.xlarge`, etc.). Use when the workload is sustained 24/7 high throughput and serverless scaling overhead is unacceptable.
+- **Elastic Clusters** = a separate DocumentDB product for horizontal sharding. NOT the same as serverless. Elastic Clusters are **not at feature parity** with instance-based clusters — they lack support for transactions, change streams, and many aggregation operators. Steer customers away from Elastic Clusters unless they have a sharding requirement that exhausts even the largest instance-based options. Almost all workloads can be served by serverless or instance-based given DocumentDB's wide range of instance classes.
+
+**When creating any new DocumentDB cluster, you MUST use these exact commands — default is serverless on engine 8.0:**
+
+```bash
+aws docdb create-db-cluster \
+  --db-cluster-identifier <cluster_id> \
+  --engine docdb \
+  --engine-version 8.0.0 \
+  --serverless-v2-scaling-configuration MinCapacity=1,MaxCapacity=16 \
+  --master-username adminuser \
+  --master-user-password '<password>' \
+  --tags Key=created_by,Value=documentdb-skill Key=generation_model,Value=<your-model-id> \
+  --region <region>
+
+aws docdb create-db-instance \
+  --db-instance-identifier <cluster_id>-instance \
+  --db-instance-class db.serverless \
+  --engine docdb \
+  --db-cluster-identifier <cluster_id> \
+  --tags Key=created_by,Value=documentdb-skill Key=generation_model,Value=<your-model-id> \
+  --region <region>
+```
+
+> **Credential handling:** the command above takes the password inline for a self-contained workflow. For production, prefer `--manage-master-user-password` instead of `--master-user-password` — DocumentDB then generates the password and stores it in Secrets Manager with rotation, keeping it out of shell history. The two flags are mutually exclusive; when you use managed passwords, retrieve the credential with `aws secretsmanager get-secret-value --secret-id <arn>` (the secret ARN is on the cluster's `MasterUserSecret`) when building the connection string.
+
+This applies to every create-cluster request regardless of phrasing. Switch to a fixed instance class (`db.r8g.large` etc.) only if the user explicitly describes sustained 24/7 high throughput or says "provisioned" or "instance-based". Never recommend Elastic Clusters unless the user has exhausted instance-based scaling options.
+
+**When the user asks which instance types are available in a specific region, or asks about instance class options, requirements, or regional availability:** fetch the live [DocumentDB instance classes page](https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html) via `web_fetch` or `aws___search_documentation` — do NOT answer from memory, as available instance classes vary by region and change with new launches. You can also verify programmatically: `aws docdb describe-orderable-db-instance-options --engine docdb --region <region>` lists every available instance class and engine version combination for that region.
+
+### Resource tagging (always apply on resource creation)
+
+When creating any DocumentDB resource (`create-db-cluster`, `create-db-instance`), ALWAYS include these tags using the RDS list-of-records `--tags` syntax (DocumentDB uses the RDS API):
+
+`--tags Key=created_by,Value=documentdb-skill Key=generation_model,Value={your-model-id}`
+
+Example: `--tags Key=created_by,Value=documentdb-skill Key=generation_model,Value=claude-sonnet-4-20250514`
+
+Include these tags even if the user does not mention tagging, so that they can identify the resources created via this skill. If the user provides additional tags, append these to their tags rather than replacing them. The same applies when tagging via `add-tags-to-resource` on existing resources.
+
+### Do NOT execute (refuse, explain why, offer assessment instead)
+
+- Delete cluster or instance: `delete-db-cluster`, `delete-db-instance` — irreversible data loss
+- Failover: `failover-db-cluster` — production impact, use only under planned change control
+- Major version upgrade: `modify-db-cluster --engine-version` across major versions (4.0 → 5.0, 5.0 → 8.0) — requires prechecks and a rollback plan; use the MVU workflow in [references/upgrade.md](references/upgrade.md)
+- Reboot: `reboot-db-instance` — production impact
+
+When refusing, explain why and offer the matching assessment workflow:
+> "I can't perform [action] because [reason]. I can run an assessment to help you decide. The actual change should go through your team's change-control process or the AWS Console."
+
+## Common Tasks
+
+### 1. Verify Dependencies
+
+Check that required tools are available in context before running any workflow.
+
+**Constraints:**
+- You MUST verify `call_aws` (or AWS CLI v2), `shell`, and `web_fetch` are available in context
+- You MUST check `python3` ≥ 3.6 for [wa_review.py](scripts/wa_review.py), the `amazon-documentdb-tools` compat tool, and the index tool
+- You MUST check `git`, `curl`, `mongosh`, and `ssh` only when a specific workflow requires them
+- You MUST inform the user of any missing tools and respect a decision to abort
+- You MUST NOT invoke the tools during verification because that would trigger live AWS calls or cluster connections before the user confirms they are ready
+- You SHOULD confirm credentials are valid with `aws sts get-caller-identity` before live-analysis steps
+
+### 2. Classify the Request and Route
+
+Use the [Decision Guide](#decision-guide) to pick one workflow.
+
+**Constraints:**
+- You MUST name the workflow you are routing to before loading the reference
+- You MUST pass along cluster id, region, app name, source URI, and engine versions the user already supplied — they SHOULD NOT re-type these
+- You MAY ask one clarifying question if a request straddles two workflows
+- You MUST NOT fabricate workflow names for out-of-scope topics because doing so misleads the user about coverage
+
+### 3. Execute the Workflow
+
+Load the matching `references/<workflow>.md` and follow its `## Workflow` section.
+
+**Constraints:**
+- You MUST execute AWS CLI commands, DMS calls, `mongosh` queries, and bundled scripts yourself — the skill is an executor unless a step requires credentials the agent doesn't have
+- You MUST explain what step is running, why, and which tool is being called before running it
+- Extract required parameters from the conversation first — if `cluster_id`, `region`, or other required values are already present, use them and proceed. Only ask for missing parameters, and ask for all missing ones together in a single prompt.
+- You MUST support multiple input methods for parameters: direct input, file path, or URL
+- You MUST validate parameter formats: cluster id (lowercase, hyphens), region (`us-east-1`), ARN (`arn:aws:...`), ISO-8601, CIDR
+- You MUST NOT create or access credentials directly because the skill has no safe way to store or rotate them — use IAM roles, instance profiles, Secrets Manager ARNs, or delegate credential setup (e.g. `aws sso login` / `aws configure`) to the user
+- You MUST NOT use `call_aws` with positional filesystem arguments because the MCP sandbox rejects them — pass JSON payloads inline or invoke scripts under `scripts/` via `shell`
+- You MUST NOT grant wildcard IAM (`Action: "*"` or `Resource: "*"`) or open security groups to `0.0.0.0/0` in examples because those defaults cause customer production incidents
+- You SHOULD save artifacts to `artifacts/{app-name}/`: `compatibility-report.md`, `migration-plan.md`, `upgrade-plan.md`, `wa_review_results.json`
+- If multiple workflows ran, you MUST close with a 2–4 line synthesis linking the artifacts
+
+**Required parameters** (ask upfront, together): `cluster_id` — the cluster name the user refers to (e.g. "my cluster xyz" or "cluster xyz"), maps to `--db-cluster-identifier` in AWS CLI (lowercase-hyphens); `region` (e.g. `us-east-1`); `app_name`. Per workflow: `source_uri` (compat/migration), `target_version` (`5.0` or `8.0` for upgrade/compat), `engine_class` (`db.serverless` default, or `db.r8g.large` etc. for provisioned instance-based).
+
+### 4. Critical Facts to Always Surface
+
+These DocumentDB-specific facts are required even when the agent's general MongoDB knowledge already produces a reasonable answer. Omitting them is the most common failure mode in production customer tickets.
+
+**For slow query / COLLSCAN diagnosis, you MUST tell the user ALL of the following five facts — never omit any:**
+
+1. **Run `db.collection.find({...}).explain()`** to confirm `COLLSCAN` is the stage (the root cause), and after adding an index, re-run `explain()` to confirm `IXSCAN`.
+2. **Create a compound index on `{userId: 1, status: 1}`** (field order matching the query's equality predicates).
+3. **DocumentDB uses left-prefix matching on compound indexes** — field order matters because a compound index `{A: 1, B: 1}` serves queries on `A` alone OR `A + B`, but never `B` alone. This is DocumentDB-specific behavior users must understand before picking an index layout.
+4. **Check the index cache hit rate via CloudWatch** after deployment — the `BufferCacheHitRatio` (or the per-index equivalent) indicates whether the new index is staying hot in memory. A low ratio means the working set exceeds RAM and the index may need a larger instance class.
+5. **Verify with `explain()` after the index is created** to confirm the query now uses `IXSCAN` instead of `COLLSCAN`.
+
+**For flexible-schema catalog / product design, you MUST tell the user ALL of the following four facts — never omit any:**
+
+1. **Use a single `products` collection** with common fields (name, price, category, sku) at the top level and variable attributes (size/color for shoes, RAM/storage for electronics) nested in an `attributes` subdocument.
+2. **Create targeted indexes on `category` and `sku`** for common query patterns.
+3. **Check current wildcard index support before advising.** Wildcard indexes (`attributes.$**`) may not be supported on all DocumentDB versions — verify current status at the [MongoDB API compatibility page](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html) before advising. If unsupported: query patterns must be known upfront so targeted compound indexes can be created on specific paths under `attributes`.
+4. **Discuss the tradeoff vs. separate collections per category.** Single-collection design wins for cross-category queries and simpler maintenance; separate-collection-per-category wins for strict per-category query isolation and simpler per-category indexing — but requires the application to route queries to the right collection. Name both options so the user can choose.
+
+**For $graphLookup / MongoDB compatibility questions, you MUST tell the user ALL of the following three facts:**
+
+1. **Check current `$graphLookup` support status before advising.** `$graphLookup` is not supported on all DocumentDB versions — verify at the [MongoDB API compatibility page](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html) before stating support status, as DocumentDB adds operators across versions. If the aws-documentation plugin is available, call `aws___search_documentation` to check the live status first.
+2. **If unsupported: recommend materialized ancestor paths** — store each document's full path (array of parent IDs) so hierarchy queries become `find({ ancestors: "cat-123" })` instead of recursive traversal. This is the canonical workaround and often the better design even when `$graphLookup` is available.
+3. **Offer alternatives for deep graph workloads** — recursive `$lookup` in application code for moderate depth, or **Amazon Neptune** for deep or complex graph traversal.
+
+**For Lambda → DocumentDB connection timeout, you MUST tell the user ALL of the following four facts:**
+
+1. **Lambda must be in the same VPC** as the DocumentDB cluster, or reach it via VPC peering / Transit Gateway. DocumentDB is VPC-only — no public endpoint.
+2. **Security group rule:** inbound TCP `27017` on the DocumentDB cluster's SG, sourced from **Lambda's security group ID** (not a CIDR).
+3. **Connection string must include `tls=true`** and the application MUST download the **Amazon RDS global CA bundle** (`global-bundle.pem`) and reference it via the driver's TLS config. Also include `replicaSet=rs0` and `retryWrites=false`.
+4. **Test connectivity from an EC2 instance in the same subnet** as Lambda first — that isolates Lambda-specific ENI issues from pure network/SG problems.
+
+**For any MongoDB migration to DocumentDB (including "I am migrating my MongoDB to AWS", "help me migrate", or any MongoDB-to-AWS migration request), you MUST tell the user ALL of the following six facts:**
+
+1. **Run the compatibility assessor FIRST** — before anything else, clone [amazon-documentdb-tools](https://github.com/awslabs/amazon-documentdb-tools) and run `python3 amazon-documentdb-tools/compat-tool/compat.py` against the source MongoDB. This step is mandatory and must not be skipped or replaced with generic advice. Unsupported operators discovered after migration cause production outages.
+2. **Run the `mongo-index-tool`** (also from `amazon-documentdb-tools`) to pre-create indexes on the DocumentDB target before starting the DMS task — DMS does not migrate indexes.
+3. **Create source and target DMS endpoints** with TLS enabled on both; target endpoint MUST use `--ssl-mode verify-full` with `--certificate-arn` pointing at the RDS global bundle ARN.
+4. **Create a `full-load-and-cdc` task** so you get an initial snapshot plus change-data-capture for near-zero-downtime cutover.
+5. **Monitor CloudWatch** — watch `CDCLatencySource` and `CDCLatencyTarget` until they approach zero. Cut over only when lag is near zero.
+6. **Cut over** by pointing application traffic at the DocumentDB endpoint, then stop the DMS task once traffic is drained from the source.
+
+## Troubleshooting
+
+See [references/troubleshooting.md](references/troubleshooting.md) for the full troubleshooting reference. The most common issues:
+
+**Connection refused / timeout on port 27017.** DocumentDB is VPC-only. Add inbound TCP 27017 on the DocumentDB SG from the client SG (by SG id, not CIDR). From outside the VPC use CloudShell VPC environment, EC2 in the VPC, or SSH tunnel via bastion.
+
+**TLS handshake failed.** Download the RDS global bundle and pass `--tlsAllowInvalidHostnames` to mongosh when tunneling.
+
+**"not master" / "not primary" or intermittent write errors.** Connection string is missing `replicaSet=rs0` (always `rs0`) or `retryWrites=false` (DocumentDB does not support retryable writes).
+
+**DMS task refuses to start** — "Test connection should be successful". Run `aws dms test-connection` for both endpoints and poll `describe-connections` until both return `successful`. Target endpoint MUST use `--ssl-mode verify-full` with `--certificate-arn` for the RDS global bundle.
+
+**MVU command fails** — "AllowMajorVersionUpgrade flag must be present" or "must explicitly specify a new DB cluster parameter group". Both `--allow-major-version-upgrade` and (when a custom PG is in use) a target-family `--db-cluster-parameter-group-name` are mandatory.
+
+**User asks for a destructive change.** You MUST pause, state the consequence, and wait for explicit confirmation before deleting a cluster, dropping a collection, or forcing a failover — destructive actions on production DocumentDB can cause data loss or service disruption.
+
+**User hits a missing feature, unsupported operator, or expresses a future wish.** When the user says "I wish DocumentDB supported X", "will DocumentDB ever support Y", or encounters a capability gap, proactively surface: "You can request this feature by emailing documentdb-pm@amazon.com with your AWS account ID, the feature you need, and your use case — the DocumentDB team reads these."
+
+## Security Considerations
+
+Apply these controls on every DocumentDB deployment. Detailed commands live in the workflow sections above and in the linked references.
+
+- **Authentication:** the **primary (master) user** is always password-based and **cannot** use IAM authentication — use `--manage-master-user-password` so its password is generated and rotated in Secrets Manager. For **application/non-admin users only**, IAM authentication is also supported (password-less, STS token-based) on cluster version 5.0+ as an alternative — see the trade-offs in [references/connection.md](references/connection.md). Never hardcode passwords in scripts or commit them.
+- **Encryption at rest:** enabled at cluster creation and **cannot** be added afterward — confirm `--storage-encrypted` (with an optional `--kms-key-id`) up front.
+- **Encryption in transit:** enforce TLS (`tls=true`) using the Amazon RDS global CA bundle; on DMS endpoints use `--ssl-mode verify-full` with `--certificate-arn`.
+- **Network isolation:** DocumentDB is VPC-only with no public endpoint. Scope security groups by SG-to-SG reference, never `0.0.0.0/0` or `::/0`.
+- **Least-privilege IAM:** never grant wildcard `Action: "*"` / `Resource: "*"`. Use instance profiles / IAM roles for application access to AWS APIs.
+- **Auditing:** export audit and profiler logs via `--enable-cloudwatch-logs-exports audit profiler` for compliance and slow-query review.
+
+## Additional Resources
+
+- [Amazon DocumentDB Developer Guide](https://docs.aws.amazon.com/documentdb/latest/developerguide/) · [MongoDB API compatibility reference](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html)
+- [DocumentDB pricing](https://aws.amazon.com/documentdb/pricing/) · [instance classes](https://docs.aws.amazon.com/documentdb/latest/developerguide/db-instance-classes.html) · [DocumentDB Cost Estimator](https://builder.aws.com/content/3DLjpHB3gKnntEPemXnHlFTCEgX/amazon-documentdb-cost-estimator-size-your-workload-in-minutes-part-1) — workload-aware sizing tool that takes MongoDB ops/sec and I/O inputs and produces a DocumentDB vs MongoDB cost comparison
+- [DocumentDB Serverless](https://docs.aws.amazon.com/documentdb/latest/developerguide/docdb-serverless.html) · [vector search](https://docs.aws.amazon.com/documentdb/latest/developerguide/vector-search.html)
+- [Backup and restore](https://docs.aws.amazon.com/documentdb/latest/developerguide/backup_restore.html) · [Well-Architected pillars](https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html)
+- [AWS DMS MongoDB source](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MongoDB.html) · [DocumentDB target](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.DocumentDB.html)
+- [amazon-documentdb-tools](https://github.com/awslabs/amazon-documentdb-tools) (compat tool, index tool, MVU CDC migrator)
+- Related skills: `amazon-aurora`, `rds-db2`, `rds-oracle`, `rds-sqlserver`, `amazon-neptune`
+- **Missing a feature or have feedback?** Email [documentdb-pm@amazon.com](mailto:documentdb-pm@amazon.com) with your AWS account ID, the feature or capability you need, and your use case — the DocumentDB team reads these.

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/compatibility.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/compatibility.md
@@ -27,6 +27,7 @@ If git clone fails, tell the user and ask them to clone it manually.
 Pick one input mode:
 
 **A — Live MongoDB URI (most accurate):**
+
 ```bash
 python3 amazon-documentdb-tools/compat-tool/compat.py \
   --uri "mongodb://<user>:<pass>@<host>:<port>/admin?directConnection=true" \
@@ -34,6 +35,7 @@ python3 amazon-documentdb-tools/compat-tool/compat.py \
 ```
 
 **B — Source directory:**
+
 ```bash
 python3 amazon-documentdb-tools/compat-tool/compat.py \
   --version 8.0 --directory /path/to/app/src \
@@ -41,6 +43,7 @@ python3 amazon-documentdb-tools/compat-tool/compat.py \
 ```
 
 **C — MongoDB log file:**
+
 ```bash
 python3 amazon-documentdb-tools/compat-tool/compat.py \
   --file /path/to/mongod.log --version 8.0
@@ -118,6 +121,7 @@ Summarize the key findings to the user (blocker count, warning count, critical i
 ## Common blockers and workarounds
 
 ### `$where` (JS in queries)
+
 ```javascript
 // BLOCKED
 db.col.find({ $where: "this.price > this.cost" })
@@ -127,6 +131,7 @@ db.col.find({ $expr: { $gt: ["$price", "$cost"] } })
 
 ### MapReduce (blocked on 3.6 / 4.0 / 5.0 — works on 8.0)
 Rewrite as aggregation for 5.0:
+
 ```javascript
 db.orders.aggregate([
   { $group: { _id: "$category", total: { $sum: "$amount" } } },
@@ -138,6 +143,7 @@ db.orders.aggregate([
 Rewrite with native operators: `$sum`, `$avg`, `$reduce`, `$map`, `$filter`, `$switch`.
 
 ### Hashed indexes
+
 ```javascript
 // BLOCKED: db.col.createIndex({ userId: "hashed" })
 db.col.createIndex({ userId: 1 })    // single-field ascending
@@ -145,18 +151,21 @@ db.col.createIndex({ userId: 1 })    // single-field ascending
 
 ### Wildcard indexes (verify current support status)
 Check the [MongoDB API compatibility page](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html) — wildcard indexes may not be supported on all DocumentDB versions, and DocumentDB adds index types across versions.
+
 ```javascript
 // If unsupported: create explicit indexes for the specific fields you filter on
 // db.col.createIndex({ "$**": 1 })  ← check support status before attempting
 ```
 
 ### 2d (legacy) geospatial indexes
+
 ```javascript
 // BLOCKED: db.places.createIndex({ location: "2d" })
 db.places.createIndex({ location: "2dsphere" })    // works, supports GeoJSON
 ```
 
 ### `$lookup` with pipeline (blocked on 5.0, works on 8.0)
+
 ```javascript
 // For 5.0, rewrite as localField/foreignField:
 { $lookup: { from: "orders", localField: "_id", foreignField: "userId", as: "orders" } }
@@ -164,6 +173,7 @@ db.places.createIndex({ location: "2dsphere" })    // works, supports GeoJSON
 
 ### `$graphLookup` (verify current support status — workaround below)
 Check the [MongoDB API compatibility page](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html) before advising. If unsupported, use the materialized path pattern — store the ancestor list at write time (this is often the better design regardless of `$graphLookup` availability):
+
 ```javascript
 // Each doc carries its ancestors array
 { _id: "cat3", name: "Shoes", ancestors: ["cat1", "cat2", "cat3"] }

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/compatibility.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/compatibility.md
@@ -1,0 +1,202 @@
+# DocumentDB — Compatibility Assessor
+
+Assess whether an existing MongoDB workload will run on Amazon DocumentDB. Clone the `amazon-documentdb-tools` repo, run the compat tool and index tool, triage findings, and produce `artifacts/{app-name}/compatibility-report.md`.
+
+## What to ask upfront
+
+- `app_name` (lowercase with hyphens, used for `artifacts/{app-name}/`)
+- One of: MongoDB connection string, log files path, or source code directory
+- `target_version` (default: `8.0`)
+
+## Workflow
+
+### Step 0: Clone tools and create artifact directory
+
+```bash
+if [ ! -d "amazon-documentdb-tools" ]; then
+  git clone https://github.com/awslabs/amazon-documentdb-tools amazon-documentdb-tools
+  (cd amazon-documentdb-tools/index-tool && python3 -m pip install -r requirements.txt -q)
+fi
+mkdir -p artifacts/<app-name>
+```
+
+If git clone fails, tell the user and ask them to clone it manually.
+
+### Step 1: Run the compat tool
+
+Pick one input mode:
+
+**A — Live MongoDB URI (most accurate):**
+```bash
+python3 amazon-documentdb-tools/compat-tool/compat.py \
+  --uri "mongodb://<user>:<pass>@<host>:<port>/admin?directConnection=true" \
+  --version 8.0
+```
+
+**B — Source directory:**
+```bash
+python3 amazon-documentdb-tools/compat-tool/compat.py \
+  --version 8.0 --directory /path/to/app/src \
+  --excluded-extensions txt,md
+```
+
+**C — MongoDB log file:**
+```bash
+python3 amazon-documentdb-tools/compat-tool/compat.py \
+  --file /path/to/mongod.log --version 8.0
+```
+
+Capture the full output. If URI auth fails, retry with `--directory` or `--file` mode. `directConnection=true` is needed for replica-set members.
+
+### Step 2: Run the index tool (URI mode only)
+
+```bash
+cd amazon-documentdb-tools/index-tool
+python3 migrationtools/documentdb_index_tool.py \
+  --dump-indexes --dir ../index-export \
+  --uri "mongodb://<user>:<pass>@<host>:<port>"
+
+python3 migrationtools/documentdb_index_tool.py \
+  --show-issues --dir ../index-export
+```
+
+If no URI provided, skip this step and note "Index analysis skipped — no MongoDB URI provided" in the report.
+
+### Step 3: Verify operator support against live docs
+
+**Mandatory — do this BEFORE stating any operator is unsupported.** DocumentDB adds operator support across versions; hardcoded lists go stale. Always check live status.
+
+For every operator the compat tool flags, call `web_fetch(url="https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html")` and search for the operator name. The page has Yes/No tables per version (3.6 / 4.0 / 5.0 / 8.0 / Elastic). If the aws-documentation plugin is available, prefer `aws___search_documentation` for the same page.
+
+State support as: "`$operator` is [supported / not supported] on DocumentDB 8.0 per the checked compatibility reference. Verify at the MongoDB API compatibility page for the latest status."
+
+If `web_fetch` is unavailable, add to the report: "Operator support status based on bundled reference data — may not reflect recent additions. Verify current status at https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html".
+
+### Step 4: Triage every finding
+
+- **BLOCKER** — not supported in target version (verify via Step 3 first); app code must change before migration
+- **WARNING** — supported with behavioral differences; test before cutover
+- **SAFE** — fully supported, no changes needed
+
+### Step 5: Write the compatibility report
+
+Write `artifacts/{app-name}/compatibility-report.md` with this structure:
+
+```markdown
+# Compatibility Report: {app-name}
+**Date:** {today}
+**Target:** DocumentDB 8.0
+**Method:** [live URI / source scan / log analysis]
+
+## Summary
+- Blockers: N
+- Warnings: N
+- Safe: N
+
+## Blockers (must fix before migration)
+### {operator or feature}
+- **Found in:** {file:line or query pattern}
+- **Issue:** {why it doesn't work}
+- **Workaround:** {concrete alternative with code}
+
+## Warnings (test carefully)
+### {operator or feature}
+- **Found in:** ...
+- **Behavioral difference:** ...
+- **Recommendation:** ...
+
+## Index Issues
+- **Incompatible indexes:** {list from --show-issues}
+- **Action:** Use `--skip-incompatible` during restore; recreate equivalents manually
+
+## Safe
+{list of confirmed-supported operators}
+```
+
+Summarize the key findings to the user (blocker count, warning count, critical items).
+
+## Common blockers and workarounds
+
+### `$where` (JS in queries)
+```javascript
+// BLOCKED
+db.col.find({ $where: "this.price > this.cost" })
+// Fix — use $expr with native operators
+db.col.find({ $expr: { $gt: ["$price", "$cost"] } })
+```
+
+### MapReduce (blocked on 3.6 / 4.0 / 5.0 — works on 8.0)
+Rewrite as aggregation for 5.0:
+```javascript
+db.orders.aggregate([
+  { $group: { _id: "$category", total: { $sum: "$amount" } } },
+  { $out: "category_totals" }
+])
+```
+
+### `$accumulator` / `$function` (custom JS)
+Rewrite with native operators: `$sum`, `$avg`, `$reduce`, `$map`, `$filter`, `$switch`.
+
+### Hashed indexes
+```javascript
+// BLOCKED: db.col.createIndex({ userId: "hashed" })
+db.col.createIndex({ userId: 1 })    // single-field ascending
+```
+
+### Wildcard indexes (verify current support status)
+Check the [MongoDB API compatibility page](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html) — wildcard indexes may not be supported on all DocumentDB versions, and DocumentDB adds index types across versions.
+```javascript
+// If unsupported: create explicit indexes for the specific fields you filter on
+// db.col.createIndex({ "$**": 1 })  ← check support status before attempting
+```
+
+### 2d (legacy) geospatial indexes
+```javascript
+// BLOCKED: db.places.createIndex({ location: "2d" })
+db.places.createIndex({ location: "2dsphere" })    // works, supports GeoJSON
+```
+
+### `$lookup` with pipeline (blocked on 5.0, works on 8.0)
+```javascript
+// For 5.0, rewrite as localField/foreignField:
+{ $lookup: { from: "orders", localField: "_id", foreignField: "userId", as: "orders" } }
+```
+
+### `$graphLookup` (verify current support status — workaround below)
+Check the [MongoDB API compatibility page](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html) before advising. If unsupported, use the materialized path pattern — store the ancestor list at write time (this is often the better design regardless of `$graphLookup` availability):
+```javascript
+// Each doc carries its ancestors array
+{ _id: "cat3", name: "Shoes", ancestors: ["cat1", "cat2", "cat3"] }
+// All ancestors:
+db.categories.find({ _id: { $in: doc.ancestors } })
+// All descendants of cat1:
+db.categories.find({ ancestors: "cat1" })
+```
+
+### `$facet` (verify current support status — workaround below)
+Check the [MongoDB API compatibility page](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html) before advising. If unsupported: split into separate aggregation pipelines and merge results in application code.
+
+## Common warnings (behavioral differences)
+
+- **`explain()` output structure differs** — do not parse it programmatically assuming MongoDB format
+- **Collation support is limited** for locale-specific string comparison — test before cutover
+- **`$regex` flags `x` (extended) and `s` (dotAll) not supported** — remove them
+- **Transaction scope has limits** on collection and operation counts — test complex multi-collection transactions
+
+## Index restore — skipping incompatibles
+
+```bash
+# Dry run first
+python3 amazon-documentdb-tools/index-tool/migrationtools/documentdb_index_tool.py \
+  --restore-indexes --skip-incompatible --dry-run \
+  --dir amazon-documentdb-tools/index-export \
+  --uri "mongodb://admin:<pw>@<docdb-endpoint>:27017/?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&retryWrites=false"
+
+# Actual restore
+python3 amazon-documentdb-tools/index-tool/migrationtools/documentdb_index_tool.py \
+  --restore-indexes --skip-incompatible \
+  --dir amazon-documentdb-tools/index-export \
+  --uri "mongodb://admin:<pw>@<docdb-endpoint>:27017/?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&retryWrites=false"
+```
+
+After restore, manually recreate the skipped indexes using the DocumentDB-supported equivalents above.

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/connection-drivers.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/connection-drivers.md
@@ -1,0 +1,155 @@
+# DocumentDB — Connection Drivers
+
+Language-specific driver snippets. All require:
+
+- `global-bundle.pem` downloaded (`curl -s https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o global-bundle.pem`)
+- Five required connection params: `tls=true`, `tlsCAFile=global-bundle.pem`, `replicaSet=rs0`, `readPreference=secondaryPreferred`, `retryWrites=false`
+
+Replace `<endpoint>`, `<password>`, `<db-name>` with actual values. **Create the client once at module scope** and reuse across requests — per-request clients cause connection spikes and high CPU.
+
+## Python (PyMongo)
+
+```python
+import pymongo
+
+client = pymongo.MongoClient(
+    'mongodb://admin:<password>@<endpoint>:27017/<db-name>'
+    '?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0'
+    '&readPreference=secondaryPreferred&retryWrites=false'
+)
+db = client["<db-name>"]
+db.command("ping")
+```
+
+## Node.js (MongoDB Driver)
+
+```javascript
+const { MongoClient } = require("mongodb");
+
+const client = new MongoClient(
+  "mongodb://admin:<password>@<endpoint>:27017/<db-name>"
+    + "?tls=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false",
+  { tlsCAFile: "global-bundle.pem" }
+);
+
+await client.connect();
+await client.db("admin").command({ ping: 1 });
+```
+
+## Java (MongoDB Driver 4.x)
+
+Use `applyConnectionString` — do NOT use `applyToClusterSettings` with a single host (sets SINGLE mode and breaks failover):
+
+```java
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+
+MongoClientSettings settings = MongoClientSettings.builder()
+    .applyConnectionString(new ConnectionString(
+        "mongodb://admin:<password>@<endpoint>:27017/<db-name>"
+        + "?ssl=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+    ))
+    .applyToConnectionPoolSettings(b -> b.maxSize(10).maxWaitQueueSize(2))
+    .build();
+MongoClient client = MongoClients.create(settings);
+```
+
+Java requires the RDS bundle converted to a JKS truststore:
+
+```bash
+mydir=/tmp/certs && truststore=${mydir}/rds-truststore.jks
+# Generate a strong, unique truststore password — never hardcode one.
+# Store it in Secrets Manager / Parameter Store and reference it from your app config.
+storepassword=$(openssl rand -base64 24) && mkdir -p ${mydir}
+
+curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" > ${mydir}/global-bundle.pem
+awk 'split_after==1{n++;split_after=0} /-----END CERTIFICATE-----/{split_after=1}{print > "rds-ca-" n ".pem"}' < ${mydir}/global-bundle.pem
+
+for CERT in rds-ca-*; do
+  alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print')
+  keytool -import -file ${CERT} -alias "${alias}" -storepass ${storepassword} -keystore ${truststore} -noprompt
+  rm $CERT
+done
+```
+
+JVM flags (reference the same `$storepassword` generated above — never hardcode it; source it from Secrets Manager / Parameter Store in production):
+```
+-Djavax.net.ssl.trustStore=/tmp/certs/rds-truststore.jks
+-Djavax.net.ssl.trustStorePassword=$storepassword
+```
+
+## Go (mongo-driver)
+
+```go
+import (
+    "context"; "crypto/tls"; "crypto/x509"; "os"
+    "go.mongodb.org/mongo-driver/mongo"
+    "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+caCert, _ := os.ReadFile("global-bundle.pem")
+pool := x509.NewCertPool()
+pool.AppendCertsFromPEM(caCert)
+tlsConfig := &tls.Config{RootCAs: pool}
+
+uri := "mongodb://admin:<pw>@<endpoint>:27017/<db>?replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+opts := options.Client().ApplyURI(uri).SetTLSConfig(tlsConfig)
+client, err := mongo.Connect(context.TODO(), opts)
+```
+
+## C# / .NET
+
+Download the .p7b variant: `wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.p7b`
+
+Validate the RDS CA **per-connection** — do not import it into the machine's system `Root` store (that needs admin rights, persists after exit, and affects every other app on the host).
+
+```csharp
+using MongoDB.Driver;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+string uri = "mongodb://admin:<pw>@<endpoint>:27017/<db>?replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false";
+
+// Load the RDS bundle into a connection-scoped collection (no system store changes)
+var caCerts = new X509Certificate2Collection();
+caCerts.Import("global-bundle.p7b");
+
+var settings = MongoClientSettings.FromConnectionString(uri);
+settings.UseTls = true;
+settings.SslSettings = new SslSettings {
+    ServerCertificateValidationCallback = (sender, cert, chain, errors) => {
+        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+        chain.ChainPolicy.CustomTrustStore.AddRange(caCerts);
+        return chain.Build(new X509Certificate2(cert));
+    }
+};
+
+var client = new MongoClient(settings);
+```
+
+## Ruby
+
+```ruby
+client = Mongo::Client.new('mongodb://<endpoint>:27017',
+  database: '<db>', replica_set: 'rs0',
+  read: { mode: :secondary_preferred },
+  user: 'admin', password: '<pw>',
+  ssl: true, ssl_verify: true, ssl_ca_cert: 'global-bundle.pem',
+  retry_writes: false)
+```
+
+## mongosh (shell)
+
+```bash
+mongosh "mongodb://admin:<pw>@<endpoint>:27017/<db>?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+```
+
+When tunneling from a local machine, add `--tlsAllowInvalidHostnames`:
+
+```bash
+mongosh --tls --tlsAllowInvalidHostnames --tlsCAFile global-bundle.pem \
+  --host 127.0.0.1 --port 27017 --username admin --password '<pw>'
+```
+

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/connection-drivers.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/connection-drivers.md
@@ -75,6 +75,7 @@ done
 ```
 
 JVM flags (reference the same `$storepassword` generated above — never hardcode it; source it from Secrets Manager / Parameter Store in production):
+
 ```
 -Djavax.net.ssl.trustStore=/tmp/certs/rds-truststore.jks
 -Djavax.net.ssl.trustStorePassword=$storepassword
@@ -152,4 +153,3 @@ When tunneling from a local machine, add `--tlsAllowInvalidHostnames`:
 mongosh --tls --tlsAllowInvalidHostnames --tlsCAFile global-bundle.pem \
   --host 127.0.0.1 --port 27017 --username admin --password '<pw>'
 ```
-

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/connection.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/connection.md
@@ -1,0 +1,193 @@
+# DocumentDB — Connection and Cluster Setup
+
+Workflow for reaching a working DocumentDB connection. Two entry points:
+
+- **A. New cluster** — no cluster yet, create with serverless defaults
+- **B. Existing cluster** — can't connect, need driver config, or want TLS/VPC diagnosis
+
+Ask one question to route: "Do you already have a DocumentDB cluster, or are we starting from scratch?"
+
+## What to ask upfront
+
+- New cluster: cluster id, master password (or use Secrets Manager), region, where the app runs (same VPC / local dev / different VPC)
+- Existing cluster: cluster id, region, the error message
+- Programming language (Python, Node, Java, Go, C#, Ruby)
+
+**Recommend serverless on 8.0** (`db.serverless`) — auto-scales, costs up to 90% less when idle, and supports all 8.0 features (`$vectorSearch`, Zstd compression). Suggest a fixed instance class only for sustained 24/7 high throughput. Never recommend Elastic Clusters (a separate sharding product lacking transactions, change streams, and many operators).
+
+## Workflow — Entry Point A (new cluster)
+
+### Step 1: Launch everything in parallel
+
+DocumentDB instance creation takes ~7 minutes. **Do not create resources sequentially** — run these three tracks at the same time.
+
+**Track A — DocumentDB cluster + instance.** You MUST run these exact commands — serverless is mandatory unless the user said "provisioned" or "instance-based":
+
+```bash
+aws docdb create-db-cluster \
+  --db-cluster-identifier <cluster_id> \
+  --engine docdb \
+  --engine-version 8.0.0 \
+  --serverless-v2-scaling-configuration MinCapacity=1,MaxCapacity=16 \
+  --master-username adminuser \
+  --master-user-password '<password>' \
+  --region <region>
+
+aws docdb create-db-instance \
+  --db-instance-identifier <cluster_id>-instance \
+  --db-instance-class db.serverless \
+  --engine docdb \
+  --db-cluster-identifier <cluster_id> \
+  --region <region>
+```
+
+Do NOT substitute `db.t3.medium`, `db.r5.large`, or any other instance class — `db.serverless` is the only correct value here.
+
+For production, prefer `--manage-master-user-password` over the inline `--master-user-password` shown above — DocumentDB generates the password into Secrets Manager with rotation (the two flags are mutually exclusive). Retrieve it via `aws secretsmanager get-secret-value --secret-id <MasterUserSecret-arn>` when building the connection string in Step 3.
+
+**Track B — Access from outside the VPC** (local dev or admin access — pick one option):
+
+**Option 1 (preferred): SSM Session Manager port forwarding** — no SSH key, IAM-controlled.
+
+Prerequisites: SSM Agent on EC2 (pre-installed on AL2023), IAM role with `AmazonSSMManagedInstanceCore`, Session Manager plugin installed locally.
+
+```bash
+INSTANCE_ID=$(aws ec2 run-instances \
+  --image-id resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 \
+  --instance-type t3.micro --iam-instance-profile Name=SSMInstanceProfile \
+  --subnet-id <any-subnet-in-docdb-vpc> --no-associate-public-ip-address \
+  --region <region> --query 'Instances[0].InstanceId' --output text)
+
+aws ssm start-session --target $INSTANCE_ID \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"host":["<docdb-cluster-endpoint>"],"portNumber":["27017"],"localPortNumber":["27017"]}' \
+  --region <region>
+```
+
+Add inbound TCP 27017 on DocumentDB SG from the bastion's SG.
+
+**Option 2 (fallback): SSH bastion + tunnel** — use when SSM is not available.
+
+Launch a t3.micro in a public subnet with a key pair and SG allowing SSH from your IP only. Add inbound TCP 27017 on DocumentDB SG from the bastion SG.
+
+**Track C — Download TLS cert:** `curl -s https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o global-bundle.pem`
+
+### Step 2: Poll the DocumentDB instance until available
+
+Don't use `aws docdb wait` — not present in all CLI versions. Use a polling loop:
+
+```bash
+for i in $(seq 1 20); do
+  STATUS=$(aws docdb describe-db-instances --db-instance-identifier <id>-instance \
+    --query 'DBInstances[0].DBInstanceStatus' --output text --region <region>)
+  [ "$STATUS" = "available" ] && break
+  sleep 30
+done
+```
+
+### Step 3: Build the connection string
+
+All five parameters are required — DocumentDB rejects or behaves incorrectly without them:
+
+```
+mongodb://adminuser:<password>@<endpoint>:27017/?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false
+```
+
+| Param | Why |
+|---|---|
+| `tls=true` + `tlsCAFile` | TLS is required; absent → connection refused |
+| `replicaSet=rs0` | Without this, the driver connects to one node only |
+| `retryWrites=false` | DocumentDB does not support retryable writes |
+| `readPreference=secondaryPreferred` | Distributes reads to replicas |
+
+The string above uses the **primary (master) user**, which is always password-based.
+
+**IAM authentication is also supported** for application / non-admin users (not the primary user) on cluster version 5.0+. It is password-less — connections use short-lived STS tokens — suiting Lambda/ECS/EC2 workloads that run with an IAM role. Trade-offs: requires instance-based 5.0+, a `MONGODB-AWS`-capable driver (`pip install 'pymongo[aws]'`; Node.js ≥ 6.13.1), and an STS dependency at connect time (watch STS throttling at high connection rates).
+
+Create an IAM-backed user as the master user in the `$external` database, then connect with `authSource=$external&authMechanism=MONGODB-AWS` (no credentials in the URI — the driver fetches them from the attached role):
+
+```javascript
+use $external;
+db.createUser({ user: "arn:aws:iam::<account-id>:role/<app-role>",
+  mechanisms: ["MONGODB-AWS"], roles: [ { role: "readWrite", db: "<app-db>" } ] });
+```
+```
+mongodb://<endpoint>:27017/?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&authSource=%24external&authMechanism=MONGODB-AWS
+```
+
+### Step 4: Connect from outside the VPC (local dev only)
+
+**If using SSM (Option 1):** the `aws ssm start-session` command in Track B already establishes the port-forward tunnel. No separate SSH step needed. Connect directly:
+
+```bash
+mongosh --tls --tlsAllowInvalidHostnames --tlsCAFile global-bundle.pem \
+  --host 127.0.0.1 --port 27017 --username adminuser --password '<pw>' \
+  --eval "db.runCommand({ping:1})"
+```
+
+**If using SSH bastion (Option 2):** wait 15 seconds after the bastion is running (sshd needs to start), then:
+
+```bash
+ssh -i <key-pair-name>.pem \
+  -L 27017:<cluster-endpoint>:27017 \
+  -o StrictHostKeyChecking=no -o ServerAliveInterval=30 \
+  ec2-user@<bastion-public-ip> -N -f
+```
+
+Then connect the same way — mongosh needs `--tlsAllowInvalidHostnames` because the hostname resolves to `127.0.0.1`, not the cluster endpoint.
+
+Expected: `{ ok: 1 }`.
+
+### Step 5: Return a ready-to-use driver snippet
+
+Read `references/connection-drivers.md` and substitute the actual endpoint, password, and database name.
+
+## Workflow — Entry Point B (existing cluster)
+
+### Diagnostic commands (always run first)
+
+```bash
+aws docdb describe-db-clusters --db-cluster-identifier <name> \
+  --query 'DBClusters[*].[DBClusterIdentifier,Endpoint,Port]' --region <region>
+
+aws docdb describe-db-instances --db-instance-identifier <instance-name> \
+  --query 'DBInstances[*].DBSubnetGroup.VpcId' --region <region>
+
+nc -zv <cluster-endpoint> 27017
+```
+
+### Match the error and apply the fix
+
+| Error | Fix |
+|---|---|
+| `connection refused`, timeout after 5000ms | SG missing inbound TCP 27017. Add rule from app SG; if outside VPC, set up tunnel |
+| `SSL handshake failed`, `certificate verify failed` | Download RDS bundle; verify `tlsCAFile` path |
+| `not master` / `not primary` | Add `replicaSet=rs0` to the connection string |
+| `Server selection timed out after 30000ms` | Bad cert path or unreachable endpoint — re-run `nc -zv` |
+| `getaddrinfo failed` | Wrong endpoint — run `describe-db-clusters` to get the correct one |
+| Intermittent write errors under load | Add `retryWrites=false` |
+
+### VPC checklist
+
+- EC2/Lambda and DocumentDB in the **same region** and **same VPC** (or VPC peering)
+- DocumentDB SG inbound TCP 27017 from the app SG (preferred) or from a specific IP
+- Never open to `0.0.0.0/0`
+
+```bash
+aws ec2 authorize-security-group-ingress \
+  --group-id <docdb-sg> --protocol tcp --port 27017 \
+  --source-group <app-sg> --region <region>
+```
+
+### TLS verification
+
+Check the `tls` parameter in the cluster's parameter group (`enabled` default, `disabled`, or `fips-140-3`).
+
+## Serverless constraints
+
+- **Supported on engine 5.0.0 and 8.0.0** — not 3.6 or 4.0
+- Supported with Global Clusters
+- DCU scaling in 0.5 increments via `MinCapacity` / `MaxCapacity`
+- Verify regional availability: `aws docdb describe-orderable-db-instance-options --region <r> --db-instance-class db.serverless --engine docdb`
+
+For driver snippets (Python, Node, Java, Go, C#, Ruby, mongosh), see `references/connection-drivers.md`.

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/connection.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/connection.md
@@ -111,6 +111,7 @@ use $external;
 db.createUser({ user: "arn:aws:iam::<account-id>:role/<app-role>",
   mechanisms: ["MONGODB-AWS"], roles: [ { role: "readWrite", db: "<app-db>" } ] });
 ```
+
 ```
 mongodb://<endpoint>:27017/?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&authSource=%24external&authMechanism=MONGODB-AWS
 ```

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/migration.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/migration.md
@@ -1,0 +1,246 @@
+# DocumentDB — Migration Executor
+
+End-to-end migration from MongoDB to DocumentDB using AWS DMS for data, the index tool for indexes, and manual steps for users/roles. Produces `artifacts/{app-name}/migration-plan.md`.
+
+## What to ask upfront
+
+- `app_name` (lowercase with hyphens)
+- MongoDB source URI
+- DocumentDB target endpoint, admin credentials, region
+- Migration type: `full-load` or `full-load-and-cdc`
+
+## Prerequisites
+
+Check for the compatibility report first:
+```bash
+ls artifacts/<app-name>/compatibility-report.md 2>/dev/null || \
+  echo "WARNING: Run the compatibility sub-skill first to identify blockers."
+```
+
+If missing, warn the user and ask whether to proceed.
+
+## Workflow
+
+### Step 1: Workload discovery
+
+Run against MongoDB source via mongosh:
+```javascript
+// Counts per collection
+db.getCollectionNames().forEach(c => print(c, db[c].countDocuments()))
+// Data and index sizes
+db.stats()
+// Active indexes
+db.getCollectionNames().forEach(c => db[c].getIndexes().forEach(i => printjson(i)))
+// Index usage
+db.getCollectionNames().forEach(c => db[c].aggregate([{ $indexStats: {} }]).forEach(printjson))
+```
+
+Record totals for the migration plan.
+
+### Step 2: Index migration
+
+```bash
+# Export
+python3 amazon-documentdb-tools/index-tool/migrationtools/documentdb_index_tool.py \
+  --dump-indexes --dir ./migration-index-export \
+  --uri "mongodb://<user>:<pass>@<mongo-host>:27017"
+
+# Check compatibility
+python3 amazon-documentdb-tools/index-tool/migrationtools/documentdb_index_tool.py \
+  --show-issues --dir ./migration-index-export
+
+# Dry run restore
+python3 amazon-documentdb-tools/index-tool/migrationtools/documentdb_index_tool.py \
+  --restore-indexes --skip-incompatible --dry-run \
+  --dir ./migration-index-export \
+  --uri "mongodb://admin:<pw>@<docdb-endpoint>:27017/?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&retryWrites=false"
+
+# Actual restore
+python3 amazon-documentdb-tools/index-tool/migrationtools/documentdb_index_tool.py \
+  --restore-indexes --skip-incompatible \
+  --dir ./migration-index-export \
+  --uri "mongodb://admin:<pw>@<docdb-endpoint>:27017/?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&retryWrites=false"
+```
+
+Add `--shorten-index-name` for long names and `--support-2dsphere` for 2dsphere indexes. Record the count restored and any skipped.
+
+### Step 3: Users and roles
+
+DocumentDB built-in roles: `read`, `readWrite`, `dbAdmin`, `dbAdminAnyDatabase`, `readAnyDatabase`, `readWriteAnyDatabase`. Custom roles are not supported — map each MongoDB custom role to the nearest built-in.
+
+```javascript
+db.createUser({
+  user: "<username>", pwd: "<password>",
+  roles: [{ role: "readWrite", db: "<database>" }]
+})
+```
+
+### Step 4: DMS setup (full load + CDC)
+
+**4a. Security group.** DocumentDB SG must allow inbound TCP 27017 from the DMS replication instance's SG. Self-referencing rule if in the same SG:
+
+```bash
+DOCDB_SG=$(aws docdb describe-db-clusters --db-cluster-identifier <docdb-id> \
+  --query 'DBClusters[0].VpcSecurityGroups[0].VpcSecurityGroupId' --output text --region <region>)
+aws ec2 authorize-security-group-ingress \
+  --group-id $DOCDB_SG --protocol tcp --port 27017 \
+  --source-group $DOCDB_SG --region <region> 2>/dev/null || true
+```
+
+**4b. DMS replication subnet group** (must be in the same VPC as DocumentDB):
+
+```bash
+VPC_ID=$(aws docdb describe-db-instances --db-instance-identifier <docdb-inst> \
+  --query 'DBInstances[0].DBSubnetGroup.VpcId' --output text --region <region>)
+SUBNET_IDS=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$VPC_ID" \
+  --query 'Subnets[*].SubnetId' --output text --region <region>)
+aws dms create-replication-subnet-group \
+  --replication-subnet-group-identifier <app>-migration-sg \
+  --replication-subnet-group-description "MongoDB to DocumentDB" \
+  --subnet-ids $SUBNET_IDS --region <region>
+```
+
+**4c. DMS replication instance:**
+
+```bash
+aws dms create-replication-instance \
+  --replication-instance-identifier <app>-dms \
+  --replication-instance-class dms.r5.large --allocated-storage 50 \
+  --vpc-security-group-ids $DOCDB_SG \
+  --replication-subnet-group-identifier <app>-migration-sg \
+  --no-publicly-accessible --multi-az --region <region>
+```
+
+Poll `aws dms describe-replication-instances` until `ReplicationInstanceStatus=available`.
+
+**4d. Import the RDS CA bundle into DMS** (once per region):
+
+```bash
+DMS_CERT_ARN=$(aws dms describe-certificates --region <region> \
+  --query 'Certificates[?CertificateIdentifier==`global-bundle`].CertificateArn' --output text)
+if [ -z "$DMS_CERT_ARN" ] || [ "$DMS_CERT_ARN" = "None" ]; then
+  curl -s https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /tmp/global-bundle.pem
+  DMS_CERT_ARN=$(aws dms import-certificate \
+    --certificate-identifier global-bundle \
+    --certificate-pem file:///tmp/global-bundle.pem --region <region> \
+    --query 'Certificate.CertificateArn' --output text)
+fi
+```
+
+**4e. Source endpoint (MongoDB):**
+
+```bash
+aws dms create-endpoint --endpoint-identifier <app>-source \
+  --endpoint-type source --engine-name mongodb \
+  --server-name <mongo-host> --port 27017 \
+  --username <u> --password '<pw>' --database-name admin --region <region>
+```
+
+For production, keep credentials off the command line: replace `--username/--password` with `--mongo-db-settings` referencing a Secrets Manager secret — `'ServerName=<host>,Port=27017,DatabaseName=admin,SecretsManagerAccessRoleArn=<role-arn>,SecretsManagerSecretId=<secret-arn>'`. The role needs `secretsmanager:GetSecretValue` plus `iam:PassRole`.
+
+**4f. Target endpoint (DocumentDB).** MUST use `--ssl-mode verify-full` with `--certificate-arn` — without TLS DMS hits socket timeouts:
+
+```bash
+aws dms create-endpoint --endpoint-identifier <app>-target \
+  --endpoint-type target --engine-name docdb \
+  --server-name <docdb-endpoint> --port 27017 \
+  --username admin --password '<pw>' \
+  --ssl-mode verify-full --certificate-arn $DMS_CERT_ARN \
+  --database-name "" --region <region>
+```
+
+As with the source endpoint (4e), for production keep credentials off the command line by passing `--doc-db-settings` with `SecretsManagerSecretId` + `SecretsManagerAccessRoleArn` instead of `--username/--password`.
+
+**4g. Test both endpoints** (DMS refuses to start a task without passing tests):
+
+```bash
+DMS_INSTANCE_ARN=$(aws dms describe-replication-instances \
+  --filters Name=replication-instance-id,Values=<app>-dms \
+  --query 'ReplicationInstances[0].ReplicationInstanceArn' --output text --region <region>)
+SRC_ARN=$(aws dms describe-endpoints --filters Name=endpoint-id,Values=<app>-source \
+  --query 'Endpoints[0].EndpointArn' --output text --region <region>)
+TGT_ARN=$(aws dms describe-endpoints --filters Name=endpoint-id,Values=<app>-target \
+  --query 'Endpoints[0].EndpointArn' --output text --region <region>)
+
+aws dms test-connection --replication-instance-arn $DMS_INSTANCE_ARN \
+  --endpoint-arn $SRC_ARN --region <region>
+aws dms test-connection --replication-instance-arn $DMS_INSTANCE_ARN \
+  --endpoint-arn $TGT_ARN --region <region>
+
+# Poll both until successful
+aws dms describe-connections \
+  --filters Name=endpoint-arn,Values=$SRC_ARN,$TGT_ARN --region <region>
+```
+
+**4h. Migration task** — set `FailOnNoTablesCaptured: false` or the task fails fatally on an empty source:
+
+```bash
+TASK_ARN=$(aws dms create-replication-task \
+  --replication-task-identifier <app>-migration \
+  --source-endpoint-arn $SRC_ARN --target-endpoint-arn $TGT_ARN \
+  --replication-instance-arn $DMS_INSTANCE_ARN \
+  --migration-type full-load-and-cdc \
+  --table-mappings '{"rules":[{"rule-type":"selection","rule-id":"1","rule-name":"include-all","object-locator":{"schema-name":"%","table-name":"%"},"rule-action":"include"}]}' \
+  --replication-task-settings '{"TargetMetadata":{"SupportLobs":true,"FullLobMode":false,"LimitedSizeLobMode":true,"LobMaxSize":32},"FullLoadSettings":{"TargetTablePrepMode":"DO_NOTHING"},"ErrorBehavior":{"FailOnNoTablesCaptured":false},"Logging":{"EnableLogging":true}}' \
+  --query 'ReplicationTask.ReplicationTaskArn' --output text --region <region>)
+```
+
+Wait for `Status=ready`, then start the task using the captured ARN:
+
+```bash
+aws dms start-replication-task \
+  --replication-task-arn $TASK_ARN \
+  --start-replication-task-type start-replication --region <region>
+```
+
+Default 32 KB LOB limit truncates larger documents — check the user's largest docs and adjust if needed.
+
+### Step 5: Monitor
+
+```bash
+# Progress + CDC latency
+aws dms describe-replication-tasks --filters Name=replication-task-arn,Values=$TASK_ARN \
+  --query 'ReplicationTasks[0].{Status:Status,Progress:ReplicationTaskStats.FullLoadProgressPercent,CDCLatency:ReplicationTaskStats.CDCLatencySource}'
+# Table-level errors
+aws dms describe-table-statistics --replication-task-arn $TASK_ARN \
+  --query 'TableStatistics[?TableState==`Table error`]'
+```
+
+### Step 6: Validation
+
+Compare counts and sample documents on MongoDB and DocumentDB. Acceptable variance < 0.1% during active CDC.
+
+### Step 7: Write the migration plan
+
+`artifacts/{app-name}/migration-plan.md` — collections migrated with counts, indexes restored/skipped, users created, DMS task ARN + status, validation results, planned cutover time.
+
+### Step 8: Cutover
+
+Before switching traffic, complete every item:
+
+**Data & indexes**
+- Counts match within < 0.1% on all collections
+- Sample docs from 3+ largest collections compare correctly
+- All indexes exist on DocumentDB; incompatibles recreated with supported equivalents
+- Top 5 queries show IXSCAN (not COLLSCAN) in `explain()`
+
+**Application**
+- Every blocker from compatibility report resolved in app code
+- Connection string has all five required params (`tls`, `tlsCAFile`, `replicaSet`, `readPreference`, `retryWrites=false`)
+- Staged run against DocumentDB with real traffic patterns completed
+
+**DMS**
+- Both endpoint tests pass (`successful`)
+- CDC lag < 60 seconds, zero table errors, task in `Replication ongoing`
+
+**Cutover steps (in order):**
+1. Put app in maintenance mode (stop writes)
+2. Wait for DMS CDC lag to reach 0 (`CDCLatencySource`)
+3. Stop the DMS task
+4. Final count check on both sides
+5. Update app connection strings to the DocumentDB endpoint
+6. Start the app, run smoke tests
+7. Monitor CloudWatch for 15–30 minutes (`CPUUtilization`, `DatabaseConnections`)
+8. Keep MongoDB read-only for 24–48 hours as rollback — do NOT write to it
+
+**Rollback within 24–48 hours:** point app back at MongoDB, fix the issue in staging, re-plan cutover.

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/migration.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/migration.md
@@ -12,6 +12,7 @@ End-to-end migration from MongoDB to DocumentDB using AWS DMS for data, the inde
 ## Prerequisites
 
 Check for the compatibility report first:
+
 ```bash
 ls artifacts/<app-name>/compatibility-report.md 2>/dev/null || \
   echo "WARNING: Run the compatibility sub-skill first to identify blockers."
@@ -24,6 +25,7 @@ If missing, warn the user and ask whether to proceed.
 ### Step 1: Workload discovery
 
 Run against MongoDB source via mongosh:
+
 ```javascript
 // Counts per collection
 db.getCollectionNames().forEach(c => print(c, db[c].countDocuments()))
@@ -218,22 +220,26 @@ Compare counts and sample documents on MongoDB and DocumentDB. Acceptable varian
 
 Before switching traffic, complete every item:
 
-**Data & indexes**
+#### Data & indexes
+
 - Counts match within < 0.1% on all collections
 - Sample docs from 3+ largest collections compare correctly
 - All indexes exist on DocumentDB; incompatibles recreated with supported equivalents
 - Top 5 queries show IXSCAN (not COLLSCAN) in `explain()`
 
-**Application**
+#### Application
+
 - Every blocker from compatibility report resolved in app code
 - Connection string has all five required params (`tls`, `tlsCAFile`, `replicaSet`, `readPreference`, `retryWrites=false`)
 - Staged run against DocumentDB with real traffic patterns completed
 
-**DMS**
+#### DMS
+
 - Both endpoint tests pass (`successful`)
 - CDC lag < 60 seconds, zero table errors, task in `Replication ongoing`
 
 **Cutover steps (in order):**
+
 1. Put app in maintenance mode (stop writes)
 2. Wait for DMS CDC lag to reach 0 (`CDCLatencySource`)
 3. Stop the DMS task

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/performance.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/performance.md
@@ -96,6 +96,7 @@ db.collection.aggregate([{ $indexStats: {} }])   // unused since last restart
 ```
 
 Look for:
+
 - **Redundant indexes** — `{a:1}` and `{a:1, b:1}` on the same collection. The single-field is covered by the compound; drop it.
 - **Compound indexes with > 3 fields** — most filtering uses the first 1–3 fields; extras add write overhead.
 - **Multikey indexes on large arrays** — each element is a separate index entry; storage bloat.
@@ -117,6 +118,7 @@ Look for:
 ### Step 4: Produce a report
 
 Organize findings by severity:
+
 - **Critical** — COLLSCAN on large collections, long-running queries blocking GC
 - **Warning** — redundant indexes, high-cardinality sorts without index
 - **Improvement** — missing projections, pipeline ordering
@@ -133,4 +135,3 @@ For each finding, give the exact fix command.
 | `LongestRunningGCProcess` | > 1800s = long query blocking GC |
 | `AvailableMVCCIds` | Low = risk of read-only mode |
 | `BufferCacheHitRatio` | Low = queries hitting disk; scale up or add indexes |
-

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/performance.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/performance.md
@@ -1,0 +1,136 @@
+# DocumentDB — Performance Tuner
+
+Two modes: **reactive** (user has a slow query — diagnose and fix) and **proactive** (general performance review). Both produce concrete index commands and query rewrites you execute against the user's cluster.
+
+**Operator verification:** Before suggesting query rewrites that use specific aggregation operators, verify support by calling `web_fetch(url="https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html")` and searching the content.
+
+## What to ask upfront
+
+- Slow query vs general review?
+- If slow query: the query itself, collection name, approximate collection size
+- Cluster id, region, connection string
+
+## Reactive mode: fix a slow query
+
+### Step 1: Run `explain("executionStats")`
+
+```javascript
+// find()
+db.collection.find({ field: "value" }).explain("executionStats")
+
+// aggregate()
+db.runCommand({
+  explain: { aggregate: "collection", pipeline: [...], cursor: {} },
+  verbosity: "executionStats"
+})
+```
+
+### Step 2: Interpret output
+
+| Field | Look for |
+|---|---|
+| `queryPlanner.winningPlan.stage` | `COLLSCAN` = no index (bad), `IXSCAN` = index used, `SORT` = in-memory sort |
+| `executionStats.totalDocsExamined` (8.0+) | Should be close to `nReturned`; large gap = inefficient |
+| `executionStats.totalKeysExamined` | Large vs `nReturned` = index not selective enough |
+| `executionStats.executionTimeMillis` | Baseline for improvement |
+| `queryPlanner.winningPlan.inputStage.indexName` | Which index was chosen |
+
+### Step 3: Apply the fix
+
+**COLLSCAN → create a missing index (ESR rule — equality first, sort, then range):**
+
+```javascript
+// Query: db.orders.find({ userId, status })
+db.orders.createIndex({ userId: 1, status: 1 })
+
+// Query with sort: include sort field in the same direction
+db.products.createIndex({ category: 1, price: -1 })
+
+// Full ESR: equality → sort → range
+db.orders.createIndex({ userId: 1, createdAt: -1, price: 1 })
+```
+
+**Aggregation pipeline not using an index → put `$match` first:**
+
+```javascript
+// BAD — $project before $match destroys indexed field paths
+[{ $project: { total: ... } }, { $match: { total: { $gt: 100 } } }]
+
+// GOOD — $match first on indexed fields, compute derived fields after
+[{ $match: { price: { $gt: 10 } } }, { $project: { total: ... } }]
+```
+
+**IXSCAN with high docs-examined / returned ratio → add selective fields to the compound index.**
+
+**Long-running queries (> 30 minutes) → kill them:**
+
+```javascript
+db.adminCommand({ aggregate: 1, pipeline: [
+  { $currentOp: {} },
+  { $match: { $or: [{ secs_running: { $gt: 1800 } }, { WaitState: { $exists: true } }] } }
+], cursor: {} })
+```
+
+Long queries block MVCC garbage collection → storage growth → CPU/memory pressure. Recommend application-level query timeouts.
+
+### Step 4: Verify
+
+Re-run `explain()`. Stage should change from `COLLSCAN` to `IXSCAN`, `executionTimeMillis` decrease, `totalDocsExamined` close to `nReturned`. Report before/after.
+
+## Proactive mode: performance review
+
+### Step 1: Query CloudWatch Logs Insights
+
+Profiler log group: `/aws/docdb/<cluster-id>/profiler`.
+
+```
+filter ns="<db>.<coll>" | sort millis desc | limit 10
+filter planSummary="COLLSCAN" | sort millis desc | limit 20
+```
+
+### Step 2: Review indexes
+
+```javascript
+db.getCollectionNames().forEach(c => db[c].getIndexes().forEach(printjson))
+db.collection.aggregate([{ $indexStats: {} }])   // unused since last restart
+```
+
+Look for:
+- **Redundant indexes** — `{a:1}` and `{a:1, b:1}` on the same collection. The single-field is covered by the compound; drop it.
+- **Compound indexes with > 3 fields** — most filtering uses the first 1–3 fields; extras add write overhead.
+- **Multikey indexes on large arrays** — each element is a separate index entry; storage bloat.
+
+### Step 3: Check anti-patterns
+
+| # | Anti-pattern | Fix |
+|---|---|---|
+| 1 | `COLLSCAN` on large collections | Add index on filter fields; apply ESR rule |
+| 2 | Unbounded arrays in documents | Move to a separate collection with a parent-id index |
+| 3 | `$match` after `$project` | Put `$match` first on indexed fields |
+| 4 | `find()` without projection | Project only needed fields to reduce data transfer |
+| 5 | Redundant indexes | Drop prefix indexes covered by compounds |
+| 6 | High-cardinality `SORT` without index | Include sort field in the index (matching direction) |
+| 7 | Frequent `$lookup` on hot path | Denormalize at write time; add indexes on join keys |
+
+**Connection anti-pattern** (very common): creating `MongoClient` per request skips connection pooling. Create once at module scope; Lambda: outside the handler.
+
+### Step 4: Produce a report
+
+Organize findings by severity:
+- **Critical** — COLLSCAN on large collections, long-running queries blocking GC
+- **Warning** — redundant indexes, high-cardinality sorts without index
+- **Improvement** — missing projections, pipeline ordering
+
+For each finding, give the exact fix command.
+
+## CloudWatch metrics to monitor
+
+| Metric | Meaning |
+|---|---|
+| `CPUUtilization` | High = COLLSCANs, complex aggregations, connection spikes |
+| `DatabaseConnections` | Current connection count |
+| `DatabaseConnectionsLimit` | Max allowed — alert when approaching |
+| `LongestRunningGCProcess` | > 1800s = long query blocking GC |
+| `AvailableMVCCIds` | Low = risk of read-only mode |
+| `BufferCacheHitRatio` | Low = queries hitting disk; scale up or add indexes |
+

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/schema-advisor.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/schema-advisor.md
@@ -14,6 +14,7 @@ Use-case-first schema design. Start by understanding what the user is building, 
 ### Step 1: Identify entities, relationships, access patterns
 
 From the user's description, extract:
+
 - **Entities** — the main "things" (products, users, orders, messages)
 - **Relationships** — how they relate (users have orders, orders have items)
 - **Access patterns** — what queries the app runs (get user by id, list orders by user, search by category)
@@ -32,6 +33,7 @@ Core principle: embed when data is always accessed together; reference when it's
 | Post → comments | 1:many, need latest N | Mixed | **Hybrid**: embed latest 3, reference the rest |
 
 **Anti-patterns:**
+
 - **Unbounded arrays** (comments, events, messages) — they push documents toward the 16MB limit. Move to a separate collection.
 - **Recreating SQL tables 1:1** — if you always join two tables in SQL, embed them in DocumentDB.
 - **Excessive `$lookup`** — denormalize frequently-joined fields at write time.
@@ -82,6 +84,7 @@ db.articles.createIndex({ "title": "text", "body": "text" })
 ```
 
 **Constraints:**
+
 - Only one field in a compound index can be an array (multikey)
 - `sparse` and `partialFilterExpression` cannot be combined
 - Avoid compound indexes with more than 3 fields — write overhead outweighs query benefit for most workloads
@@ -91,6 +94,7 @@ db.articles.createIndex({ "title": "text", "body": "text" })
 Use DocumentDB native vector search for semantic search, RAG, chatbot memory, recommendations, or anomaly detection.
 
 **Availability:**
+
 - Vector indexes: DocumentDB 5.0+ (instance-based clusters)
 - Classic operator (`$search.vectorSearch`): DocumentDB 5.0+
 - `$vectorSearch` operator: DocumentDB 8.0+ (both instance-based and serverless)
@@ -175,6 +179,7 @@ Check these against the schema and warn the user about any that apply:
 ## Output format
 
 Every schema advisor response has three deliverables:
+
 1. **JSON document examples** (one per collection, with field-level comments)
 2. **`db.createIndex()` commands** (one per access pattern, ready to run in mongosh)
 3. **One-sentence rationale** per embed/reference decision

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/schema-advisor.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/schema-advisor.md
@@ -1,0 +1,180 @@
+# DocumentDB — Schema Advisor
+
+Use-case-first schema design. Start by understanding what the user is building, then produce a concrete schema, index commands, and rationale. DocumentDB's flexible schema means **data accessed together should be stored together** — design for access patterns, not entities.
+
+**Operator verification:** Before recommending any aggregation operator, you MUST verify it is supported in the target DocumentDB version by calling `web_fetch(url="https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html")` and searching the returned content. Do not assume support from MongoDB knowledge.
+
+## What to ask upfront
+
+- What they're building (one sentence)
+- Target DocumentDB version (default: `8.0` — applies to both instance-based and serverless)
+
+## Workflow
+
+### Step 1: Identify entities, relationships, access patterns
+
+From the user's description, extract:
+- **Entities** — the main "things" (products, users, orders, messages)
+- **Relationships** — how they relate (users have orders, orders have items)
+- **Access patterns** — what queries the app runs (get user by id, list orders by user, search by category)
+- **AI/vector need** — does it involve search, recommendations, or embeddings?
+
+### Step 2: Embed vs reference
+
+Core principle: embed when data is always accessed together; reference when it's accessed independently or grows without bound.
+
+| Relationship | Cardinality | Access | Recommendation |
+|---|---|---|---|
+| User → profile | 1:1 | Always together | **Embed** |
+| Order → line items | 1:few (< 100) | Always together | **Embed array** |
+| User → orders | 1:many, unbounded | Often separate | **Reference** (orders collection with `userId`) |
+| Product → categories | many:many | Varies | **Two-way reference** |
+| Post → comments | 1:many, need latest N | Mixed | **Hybrid**: embed latest 3, reference the rest |
+
+**Anti-patterns:**
+- **Unbounded arrays** (comments, events, messages) — they push documents toward the 16MB limit. Move to a separate collection.
+- **Recreating SQL tables 1:1** — if you always join two tables in SQL, embed them in DocumentDB.
+- **Excessive `$lookup`** — denormalize frequently-joined fields at write time.
+- **Fields accessed at different frequencies in the same document** — split into hot/cold collections.
+
+### Step 3: Produce JSON document examples
+
+One example per collection, with comments explaining each field choice:
+
+```javascript
+{
+  "_id": ObjectId("..."),
+  "sku": "SHIRT-BLU-L",
+  "name": "Classic Blue Shirt",
+  "category": "apparel",
+  "price": 49.99,
+  "attributes": {           // embedded — always accessed with product
+    "color": "blue", "size": "L", "material": "cotton"
+  },
+  "tags": ["shirt", "blue", "cotton"]  // bounded array, safe to embed
+}
+```
+
+Different documents in the same collection can have different fields — use this for polymorphic data (shoes have size+color, electronics have RAM+storage).
+
+### Step 4: Generate index commands
+
+For every access pattern, produce a ready-to-run `createIndex`. Apply the **ESR rule** for compound indexes — Equality fields first, Sort fields middle, Range fields last:
+
+```javascript
+// Single field
+db.products.createIndex({ "category": 1 })
+
+// Compound — ESR: equality(userId) → sort(createdAt) → range(price)
+db.orders.createIndex({ "userId": 1, "createdAt": -1, "price": 1 })
+
+// TTL — expire documents 30 days after createdAt
+db.sessions.createIndex({ "createdAt": 1 }, { expireAfterSeconds: 2592000 })
+
+// Partial (5.0+) — only index active products
+db.products.createIndex(
+  { "price": 1 },
+  { partialFilterExpression: { "status": { "$eq": "active" } } }
+)
+
+// Text search
+db.articles.createIndex({ "title": "text", "body": "text" })
+```
+
+**Constraints:**
+- Only one field in a compound index can be an array (multikey)
+- `sparse` and `partialFilterExpression` cannot be combined
+- Avoid compound indexes with more than 3 fields — write overhead outweighs query benefit for most workloads
+
+### Step 5: Vector search (AI / RAG workloads)
+
+Use DocumentDB native vector search for semantic search, RAG, chatbot memory, recommendations, or anomaly detection.
+
+**Availability:**
+- Vector indexes: DocumentDB 5.0+ (instance-based clusters)
+- Classic operator (`$search.vectorSearch`): DocumentDB 5.0+
+- `$vectorSearch` operator: DocumentDB 8.0+ (both instance-based and serverless)
+
+**Schema — store embedding with source content:**
+
+```javascript
+{
+  "_id": ObjectId("..."),
+  "source": "docs/getting-started.md",
+  "chunk_index": 3,
+  "text": "Amazon DocumentDB Serverless auto-scales...",
+  "embedding": [0.023, -0.117, 0.891, ...],    // 1536 floats for OpenAI ada-002
+  "metadata": { "doc_type": "documentation" }
+}
+```
+
+**Create an HNSW index (recommended for most workloads):**
+
+```javascript
+db.runCommand({
+  createIndexes: "documents",
+  indexes: [{
+    key: { "embedding": "vector" },
+    name: "embedding_hnsw_idx",
+    vectorOptions: {
+      type: "hnsw",
+      dimensions: 1536,          // match your embedding model
+      similarity: "cosine",      // cosine for text; euclidean for images; dotProduct for normalized
+      m: 16, efConstruction: 64
+    }
+  }]
+})
+```
+
+Use **IVFFlat** instead when index build speed matters more than recall and you have > 1M vectors. Set `lists: sqrt(num_documents)`.
+
+**Query — DocumentDB 8.0+ (`$vectorSearch`):**
+
+```javascript
+db.documents.aggregate([
+  { $vectorSearch: {
+      queryVector: [...],
+      path: "embedding",
+      index: "embedding_hnsw_idx",
+      limit: 10,
+      numCandidates: 150
+  }}
+])
+```
+
+**Query — DocumentDB 5.0 (Classic `$search.vectorSearch`):**
+
+```javascript
+db.documents.aggregate([
+  { $search: {
+      vectorSearch: {
+        vector: [...],
+        path: "embedding",
+        similarity: "cosine",
+        k: 10,
+        efSearch: 40
+      }
+  }}
+])
+```
+
+**Dimension limits:** 2,000 with an index, 16,000 without (brute-force scan).
+
+**Note:** DocumentDB does NOT support `knnBeta` or `{ $meta: "vectorSearchScore" }` — those are MongoDB Atlas features. DocumentDB returns matching documents ordered by similarity without an explicit score field.
+
+### Step 6: Flag DocumentDB constraints
+
+Check these against the schema and warn the user about any that apply:
+
+- **16MB document hard limit.** Monitor with `Object.bsonsize(doc)` in mongosh (`$bsonSize` is NOT supported). Use `db.runCommand({collStats: "..."}).avgObjSize` for averages.
+- **No schema enforcement by default.** Recommend `$jsonSchema` validation for critical collections.
+- **`$graphLookup`** — verify current support status at the [MongoDB API compatibility page](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html) before advising. If unsupported: use the materialized path pattern (store `ancestors` array) or Amazon Neptune. Materialized paths are often the better design even when `$graphLookup` is available.
+- **`$facet`** — verify current support status at the same page. If unsupported: split into separate aggregation pipelines and merge in app code.
+- **Multikey indexes on large arrays** bloat storage — each element is a separate index entry.
+
+## Output format
+
+Every schema advisor response has three deliverables:
+1. **JSON document examples** (one per collection, with field-level comments)
+2. **`db.createIndex()` commands** (one per access pattern, ready to run in mongosh)
+3. **One-sentence rationale** per embed/reference decision

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/troubleshooting.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/troubleshooting.md
@@ -1,0 +1,92 @@
+# DocumentDB — Troubleshooting
+
+Expanded troubleshooting reference for issues beyond the SKILL.md summary. Grouped by failure class.
+
+## Authentication and credentials
+
+**`AccessDenied` / `UnauthorizedOperation`.** Caller lacks permissions for DocumentDB, DMS, CloudWatch, EC2, or Secrets Manager. Attach `AmazonDocDBReadOnlyAccess` + `CloudWatchReadOnlyAccess` for read-only flows. For migration add `AmazonDMSVPCManagementRole` and scoped write actions. Do NOT grant admin as a workaround.
+
+**`ExpiredToken` / `RequestExpired`.** Refresh your credentials (e.g. `aws sso login`, or renew the credentials for your configured profile) and verify with `aws sts get-caller-identity`, then retry.
+
+## Connectivity
+
+**Connection refused / timeout on port 27017.** DocumentDB is VPC-only (no public endpoint). Run `aws ec2 describe-security-groups --group-ids <sg>` — the DocumentDB SG needs inbound TCP 27017 from the client SG. Reference by SG id, not CIDR. From outside the VPC use CloudShell VPC environment, EC2 in the VPC, or SSH tunnel via bastion.
+
+**TLS handshake failed / certificate verify failed.** Download the RDS global bundle: `curl -s https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o global-bundle.pem`. Verify the `tlsCAFile` path matches where the cert actually is. When tunneling, pass `--tlsAllowInvalidHostnames` to mongosh because the hostname resolves to `127.0.0.1`, not the cluster endpoint.
+
+**`Server selection timed out after 30000ms`.** TLS cert at wrong path, or endpoint unreachable. Verify cert path and run `nc -zv <endpoint> 27017` from the client network.
+
+**`getaddrinfo failed`.** Wrong endpoint. Run `aws docdb describe-db-clusters --db-cluster-identifier <name> --query 'DBClusters[*].[Endpoint,Port]'` to get the correct endpoint.
+
+## Driver behavior
+
+**"not master" / "not primary".** Missing `replicaSet=rs0` in the connection string. DocumentDB always uses `rs0`.
+
+**Intermittent write errors under load.** Missing `retryWrites=false`. DocumentDB does not support retryable writes — drivers default to `true`.
+
+**Java driver only connects to primary.** Using `applyToClusterSettings` with a single host sets mode to SINGLE and breaks failover. Use `applyConnectionString` instead — see `references/connection-drivers.md`.
+
+**Connection storm / `DatabaseConnections` spike.** Creating `MongoClient` per request skips connection pooling. Create the client once at module scope (Lambda: outside the handler) and reuse across requests.
+
+**Cursor timeout / `CursorNotFound`.** Idle cursors close after 10 minutes. Process results faster, add early `$match`/`$limit` to reduce set size, or use `noCursorTimeout` sparingly. `cursor.maxTimeMS` resets on each `getMore` — DocumentDB differs from MongoDB here.
+
+## DMS
+
+**DMS task refuses to start — "Test connection should be successful".** DMS requires explicit `aws dms test-connection` calls that pass for both source and target endpoints before starting a task. Call `test-connection` for each endpoint, then poll `describe-connections` until both return `successful`:
+
+```bash
+aws dms describe-connections \
+  --filters Name=endpoint-arn,Values=<src-arn>,<tgt-arn> \
+  --region <region>
+```
+
+**DMS target endpoint socket timeout.** Target endpoint MUST use `--ssl-mode verify-full` with `--certificate-arn` pointing to the RDS global bundle imported into DMS. Without TLS, DocumentDB rejects the connection.
+
+Import the RDS bundle into DMS if missing:
+
+```bash
+curl -s https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -o /tmp/global-bundle.pem
+aws dms import-certificate \
+  --certificate-identifier global-bundle \
+  --certificate-pem file:///tmp/global-bundle.pem \
+  --region <region>
+```
+
+Also verify the DocumentDB SG allows inbound TCP 27017 from the DMS replication instance's SG (self-referencing rule if in same SG, or cross-SG rule).
+
+**DMS CDC task fails — "No tables found at task initialization".** Source has no collections yet. Set `FailOnNoTablesCaptured: false` in the replication task settings.
+
+## Major Version Upgrade (MVU)
+
+**"AllowMajorVersionUpgrade flag must be present".** `--allow-major-version-upgrade` is mandatory on every `modify-db-cluster` MVU command. Include it.
+
+**"Must explicitly specify a new DB cluster parameter group".** The cluster uses a custom parameter group, but you didn't specify one for the target engine family. Create a new PG for the target (e.g. `docdb5.0`, `docdb8.0`) and pass `--db-cluster-parameter-group-name`.
+
+**MVU fails / rolls back.** In-place MVU auto-rolls back on failure. Check cluster events for "Database cluster is in a state that cannot be upgraded." Verify: no db.r4 instances (not supported on 4.0+), no pending OS maintenance, burstable-instance index counts within limits (t4g.medium: 3,000; t3.medium: 10,000). Contact AWS support before re-attempting.
+
+**Post-upgrade performance degradation (5.0→8.0).** Index metadata refresh is running — wait for "Index metadata refresh process completed" event (up to 2 hours). Do NOT reboot or failover the writer during this window.
+
+**MVU CDC migrator connection error.** Source URI must NOT include `readPreference=secondaryPreferred` — change streams only work on the primary.
+
+**Clone creation fails.** Source cluster must be in "available" state. Check encryption settings are compatible. Ensure IAM permissions include `rds:RestoreDBClusterToPointInTime`.
+
+**CDC replication lag not decreasing.** DMS: check CloudWatch logs and increase parallel threads. MVU tool: verify network connectivity and that change stream retention hasn't expired (default 3 hours — raise to 24 hours with `change_stream_log_retention_duration=86400`).
+
+## Performance and operations
+
+**High CPU with no obvious slow queries.** Run `db.adminCommand({currentOp: 1})` — look for index builds. Check CloudWatch `OpcountersInsert` + `OpcountersDelete` for TTL activity. If query volume: scale up instance or add read replicas.
+
+**GC pressure / `AvailableMVCCIds` dropping.** Long-running ops blocking MVCC garbage collection. Kill them: `db.adminCommand({killOp: 1, op: <opid>})`. Recommend avoiding transactions longer than 1 minute.
+
+**`explain()` output differs from MongoDB.** Field names and nesting are different. Read output manually; do not parse it programmatically assuming MongoDB format.
+
+## Throttling and resource availability
+
+**`ReadTimeoutError`, `ThrottlingException`, `Rate exceeded`.** Retry once; if persistent, narrow scope (single cluster, shorter window, smaller batch).
+
+**`DBClusterNotFoundFault`.** Verify region and cluster identifier spelling. For Global Clusters use `describe-global-clusters`. Empty DMS endpoint list — confirm resources exist in the region you queried.
+
+## Escalation
+
+- If a command fails twice with the same error, **stop and show the full error to the user** with a suggested manual step rather than retrying the same command
+- Destructive changes (delete cluster, drop collection, force failover) require explicit user confirmation before proceeding

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/upgrade.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/upgrade.md
@@ -1,0 +1,181 @@
+# DocumentDB — Major Version Upgrade
+
+Orchestrate DocumentDB major version upgrades. Supports two paths:
+- **4.0 → 5.0**
+- **5.0 → 8.0**
+
+Two approaches:
+- **Option A: In-place MVU** — simpler, has downtime (multiple reboots). Best for dev/staging, small clusters, or when downtime is acceptable.
+- **Option B: Near-zero downtime** — clone + MVU on clone + CDC + cutover. Source stays online. Best for production.
+
+**Cannot skip versions** (3.6 must go 3.6→5.0→8.0). **Elastic Clusters:** MVU is not supported — no workaround. **Global Clusters:** direct in-place MVU is not supported. Workaround: remove the cluster from the Global Cluster first (this converts it to a standalone regional cluster), perform the upgrade using Option A or B below, then re-add it to the Global Cluster.
+
+## What to ask upfront
+
+- Source cluster id, region
+- Current engine version (detect with `aws docdb describe-db-clusters --query 'DBClusters[0].EngineVersion'`)
+- Target version (`5.0` or `8.0`)
+- `app_name` (artifact naming)
+- Tolerate downtime (Option A) or need near-zero downtime (Option B)
+
+## Prerequisites (all paths)
+
+**Mandatory on every `modify-db-cluster` MVU command:** `--allow-major-version-upgrade`. **When cluster uses a custom parameter group:** also `--db-cluster-parameter-group-name` pointing at a new PG for the target engine family (`docdb5.0`, `docdb8.0`).
+
+**Pre-upgrade checks:**
+- Manual snapshot created and available (use polling loop — `aws docdb wait` is not in all CLI versions)
+- Pending OS maintenance applied
+- No `db.r4` instances (not supported on 4.0+) — upgrade to `db.r5+` first
+- Burstable instance index counts within limits: `db.t4g.medium` ≤ 3,000 indexes, `db.t3.medium` ≤ 10,000. If over, scale primary to `db.r5.large` before upgrading
+
+## Option A: In-Place MVU
+
+### Step 1: Create manual snapshot
+
+```bash
+aws docdb create-db-cluster-snapshot \
+  --db-cluster-identifier <id> \
+  --db-cluster-snapshot-identifier <id>-pre-mvu-$(date +%Y%m%d) \
+  --region <region>
+```
+
+Poll until `Status=available`.
+
+### Step 2: Create target parameter group (if custom PG in use)
+
+```bash
+aws docdb create-db-cluster-parameter-group \
+  --db-cluster-parameter-group-name <id>-docdb<version>-pg \
+  --db-parameter-group-family docdb<version> \
+  --description "MVU target for <id>" --region <region>
+```
+
+### Step 3: Execute the upgrade
+
+```bash
+aws docdb modify-db-cluster \
+  --db-cluster-identifier <id> \
+  --engine-version <target-version> \
+  --db-cluster-parameter-group-name <id>-docdb<version>-pg \
+  --allow-major-version-upgrade --apply-immediately \
+  --region <region>
+```
+
+Cluster unavailable during upgrade (multiple reboots). Time depends on collection / index / instance count.
+
+### Step 4: Verify
+
+```bash
+# Engine version
+aws docdb describe-db-clusters --db-cluster-identifier <id> \
+  --query 'DBClusters[0].EngineVersion' --region <region>
+# Confirm via mongosh: db.version() and db.runCommand({ping: 1})
+```
+
+For 5.0→8.0: wait for "Index metadata refresh process completed" event (up to 2 hours). Do NOT reboot, failover, or scale the writer during this time.
+
+## Option B: Near-Zero Downtime (clone + MVU + CDC)
+
+### Step 1: Enable change streams on the source
+
+Custom parameter group required (defaults can't be modified). After switching to a custom PG, **reboot the instance** and confirm `DBClusterParameterGroupStatus=in-sync` before proceeding:
+
+```
+change_stream_log_retention_duration = 86400    # 24 hours
+```
+
+Enable change streams on all databases:
+
+```javascript
+db.adminCommand({ modifyChangeStreams: 1, database: "", collection: "", enable: true })
+```
+
+### Step 2: Clone the source cluster
+
+```bash
+aws docdb restore-db-cluster-to-point-in-time \
+  --db-cluster-identifier <id>-clone \
+  --source-db-cluster-identifier <id> \
+  --use-latest-restorable-time \
+  --region <region>
+```
+
+Record clone creation time (DMS CDC start = 2 min before, as Unix epoch). Add instances to the clone and wait for `available`.
+
+### Step 3: Upgrade the clone in place
+
+Apply Option A Steps 2–4 to the clone. Do NOT write to the clone after it's upgraded.
+
+### Step 4: Set up CDC replication (DMS is the primary method)
+
+Follow `references/migration.md` for DMS setup:
+- SG allows inbound TCP 27017 on the DocumentDB SG from DMS instance SG
+- DMS replication subnet group in the same VPC
+- RDS CA cert imported into DMS
+- Endpoints created with `--ssl-mode verify-full` and the cert ARN
+- Both endpoint connection tests pass (`successful`)
+
+Then create the replication task with `migration-type cdc` (data changes only — clone already has the data) and CDC start time = 2 minutes before clone creation:
+
+```bash
+aws dms create-replication-task \
+  --replication-task-identifier <id>-mvu-cdc \
+  --source-endpoint-arn <source-ep-arn> \
+  --target-endpoint-arn <clone-ep-arn> \
+  --replication-instance-arn <dms-instance-arn> \
+  --migration-type cdc \
+  --cdc-start-position "checkpoint:<2-min-before-clone-time-epoch>" \
+  --table-mappings '{"rules":[{"rule-type":"selection","rule-id":"1","rule-name":"all","object-locator":{"schema-name":"%","table-name":"%"},"rule-action":"include"}]}' \
+  --replication-task-settings '{"ErrorBehavior":{"FailOnNoTablesCaptured":false}}' \
+  --region <region>
+```
+
+Start the task. Monitor `CDCLatencySource` — should decrease toward 0.
+
+**Fallback:** `amazon-documentdb-tools/migration/mvu-tool/mvu-cdc-migrator.py`. Source URI MUST NOT include `readPreference=secondaryPreferred` (change streams are primary-only).
+
+### Step 5: Pre-cutover checklist
+
+- CDC lag near zero (`CDCLatencySource` < 60s)
+- Counts match within 0.1% on 3+ largest collections
+- All indexes exist on clone; critical queries tested
+- For 5.0→8.0: Query Planner v3 active, Zstd on new collections, driver updated
+
+### Step 6: Cutover (in order)
+
+1. Put app in maintenance mode
+2. Wait for CDC lag = 0
+3. Final document count verification
+4. Stop the DMS task; update app connection strings to the upgraded clone's endpoint
+5. Update driver version if needed; start app; run smoke tests
+6. Monitor CloudWatch for 15–30 minutes
+7. Keep source running read-only for 24–48 hours as rollback — do NOT write to it
+
+### Step 7: Rollback
+
+**Before cutover:** delete the clone; source is untouched.
+```bash
+aws docdb delete-db-cluster --db-cluster-identifier <clone-id> --skip-final-snapshot
+```
+
+**After cutover, within 24–48 hours:** point app back at source (still has data up to cutover). Manual reconciliation needed for writes made to the clone after cutover.
+
+**If source was already deleted:** restore from the pre-upgrade snapshot:
+```bash
+aws docdb restore-db-cluster-from-snapshot \
+  --db-cluster-identifier <id>-restored \
+  --snapshot-identifier <pre-upgrade-snapshot-id> --engine docdb
+```
+
+### Step 8: Post-cutover cleanup (after 24–48 hours)
+
+- Delete old source cluster; disable change streams on upgraded cluster
+- Delete DMS resources (instance, endpoints, task)
+- Add read replicas to match production topology; copy alerts
+- Update IaC; take a manual snapshot
+
+## What changes by target version
+
+**4.0 → 5.0:** Vector search, LZ4 compression (off by default), I/O-Optimized storage, partial indexes, text indexes v1. Recommended but optional: `db.collection.reIndex()` on low-cardinality indexes.
+
+**5.0 → 8.0:** Query Planner v3 (7× faster aggregations), Zstd compression (on by default, 5× ratio), Text v2 parser, Collation (default-on), Views, new stages (`$merge`, `$bucket`, `$replaceWith`, `$vectorSearch`), 30× faster vector index builds. No index rebuild needed. Update driver to MongoDB 6.0+/7.0+/8.0 to use new features.

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/upgrade.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/upgrade.md
@@ -1,10 +1,12 @@
 # DocumentDB — Major Version Upgrade
 
 Orchestrate DocumentDB major version upgrades. Supports two paths:
+
 - **4.0 → 5.0**
 - **5.0 → 8.0**
 
 Two approaches:
+
 - **Option A: In-place MVU** — simpler, has downtime (multiple reboots). Best for dev/staging, small clusters, or when downtime is acceptable.
 - **Option B: Near-zero downtime** — clone + MVU on clone + CDC + cutover. Source stays online. Best for production.
 
@@ -23,6 +25,7 @@ Two approaches:
 **Mandatory on every `modify-db-cluster` MVU command:** `--allow-major-version-upgrade`. **When cluster uses a custom parameter group:** also `--db-cluster-parameter-group-name` pointing at a new PG for the target engine family (`docdb5.0`, `docdb8.0`).
 
 **Pre-upgrade checks:**
+
 - Manual snapshot created and available (use polling loop — `aws docdb wait` is not in all CLI versions)
 - Pending OS maintenance applied
 - No `db.r4` instances (not supported on 4.0+) — upgrade to `db.r5+` first
@@ -109,6 +112,7 @@ Apply Option A Steps 2–4 to the clone. Do NOT write to the clone after it's up
 ### Step 4: Set up CDC replication (DMS is the primary method)
 
 Follow `references/migration.md` for DMS setup:
+
 - SG allows inbound TCP 27017 on the DocumentDB SG from DMS instance SG
 - DMS replication subnet group in the same VPC
 - RDS CA cert imported into DMS
@@ -154,6 +158,7 @@ Start the task. Monitor `CDCLatencySource` — should decrease toward 0.
 ### Step 7: Rollback
 
 **Before cutover:** delete the clone; source is untouched.
+
 ```bash
 aws docdb delete-db-cluster --db-cluster-identifier <clone-id> --skip-final-snapshot
 ```
@@ -161,6 +166,7 @@ aws docdb delete-db-cluster --db-cluster-identifier <clone-id> --skip-final-snap
 **After cutover, within 24–48 hours:** point app back at source (still has data up to cutover). Manual reconciliation needed for writes made to the clone after cutover.
 
 **If source was already deleted:** restore from the pre-upgrade snapshot:
+
 ```bash
 aws docdb restore-db-cluster-from-snapshot \
   --db-cluster-identifier <id>-restored \

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/well-architected.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/well-architected.md
@@ -44,6 +44,7 @@ Read `artifacts/<cluster-id>/wa_review_results.json`. Categorize findings:
 Organize findings by priority. For each FAIL and WARN, give the specific command:
 
 **Enable deletion protection:**
+
 ```bash
 aws docdb modify-db-cluster \
   --db-cluster-identifier <cluster-id> \
@@ -51,6 +52,7 @@ aws docdb modify-db-cluster \
 ```
 
 **Add a reader replica for HA:**
+
 ```bash
 aws docdb create-db-instance \
   --db-instance-identifier <cluster-id>-reader \
@@ -59,6 +61,7 @@ aws docdb create-db-instance \
 ```
 
 **Increase backup retention:**
+
 ```bash
 aws docdb modify-db-cluster \
   --db-cluster-identifier <cluster-id> \
@@ -66,6 +69,7 @@ aws docdb modify-db-cluster \
 ```
 
 **Enable audit logging:**
+
 ```bash
 aws docdb modify-db-cluster-parameter-group \
   --db-cluster-parameter-group-name <pg> \
@@ -73,6 +77,7 @@ aws docdb modify-db-cluster-parameter-group \
 ```
 
 For each finding include:
+
 1. What was checked and the result
 2. Why it matters (one sentence)
 3. The specific command to execute
@@ -104,6 +109,7 @@ SUST1 Graviton instance family (`r6g`/`r8g`/`t4g`) · SUST2 compression enabled 
 **Enable Zstd compression (SUST2, COST7):** Available in 8.0, enabled by default on new collections. For existing collections, modify compression settings per collection.
 
 **Remove unused indexes (COST3):**
+
 ```javascript
 // Find indexes with zero usage
 db.collection.aggregate([{ $indexStats: {} }])

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/well-architected.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/well-architected.md
@@ -1,0 +1,121 @@
+# DocumentDB — Well-Architected Review
+
+Automated 41-check assessment across 6 pillars. Runs the bundled `scripts/wa_review.py`, reads the JSON results, and presents prioritized remediation commands.
+
+## What to ask upfront
+
+- `cluster_id` — the cluster name the user mentions in conversation (e.g., "my cluster xyz", "cluster docdb-prod") — this is the `--db-cluster-identifier` value, not a separate ID. Extract it directly from what the user said.
+- `region` — AWS region the user mentioned (e.g., `us-east-1`)
+- Optional: database connection string (enables 11 additional database-level checks)
+
+If both are present in the user's message, use them and proceed directly to Step 1 without asking.
+
+## Prerequisites
+
+- AWS credentials with read access to: DocumentDB, CloudWatch, EC2, Secrets Manager
+- Python 3.6+
+
+## Workflow
+
+### Step 1: Run the review
+
+```bash
+python3 scripts/wa_review.py \
+  --cluster-id <cluster-id> \
+  --region <region> \
+  --output artifacts/<cluster-id>/ \
+  [--uri "mongodb://admin:<pw>@<endpoint>:27017/?tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&retryWrites=false"] \
+  [--tls-ca-file global-bundle.pem]
+```
+
+If connection via URI fails, retry without `--uri` — infrastructure-only checks still run.
+
+### Step 2: Read the results
+
+Read `artifacts/<cluster-id>/wa_review_results.json`. Categorize findings:
+
+- **FAIL** — must fix before production. Blockers: no deletion protection, TLS disabled, single AZ, swap usage, MVCC exhaustion risk
+- **WARN** — should fix. Low backup retention, no audit logging, oversized instances, unused indexes, idle readers
+- **PASS** — no action needed
+- **INFO** — informational
+
+### Step 3: Present recommendations with remediation commands
+
+Organize findings by priority. For each FAIL and WARN, give the specific command:
+
+**Enable deletion protection:**
+```bash
+aws docdb modify-db-cluster \
+  --db-cluster-identifier <cluster-id> \
+  --deletion-protection --region <region>
+```
+
+**Add a reader replica for HA:**
+```bash
+aws docdb create-db-instance \
+  --db-instance-identifier <cluster-id>-reader \
+  --db-instance-class <same-class-as-writer> --engine docdb \
+  --db-cluster-identifier <cluster-id> --region <region>
+```
+
+**Increase backup retention:**
+```bash
+aws docdb modify-db-cluster \
+  --db-cluster-identifier <cluster-id> \
+  --backup-retention-period 7 --region <region>
+```
+
+**Enable audit logging:**
+```bash
+aws docdb modify-db-cluster-parameter-group \
+  --db-cluster-parameter-group-name <pg> \
+  --parameters "ParameterName=audit_logs,ParameterValue=enabled,ApplyMethod=immediate"
+```
+
+For each finding include:
+1. What was checked and the result
+2. Why it matters (one sentence)
+3. The specific command to execute
+
+## Checks reference (41 total)
+
+### Reliability (8)
+REL1 backup retention ≥ 7 days · REL2 deletion protection enabled · REL5a instances ≥ 2 · REL5b instances across ≥ 2 AZs · REL6 engine version currency · REL7 no failover events in last 13 days · REL8 no cursor timeouts · REL9 `AvailableMVCCIds` > 50%
+
+### Security (6)
+SEC1a encryption at rest · SEC1b TLS enabled · SEC2 SG not open to `0.0.0.0/0` · SEC3 credentials in Secrets Manager · SEC5 audit logging · SEC6 TLS ≥ 1.2
+
+### Operational Excellence (5)
+OPS2 subnet group spans ≥ 3 AZs · OPS5a profiler logging · OPS5b ≥ 3 CloudWatch alarms · OPS5c custom parameter group · OPS7 maintenance window review
+
+### Cost Optimization (6)
+COST1 CPU P95 per instance (< 10% = oversized) · COST3 unused indexes · COST4 TTL indexes present · COST6 ≥ 2 cost allocation tags · COST7 storage type (Standard vs I/O-Optimized) · COST9 idle reader detection
+
+### Performance Efficiency (14)
+PERF1 avg doc size < 8 KB · PERF1b no redundant (prefix) indexes · PERF1c no low-cardinality indexes · PERF5 connections < 70% of instance limit · PERF6 `BufferCacheHitRatio` ≥ 99% · PERF8 index-to-data ratio < 50% · PERF9 storage bloat < 30% · PERF10 no over-indexed collections (> 10 indexes) · PERF11 `FreeableMemory` > 10% of instance RAM · PERF12 no swap usage · PERF13 `DiskQueueDepth` < 5 · PERF14 `IndexBufferCacheHitRatio` ≥ 99% · PERF15 large collections have secondary indexes · PERF16 index size < 2× data size per collection
+
+### Sustainability (2)
+SUST1 Graviton instance family (`r6g`/`r8g`/`t4g`) · SUST2 compression enabled on all collections
+
+## Common remediation patterns
+
+**Upgrade to Graviton family (SUST1, COST1):** Scale each instance to a `db.r8g.*` or `db.r6g.*` class via `modify-db-instance --db-instance-class`. Requires engine 5.0+ for R8G.
+
+**Enable Zstd compression (SUST2, COST7):** Available in 8.0, enabled by default on new collections. For existing collections, modify compression settings per collection.
+
+**Remove unused indexes (COST3):**
+```javascript
+// Find indexes with zero usage
+db.collection.aggregate([{ $indexStats: {} }])
+db.collection.dropIndex("index_name")
+```
+
+**Fix redundant indexes (PERF1b):** If both `{a: 1}` and `{a: 1, b: 1}` exist, drop the single-field — the compound covers both access patterns.
+
+**Enable I/O-Optimized (COST7):** When monthly I/O cost exceeds the I/O-Optimized storage + compute premium (~25% breakeven). Switch via `modify-db-cluster --storage-type iopt1`.
+
+**Size a new workload or compare DocumentDB vs MongoDB costs:** Use the [DocumentDB Cost Estimator](https://builder.aws.com/content/3DLjpHB3gKnntEPemXnHlFTCEgX/amazon-documentdb-cost-estimator-size-your-workload-in-minutes-part-1) — it accepts MongoDB ops/sec, storage, and I/O patterns as inputs and produces a DocumentDB cost comparison in minutes. Surface this whenever the user asks about cost estimation or workload sizing.
+
+## Output format
+
+Present findings as a table grouped by pillar, with FAILs surfaced first. For each finding: check id, status, one-sentence rationale, remediation command. Then write a summary header to the user with the total FAIL / WARN / PASS counts and the top three remediation priorities.

--- a/skills/specialized-skills/database-skills/amazon-documentdb/scripts/wa_review.py
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/scripts/wa_review.py
@@ -1,0 +1,1341 @@
+#!/usr/bin/env python3
+"""DocumentDB Well-Architected Review — standalone CLI.
+
+Runs 41 automated checks across 6 pillars against a DocumentDB cluster.
+Infrastructure checks use boto3 (AWS APIs). Database-level checks use
+a pre-collected analysis JSON file (from pymongo collStats/indexStats).
+
+Usage:
+    python3 wa_review.py --cluster-id <id> --region <region> [--analysis-data <path>]
+
+Output:
+    wa_review_results.json  — structured check results
+    wa_review_report.md     — human-readable summary
+
+Requires: boto3, AWS credentials with docdb/cloudwatch/ec2/secretsmanager read access.
+"""
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+try:
+    import boto3
+except ImportError:
+    print("ERROR: boto3 required. Install with: pip install boto3")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+CONN_LIMITS = {
+    "db.t3.medium": 1000,
+    "db.t4g.medium": 1000,
+    "db.r5.large": 3400,
+    "db.r6g.large": 3400,
+    "db.r6gd.large": 3400,
+    "db.r8g.large": 3400,
+    "db.r5.xlarge": 7000,
+    "db.r6g.xlarge": 7000,
+    "db.r6gd.xlarge": 7000,
+    "db.r8g.xlarge": 7000,
+    "db.r5.2xlarge": 14200,
+    "db.r6g.2xlarge": 14200,
+    "db.r6gd.2xlarge": 14200,
+    "db.r8g.2xlarge": 14200,
+    "db.r5.4xlarge": 28400,
+    "db.r6g.4xlarge": 28400,
+    "db.r6gd.4xlarge": 28400,
+    "db.r8g.4xlarge": 28400,
+    "db.r5.8xlarge": 60000,
+    "db.r6g.8xlarge": 60000,
+    "db.r6gd.8xlarge": 60000,
+    "db.r8g.8xlarge": 60000,
+    "db.r5.12xlarge": 60000,
+    "db.r6g.12xlarge": 60000,
+    "db.r6gd.12xlarge": 60000,
+    "db.r8g.12xlarge": 60000,
+    "db.r5.16xlarge": 60000,
+    "db.r6g.16xlarge": 60000,
+    "db.r6gd.16xlarge": 60000,
+    "db.r8g.16xlarge": 60000,
+    "db.r5.24xlarge": 60000,
+}
+INSTANCE_RAM_GIB = {
+    "db.t3.medium": 4,
+    "db.t4g.medium": 4,
+    "db.r5.large": 16,
+    "db.r6g.large": 16,
+    "db.r6gd.large": 16,
+    "db.r8g.large": 16,
+    "db.r5.xlarge": 32,
+    "db.r6g.xlarge": 32,
+    "db.r6gd.xlarge": 32,
+    "db.r8g.xlarge": 32,
+    "db.r5.2xlarge": 64,
+    "db.r6g.2xlarge": 64,
+    "db.r6gd.2xlarge": 64,
+    "db.r8g.2xlarge": 64,
+    "db.r5.4xlarge": 128,
+    "db.r6g.4xlarge": 128,
+    "db.r6gd.4xlarge": 128,
+    "db.r8g.4xlarge": 128,
+    "db.r5.8xlarge": 256,
+    "db.r6g.8xlarge": 256,
+    "db.r6gd.8xlarge": 256,
+    "db.r8g.8xlarge": 256,
+    "db.r5.12xlarge": 384,
+    "db.r6g.12xlarge": 384,
+    "db.r6gd.12xlarge": 384,
+    "db.r8g.12xlarge": 384,
+    "db.r5.16xlarge": 512,
+    "db.r6g.16xlarge": 512,
+    "db.r6gd.16xlarge": 512,
+    "db.r8g.16xlarge": 512,
+    "db.r5.24xlarge": 768,
+}
+GRAVITON_FAMILIES = ("r6g", "r7g", "r8g", "t4g", "r6gd")
+
+
+def _add(results, pillar, check_id, label, status, detail=""):
+    results.append(
+        {"pillar": pillar, "id": check_id, "label": label, "status": status, "detail": detail}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure checks (boto3)
+# ---------------------------------------------------------------------------
+def run_infra_checks(cluster_id, region):
+    results: list[dict] = []
+    docdb = boto3.client("docdb", region_name=region)
+    cw = boto3.client("cloudwatch", region_name=region)
+    ec2 = boto3.client("ec2", region_name=region)
+
+    try:
+        cl = docdb.describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]
+    except Exception as e:
+        _add(results, "Other", "ERR", f"Cannot describe cluster: {e}", "fail")
+        return results
+
+    try:
+        insts = docdb.describe_db_instances(
+            Filters=[{"Name": "db-cluster-id", "Values": [cluster_id]}]
+        )["DBInstances"]
+    except Exception as e:
+        insts = []
+        _add(results, "Other", "ERR", f"Cannot describe instances: {e}", "fail")
+
+    # -- RELIABILITY --------------------------------------------------------
+    retention = cl.get("BackupRetentionPeriod", 1)
+    _add(
+        results,
+        "Reliability",
+        "REL1",
+        f"Backup retention period ({retention} days)",
+        "pass" if retention >= 7 else "warn" if retention >= 3 else "fail",
+        "Recommended: 7+ days for production" if retention < 7 else "",
+    )
+
+    del_prot = cl.get("DeletionProtection", False)
+    _add(
+        results,
+        "Reliability",
+        "REL2",
+        f"Deletion protection ({'enabled' if del_prot else 'disabled'})",
+        "pass" if del_prot else "fail",
+        "" if del_prot else "Enable deletion protection for production clusters",
+    )
+
+    n_inst = len(insts)
+    _add(
+        results,
+        "Reliability",
+        "REL5a",
+        f"Instance count ({n_inst})",
+        "pass" if n_inst >= 2 else "fail",
+        "Minimum 2 instances required for auto failover" if n_inst < 2 else "",
+    )
+
+    azs = {i.get("AvailabilityZone", "") for i in insts}
+    _add(
+        results,
+        "Reliability",
+        "REL5b",
+        f"Instances across {len(azs)} AZ(s)",
+        "pass" if len(azs) >= 2 else "fail",
+        "Single AZ -- no failover protection" if len(azs) < 2 else "",
+    )
+
+    engine_ver = cl.get("EngineVersion", "unknown")
+    major = engine_ver.split(".")[0] if engine_ver != "unknown" else ""
+    if major in ("3", "4"):
+        _add(
+            results,
+            "Reliability",
+            "REL6",
+            f"Engine version {engine_ver} (approaching or past end-of-life)",
+            "fail",
+            "Upgrade to DocumentDB 5.0 or 8.0",
+        )
+    elif major == "5":
+        _add(
+            results,
+            "Reliability",
+            "REL6",
+            f"Engine version {engine_ver}",
+            "pass",
+            "Consider upgrading to 8.0 for Zstandard compression and Query Planner v3",
+        )
+    else:
+        _add(results, "Reliability", "REL6", f"Engine version {engine_ver}", "pass")
+
+    # Recent failover events (14 days) — paginated
+    try:
+        evt_end = datetime.now(timezone.utc)
+        evt_start = evt_end - timedelta(days=13)
+        events_list = []
+        paginator = docdb.get_paginator("describe_events")
+        for page in paginator.paginate(
+            SourceIdentifier=cluster_id,
+            SourceType="db-cluster",
+            StartTime=evt_start,
+            EndTime=evt_end,
+        ):
+            events_list.extend(page.get("Events", []))
+        failover_events = [
+            e
+            for e in events_list
+            if "failover" in e.get("Message", "").lower()
+            or "failover" in ",".join(e.get("EventCategories", [])).lower()
+        ]
+        if failover_events:
+            _add(
+                results,
+                "Reliability",
+                "REL7",
+                f"{len(failover_events)} failover event(s) in last 13 days",
+                "warn",
+                f"Most recent: {failover_events[-1].get('Message', '')[:120]}",
+            )
+        else:
+            _add(results, "Reliability", "REL7", "No failover events in last 13 days", "pass")
+    except Exception as e:
+        _add(results, "Reliability", "REL7", f"Cannot check events: {e}", "warn")
+
+    # -- SECURITY -----------------------------------------------------------
+    encrypted = cl.get("StorageEncrypted", False)
+    _add(
+        results,
+        "Security",
+        "SEC1a",
+        f"Encryption at rest ({'enabled' if encrypted else 'disabled'})",
+        "pass" if encrypted else "fail",
+        "" if encrypted else "Enable encryption at rest (requires new cluster)",
+    )
+
+    tls_val = "unknown"
+    try:
+        pg_name = cl.get("DBClusterParameterGroup", "")
+        if pg_name:
+            params = docdb.describe_db_cluster_parameters(DBClusterParameterGroupName=pg_name).get(
+                "Parameters", []
+            )
+            for p in params:
+                if p.get("ParameterName") == "tls":
+                    tls_val = p.get("ParameterValue", "enabled")
+                elif p.get("ParameterName") == "tls_version":
+                    tv = p.get("ParameterValue", "")
+                    if tv and "1.2" in tv and "1.0" not in tv and "1.1" not in tv:
+                        _add(results, "Security", "SEC6", f"TLS minimum version: {tv}", "pass")
+                    elif tv:
+                        _add(
+                            results,
+                            "Security",
+                            "SEC6",
+                            f"TLS minimum version: {tv}",
+                            "warn",
+                            "Set tls_version to TLSv1.2 to disable older protocols",
+                        )
+    except Exception as e:
+        _add(results, "Security", "SEC6", f"Cannot check TLS parameters: {e}", "warn")
+    # Ensure SEC6 is always present
+    if not any(r["id"] == "SEC6" for r in results):
+        _add(
+            results,
+            "Security",
+            "SEC6",
+            "TLS minimum version: unknown",
+            "warn",
+            "Could not determine tls_version parameter",
+        )
+    _add(
+        results,
+        "Security",
+        "SEC1b",
+        f"TLS ({tls_val})",
+        "pass" if tls_val == "enabled" else "warn" if tls_val == "unknown" else "fail",
+        (
+            "Could not determine TLS status"
+            if tls_val == "unknown"
+            else ("" if tls_val == "enabled" else "TLS should be enabled")
+        ),
+    )
+
+    # Security groups
+    sg_open = False
+    sg_checked = 0
+    for vsg in cl.get("VpcSecurityGroups", []):
+        sg_id = vsg.get("VpcSecurityGroupId", "")
+        if not sg_id:
+            continue
+        try:
+            sg_detail = ec2.describe_security_groups(GroupIds=[sg_id])["SecurityGroups"][0]
+            sg_checked += 1
+            for rule in sg_detail.get("IpPermissions", []):
+                for ip_range in rule.get("IpRanges", []):
+                    if ip_range.get("CidrIp") == "0.0.0.0/0":
+                        sg_open = True
+                        _add(
+                            results,
+                            "Security",
+                            "SEC2",
+                            f"Security group {sg_id} open to 0.0.0.0/0",
+                            "fail",
+                            "Restrict to specific CIDR ranges",
+                        )
+                for ip_range in rule.get("Ipv6Ranges", []):
+                    if ip_range.get("CidrIpv6") == "::/0":
+                        sg_open = True
+                        _add(
+                            results,
+                            "Security",
+                            "SEC2",
+                            f"Security group {sg_id} open to ::/0",
+                            "fail",
+                            "Restrict to specific CIDR ranges",
+                        )
+        except Exception as e:
+            _add(results, "Security", "SEC2", f"Cannot check SG {sg_id}: {e}", "warn")
+    if not sg_open and sg_checked > 0:
+        _add(
+            results,
+            "Security",
+            "SEC2",
+            f"Security groups properly restricted ({sg_checked} checked)",
+            "pass",
+        )
+
+    logs = cl.get("EnabledCloudwatchLogsExports", [])
+    audit_enabled = "audit" in logs
+    profiler_enabled = "profiler" in logs
+    _add(
+        results,
+        "Security",
+        "SEC5",
+        f"Audit logging ({'enabled' if audit_enabled else 'disabled'})",
+        "pass" if audit_enabled else "warn",
+        "" if audit_enabled else "Enable audit logging for compliance",
+    )
+
+    # Secrets Manager
+    try:
+        sm = boto3.client("secretsmanager", region_name=region)
+        found_secret = False
+        for page in sm.get_paginator("list_secrets").paginate():
+            for s in page.get("SecretList", []):
+                name = (s.get("Name", "") or "").lower()
+                desc = (s.get("Description", "") or "").lower()
+                if cluster_id.lower() in name or cluster_id.lower() in desc:
+                    found_secret = True
+                    break
+            if found_secret:
+                break
+        _add(
+            results,
+            "Security",
+            "SEC3",
+            f"Secrets Manager {'references' if found_secret else 'does not reference'} this cluster",
+            "pass" if found_secret else "warn",
+            "" if found_secret else "Store credentials in Secrets Manager",
+        )
+    except Exception as e:
+        _add(results, "Security", "SEC3", f"Cannot check Secrets Manager: {e}", "warn")
+
+    # -- OPERATIONAL EXCELLENCE ---------------------------------------------
+    sg_name = cl.get("DBSubnetGroup", "")
+    try:
+        if sg_name:
+            sg = docdb.describe_db_subnet_groups(DBSubnetGroupName=sg_name)["DBSubnetGroups"][0]
+            sg_azs = {s["SubnetAvailabilityZone"]["Name"] for s in sg.get("Subnets", [])}
+            _add(
+                results,
+                "Operational Excellence",
+                "OPS2",
+                f"Subnet group spans {len(sg_azs)} AZ(s)",
+                "pass" if len(sg_azs) >= 3 else "warn",
+                "Recommended: 3 AZs for failover flexibility" if len(sg_azs) < 3 else "",
+            )
+    except Exception as e:
+        _add(results, "Operational Excellence", "OPS2", f"Cannot check subnet group: {e}", "warn")
+
+    _add(
+        results,
+        "Operational Excellence",
+        "OPS5a",
+        f"Profiler logging ({'enabled' if profiler_enabled else 'disabled'})",
+        "pass" if profiler_enabled else "warn",
+        "" if profiler_enabled else "Enable profiler for slow query analysis",
+    )
+
+    pg_name = cl.get("DBClusterParameterGroup", "")
+    _add(
+        results,
+        "Operational Excellence",
+        "OPS5c",
+        f"Parameter group: {pg_name}",
+        "warn" if pg_name.startswith("default.") else "pass",
+        (
+            "Use a custom parameter group for workload-specific tuning"
+            if pg_name.startswith("default.")
+            else ""
+        ),
+    )
+
+    _add(
+        results,
+        "Operational Excellence",
+        "OPS7",
+        f"Maintenance window: {cl.get('PreferredMaintenanceWindow', 'not set')}",
+        "info",
+        "Verify this window aligns with your lowest-traffic period",
+    )
+
+    try:
+        n_alarms = len(cw.describe_alarms(AlarmNamePrefix=cluster_id).get("MetricAlarms", []))
+        _add(
+            results,
+            "Operational Excellence",
+            "OPS5b",
+            f"CloudWatch alarms ({n_alarms} configured)",
+            "pass" if n_alarms >= 3 else "warn" if n_alarms > 0 else "fail",
+            (
+                "Recommended: alarms for CPU, FreeableMemory, DatabaseConnections"
+                if n_alarms < 3
+                else ""
+            ),
+        )
+    except Exception as e:
+        _add(results, "Operational Excellence", "OPS5b", f"Cannot check alarms: {e}", "warn")
+
+    # -- COST OPTIMIZATION --------------------------------------------------
+    try:
+        n_tags = len(
+            docdb.list_tags_for_resource(ResourceName=cl["DBClusterArn"]).get("TagList", [])
+        )
+        _add(
+            results,
+            "Cost Optimization",
+            "COST6",
+            f"Cost allocation tags ({n_tags} tags)",
+            "pass" if n_tags >= 2 else "warn",
+            "Add cost allocation tags for expense tracking" if n_tags < 2 else "",
+        )
+    except Exception as e:
+        _add(results, "Cost Optimization", "COST6", f"Cannot check tags: {e}", "warn")
+
+    storage_type = cl.get("StorageType", "standard")
+    _add(
+        results,
+        "Cost Optimization",
+        "COST7",
+        f"Storage type: {storage_type}",
+        "info",
+        (
+            "Evaluate I/O-Optimized for write-heavy workloads"
+            if storage_type != "iopt1"
+            else "I/O-Optimized active -- no per-I/O charges"
+        ),
+    )
+
+    # -- PER-INSTANCE CHECKS ------------------------------------------------
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=7)
+
+    for inst in insts:
+        iid = inst["DBInstanceIdentifier"]
+        itype = inst["DBInstanceClass"]
+        dim = [{"Name": "DBInstanceIdentifier", "Value": iid}]
+        is_writer = inst.get("IsClusterWriter", False)
+        family = itype.replace("db.", "").split(".")[0] if itype.startswith("db.") else ""
+
+        # CPU — use hourly Maximum for P95 to capture peak usage within each hour
+        try:
+            raw_dps = cw.get_metric_statistics(
+                Namespace="AWS/DocDB",
+                MetricName="CPUUtilization",
+                Dimensions=dim,
+                StartTime=start,
+                EndTime=end,
+                Period=3600,
+                Statistics=["Average", "Maximum"],
+            ).get("Datapoints", [])
+            if raw_dps:
+                avg_cpu = sum(d["Average"] for d in raw_dps) / len(raw_dps)
+                max_vals = sorted(d["Maximum"] for d in raw_dps)
+                p95_cpu = max_vals[int(len(max_vals) * 0.95)]
+                _add(
+                    results,
+                    "Cost Optimization",
+                    "COST1",
+                    f"CPU for {iid} (avg {avg_cpu:.1f}%, P95 {p95_cpu:.1f}%)",
+                    "warn" if p95_cpu < 10 else "pass",
+                    f"Instance {itype} may be oversized" if p95_cpu < 10 else "",
+                )
+        except Exception as e:
+            _add(results, "Cost Optimization", "COST1", f"Cannot check CPU for {iid}: {e}", "warn")
+
+        # Graviton
+        _add(
+            results,
+            "Sustainability",
+            "SUST1",
+            f"{iid} {'uses' if family in GRAVITON_FAMILIES else 'does not use'} Graviton ({itype})",
+            "pass" if family in GRAVITON_FAMILIES else "warn",
+            (
+                ""
+                if family in GRAVITON_FAMILIES
+                else "Migrate to Graviton (r6g/r8g) for better price-performance"
+            ),
+        )
+
+        # Buffer cache hit ratio
+        try:
+            dps = [
+                d["Average"]
+                for d in cw.get_metric_statistics(
+                    Namespace="AWS/DocDB",
+                    MetricName="BufferCacheHitRatio",
+                    Dimensions=dim,
+                    StartTime=start,
+                    EndTime=end,
+                    Period=3600,
+                    Statistics=["Average"],
+                ).get("Datapoints", [])
+            ]
+            if dps:
+                avg_cache = sum(dps) / len(dps)
+                _add(
+                    results,
+                    "Performance Efficiency",
+                    "PERF6",
+                    f"Buffer cache hit ratio for {iid} ({avg_cache:.1f}%)",
+                    "pass" if avg_cache >= 99 else "warn" if avg_cache >= 95 else "fail",
+                    "Working set may not fit in memory" if avg_cache < 95 else "",
+                )
+        except Exception as e:
+            _add(
+                results,
+                "Performance Efficiency",
+                "PERF6",
+                f"Cannot check cache for {iid}: {e}",
+                "warn",
+            )
+
+        # Connections vs limits
+        try:
+            dps = [
+                d["Maximum"]
+                for d in cw.get_metric_statistics(
+                    Namespace="AWS/DocDB",
+                    MetricName="DatabaseConnections",
+                    Dimensions=dim,
+                    StartTime=start,
+                    EndTime=end,
+                    Period=3600,
+                    Statistics=["Maximum"],
+                ).get("Datapoints", [])
+            ]
+            limit = CONN_LIMITS.get(itype, 0)
+            if dps and limit:
+                max_conn = max(dps)
+                pct = max_conn / limit * 100
+                _add(
+                    results,
+                    "Performance Efficiency",
+                    "PERF5",
+                    f"Peak connections for {iid} ({int(max_conn)}/{limit} = {pct:.0f}%)",
+                    "pass" if pct < 70 else "warn" if pct < 90 else "fail",
+                    "Consider upsizing or connection pooling" if pct >= 70 else "",
+                )
+            elif dps:
+                _add(
+                    results,
+                    "Performance Efficiency",
+                    "PERF5",
+                    f"Connection limit unknown for {iid} ({itype})",
+                    "warn",
+                    "Instance type not in lookup table",
+                )
+        except Exception as e:
+            _add(
+                results,
+                "Performance Efficiency",
+                "PERF5",
+                f"Cannot check connections for {iid}: {e}",
+                "warn",
+            )
+
+        # Idle reader detection
+        if not is_writer:
+            try:
+                conn_dps = [
+                    d["Average"]
+                    for d in cw.get_metric_statistics(
+                        Namespace="AWS/DocDB",
+                        MetricName="DatabaseConnections",
+                        Dimensions=dim,
+                        StartTime=start,
+                        EndTime=end,
+                        Period=3600,
+                        Statistics=["Average"],
+                    ).get("Datapoints", [])
+                ]
+                io_dps = [
+                    d["Average"]
+                    for d in cw.get_metric_statistics(
+                        Namespace="AWS/DocDB",
+                        MetricName="ReadIOPS",
+                        Dimensions=dim,
+                        StartTime=start,
+                        EndTime=end,
+                        Period=3600,
+                        Statistics=["Average"],
+                    ).get("Datapoints", [])
+                ]
+                avg_conn = sum(conn_dps) / len(conn_dps) if conn_dps else 0
+                avg_iops = sum(io_dps) / len(io_dps) if io_dps else 0
+                if avg_conn < 2 and avg_iops < 5:
+                    _add(
+                        results,
+                        "Cost Optimization",
+                        "COST9",
+                        f"Reader {iid} appears idle (avg {avg_conn:.0f} conn, {avg_iops:.0f} ReadIOPS)",
+                        "warn",
+                        "Consider removing this replica to reduce cost",
+                    )
+                else:
+                    _add(
+                        results,
+                        "Cost Optimization",
+                        "COST9",
+                        f"Reader {iid} is active (avg {avg_conn:.0f} conn, {avg_iops:.0f} ReadIOPS)",
+                        "pass",
+                    )
+            except Exception as e:
+                _add(
+                    results, "Cost Optimization", "COST9", f"Cannot check reader {iid}: {e}", "warn"
+                )
+
+        # FreeableMemory
+        ram_gib = INSTANCE_RAM_GIB.get(itype, 0)
+        if ram_gib:
+            try:
+                dps = [
+                    d["Minimum"]
+                    for d in cw.get_metric_statistics(
+                        Namespace="AWS/DocDB",
+                        MetricName="FreeableMemory",
+                        Dimensions=dim,
+                        StartTime=start,
+                        EndTime=end,
+                        Period=3600,
+                        Statistics=["Minimum"],
+                    ).get("Datapoints", [])
+                ]
+                if dps:
+                    min_free = min(dps)
+                    free_pct = min_free / (ram_gib * 1024**3) * 100
+                    _add(
+                        results,
+                        "Performance Efficiency",
+                        "PERF11",
+                        f"FreeableMemory min for {iid}: {min_free / (1024**3):.1f} GiB ({free_pct:.0f}%)",
+                        "fail" if free_pct < 5 else "warn" if free_pct < 10 else "pass",
+                        "Instance under memory pressure" if free_pct < 10 else "",
+                    )
+            except Exception as e:
+                _add(
+                    results,
+                    "Performance Efficiency",
+                    "PERF11",
+                    f"Cannot check memory for {iid}: {e}",
+                    "warn",
+                )
+        else:
+            _add(
+                results,
+                "Performance Efficiency",
+                "PERF11",
+                f"Unknown instance type {itype} -- cannot check FreeableMemory",
+                "warn",
+            )
+
+        # SwapUsage
+        try:
+            dps = [
+                d["Maximum"]
+                for d in cw.get_metric_statistics(
+                    Namespace="AWS/DocDB",
+                    MetricName="SwapUsage",
+                    Dimensions=dim,
+                    StartTime=start,
+                    EndTime=end,
+                    Period=3600,
+                    Statistics=["Maximum"],
+                ).get("Datapoints", [])
+            ]
+            if dps and max(dps) > 0:
+                _add(
+                    results,
+                    "Performance Efficiency",
+                    "PERF12",
+                    f"SwapUsage max for {iid}: {max(dps) / (1024**2):.0f} MB",
+                    "fail",
+                    "Instance is swapping -- critically undersized",
+                )
+            elif dps:
+                _add(results, "Performance Efficiency", "PERF12", f"No swap on {iid}", "pass")
+        except Exception as e:
+            _add(
+                results,
+                "Performance Efficiency",
+                "PERF12",
+                f"Cannot check swap for {iid}: {e}",
+                "warn",
+            )
+
+        # DiskQueueDepth
+        try:
+            dps = [
+                d["Average"]
+                for d in cw.get_metric_statistics(
+                    Namespace="AWS/DocDB",
+                    MetricName="DiskQueueDepth",
+                    Dimensions=dim,
+                    StartTime=start,
+                    EndTime=end,
+                    Period=3600,
+                    Statistics=["Average"],
+                ).get("Datapoints", [])
+            ]
+            if dps:
+                avg_dqd = sum(dps) / len(dps)
+                _add(
+                    results,
+                    "Performance Efficiency",
+                    "PERF13",
+                    f"DiskQueueDepth avg for {iid}: {avg_dqd:.1f}",
+                    "warn" if avg_dqd > 5 else "pass",
+                    "I/O backing up -- evaluate I/O-Optimized or upsizing" if avg_dqd > 5 else "",
+                )
+        except Exception as e:
+            _add(
+                results,
+                "Performance Efficiency",
+                "PERF13",
+                f"Cannot check DiskQueueDepth for {iid}: {e}",
+                "warn",
+            )
+
+        # IndexBufferCacheHitRatio
+        try:
+            dps = [
+                d["Average"]
+                for d in cw.get_metric_statistics(
+                    Namespace="AWS/DocDB",
+                    MetricName="IndexBufferCacheHitRatio",
+                    Dimensions=dim,
+                    StartTime=start,
+                    EndTime=end,
+                    Period=3600,
+                    Statistics=["Average"],
+                ).get("Datapoints", [])
+            ]
+            if dps:
+                avg_idx = sum(dps) / len(dps)
+                _add(
+                    results,
+                    "Performance Efficiency",
+                    "PERF14",
+                    f"IndexBufferCacheHitRatio for {iid}: {avg_idx:.1f}%",
+                    "pass" if avg_idx >= 99 else "warn" if avg_idx >= 95 else "fail",
+                    "Indexes do not fit in memory" if avg_idx < 95 else "",
+                )
+        except Exception as e:
+            _add(
+                results,
+                "Performance Efficiency",
+                "PERF14",
+                f"Cannot check index cache for {iid}: {e}",
+                "warn",
+            )
+
+        # DatabaseCursorsTimedOut
+        try:
+            dps = [
+                d["Sum"]
+                for d in cw.get_metric_statistics(
+                    Namespace="AWS/DocDB",
+                    MetricName="DatabaseCursorsTimedOut",
+                    Dimensions=dim,
+                    StartTime=start,
+                    EndTime=end,
+                    Period=86400,
+                    Statistics=["Sum"],
+                ).get("Datapoints", [])
+            ]
+            total = sum(dps) if dps else 0
+            if total > 0:
+                _add(
+                    results,
+                    "Reliability",
+                    "REL8",
+                    f"{int(total)} cursor(s) timed out on {iid} in last 7 days",
+                    "warn",
+                    "Application may not be closing cursors properly",
+                )
+            else:
+                _add(results, "Reliability", "REL8", f"No cursor timeouts on {iid}", "pass")
+        except Exception as e:
+            _add(results, "Reliability", "REL8", f"Cannot check cursors for {iid}: {e}", "warn")
+
+        # AvailableMVCCIds (writer only)
+        if is_writer:
+            try:
+                dps = [
+                    d["Minimum"]
+                    for d in cw.get_metric_statistics(
+                        Namespace="AWS/DocDB",
+                        MetricName="AvailableMVCCIds",
+                        Dimensions=dim,
+                        StartTime=start,
+                        EndTime=end,
+                        Period=3600,
+                        Statistics=["Minimum"],
+                    ).get("Datapoints", [])
+                ]
+                if dps:
+                    min_mvcc = min(dps)
+                    pct = min_mvcc / 1_400_000_000 * 100
+                    _add(
+                        results,
+                        "Reliability",
+                        "REL9",
+                        f"AvailableMVCCIds min: {min_mvcc:,.0f} ({pct:.0f}%)",
+                        "fail" if pct < 25 else "warn" if pct < 50 else "pass",
+                        (
+                            "MVCC ID exhaustion risk -- investigate long-running transactions"
+                            if pct < 50
+                            else ""
+                        ),
+                    )
+            except Exception as e:
+                _add(results, "Reliability", "REL9", f"Cannot check MVCCIds: {e}", "warn")
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Database-level checks (from pre-collected analysis JSON)
+# ---------------------------------------------------------------------------
+def run_db_checks(analysis_data):
+    results: list[dict] = []
+    if not analysis_data:
+        return results
+
+    total_indexes = 0
+    unused_indexes = 0
+    redundant = 0
+    low_cardinality = 0
+    low_card_names = []
+    large_docs = []
+    ttl_colls = []
+    total_data_size = 0
+    total_index_size = 0
+    total_unused_bytes = 0
+    bloated_colls = []
+    over_indexed_colls = []
+    compression_disabled = []
+    collscan_candidates = []
+    write_amp_colls = []
+
+    for db_name, collections in analysis_data.items():
+        if not isinstance(collections, dict):
+            continue
+        for coll_name, stats in collections.items():
+            if not isinstance(stats, dict) or "error" in stats:
+                continue
+            indexes = stats.get("indexes", [])
+            total_indexes += len(indexes)
+
+            for idx in indexes:
+                if idx.get("usage", {}).get("potential_unused"):
+                    unused_indexes += 1
+                if idx.get("cardinality", {}).get("is_low"):
+                    low_cardinality += 1
+                    low_card_names.append(f"{db_name}.{coll_name}.{idx['name']}")
+                if idx.get("expireAfterSeconds") is not None:
+                    if f"{db_name}.{coll_name}" not in ttl_colls:
+                        ttl_colls.append(f"{db_name}.{coll_name}")
+
+            avg_obj = stats.get("avgObjSize", 0)
+            if avg_obj > 8192:
+                large_docs.append(f"{db_name}.{coll_name} ({avg_obj:,} bytes)")
+
+            # Redundant indexes (prefix subset)
+            ordered = [tuple(idx.get("ordered_fields", [])) for idx in indexes]
+            for i, a in enumerate(ordered):
+                for j, b in enumerate(ordered):
+                    if i != j and len(a) > 0 and len(a) < len(b) and b[: len(a)] == a:
+                        redundant += 1
+                        break
+
+            total_data_size += stats.get("size", 0)
+            for idx in indexes:
+                total_index_size += idx.get("size", 0)
+
+            unused_info = stats.get("unusedStorageSize", {})
+            unused_pct = unused_info.get("unusedPercent", 0.0)
+            total_unused_bytes += unused_info.get("unusedBytes", 0)
+            if unused_pct > 30:
+                bloated_colls.append(f"{db_name}.{coll_name} ({unused_pct:.0f}%)")
+
+            if len(indexes) > 10:
+                over_indexed_colls.append(f"{db_name}.{coll_name} ({len(indexes)} indexes)")
+
+            comp = stats.get("compression", {})
+            if not comp.get("enabled", False):
+                compression_disabled.append(f"{db_name}.{coll_name}")
+
+            doc_count = stats.get("count", 0)
+            non_id = [idx for idx in indexes if idx.get("name") != "_id_"]
+            if doc_count > 100000 and len(non_id) == 0:
+                collscan_candidates.append(f"{db_name}.{coll_name} ({doc_count:,} docs)")
+
+            coll_data = stats.get("size", 0)
+            coll_idx = sum(idx.get("size", 0) for idx in indexes)
+            if coll_data > 0 and coll_idx > 2 * coll_data:
+                write_amp_colls.append(
+                    f"{db_name}.{coll_name} (index {coll_idx / coll_data:.1f}x data)"
+                )
+
+    # Emit checks
+    if large_docs:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF1",
+            f"{len(large_docs)} collection(s) with avg doc size > 8 KB",
+            "warn",
+            ", ".join(large_docs[:5]),
+        )
+    else:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF1",
+            "All collections have avg doc size < 8 KB",
+            "pass",
+        )
+
+    if redundant > 0:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF1b",
+            f"{redundant} redundant index(es) (prefix subsets)",
+            "warn",
+        )
+    else:
+        _add(results, "Performance Efficiency", "PERF1b", "No redundant indexes detected", "pass")
+
+    if low_cardinality > 0:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF1c",
+            f"{low_cardinality} low cardinality index(es)",
+            "warn",
+            ", ".join(low_card_names[:5]),
+        )
+    else:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF1c",
+            "No low cardinality indexes detected",
+            "pass",
+        )
+
+    if unused_indexes > 0:
+        _add(
+            results,
+            "Cost Optimization",
+            "COST3",
+            f"{unused_indexes} unused index(es) of {total_indexes} total",
+            "warn",
+            "Remove unused indexes to reduce write overhead and storage",
+        )
+    else:
+        _add(
+            results,
+            "Cost Optimization",
+            "COST3",
+            f"No unused indexes ({total_indexes} total)",
+            "pass",
+        )
+
+    if ttl_colls:
+        _add(
+            results,
+            "Cost Optimization",
+            "COST4",
+            f"TTL indexes on {len(ttl_colls)} collection(s)",
+            "pass",
+            ", ".join(ttl_colls[:5]),
+        )
+    else:
+        _add(
+            results,
+            "Cost Optimization",
+            "COST4",
+            "No TTL indexes found",
+            "warn",
+            "Consider TTL indexes for automatic data expiration",
+        )
+
+    if total_data_size > 0:
+        ratio = total_index_size / total_data_size * 100
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF8",
+            f"Index-to-data ratio: {ratio:.0f}%",
+            "warn" if ratio > 50 else "pass",
+            "Indexes exceed 50% of data size" if ratio > 50 else "",
+        )
+
+    if bloated_colls:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF9",
+            f"{len(bloated_colls)} collection(s) with >30% storage bloat",
+            "warn",
+            "Run compact command. " + ", ".join(bloated_colls[:5]),
+        )
+    else:
+        _add(results, "Performance Efficiency", "PERF9", "No significant storage bloat", "pass")
+
+    if over_indexed_colls:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF10",
+            f"{len(over_indexed_colls)} collection(s) with >10 indexes",
+            "warn",
+            ", ".join(over_indexed_colls[:5]),
+        )
+    else:
+        _add(results, "Performance Efficiency", "PERF10", "No over-indexed collections", "pass")
+
+    if compression_disabled:
+        _add(
+            results,
+            "Sustainability",
+            "SUST2",
+            f"Compression disabled on {len(compression_disabled)} collection(s)",
+            "warn",
+            ", ".join(compression_disabled[:5]),
+        )
+    else:
+        _add(results, "Sustainability", "SUST2", "Compression enabled on all collections", "pass")
+
+    if collscan_candidates:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF15",
+            f"{len(collscan_candidates)} large collection(s) with no secondary indexes",
+            "warn",
+            ", ".join(collscan_candidates[:5]),
+        )
+    else:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF15",
+            "All large collections have secondary indexes",
+            "pass",
+        )
+
+    if write_amp_colls:
+        _add(
+            results,
+            "Performance Efficiency",
+            "PERF16",
+            f"{len(write_amp_colls)} collection(s) with index size > 2x data",
+            "warn",
+            ", ".join(write_amp_colls[:5]),
+        )
+    else:
+        _add(
+            results, "Performance Efficiency", "PERF16", "No excessive index-to-data ratio", "pass"
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+def generate_report(results, cluster_id, output_dir):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # JSON output
+    json_path = output_dir / "wa_review_results.json"
+    with open(json_path, "w") as f:
+        json.dump(
+            {
+                "cluster": cluster_id,
+                "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "checks": results,
+            },
+            f,
+            indent=2,
+        )
+
+    # Markdown summary
+    md_path = output_dir / "wa_review_report.md"
+    pillars: dict[str, list] = {}
+    for r in results:
+        pillars.setdefault(r["pillar"], []).append(r)
+
+    counts = {"pass": 0, "warn": 0, "fail": 0, "info": 0}
+    for r in results:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+
+    lines = [
+        f"# Well-Architected Review: {cluster_id}\n",
+        f"**Date:** {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}\n",
+        f"**Summary:** {counts['pass']} pass, {counts['warn']} warnings, "
+        f"{counts['fail']} failures, {counts['info']} info\n",
+    ]
+
+    status_icon = {"pass": "[PASS]", "warn": "[WARN]", "fail": "[FAIL]", "info": "[INFO]"}
+    for pillar in [
+        "Reliability",
+        "Security",
+        "Operational Excellence",
+        "Cost Optimization",
+        "Performance Efficiency",
+        "Sustainability",
+    ]:
+        checks = pillars.get(pillar, [])
+        if not checks:
+            continue
+        lines.append(f"\n## {pillar}\n")
+        lines.append("| Status | Check | Detail |")
+        lines.append("|--------|-------|--------|")
+        for c in checks:
+            icon = status_icon.get(c["status"], c["status"])
+            label = c.get("label", "").replace("|", "/")
+            detail = c.get("detail", "").replace("|", "/")
+            lines.append(f"| {icon} | {label} | {detail} |")
+
+    with open(md_path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    return json_path, md_path
+
+
+# ---------------------------------------------------------------------------
+# Collect database stats via pymongo (--uri)
+# ---------------------------------------------------------------------------
+def _redact_uri_creds(msg):
+    """Strip any embedded mongodb credentials (user:pass@) from an error
+    message so they are never printed to stdout/logs."""
+    return re.sub(r"://[^/@\s]*@", "://<redacted>@", str(msg))
+
+
+def collect_db_stats(uri, tls_ca_file=None, tls_allow_invalid_certs=False):
+    """Connect to DocumentDB/MongoDB, collect collStats + indexStats for all
+    collections across all databases. Returns analysis_data dict compatible
+    with run_db_checks()."""
+    try:
+        import pymongo
+    except ImportError:
+        print("ERROR: pymongo required for --uri. Install with: pip install pymongo")
+        sys.exit(1)
+
+    client = pymongo.MongoClient(
+        uri,
+        serverSelectionTimeoutMS=10000,
+        tlsAllowInvalidCertificates=tls_allow_invalid_certs,
+        **({"tlsCAFile": tls_ca_file} if tls_ca_file else {}),
+    )
+    analysis: dict[str, dict] = {}
+    skip_dbs = {"admin", "local", "config"}
+
+    try:
+        for db_name in client.list_database_names():
+            if db_name in skip_dbs:
+                continue
+            db = client[db_name]
+            collections: dict[str, dict] = {}
+            for coll_name in db.list_collection_names():
+                if coll_name.startswith("system."):
+                    continue
+                try:
+                    stats = db.command("collStats", coll_name)
+                    idx_stats = list(db[coll_name].aggregate([{"$indexStats": {}}]))
+
+                    indexes: list[dict] = []
+                    raw_indexes = list(db[coll_name].list_indexes())
+                    idx_usage = {s["name"]: s.get("accesses", {}).get("ops", 0) for s in idx_stats}
+
+                    for idx in raw_indexes:
+                        name = idx["name"]
+                        key = idx.get("key", {})
+                        size = stats.get("indexSizes", {}).get(name, 0)
+                        ops = idx_usage.get(name, 0)
+                        ordered_fields = list(key.keys())
+
+                        entry = {
+                            "name": name,
+                            "fields": key,
+                            "ordered_fields": ordered_fields,
+                            "size": size,
+                            "usage": {"ops": ops, "potential_unused": ops == 0 and name != "_id_"},
+                            "cardinality": {"is_low": False},
+                        }
+                        if idx.get("expireAfterSeconds") is not None:
+                            entry["expireAfterSeconds"] = idx["expireAfterSeconds"]
+                        indexes.append(entry)
+
+                    comp_enabled = False
+                    comp_info = stats.get("compression", {})
+                    comp_enabled = comp_info.get("enabled", False) or comp_info.get("enable", False)
+
+                    data_size = stats.get("size", 0)
+                    storage_size = stats.get("storageSize", 0)
+                    unused_bytes = (
+                        max(0, storage_size - data_size) if storage_size > data_size else 0
+                    )
+                    unused_pct = (unused_bytes / storage_size * 100) if storage_size > 0 else 0
+
+                    collections[coll_name] = {
+                        "count": stats.get("count", 0),
+                        "size": data_size,
+                        "storageSize": storage_size,
+                        "avgObjSize": stats.get("avgObjSize", 0),
+                        "totalIndexSize": stats.get("totalIndexSize", 0),
+                        "indexes": indexes,
+                        "compression": {"enabled": comp_enabled},
+                        "unusedStorageSize": {
+                            "unusedBytes": unused_bytes,
+                            "unusedPercent": unused_pct,
+                        },
+                    }
+                except Exception as e:
+                    collections[coll_name] = {"error": str(e)}
+
+            if collections:
+                analysis[db_name] = collections
+    except Exception as e:
+        print(f"  ERROR: Cannot connect to database: {_redact_uri_creds(e)}")
+        return {}
+    finally:
+        client.close()
+
+    return analysis
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description="DocumentDB Well-Architected Review")
+    parser.add_argument("--cluster-id", required=True, help="DocumentDB cluster identifier")
+    parser.add_argument("--region", required=True, help="AWS region")
+    parser.add_argument(
+        "--uri", default=None, help="MongoDB/DocumentDB connection URI for database-level checks"
+    )
+    parser.add_argument(
+        "--analysis-data",
+        default=None,
+        help="Path to JSON file with database-level analysis (alternative to --uri)",
+    )
+    parser.add_argument(
+        "--tls-ca-file",
+        default=None,
+        help="Path to CA bundle (e.g., global-bundle.pem) for TLS verification",
+    )
+    parser.add_argument(
+        "--tls-allow-invalid-certs",
+        action="store_true",
+        default=False,
+        help="Disable TLS certificate verification (not recommended)",
+    )
+    parser.add_argument("--output", default=".", help="Output directory (default: current)")
+    args = parser.parse_args()
+
+    print(f"Running Well-Architected Review for {args.cluster_id} in {args.region}...")
+
+    # Infrastructure checks
+    print("  Running infrastructure checks (AWS APIs)...")
+    results = run_infra_checks(args.cluster_id, args.region)
+    print(f"  Infrastructure: {len(results)} checks completed")
+
+    # Database-level checks
+    analysis = None
+    if args.uri:
+        print(f"  Collecting database stats via pymongo...")
+        analysis = collect_db_stats(args.uri, args.tls_ca_file, args.tls_allow_invalid_certs)
+        n_colls = sum(len(v) for v in analysis.values())
+        print(f"  Collected stats for {n_colls} collections across {len(analysis)} databases")
+    elif args.analysis_data:
+        print(f"  Loading database stats from {args.analysis_data}...")
+        with open(args.analysis_data) as f:
+            analysis = json.load(f)
+
+    if analysis:
+        print("  Running database-level checks...")
+        db_results = run_db_checks(analysis)
+        results.extend(db_results)
+        print(f"  Database: {len(db_results)} checks completed")
+    else:
+        print("  Skipping database-level checks (no --uri or --analysis-data)")
+
+    # Generate report
+    json_path, md_path = generate_report(results, args.cluster_id, args.output)
+    print(f"\n  Results: {json_path}")
+    print(f"  Report:  {md_path}")
+
+    # Summary
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    print(
+        f"\n  Total: {len(results)} checks -- "
+        f"{counts.get('pass', 0)} pass, {counts.get('warn', 0)} warn, "
+        f"{counts.get('fail', 0)} fail, {counts.get('info', 0)} info"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Adds the **Amazon DocumentDB** skill under `skills/specialized-skills/database-skills/amazon-documentdb/`.

The skill provides end-to-end guidance for Amazon DocumentDB across seven workflows:

- **Connection** — serverless-default cluster setup, TLS, VPC, driver configuration
- **Schema design** — embed-vs-reference modeling, indexing, vector search for RAG
- **Compatibility assessment** — MongoDB → DocumentDB
- **Migration** — AWS DMS full-load + CDC + cutover
- **Performance tuning** — explain plans, COLLSCAN diagnosis, anti-patterns
- **Well-Architected review** — checks across the six pillars
- **Major version upgrades** — 4.0 → 5.0 → 8.0 (in-place and near-zero-downtime)

Includes safety guardrails and a Well-Architected review script.

## Type of Change

- [x] New skill

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
