### PR TITLE
fix: make aws-core hooks compatible with Codex

### DIFF
--- a/plugins/aws-core/hooks/hooks.json
+++ b/plugins/aws-core/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Prevents AI agents from directly fetching secret values via AWS Secrets Manager API calls",
   "hooks": {
     "PreToolUse": [
       {
@@ -7,55 +6,17 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(aws secretsmanager get-secret-value*)",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "if": "Bash(aws secretsmanager batch-get-secret-value*)",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "if": "Bash(curl*localhost:2773/secretsmanager/get*)",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "if": "Bash(curl*127.0.0.1:2773/secretsmanager/get*)",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "if": "Bash(*get_secret_value*)",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "if": "Bash(*batch_get_secret_value*)",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py\"",
             "timeout": 5
           }
         ]
       },
       {
-        "matcher": "use_aws|mcp__aws.*|mcp__plugin_*aws-mcp*",
+        "matcher": "use_aws|mcp__aws.*|mcp__plugin_.*aws-mcp.*",
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py"],
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/secret-safety.py\"",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Description

Fixes the aws-core secret-safety hook configuration so Codex can parse and load it.

The previous `hooks/hooks.json` used a top-level `description` field and Claude Code-specific command hook fields (`if` and `args`). Codex rejects the top-level `description` field and does not model `if` / `args` in command hook configs, so the aws-core hook was skipped at startup.

This change:
- Removes the unsupported top-level `description` field.
- Uses shell-form `command` entries that invoke `secret-safety.py` directly.
- Lets the existing Python hook inspect stdin and exit quietly for non-secret tool calls.
- Fixes the AWS MCP matcher regex from `mcp__plugin_*aws-mcp*` to `mcp__plugin_.*aws-mcp.*`.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [x] Bug fix (reported https://github.com/aws/agent-toolkit-for-aws/issues/95)
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Testing

Validated on Claude Code 2.1.178 and via direct script invocation:

**Manual unit tests** — pipe hook event JSON into `secret-safety.py` via stdin:
```
# DENY cases (6 Bash, 3 use_aws, 2 MCP)
echo '{"tool_name":"Bash","tool_input":{"command":"aws secretsmanager get-secret-value --secret-id x"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"Bash","tool_input":{"command":"aws secretsmanager batch-get-secret-value --secret-id-list x"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"Bash","tool_input":{"command":"curl localhost:2773/secretsmanager/get?secretId=x"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"Bash","tool_input":{"command":"curl http://127.0.0.1:2773/secretsmanager/get?secretId=x"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"Bash","tool_input":{"command":"python3 -c \"boto3.client(\\\"secretsmanager\\\").get_secret_value(SecretId=\\\"x\\\")\""}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"Bash","tool_input":{"command":"client.batch_get_secret_value(SecretIdList=[\\\"x\\\"])"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"use_aws","tool_input":{"service_name":"secretsmanager","operation_name":"GetSecretValue"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"use_aws","tool_input":{"service_name":"secretsmanager","operation_name":"BatchGetSecretValue"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"use_aws","tool_input":{"serviceName":"secretsmanager","operationName":"GetSecretValue"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"mcp__aws__secretsmanager","tool_input":{"service_name":"secretsmanager","operation_name":"GetSecretValue"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"mcp__plugin_aws-core_aws-mcp__aws___run_script","tool_input":{"code":"client.get_secret_value(SecretId=\"x\")"}}' | python3 plugins/aws-core/hooks/secret-safety.py

# ALLOW cases (5 Bash, 2 use_aws, 2 MCP) — should exit 0 with no output
echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"Bash","tool_input":{"command":"aws secretsmanager describe-secret --secret-id x"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"use_aws","tool_input":{"service_name":"secretsmanager","operation_name":"DescribeSecret"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"use_aws","tool_input":{"service_name":"s3","operation_name":"GetObject"}}' | python3 plugins/aws-core/hooks/secret-safety.py
echo '{"tool_name":"mcp__aws__secretsmanager","tool_input":{"service_name":"secretsmanager","operation_name":"DescribeSecret"}}' | python3 plugins/aws-core/hooks/secret-safety.py
```

Invoking Claude directly without the skill (only hook) so that the model does not self-deny -
```
# MCP GetSecretValue — hook DENIES (permission_denials array is non-empty)
claude --dangerously-skip-permissions \
    --plugin-dir plugins/aws-core-hooks-only \
    --append-system-prompt "Use only MCP tools for AWS. Never use Bash." \
    -p "Use MCP aws tool: secretsmanager GetSecretValue SecretId=test/x region=us-east-1" \
    --print --output-format json | python3 -c "
import json,sys; d=json.load(sys.stdin)
denials=d.get('permission_denials',[])
assert len(denials)>0, 'Expected hook denial'
print(f'DENIED: {denials[0][\"tool_name\"]}')
"

# MCP DescribeSecret — hook ALLOWS (permission_denials array is empty)
claude --dangerously-skip-permissions \
    --plugin-dir plugins/aws-core-hooks-only \
    --append-system-prompt "Use only MCP tools for AWS. Never use Bash." \
    -p "Use MCP aws tool: secretsmanager DescribeSecret SecretId=test/x region=us-east-1" \
    --print --output-format json | python3 -c "
import json,sys; d=json.load(sys.stdin)
assert len(d.get('permission_denials',[]))==0, 'Unexpected denial'
print('ALLOWED (reached AWS)')
"
```

For Codex, I could not find a way to automate hook tests yet. Manually verified that the hooks are installed and active by running `/hooks`

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*