### PR TITLE
feat: Add skills for custom-domain REST API and Step Functions S3 processing

### DIFF
--- a/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/SKILL.md
+++ b/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/SKILL.md
@@ -17,6 +17,7 @@ version: 1
 This SOP deploys a REST API with a Regional custom domain name, a Lambda backend function, and a request-based Lambda authorizer. It handles ACM certificate provisioning, IAM role creation, Lambda function deployment, API Gateway REST API creation with a custom authorizer, custom domain configuration, base path mapping, and Route 53 DNS setup.
 
 The architecture includes:
+
 - An API Gateway REST API with an endpoint type of REGIONAL
 - A request-based Lambda authorizer that validates headers, query string parameters, and stage variables
 - A Lambda backend function at `GET /example`

--- a/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/SKILL.md
+++ b/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: deploying-custom-domain-rest-api
+description: >
+  Deploys a Regional REST API with a custom domain name, a Lambda backend function,
+  and a request-based Lambda authorizer using AWS CLI. Covers ACM certificate
+  provisioning, API Gateway REST API creation, Lambda function deployment, request
+  authorizer setup, custom domain configuration, base path mapping, and Route 53
+  DNS record creation. Trigger keywords: custom domain, REST API, Lambda, Route 53,
+  API Gateway, regional endpoint, request authorizer, base path mapping.
+version: 1
+---
+
+# Custom Domain REST API with Lambda and Request Authorizer
+
+## Overview
+
+This SOP deploys a REST API with a Regional custom domain name, a Lambda backend function, and a request-based Lambda authorizer. It handles ACM certificate provisioning, IAM role creation, Lambda function deployment, API Gateway REST API creation with a custom authorizer, custom domain configuration, base path mapping, and Route 53 DNS setup.
+
+The architecture includes:
+- An API Gateway REST API with an endpoint type of REGIONAL
+- A request-based Lambda authorizer that validates headers, query string parameters, and stage variables
+- A Lambda backend function at `GET /example`
+- A custom domain name with TLS 1.2
+- A base path mapping connecting the custom domain to the API stage
+- A Route 53 A-alias record pointing the custom domain to the API Gateway Regional endpoint
+
+Important: This SOP uses Regional endpoints. If the user requests a private endpoint, inform them that this skill covers Regional endpoints only. Private endpoints require VPC endpoint configuration.
+
+## Parameters
+
+- custom_domain_name (required): Fully qualified domain name for the API (e.g., `api.example.com`)
+- region (required): AWS Region for all resources. The ACM certificate must be in this same Region for Regional endpoints
+- hosted_zone_id (required): Route 53 hosted zone ID for the domain
+- acm_certificate_arn (optional): ARN of an existing ACM certificate covering the custom domain. If not provided, Step 2 creates one
+- stage_name (optional, default: "dev"): API Gateway stage name
+
+Constraints for parameter acquisition:
+
+- You MUST ask for all required parameters upfront in a single prompt rather than one at a time
+- You MUST support multiple input methods (direct input, file path, URL)
+- You MUST confirm successful acquisition of all parameters before proceeding
+- You MUST inform the user that this skill uses hardcoded demo authorization values (headerValue1, queryValue1, stageValue1) that are NOT suitable for production. For production, use AWS Secrets Manager or Systems Manager Parameter Store to manage authorization credentials. See: https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
+- You MUST validate that custom_domain_name is a valid FQDN
+
+## Steps
+
+### 0. Verify Dependencies
+
+Constraints:
+
+- You MUST verify the following tools are available: aws-cli, python3, sed, node (v22+)
+- You MUST inform the user about any missing tools with a clear message
+- You MUST ask if the user wants to proceed despite missing tools
+- You MUST respect the customer's decision to abort at any point
+- You MUST explain to the customer what step is being executed, why, and which tool is being called
+
+### 1. Retrieve AWS Account ID
+
+This step MUST be performed before all other steps.
+
+Constraints:
+
+- You MUST retrieve the account ID with: `aws sts get-caller-identity --query 'Account' --output text`
+- You MUST store the result as {account_id} and reuse it in all subsequent steps that reference {account_id}
+- You MUST abort if credentials are not configured
+
+### 2. Request ACM Certificate
+
+Skip this step if acm_certificate_arn is already provided.
+
+Constraints:
+
+- You MUST request the certificate with: `aws acm request-certificate --domain-name {custom_domain_name} --validation-method DNS --region {region}`
+- You MUST capture the CertificateArn from the response
+- You MUST retrieve the DNS validation record with: `aws acm describe-certificate --certificate-arn {cert_arn} --query 'Certificate.DomainValidationOptions[0].ResourceRecord' --region {region}`
+- You MUST create the validation CNAME in Route 53 with: `aws route53 change-resource-record-sets --hosted-zone-id {hosted_zone_id} --change-batch '{"Changes":[{"Action":"UPSERT","ResourceRecordSet":{"Name":"{validation_name}","Type":"CNAME","TTL":300,"ResourceRecords":[{"Value":"{validation_value}"}]}}]}'`
+- You MUST wait for certificate validation with: `aws acm wait certificate-validated --certificate-arn {cert_arn} --region {region}`
+- The wait command may take up to 30 minutes. If it times out, check status manually with: `aws acm describe-certificate --certificate-arn {cert_arn} --query 'Certificate.Status' --region {region}` and retry the wait if status is still PENDING_VALIDATION
+- You MUST NOT proceed until the certificate status is ISSUED
+- You MUST store the certificate ARN as acm_certificate_arn for use in Step 7
+
+### 3. Create IAM Execution Roles
+
+Constraints:
+
+- You MUST create two IAM roles: one for the authorizer Lambda and one for the example function Lambda
+- Both roles use the same trust policy from `scripts/lambda-trust-policy.json`. The trust policy includes an `aws:SourceAccount` condition scoped to the user's account ID
+- You MUST create a working copy of the trust policy and replace the `ACCOUNT_ID` placeholder with the actual account ID from Step 1. Use: `sed 's/ACCOUNT_ID/{account_id}/' scripts/lambda-trust-policy.json > /tmp/lambda-trust-policy.json`
+- You MUST create the authorizer role with: `aws iam create-role --role-name request-authorizer-role --assume-role-policy-document file:///tmp/lambda-trust-policy.json`
+- You MUST attach the basic execution policy to the authorizer role with: `aws iam attach-role-policy --role-name request-authorizer-role --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole`
+- You MUST create the example function role with: `aws iam create-role --role-name example-function-role --assume-role-policy-document file:///tmp/lambda-trust-policy.json`
+- You MUST attach the basic execution policy to the example function role with: `aws iam attach-role-policy --role-name example-function-role --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole`
+- You MUST capture the role ARNs from each create-role response for use in Step 4
+- You MUST wait at least 10 seconds after role creation before creating Lambda functions because IAM role propagation is eventually consistent
+
+### 4. Create and Deploy Lambda Functions
+
+Constraints:
+
+- You MUST create two Lambda functions: the request authorizer and the example function
+- For the authorizer function:
+  - You MUST create the function with inline code. First write the code to a file and package it:
+    `python3 -c "import zipfile,io,base64; z=io.BytesIO(); f=zipfile.ZipFile(z,'w'); f.writestr('index.mjs', open('scripts/authorizer.mjs').read()); f.close(); open('/tmp/authorizer.zip','wb').write(z.getvalue())"`
+  - Then create the function with: `aws lambda create-function --function-name request-authorizer --runtime nodejs22.x --handler index.handler --role {authorizer_role_arn} --zip-file fileb:///tmp/authorizer.zip --timeout 10 --region {region}`
+- For the example function:
+  - You MUST create the function with inline code. First write the code to a file and package it:
+    `python3 -c "import zipfile,io; z=io.BytesIO(); f=zipfile.ZipFile(z,'w'); f.writestr('index.mjs', open('scripts/example_function.mjs').read()); f.close(); open('/tmp/example_function.zip','wb').write(z.getvalue())"`
+  - Then create the function with: `aws lambda create-function --function-name example-function --runtime nodejs22.x --handler index.handler --role {example_role_arn} --zip-file fileb:///tmp/example_function.zip --timeout 10 --region {region}`
+- You MUST verify each function was created by calling: `aws lambda get-function --function-name {function_name} --region {region}`
+
+### 5. Create REST API with Request Authorizer
+
+Constraints:
+
+- You MUST create the REST API with: `aws apigateway create-rest-api --name custom-domain-api --endpoint-configuration types=REGIONAL --region {region}`
+- You MUST capture the API id and get the root resource ID with: `aws apigateway get-resources --rest-api-id {api_id} --region {region}`
+- You MUST create the request-based Lambda authorizer with: `aws apigateway create-authorizer --rest-api-id {api_id} --name request-authorizer --type REQUEST --authorizer-uri 'arn:aws:apigateway:{region}:lambda:path/2015-03-31/functions/arn:aws:lambda:{region}:{account_id}:function:request-authorizer/invocations' --identity-source 'method.request.header.HeaderAuth1,method.request.querystring.QueryString1,context.stage' --region {region}`
+- You MUST capture the authorizer ID from the response
+- You MUST grant API Gateway permission to invoke the authorizer with: `aws lambda add-permission --function-name request-authorizer --statement-id apigateway-auth-invoke --action lambda:InvokeFunction --principal apigateway.amazonaws.com --source-arn 'arn:aws:execute-api:{region}:{account_id}:{api_id}/authorizers/{authorizer_id}' --region {region}`
+- You MUST create the /example resource with: `aws apigateway create-resource --rest-api-id {api_id} --parent-id {root_resource_id} --path-part example --region {region}`
+- You MUST create the GET method with: `aws apigateway put-method --rest-api-id {api_id} --resource-id {example_resource_id} --http-method GET --authorization-type CUSTOM --authorizer-id {authorizer_id} --region {region}`
+- You MUST create the Lambda proxy integration with: `aws apigateway put-integration --rest-api-id {api_id} --resource-id {example_resource_id} --http-method GET --type AWS_PROXY --integration-http-method POST --uri 'arn:aws:apigateway:{region}:lambda:path/2015-03-31/functions/arn:aws:lambda:{region}:{account_id}:function:example-function/invocations' --region {region}`
+- You MUST grant API Gateway permission to invoke the example function with: `aws lambda add-permission --function-name example-function --statement-id apigateway-invoke --action lambda:InvokeFunction --principal apigateway.amazonaws.com --source-arn 'arn:aws:execute-api:{region}:{account_id}:{api_id}/*/GET/example' --region {region}`
+- You MUST NOT create the deployment until all resources, methods, and integrations are configured
+- You MUST configure request validation to reject malformed query parameters and headers by validating that QueryString1 and HeaderAuth1 match expected patterns and enforcing size limits
+
+### 6. Deploy the API
+
+Constraints:
+
+- You MUST create the deployment with: `aws apigateway create-deployment --rest-api-id {api_id} --stage-name {stage_name} --region {region}`
+- You MUST set the stage variable required by the authorizer with: `aws apigateway update-stage --rest-api-id {api_id} --stage-name {stage_name} --patch-operations op=replace,path=/variables/StageVar1,value=stageValue1 --region {region}`
+- You MUST verify the deployment and stage variable by calling: `aws apigateway get-stage --rest-api-id {api_id} --stage-name {stage_name} --region {region}` and confirming StageVar1 is present in the variables
+- You MUST enable access logging on the stage. First create the log group: `aws logs create-log-group --log-group-name api-gw-access-logs --region {region}`. Then enable logging with format: `aws apigateway update-stage --rest-api-id {api_id} --stage-name {stage_name} --patch-operations op=replace,path=/accessLogSettings/destinationArn,value=arn:aws:logs:{region}:{account_id}:log-group:api-gw-access-logs op=replace,path=/accessLogSettings/format,value='{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","status":"$context.status"}' --region {region}`
+
+### 7. Create Custom Domain and Base Path Mapping
+
+Constraints:
+
+- You MUST create the custom domain with: `aws apigateway create-domain-name --domain-name {custom_domain_name} --regional-certificate-arn {acm_certificate_arn} --endpoint-configuration types=REGIONAL --security-policy TLS_1_2 --region {region}`
+- You MUST capture the regionalDomainName and regionalHostedZoneId from the response for use in Step 8
+- You MUST create the base path mapping with: `aws apigateway create-base-path-mapping --domain-name {custom_domain_name} --rest-api-id {api_id} --stage {stage_name} --base-path '(none)' --region {region}`
+- You MUST verify the domain was created by calling: `aws apigateway get-domain-name --domain-name {custom_domain_name} --region {region}`
+- You MUST NOT downgrade the security policy below TLS_1_2
+
+### 8. Create Route 53 DNS Record
+
+Constraints:
+
+- You MUST create a working copy of `scripts/dns-record.json` with placeholders replaced: `sed -e 's/CUSTOM_DOMAIN_NAME/{custom_domain_name}/' -e 's/REGIONAL_DOMAIN_NAME/{regional_domain_name}/' -e 's/REGIONAL_HOSTED_ZONE_ID/{regional_hosted_zone_id}/' scripts/dns-record.json > /tmp/dns-record.json`
+- The command is: `aws route53 change-resource-record-sets --hosted-zone-id {hosted_zone_id} --change-batch file:///tmp/dns-record.json`
+- You MUST use the regionalDomainName and regionalHostedZoneId captured from Step 7, not the user's hosted zone ID for the AliasTarget
+- You MUST use an A-alias record (not CNAME) when using Route 53 as the DNS provider
+- You SHOULD inform the user that DNS propagation can take up to 48 hours
+
+### 9. Validate Final Setup
+
+Constraints:
+
+- You SHOULD run `scripts/validate.sh {custom_domain_name} {api_id} {region}` to check all resources
+- You MUST inform the user to test with: `curl 'https://{custom_domain_name}/example?QueryString1=queryValue1' -H 'HeaderAuth1: headerValue1'`
+- You MUST explain that the expected response is a 200 with `{"message": "Hello from the example function!"}`
+- You MUST explain that requests missing the correct HeaderAuth1 header or QueryString1 query parameter will be denied by the authorizer
+- You MUST provide a summary of all created resources including:
+  - ACM certificate ARN
+  - IAM role ARNs
+  - Lambda function ARNs
+  - REST API ID and stage name
+  - Authorizer ID
+  - Custom domain name and Regional domain name
+  - Route 53 DNS record
+
+## Examples
+
+### Example Input
+
+```
+custom_domain_name: api.example.com
+region: us-east-2
+hosted_zone_id: Z2OJLYMUO9EFXC
+stage_name: prod
+```
+
+### Example Output
+
+```
+ACM certificate issued for api.example.com
+  ARN: arn:aws:acm:us-east-2:123456789012:certificate/abc-123
+
+IAM roles created
+  Authorizer: arn:aws:iam::123456789012:role/request-authorizer-role
+  Example: arn:aws:iam::123456789012:role/example-function-role
+
+Lambda functions deployed
+  Authorizer: arn:aws:lambda:us-east-2:123456789012:function:request-authorizer
+  Example: arn:aws:lambda:us-east-2:123456789012:function:example-function
+
+REST API deployed
+  API ID: a1b2c3d4e5
+  Stage: prod (StageVar1=stageValue1)
+  Authorizer: request-authorizer (REQUEST type)
+
+Custom domain configured
+  Domain: api.example.com
+  Regional endpoint: d-abc123.execute-api.us-east-2.amazonaws.com
+  TLS: 1.2
+
+Route 53 DNS record created
+  A-alias: api.example.com -> d-abc123.execute-api.us-east-2.amazonaws.com
+
+Test command (authorized):
+  curl 'https://api.example.com/example?QueryString1=queryValue1' -H 'HeaderAuth1: headerValue1'
+
+Test command (denied):
+  curl 'https://api.example.com/example'
+```
+
+## Troubleshooting
+
+### Certificate Stuck in PENDING_VALIDATION
+Verify the DNS validation CNAME record exists in Route 53 by running `aws acm describe-certificate --certificate-arn {arn} --query 'Certificate.DomainValidationOptions'`. Ensure the CNAME was created in the correct hosted zone.
+
+### 403 Forbidden on API Calls
+The request authorizer checks three values: `HeaderAuth1` header must be `headerValue1`, `QueryString1` query parameter must be `queryValue1`, and stage variable `StageVar1` must be `stageValue1`. Verify all three are present and correct. Check CloudWatch Logs for the authorizer function for detailed error messages.
+
+### 401 Unauthorized
+API Gateway returns 401 when the authorizer function cannot be invoked. Verify the Lambda permission was added for API Gateway to invoke the authorizer. Check that the authorizer URI is correct.
+
+### Missing Authentication Token (403)
+The request path doesn't match a configured resource. Verify the `/example` resource exists with `aws apigateway get-resources --rest-api-id {api_id}`. Ensure the API was deployed after creating all resources.
+
+### Custom Domain Returns No Response
+DNS propagation can take up to 48 hours. Check with `dig {custom_domain_name}`. Verify the A-alias record points to the correct regionalDomainName and regionalHostedZoneId from the create-domain-name response.
+
+### Stage Variable Not Set
+If the authorizer denies all requests, verify the stage variable was set with `aws apigateway get-stage --rest-api-id {api_id} --stage-name {stage_name} --query 'variables'`. The StageVar1 variable must be set to `stageValue1`.
+
+### IAM Role Not Found When Creating Lambda
+IAM role propagation is eventually consistent. Wait at least 10 seconds after role creation before creating Lambda functions. Verify the role ARN with `aws iam get-role --role-name {role_name}`.
+
+### Base Path Mapping Not Working
+Verify with `aws apigateway get-base-path-mappings --domain-name {custom_domain_name}`. The base path `(none)` maps the domain root to the stage. Ensure the deployment to the stage completed successfully.
+
+## Security Considerations
+
+- The hardcoded authorization values (`headerValue1`, `queryValue1`, `stageValue1`) in the Lambda authorizer are **for demonstration only** and are NOT suitable for production. Replace with proper authentication mechanisms (JWT validation, API keys from AWS Secrets Manager, or OAuth) before deploying to production.
+- Enable request throttling on the API stage to prevent abuse. Configure rate and burst limits with: `aws apigateway update-stage --rest-api-id {api_id} --stage-name {stage_name} --patch-operations op=replace,path=/throttle/rateLimit,value=1000 op=replace,path=/throttle/burstLimit,value=2000`
+- Enable CloudWatch Logs encryption for Lambda log groups. Associate a KMS key with: `aws logs associate-kms-key --log-group-name /aws/lambda/request-authorizer --kms-key-arn <KMS_KEY_ARN>`
+- Protect the public API with AWS WAF to mitigate common exploits (SQL injection, XSS, rate-based rules): `aws wafv2 associate-web-acl --web-acl-arn <WAF_ACL_ARN> --resource-arn arn:aws:apigateway:{region}::/restapis/{api_id}/stages/{stage_name}`
+
+## Additional Resources
+
+- [API Gateway custom domain names](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html)
+- [ACM certificate validation](https://docs.aws.amazon.com/acm/latest/userguide/dns-validation.html)
+- [Lambda authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html)
+- [Route 53 alias records](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html)
+- [API Gateway Regional endpoints](https://docs.aws.amazon.com/apigateway/latest/developerguide/create-regional-api.html)

--- a/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/authorizer.mjs
+++ b/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/authorizer.mjs
@@ -1,0 +1,90 @@
+// A simple request-based authorizer example to demonstrate how to use request 
+// parameters to allow or deny a request. In this example, a request is  
+// authorized if the client-supplied HeaderAuth1 header, QueryString1
+// query parameter, and stage variable of StageVar1 all match
+// specified values of 'headerValue1', 'queryValue1', and 'stageValue1',
+// respectively.
+    
+export const handler = function(event, context, callback) {
+    // DEMO CHECK: Remove this block and replace hardcoded values with Secrets Manager in production
+    if (!process.env.AUTH_SECRET_ARN) {
+        console.warn('WARNING: Using hardcoded demo credentials. Set AUTH_SECRET_ARN env var for production.');
+    }
+
+    console.log('Received event:', JSON.stringify(event, null, 2));
+    
+    // Retrieve request parameters from the Lambda function input:
+    var headers = event.headers;
+    var queryStringParameters = event.queryStringParameters;
+    var pathParameters = event.pathParameters;
+    var stageVariables = event.stageVariables;
+        
+    // Parse the input for the parameter values
+    var tmp = event.methodArn.split(':');
+    var apiGatewayArnTmp = tmp[5].split('/');
+    var awsAccountId = tmp[4];
+    var region = tmp[3];
+    var restApiId = apiGatewayArnTmp[0];
+    var stage = apiGatewayArnTmp[1];
+    var method = apiGatewayArnTmp[2];
+    var resource = '/'; // root resource
+    if (apiGatewayArnTmp[3]) {
+        resource += apiGatewayArnTmp[3];
+    }
+        
+    // Perform authorization to return the Allow policy for correct parameters and 
+    // the 'Unauthorized' error, otherwise.
+     
+    // API Gateway lowercases header keys in REQUEST authorizer events
+    var headerAuth = headers.headerauth1 || headers.HeaderAuth1;
+
+    // Validate required parameters exist
+    if (!queryStringParameters || !stageVariables) {
+        callback(null, generateDeny('me', event.methodArn));
+        return;
+    }
+
+    // WARNING: These hardcoded values are for demo only. In production, retrieve
+    // credentials from AWS Secrets Manager or environment variables. See:
+    // https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html
+    if (headerAuth === "headerValue1"
+        && queryStringParameters.QueryString1 === "queryValue1"
+        && stageVariables.StageVar1 === "stageValue1") {
+        callback(null, generateAllow('me', event.methodArn));
+    }  else {
+        callback(null, generateDeny('me', event.methodArn));
+    }
+}
+     
+// Help function to generate an IAM policy
+var generatePolicy = function(principalId, effect, resource) {
+    // Required output:
+    var authResponse = {};
+    authResponse.principalId = principalId;
+    if (effect && resource) {
+        var policyDocument = {};
+        policyDocument.Version = '2012-10-17'; // default version
+        policyDocument.Statement = [];
+        var statementOne = {};
+        statementOne.Action = 'execute-api:Invoke'; // default action
+        statementOne.Effect = effect;
+        statementOne.Resource = resource;
+        policyDocument.Statement[0] = statementOne;
+        authResponse.policyDocument = policyDocument;
+    }
+    // Optional output with custom properties of the String, Number or Boolean type.
+    authResponse.context = {
+        "stringKey": "stringval",
+        "numberKey": 123,
+        "booleanKey": true
+    };
+    return authResponse;
+}
+     
+var generateAllow = function(principalId, resource) {
+    return generatePolicy(principalId, 'Allow', resource);
+}
+     
+var generateDeny = function(principalId, resource) {
+    return generatePolicy(principalId, 'Deny', resource);
+}

--- a/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/dns-record.json
+++ b/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/dns-record.json
@@ -1,0 +1,16 @@
+{
+  "Changes": [
+    {
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "CUSTOM_DOMAIN_NAME",
+        "Type": "A",
+        "AliasTarget": {
+          "DNSName": "REGIONAL_DOMAIN_NAME",
+          "HostedZoneId": "REGIONAL_HOSTED_ZONE_ID",
+          "EvaluateTargetHealth": false
+        }
+      }
+    }
+  ]
+}

--- a/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/example_function.mjs
+++ b/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/example_function.mjs
@@ -1,0 +1,14 @@
+export const handler = async (event, context) => {
+    return {
+        statusCode: 200,
+        headers: {
+            'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+            'Content-Type': 'application/json',
+            'X-Content-Type-Options': 'nosniff',
+            'X-Frame-Options': 'DENY',
+        },
+        body: JSON.stringify({
+            message: "Hello from the example function!",
+        }),
+    };
+};

--- a/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/lambda-trust-policy.json
+++ b/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/lambda-trust-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "ACCOUNT_ID"
+        }
+      }
+    }
+  ]
+}

--- a/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/validate.sh
+++ b/skills/specialized-skills/serverless-skills/deploying-custom-domain-rest-api/scripts/validate.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Validates the deployed REST API with custom domain.
+# Usage: ./validate.sh <custom_domain_name> <api_id> <region>
+
+set -euo pipefail
+
+DOMAIN="$1"
+API_ID="$2"
+REGION="$3"
+
+echo "=== Validating deployment ==="
+
+echo ""
+echo "1. Checking DNS resolution..."
+DIG_RESULT=$(dig +short "$DOMAIN" 2>/dev/null || true)
+if [ -z "$DIG_RESULT" ]; then
+    echo "  WARNING: DNS not yet propagated"
+else
+    echo "  $DIG_RESULT"
+fi
+
+echo ""
+echo "2. Checking API Gateway..."
+aws apigateway get-rest-api --rest-api-id "$API_ID" --region "$REGION" \
+    --query '{Name:name,Id:id,Endpoint:endpointConfiguration.types[0]}' \
+    --output table
+
+echo ""
+echo "3. Checking custom domain..."
+aws apigateway get-domain-name --domain-name "$DOMAIN" --region "$REGION" \
+    --query '{Domain:domainName,Regional:regionalDomainName,TLS:securityPolicy}' \
+    --output table
+
+echo ""
+echo "4. Checking base path mapping..."
+aws apigateway get-base-path-mappings --domain-name "$DOMAIN" --region "$REGION" \
+    --output table
+
+echo ""
+echo "5. Checking Lambda functions..."
+for fn in request-authorizer example-function; do
+    echo "  $fn:"
+    aws lambda get-function --function-name "$fn" --region "$REGION" \
+        --query 'Configuration.{State:State,Runtime:Runtime,Handler:Handler}' \
+        --output table 2>/dev/null || echo "    NOT FOUND"
+done
+
+echo ""
+echo "6. Testing API endpoint..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    "https://${DOMAIN}/example?QueryString1=queryValue1" \
+    -H "HeaderAuth1: headerValue1" 2>/dev/null || echo "000")
+
+if [ "$HTTP_CODE" = "200" ]; then
+    echo "  SUCCESS: API returned 200"
+    echo "  Response:"
+    curl -s "https://${DOMAIN}/example?QueryString1=queryValue1" -H "HeaderAuth1: headerValue1"
+    echo ""
+else
+    echo "  FAILED: API returned $HTTP_CODE"
+    echo "  If 000, DNS may not have propagated yet (can take up to 48 hours)"
+fi
+
+echo ""
+echo "=== Validation complete ==="

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/SKILL.md
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: processing-s3-uploads-with-step-functions
+description: >
+  Deploy an event-driven workflow that routes S3 uploads to either Lambda or Fargate
+  via Step Functions based on file size. Uses EventBridge to trigger a Step Functions
+  state machine when objects are uploaded to S3. Small files are processed by Lambda,
+  large files by a Fargate task. Includes VPC, ECR repository, ECS cluster, and scoped
+  IAM roles. Trigger keywords: Step Functions, Fargate, Lambda, S3 event, EventBridge,
+  ECS, ECR, file processing, workflow orchestration, serverless.
+version: 1
+---
+
+# Step Functions Workflow: Route S3 Uploads to Lambda or Fargate
+
+## Overview
+
+This skill deploys an event-driven workflow using AWS CLI. When a file is uploaded to
+an S3 bucket, EventBridge triggers a Step Functions state machine. The state machine
+checks the file size and routes processing to either a Lambda function (files ≤ 6 MB)
+or a Fargate task (files > 6 MB).
+
+The architecture includes:
+- An S3 bucket with EventBridge notifications enabled
+- An EventBridge rule that triggers Step Functions on S3 object creation
+- A Step Functions state machine with a Choice state for routing
+- A Lambda function for processing small files
+- An ECS Fargate task for processing large files
+- A VPC with two subnets, internet gateway, and security group
+- An ECR repository for the Fargate container image
+- Scoped IAM roles for Lambda, Step Functions, and ECS tasks
+
+Use this skill when:
+- You need to process S3 uploads with different compute based on file size
+- You want a serverless workflow that can handle both small and large files
+- You need Step Functions orchestration with Lambda and Fargate
+
+Do not use this skill when:
+- All files are small enough for Lambda (use S3 → Lambda directly)
+- You need real-time streaming (use Kinesis)
+- You don't need file-size-based routing
+
+## Prerequisites
+
+1. **AWS CLI v2** — Installed and configured. Verify with `aws sts get-caller-identity`.
+2. **Python 3.12** — For the Lambda function runtime.
+3. **Docker** — For building and pushing the Fargate container image.
+
+
+## Parameters
+
+- bucket_name (required): Name for the S3 bucket (globally unique, lowercase, 3-63 characters)
+- region (required): AWS region for all resources
+- ecr_repo_name (required): Name for the ECR repository
+- state_machine_name (required): Name for the Step Functions state machine
+- kms_key_arn (optional): ARN of a KMS key for CloudWatch Logs encryption. If not provided, create one with `aws kms create-key --description "Key for CloudWatch Logs encryption" --region {region}`
+
+Constraints for parameter acquisition:
+- You MUST ask for all required parameters upfront in a single prompt
+- You MUST support multiple input methods (direct input, file path, URL)
+- You MUST confirm successful acquisition of all parameters before proceeding
+- You MUST validate that bucket_name follows S3 naming rules
+
+## Procedures
+
+### Step 0: Verify Dependencies
+
+Constraints:
+- You MUST verify the following tools are available: aws-cli, python3 (3.12+), docker
+- You MUST inform the user about any missing tools with a clear message
+- You MUST ask if the user wants to proceed despite missing tools
+- You MUST respect the customer's decision to abort at any point
+- You MUST explain to the customer what step is being executed, why, and which tool is being called
+
+### Step 1: Retrieve AWS Account ID
+
+Constraints:
+- You MUST retrieve the account ID with: `aws sts get-caller-identity --query 'Account' --output text`
+- You MUST store the result as {account_id} for use in all subsequent steps
+- You MUST abort if credentials are not configured
+
+### Step 2: Get the Default VPC and Networking
+
+Constraints:
+- You MUST retrieve the default VPC ID with:
+  `aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text --region {region}`
+- If no default VPC exists, inform the user they must create one with `aws ec2 create-default-vpc --region {region}` or provide a VPC ID manually
+- You MUST retrieve two subnet IDs from the default VPC:
+  `aws ec2 describe-subnets --filters Name=vpc-id,Values={vpc_id} --query 'Subnets[0:2].SubnetId' --output text --region {region}`
+- You MUST create a security group in the default VPC:
+  `aws ec2 create-security-group --group-name fargate-sg --description "Security group for Fargate tasks" --vpc-id {vpc_id} --region {region}`
+- You MUST configure security group egress rules to allow only HTTPS and DNS outbound. First revoke the default allow-all egress rule:
+  `aws ec2 revoke-security-group-egress --group-id {sg_id} --ip-permissions IpProtocol=-1,IpRanges='[{CidrIp=0.0.0.0/0}]' --region {region}`
+  Then add scoped rules:
+  `aws ec2 authorize-security-group-egress --group-id {sg_id} --protocol tcp --port 443 --cidr 0.0.0.0/0 --region {region}` and
+  `aws ec2 authorize-security-group-egress --group-id {sg_id} --protocol udp --port 53 --cidr 0.0.0.0/0 --region {region}`
+- You MUST recommend VPC endpoints for S3 and CloudWatch Logs for production workloads to avoid internet-routed traffic and eliminate the need for broad egress rules
+- You MUST capture {vpc_id}, {subnet1_id}, {subnet2_id}, and {sg_id} for use in later steps
+
+### Step 3: Create the ECR Repository
+
+Constraints:
+- You MUST create the repository with:
+  `aws ecr create-repository --repository-name {ecr_repo_name} --region {region}`
+- You MUST capture the repositoryUri from the response
+
+### Step 4: Build and Push the Container Image
+
+Constraints:
+- You MUST verify Docker is installed by running `docker --version`. If Docker is not installed, instruct the user to install it from https://docs.docker.com/get-docker/ and abort until it is available
+- You MUST authenticate Docker with ECR:
+  `aws ecr get-login-password --region {region} | docker login --username AWS --password-stdin {account_id}.dkr.ecr.{region}.amazonaws.com`
+- The Dockerfile and processor code are in `scripts/Dockerfile` and `scripts/fargate_processor.py`
+- You MUST build and push the image from the scripts directory:
+  ```
+  cd scripts
+  docker build --platform linux/amd64 -t {ecr_repo_name} .
+  docker tag {ecr_repo_name}:latest {account_id}.dkr.ecr.{region}.amazonaws.com/{ecr_repo_name}:latest
+  docker push {account_id}.dkr.ecr.{region}.amazonaws.com/{ecr_repo_name}:latest
+  cd ..
+  ```
+
+### Step 5: Create IAM Roles
+
+Follow the detailed instructions in `references/iam-roles.md` to create all IAM roles (Lambda, ECS task execution, ECS task, Step Functions, and EventBridge roles).
+
+- You MUST wait at least 10 seconds for IAM role propagation
+
+### Step 6: Create the Lambda Function
+
+Constraints:
+- The function code is in `scripts/lambda_function.py`
+- You MUST be in the skill root directory before packaging and creating the function
+- You MUST package it with: `python3 -c "import zipfile,io; z=io.BytesIO(); f=zipfile.ZipFile(z,'w'); f.writestr('lambda_function.py', open('scripts/lambda_function.py').read()); f.close(); open('/tmp/lambda_function.zip','wb').write(z.getvalue())"`
+- You MUST create the function with:
+  ```
+  aws lambda create-function \
+      --function-name sfn-file-processor \
+      --runtime python3.12 \
+      --handler lambda_function.lambda_handler \
+      --role arn:aws:iam::{account_id}:role/sfn-lambda-role \
+      --zip-file fileb:///tmp/lambda_function.zip \
+      --timeout 60 \
+      --architectures x86_64 \
+      --region {region}
+  ```
+- You MUST verify the function was created with:
+  `aws lambda get-function --function-name sfn-file-processor --region {region}`
+
+### Step 7: Create the CloudWatch Log Group
+
+Constraints:
+- You MUST create the log group for Fargate:
+  `aws logs create-log-group --log-group-name /StepFunctionFargateTask --region {region}`
+- You MUST encrypt the log group with a KMS key:
+  `aws logs associate-kms-key --log-group-name /StepFunctionFargateTask --kms-key-arn {kms_key_arn} --region {region}`
+
+### Step 8: Create the ECS Cluster and Task Definition
+
+Follow the detailed instructions in `references/ecs-task-definition.md` to create the ECS cluster and register the Fargate task definition.
+
+- You MUST capture the task definition ARN from the response
+
+### Step 9: Create the S3 Bucket with EventBridge Notifications
+
+Constraints:
+- You MUST create the bucket with:
+  `aws s3api create-bucket --bucket {bucket_name} --region {region} --create-bucket-configuration LocationConstraint={region}`
+- You MUST NOT include `--create-bucket-configuration` if region is us-east-1
+- You MUST enable EventBridge notifications on the bucket:
+  `aws s3api put-bucket-notification-configuration --bucket {bucket_name} --notification-configuration '{"EventBridgeConfiguration": {}}' --region {region}`
+- You MUST enable default encryption on the bucket:
+  `aws s3api put-bucket-encryption --bucket {bucket_name} --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms"}}]}' --region {region}`
+
+### Step 10: Create the Step Functions State Machine
+
+Constraints:
+- The state machine definition is in `scripts/statemachine.asl.json`
+- You MUST create a working copy and replace all placeholders:
+  ```
+  sed -e 's|${LambdaFunction}|arn:aws:lambda:{region}:{account_id}:function:sfn-file-processor|g' \
+      -e 's|${Cluster}|arn:aws:ecs:{region}:{account_id}:cluster/sfn-cluster|g' \
+      -e 's|${TaskDefinition}|{task_definition_arn}|g' \
+      -e 's|${Subnet1}|{subnet1_id}|g' \
+      -e 's|${Subnet2}|{subnet2_id}|g' \
+      -e 's|${SecurityGroup}|{sg_id}|g' \
+      scripts/statemachine.asl.json > /tmp/statemachine.asl.json
+  ```
+- You MUST create the state machine with:
+  ```
+  aws stepfunctions create-state-machine \
+      --name {state_machine_name} \
+      --definition file:///tmp/statemachine.asl.json \
+      --role-arn arn:aws:iam::{account_id}:role/sfn-state-machine-role \
+      --type STANDARD \
+      --region {region}
+  ```
+- You MUST capture the stateMachineArn from the response
+
+### Step 11: Create the EventBridge Rule
+
+Constraints:
+- You MUST create the EventBridge rule to trigger on S3 object creation:
+  ```
+  aws events put-rule \
+      --name s3-to-stepfunctions \
+      --event-pattern '{
+        "source": ["aws.s3"],
+        "detail-type": ["Object Created"],
+        "detail": {
+          "bucket": {
+            "name": ["{bucket_name}"]
+          }
+        }
+      }' \
+      --region {region}
+  ```
+- You MUST add the state machine as a target:
+  ```
+  aws events put-targets \
+      --rule s3-to-stepfunctions \
+      --targets '[{
+        "Id": "StepFunctionsTarget",
+        "Arn": "{state_machine_arn}",
+        "RoleArn": "arn:aws:iam::{account_id}:role/sfn-eventbridge-role"
+      }]' \
+      --region {region}
+  ```
+
+### Step 12: Configure Monitoring
+
+Constraints:
+- You MUST create a Dead Letter Queue for failed EventBridge invocations:
+  `aws sqs create-queue --queue-name s3-to-stepfunctions-dlq --region {region}`
+- You MUST update the EventBridge target to attach the DLQ:
+  ```
+  aws events put-targets \
+      --rule s3-to-stepfunctions \
+      --targets '[{
+        "Id": "StepFunctionsTarget",
+        "Arn": "{state_machine_arn}",
+        "RoleArn": "arn:aws:iam::{account_id}:role/sfn-eventbridge-role",
+        "DeadLetterConfig": {
+          "Arn": "arn:aws:sqs:{region}:{account_id}:s3-to-stepfunctions-dlq"
+        }
+      }]' \
+      --region {region}
+  ```
+- You MUST create a CloudWatch alarm for Step Functions execution failures:
+  `aws cloudwatch put-metric-alarm --alarm-name sfn-execution-failures --metric-name ExecutionsFailed --namespace AWS/States --statistic Sum --period 300 --threshold 1 --comparison-operator GreaterThanOrEqualToThreshold --evaluation-periods 1 --dimensions Name=StateMachineArn,Value={state_machine_arn} --region {region}`
+
+### Step 13: Validate
+
+Constraints:
+- You MUST test with a small file (< 6 MB) to verify Lambda processing:
+  ```
+  echo 'test data' > /tmp/small-file.txt
+  aws s3 cp /tmp/small-file.txt s3://{bucket_name}/small-file.txt --region {region}
+  ```
+- You MUST wait 15 seconds then check the Step Functions execution:
+  `aws stepfunctions list-executions --state-machine-arn {state_machine_arn} --region {region}`
+- You MUST verify the execution succeeded and routed to Lambda
+- You MUST provide a summary of all created resources including: VPC ID, subnet IDs, security group ID, ECR repo URI, ECS cluster ARN, task definition ARN, Lambda function ARN, state machine ARN, bucket name, and EventBridge rule name
+
+## Troubleshooting
+
+**EventBridge rule not triggering**
+- Verify EventBridge notifications are enabled on the bucket: `aws s3api get-bucket-notification-configuration --bucket {bucket_name}`
+- Verify the rule exists: `aws events describe-rule --name s3-to-stepfunctions --region {region}`
+- Check that the target has the correct state machine ARN and role
+
+**Step Functions execution fails at Fargate task**
+- Verify the container image exists in ECR: `aws ecr describe-images --repository-name {ecr_repo_name} --region {region}`
+- Check that the subnets have internet access (route table with IGW)
+- Verify the security group allows outbound traffic
+- Check CloudWatch Logs at `/StepFunctionFargateTask`
+
+**Lambda invocation fails**
+- Check CloudWatch Logs: `aws logs tail /aws/lambda/sfn-file-processor --region {region}`
+- Verify the Step Functions role has `lambda:InvokeFunction` permission
+
+**IAM PassRole errors**
+- The Step Functions role must have `iam:PassRole` for both the ECS execution role and task role ARNs
+
+**Fargate task stuck in PROVISIONING**
+- Verify the subnets have auto-assign public IP enabled
+- Verify the internet gateway is attached and route table has 0.0.0.0/0 route
+
+## Security Considerations
+
+- Fargate tasks with public IPs are exposed to the internet. Revoke the default allow-all egress rule and configure scoped egress: `aws ec2 revoke-security-group-egress --group-id {sg_id} --ip-permissions IpProtocol=-1,IpRanges='[{CidrIp=0.0.0.0/0}]'` then add `aws ec2 authorize-security-group-egress --group-id {sg_id} --protocol tcp --port 443 --cidr 0.0.0.0/0` and `aws ec2 authorize-security-group-egress --group-id {sg_id} --protocol udp --port 53 --cidr 0.0.0.0/0`. For production, consider using VPC endpoints for S3 and CloudWatch Logs instead of internet-routed traffic.
+- Scan container images for vulnerabilities before pushing to ECR. Enable ECR image scanning with: `aws ecr put-image-scanning-configuration --repository-name {ecr_repo_name} --image-scanning-configuration scanOnPush=true --region {region}`
+- Use IAM roles for credentials — never hardcode access keys in container code.
+- Enable encryption at rest for the S3 bucket: `aws s3api put-bucket-encryption --bucket {bucket_name} --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"aws:kms"}}]}'`
+- Enable CloudWatch Logs encryption for Fargate container logs: `aws logs associate-kms-key --log-group-name /StepFunctionFargateTask --kms-key-arn <KMS_KEY_ARN>`
+- Configure a Dead Letter Queue on the EventBridge rule for failed invocations
+- Set up CloudWatch alarms on Step Functions execution failures for operational visibility
+
+## Version information
+
+- **AWS CLI**: 2.x
+- **Python runtime**: 3.12
+- **Last validated**: 2026-04-27
+
+## Additional Resources
+
+- [Step Functions developer guide](https://docs.aws.amazon.com/step-functions/latest/dg/welcome.html)
+- [EventBridge S3 events](https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html)
+- [Fargate task definitions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html)
+- [ECR pushing images](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html)
+- [Step Functions Fargate integration](https://docs.aws.amazon.com/step-functions/latest/dg/connect-ecs.html)

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/SKILL.md
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/SKILL.md
@@ -20,6 +20,7 @@ checks the file size and routes processing to either a Lambda function (files �
 or a Fargate task (files > 6 MB).
 
 The architecture includes:
+
 - An S3 bucket with EventBridge notifications enabled
 - An EventBridge rule that triggers Step Functions on S3 object creation
 - A Step Functions state machine with a Choice state for routing
@@ -30,11 +31,13 @@ The architecture includes:
 - Scoped IAM roles for Lambda, Step Functions, and ECS tasks
 
 Use this skill when:
+
 - You need to process S3 uploads with different compute based on file size
 - You want a serverless workflow that can handle both small and large files
 - You need Step Functions orchestration with Lambda and Fargate
 
 Do not use this skill when:
+
 - All files are small enough for Lambda (use S3 → Lambda directly)
 - You need real-time streaming (use Kinesis)
 - You don't need file-size-based routing
@@ -45,7 +48,6 @@ Do not use this skill when:
 2. **Python 3.12** — For the Lambda function runtime.
 3. **Docker** — For building and pushing the Fargate container image.
 
-
 ## Parameters
 
 - bucket_name (required): Name for the S3 bucket (globally unique, lowercase, 3-63 characters)
@@ -55,6 +57,7 @@ Do not use this skill when:
 - kms_key_arn (optional): ARN of a KMS key for CloudWatch Logs encryption. If not provided, create one with `aws kms create-key --description "Key for CloudWatch Logs encryption" --region {region}`
 
 Constraints for parameter acquisition:
+
 - You MUST ask for all required parameters upfront in a single prompt
 - You MUST support multiple input methods (direct input, file path, URL)
 - You MUST confirm successful acquisition of all parameters before proceeding
@@ -65,6 +68,7 @@ Constraints for parameter acquisition:
 ### Step 0: Verify Dependencies
 
 Constraints:
+
 - You MUST verify the following tools are available: aws-cli, python3 (3.12+), docker
 - You MUST inform the user about any missing tools with a clear message
 - You MUST ask if the user wants to proceed despite missing tools
@@ -74,6 +78,7 @@ Constraints:
 ### Step 1: Retrieve AWS Account ID
 
 Constraints:
+
 - You MUST retrieve the account ID with: `aws sts get-caller-identity --query 'Account' --output text`
 - You MUST store the result as {account_id} for use in all subsequent steps
 - You MUST abort if credentials are not configured
@@ -81,6 +86,7 @@ Constraints:
 ### Step 2: Get the Default VPC and Networking
 
 Constraints:
+
 - You MUST retrieve the default VPC ID with:
   `aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text --region {region}`
 - If no default VPC exists, inform the user they must create one with `aws ec2 create-default-vpc --region {region}` or provide a VPC ID manually
@@ -99,6 +105,7 @@ Constraints:
 ### Step 3: Create the ECR Repository
 
 Constraints:
+
 - You MUST create the repository with:
   `aws ecr create-repository --repository-name {ecr_repo_name} --region {region}`
 - You MUST capture the repositoryUri from the response
@@ -106,11 +113,13 @@ Constraints:
 ### Step 4: Build and Push the Container Image
 
 Constraints:
+
 - You MUST verify Docker is installed by running `docker --version`. If Docker is not installed, instruct the user to install it from https://docs.docker.com/get-docker/ and abort until it is available
 - You MUST authenticate Docker with ECR:
   `aws ecr get-login-password --region {region} | docker login --username AWS --password-stdin {account_id}.dkr.ecr.{region}.amazonaws.com`
 - The Dockerfile and processor code are in `scripts/Dockerfile` and `scripts/fargate_processor.py`
 - You MUST build and push the image from the scripts directory:
+
   ```
   cd scripts
   docker build --platform linux/amd64 -t {ecr_repo_name} .
@@ -128,10 +137,12 @@ Follow the detailed instructions in `references/iam-roles.md` to create all IAM 
 ### Step 6: Create the Lambda Function
 
 Constraints:
+
 - The function code is in `scripts/lambda_function.py`
 - You MUST be in the skill root directory before packaging and creating the function
 - You MUST package it with: `python3 -c "import zipfile,io; z=io.BytesIO(); f=zipfile.ZipFile(z,'w'); f.writestr('lambda_function.py', open('scripts/lambda_function.py').read()); f.close(); open('/tmp/lambda_function.zip','wb').write(z.getvalue())"`
 - You MUST create the function with:
+
   ```
   aws lambda create-function \
       --function-name sfn-file-processor \
@@ -143,12 +154,14 @@ Constraints:
       --architectures x86_64 \
       --region {region}
   ```
+
 - You MUST verify the function was created with:
   `aws lambda get-function --function-name sfn-file-processor --region {region}`
 
 ### Step 7: Create the CloudWatch Log Group
 
 Constraints:
+
 - You MUST create the log group for Fargate:
   `aws logs create-log-group --log-group-name /StepFunctionFargateTask --region {region}`
 - You MUST encrypt the log group with a KMS key:
@@ -163,6 +176,7 @@ Follow the detailed instructions in `references/ecs-task-definition.md` to creat
 ### Step 9: Create the S3 Bucket with EventBridge Notifications
 
 Constraints:
+
 - You MUST create the bucket with:
   `aws s3api create-bucket --bucket {bucket_name} --region {region} --create-bucket-configuration LocationConstraint={region}`
 - You MUST NOT include `--create-bucket-configuration` if region is us-east-1
@@ -174,8 +188,10 @@ Constraints:
 ### Step 10: Create the Step Functions State Machine
 
 Constraints:
+
 - The state machine definition is in `scripts/statemachine.asl.json`
 - You MUST create a working copy and replace all placeholders:
+
   ```
   sed -e 's|${LambdaFunction}|arn:aws:lambda:{region}:{account_id}:function:sfn-file-processor|g' \
       -e 's|${Cluster}|arn:aws:ecs:{region}:{account_id}:cluster/sfn-cluster|g' \
@@ -185,7 +201,9 @@ Constraints:
       -e 's|${SecurityGroup}|{sg_id}|g' \
       scripts/statemachine.asl.json > /tmp/statemachine.asl.json
   ```
+
 - You MUST create the state machine with:
+
   ```
   aws stepfunctions create-state-machine \
       --name {state_machine_name} \
@@ -194,12 +212,15 @@ Constraints:
       --type STANDARD \
       --region {region}
   ```
+
 - You MUST capture the stateMachineArn from the response
 
 ### Step 11: Create the EventBridge Rule
 
 Constraints:
+
 - You MUST create the EventBridge rule to trigger on S3 object creation:
+
   ```
   aws events put-rule \
       --name s3-to-stepfunctions \
@@ -214,7 +235,9 @@ Constraints:
       }' \
       --region {region}
   ```
+
 - You MUST add the state machine as a target:
+
   ```
   aws events put-targets \
       --rule s3-to-stepfunctions \
@@ -229,9 +252,11 @@ Constraints:
 ### Step 12: Configure Monitoring
 
 Constraints:
+
 - You MUST create a Dead Letter Queue for failed EventBridge invocations:
   `aws sqs create-queue --queue-name s3-to-stepfunctions-dlq --region {region}`
 - You MUST update the EventBridge target to attach the DLQ:
+
   ```
   aws events put-targets \
       --rule s3-to-stepfunctions \
@@ -245,17 +270,21 @@ Constraints:
       }]' \
       --region {region}
   ```
+
 - You MUST create a CloudWatch alarm for Step Functions execution failures:
   `aws cloudwatch put-metric-alarm --alarm-name sfn-execution-failures --metric-name ExecutionsFailed --namespace AWS/States --statistic Sum --period 300 --threshold 1 --comparison-operator GreaterThanOrEqualToThreshold --evaluation-periods 1 --dimensions Name=StateMachineArn,Value={state_machine_arn} --region {region}`
 
 ### Step 13: Validate
 
 Constraints:
+
 - You MUST test with a small file (< 6 MB) to verify Lambda processing:
+
   ```
   echo 'test data' > /tmp/small-file.txt
   aws s3 cp /tmp/small-file.txt s3://{bucket_name}/small-file.txt --region {region}
   ```
+
 - You MUST wait 15 seconds then check the Step Functions execution:
   `aws stepfunctions list-executions --state-machine-arn {state_machine_arn} --region {region}`
 - You MUST verify the execution succeeded and routed to Lambda
@@ -263,25 +292,30 @@ Constraints:
 
 ## Troubleshooting
 
-**EventBridge rule not triggering**
+### EventBridge rule not triggering
+
 - Verify EventBridge notifications are enabled on the bucket: `aws s3api get-bucket-notification-configuration --bucket {bucket_name}`
 - Verify the rule exists: `aws events describe-rule --name s3-to-stepfunctions --region {region}`
 - Check that the target has the correct state machine ARN and role
 
-**Step Functions execution fails at Fargate task**
+### Step Functions execution fails at Fargate task
+
 - Verify the container image exists in ECR: `aws ecr describe-images --repository-name {ecr_repo_name} --region {region}`
 - Check that the subnets have internet access (route table with IGW)
 - Verify the security group allows outbound traffic
 - Check CloudWatch Logs at `/StepFunctionFargateTask`
 
-**Lambda invocation fails**
+### Lambda invocation fails
+
 - Check CloudWatch Logs: `aws logs tail /aws/lambda/sfn-file-processor --region {region}`
 - Verify the Step Functions role has `lambda:InvokeFunction` permission
 
-**IAM PassRole errors**
+### IAM PassRole errors
+
 - The Step Functions role must have `iam:PassRole` for both the ECS execution role and task role ARNs
 
-**Fargate task stuck in PROVISIONING**
+### Fargate task stuck in PROVISIONING
+
 - Verify the subnets have auto-assign public IP enabled
 - Verify the internet gateway is attached and route table has 0.0.0.0/0 route
 

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/references/ecs-task-definition.md
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/references/ecs-task-definition.md
@@ -1,9 +1,11 @@
 ### Step 8: Create the ECS Cluster and Task Definition
 
 Constraints:
+
 - You MUST create the ECS cluster:
   `aws ecs create-cluster --cluster-name sfn-cluster --capacity-providers FARGATE --region {region}`
 - You MUST register the task definition with:
+
   ```
   aws ecs register-task-definition \
       --family StepFunctionFargateTask \
@@ -30,5 +32,5 @@ Constraints:
       }]' \
       --region {region}
   ```
-- You MUST capture the task definition ARN from the response
 
+- You MUST capture the task definition ARN from the response

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/references/ecs-task-definition.md
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/references/ecs-task-definition.md
@@ -1,0 +1,34 @@
+### Step 8: Create the ECS Cluster and Task Definition
+
+Constraints:
+- You MUST create the ECS cluster:
+  `aws ecs create-cluster --cluster-name sfn-cluster --capacity-providers FARGATE --region {region}`
+- You MUST register the task definition with:
+  ```
+  aws ecs register-task-definition \
+      --family StepFunctionFargateTask \
+      --cpu 1024 \
+      --memory 8192 \
+      --network-mode awsvpc \
+      --requires-compatibilities FARGATE \
+      --execution-role-arn arn:aws:iam::{account_id}:role/sfn-ecs-execution-role \
+      --task-role-arn arn:aws:iam::{account_id}:role/sfn-ecs-task-role \
+      --runtime-platform cpuArchitecture=X86_64,operatingSystemFamily=LINUX \
+      --container-definitions '[{
+        "name": "StepFunctionFargateTask1",
+        "image": "{account_id}.dkr.ecr.{region}.amazonaws.com/{ecr_repo_name}:latest",
+        "cpu": 1024,
+        "memory": 8192,
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/StepFunctionFargateTask",
+            "awslogs-region": "{region}",
+            "awslogs-stream-prefix": "containerlog"
+          }
+        }
+      }]' \
+      --region {region}
+  ```
+- You MUST capture the task definition ARN from the response
+

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/references/iam-roles.md
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/references/iam-roles.md
@@ -1,0 +1,110 @@
+### Step 5: Create IAM Roles
+
+Constraints:
+- You MUST create four IAM roles: Lambda execution role, ECS task execution role, ECS task role, and Step Functions role
+- For each trust policy, create a working copy from `scripts/` and replace ACCOUNT_ID:
+  ```
+  sed 's/ACCOUNT_ID/{account_id}/' scripts/lambda-trust-policy.json > /tmp/lambda-trust-policy.json
+  sed 's/ACCOUNT_ID/{account_id}/' scripts/ecs-trust-policy.json > /tmp/ecs-trust-policy.json
+  sed 's/ACCOUNT_ID/{account_id}/' scripts/stepfunctions-trust-policy.json > /tmp/stepfunctions-trust-policy.json
+  sed 's/ACCOUNT_ID/{account_id}/' scripts/eventbridge-trust-policy.json > /tmp/eventbridge-trust-policy.json
+  ```
+- You MUST create the Lambda role with S3 read access:
+  ```
+  aws iam create-role --role-name sfn-lambda-role --assume-role-policy-document file:///tmp/lambda-trust-policy.json
+  aws iam attach-role-policy --role-name sfn-lambda-role --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  aws iam put-role-policy --role-name sfn-lambda-role --policy-name s3-read --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::{bucket_name}/*"
+    }]
+  }'
+  ```
+- You MUST create the ECS task execution role (for pulling images and writing logs):
+  ```
+  aws iam create-role --role-name sfn-ecs-execution-role --assume-role-policy-document file:///tmp/ecs-trust-policy.json
+  aws iam attach-role-policy --role-name sfn-ecs-execution-role --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+  ```
+- You MUST create the ECS task role with only S3 read access (not Step Functions access):
+  ```
+  aws iam create-role --role-name sfn-ecs-task-role --assume-role-policy-document file:///tmp/ecs-trust-policy.json
+  aws iam put-role-policy --role-name sfn-ecs-task-role --policy-name s3-read --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::{bucket_name}/*"
+    }]
+  }'
+  ```
+- You MUST create the Step Functions role with scoped permissions:
+  ```
+  aws iam create-role --role-name sfn-state-machine-role --assume-role-policy-document file:///tmp/stepfunctions-trust-policy.json
+  ```
+- You MUST attach a scoped policy to the Step Functions role:
+  ```
+  aws iam put-role-policy --role-name sfn-state-machine-role --policy-name sfn-policy --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "lambda:InvokeFunction",
+        "Resource": "arn:aws:lambda:{region}:{account_id}:function:sfn-file-processor"
+      },
+      {
+        "Effect": "Allow",
+        "Action": "ecs:RunTask",
+        "Resource": "arn:aws:ecs:{region}:{account_id}:task-definition/StepFunctionFargateTask:*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": "iam:PassRole",
+        "Resource": [
+          "arn:aws:iam::{account_id}:role/sfn-ecs-execution-role",
+          "arn:aws:iam::{account_id}:role/sfn-ecs-task-role"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "events:PutTargets",
+          "events:PutRule",
+          "events:DescribeRule"
+        ],
+        "Resource": "arn:aws:events:{region}:{account_id}:rule/StepFunctionsGetEventsForECSTaskRule"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ecs:StopTask",
+          "ecs:DescribeTasks"
+        ],
+        "Resource": [
+          "arn:aws:ecs:{region}:{account_id}:cluster/sfn-cluster",
+          "arn:aws:ecs:{region}:{account_id}:task/sfn-cluster/*"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": "states:StartExecution",
+        "Resource": "arn:aws:states:{region}:{account_id}:stateMachine:{state_machine_name}"
+      }
+    ]
+  }'
+  ```
+- You MUST create a separate EventBridge target role with only `states:StartExecution` permission:
+  ```
+  aws iam create-role --role-name sfn-eventbridge-role --assume-role-policy-document file:///tmp/eventbridge-trust-policy.json
+  aws iam put-role-policy --role-name sfn-eventbridge-role --policy-name eventbridge-sfn-policy --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "states:StartExecution",
+      "Resource": "arn:aws:states:{region}:{account_id}:stateMachine:{state_machine_name}"
+    }]
+  }'
+  ```
+- You MUST wait at least 10 seconds for IAM role propagation
+

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/references/iam-roles.md
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/references/iam-roles.md
@@ -1,15 +1,19 @@
 ### Step 5: Create IAM Roles
 
 Constraints:
+
 - You MUST create four IAM roles: Lambda execution role, ECS task execution role, ECS task role, and Step Functions role
 - For each trust policy, create a working copy from `scripts/` and replace ACCOUNT_ID:
+
   ```
   sed 's/ACCOUNT_ID/{account_id}/' scripts/lambda-trust-policy.json > /tmp/lambda-trust-policy.json
   sed 's/ACCOUNT_ID/{account_id}/' scripts/ecs-trust-policy.json > /tmp/ecs-trust-policy.json
   sed 's/ACCOUNT_ID/{account_id}/' scripts/stepfunctions-trust-policy.json > /tmp/stepfunctions-trust-policy.json
   sed 's/ACCOUNT_ID/{account_id}/' scripts/eventbridge-trust-policy.json > /tmp/eventbridge-trust-policy.json
   ```
+
 - You MUST create the Lambda role with S3 read access:
+
   ```
   aws iam create-role --role-name sfn-lambda-role --assume-role-policy-document file:///tmp/lambda-trust-policy.json
   aws iam attach-role-policy --role-name sfn-lambda-role --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
@@ -22,12 +26,16 @@ Constraints:
     }]
   }'
   ```
+
 - You MUST create the ECS task execution role (for pulling images and writing logs):
+
   ```
   aws iam create-role --role-name sfn-ecs-execution-role --assume-role-policy-document file:///tmp/ecs-trust-policy.json
   aws iam attach-role-policy --role-name sfn-ecs-execution-role --policy-arn arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
   ```
+
 - You MUST create the ECS task role with only S3 read access (not Step Functions access):
+
   ```
   aws iam create-role --role-name sfn-ecs-task-role --assume-role-policy-document file:///tmp/ecs-trust-policy.json
   aws iam put-role-policy --role-name sfn-ecs-task-role --policy-name s3-read --policy-document '{
@@ -39,11 +47,15 @@ Constraints:
     }]
   }'
   ```
+
 - You MUST create the Step Functions role with scoped permissions:
+
   ```
   aws iam create-role --role-name sfn-state-machine-role --assume-role-policy-document file:///tmp/stepfunctions-trust-policy.json
   ```
+
 - You MUST attach a scoped policy to the Step Functions role:
+
   ```
   aws iam put-role-policy --role-name sfn-state-machine-role --policy-name sfn-policy --policy-document '{
     "Version": "2012-10-17",
@@ -94,7 +106,9 @@ Constraints:
     ]
   }'
   ```
+
 - You MUST create a separate EventBridge target role with only `states:StartExecution` permission:
+
   ```
   aws iam create-role --role-name sfn-eventbridge-role --assume-role-policy-document file:///tmp/eventbridge-trust-policy.json
   aws iam put-role-policy --role-name sfn-eventbridge-role --policy-name eventbridge-sfn-policy --policy-document '{
@@ -106,5 +120,5 @@ Constraints:
     }]
   }'
   ```
-- You MUST wait at least 10 seconds for IAM role propagation
 
+- You MUST wait at least 10 seconds for IAM role propagation

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/Dockerfile
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir boto3
+RUN useradd --create-home appuser
+USER appuser
+
+WORKDIR /app
+COPY fargate_processor.py .
+
+CMD ["python", "fargate_processor.py"]

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/ecs-trust-policy.json
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/ecs-trust-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "ACCOUNT_ID"
+        }
+      }
+    }
+  ]
+}

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/eventbridge-trust-policy.json
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/eventbridge-trust-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "ACCOUNT_ID"
+        }
+      }
+    }
+  ]
+}

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/fargate_processor.py
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/fargate_processor.py
@@ -1,0 +1,43 @@
+import json
+import boto3
+import os
+import sys
+
+s3_client = boto3.client('s3')
+
+def process_file(bucket, key):
+    # Download the file
+    local_path = f"/tmp/{os.path.basename(key)}"
+    s3_client.download_file(bucket, key, local_path)
+    print(f"Downloaded s3://{bucket}/{key} to {local_path}")
+
+    # Log metadata
+    file_size = os.path.getsize(local_path)
+    metadata = {
+        'bucket': bucket,
+        'key': key,
+        'local_path': local_path,
+        'file_size_bytes': file_size
+    }
+    print(f"File metadata: {json.dumps(metadata)}")
+
+    return metadata
+
+if __name__ == '__main__':
+    event = json.loads(os.environ.get('TASK_EVENT', '{}'))
+
+    detail = event.get('detail', {})
+    bucket = detail.get('bucket', {}).get('name')
+    key = detail.get('object', {}).get('key')
+
+    if not bucket or not key:
+        print("Error: No bucket or key in event")
+        sys.exit(1)
+
+    # Validate inputs
+    if not isinstance(key, str) or '/..' in key or len(key) > 1024:
+        print("Error: Invalid S3 key")
+        sys.exit(1)
+
+    metadata = process_file(bucket, key)
+    print(f"Done. File size: {metadata['file_size_bytes']} bytes")

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/lambda-trust-policy.json
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/lambda-trust-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "ACCOUNT_ID"
+        }
+      }
+    }
+  ]
+}

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/lambda_function.py
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/lambda_function.py
@@ -1,0 +1,47 @@
+import json
+import boto3
+import os
+
+s3_client = boto3.client('s3')
+
+def lambda_handler(event, context):
+    print(f"Received event: {json.dumps(event)}")
+
+    detail = event.get('detail', {})
+    bucket = detail.get('bucket', {}).get('name')
+    key = detail.get('object', {}).get('key')
+    size = detail.get('object', {}).get('size', 0)
+
+    # Validate S3 parameters before downloading
+    if not bucket or not key or not isinstance(key, str) or '/..' in key:
+        raise ValueError('Invalid S3 path')
+    if len(key) > 1024:
+        raise ValueError('S3 key exceeds maximum length')
+    if size > 512 * 1024 * 1024:
+        raise ValueError('File too large for Lambda processing')
+
+    # Download the file to /tmp
+    local_path = f"/tmp/{os.path.basename(key)}"
+    try:
+        s3_client.download_file(bucket, key, local_path)
+        print(f"Downloaded s3://{bucket}/{key} to {local_path}")
+
+        # Log metadata
+        metadata = {
+            'bucket': bucket,
+            'key': key,
+            'size_bytes': size,
+            'local_path': local_path,
+            'file_size_on_disk': os.path.getsize(local_path)
+        }
+        print(f"File metadata: {json.dumps(metadata)}")
+    finally:
+        try:
+            os.remove(local_path)
+        except OSError:
+            pass
+
+    return {
+        'statusCode': 200,
+        'body': metadata
+    }

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/statemachine.asl.json
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/statemachine.asl.json
@@ -1,0 +1,63 @@
+{
+  "Comment": "Choose Lambda or Fargate based on file size",
+  "StartAt": "CheckFileSize",
+  "States": {
+    "CheckFileSize": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.detail.object.size",
+          "NumericGreaterThan": 6291456,
+          "Next": "RunFargateTask"
+        }
+      ],
+      "Default": "InvokeLambda"
+    },
+    "InvokeLambda": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${LambdaFunction}",
+        "Payload.$": "$"
+      },
+      "ResultPath": "$.lambdaResult",
+      "End": true
+    },
+    "RunFargateTask": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::ecs:runTask.sync",
+      "Parameters": {
+        "LaunchType": "FARGATE",
+        "Cluster": "${Cluster}",
+        "TaskDefinition": "${TaskDefinition}",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "Subnets": [
+              "${Subnet1}",
+              "${Subnet2}"
+            ],
+            "SecurityGroups": [
+              "${SecurityGroup}"
+            ],
+            "AssignPublicIp": "ENABLED"
+          }
+        },
+        "Overrides": {
+          "ContainerOverrides": [
+            {
+              "Name": "StepFunctionFargateTask1",
+              "Environment": [
+                {
+                  "Name": "TASK_EVENT",
+                  "Value.$": "States.JsonToString($)"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "ResultPath": "$.fargateResult",
+      "End": true
+    }
+  }
+}

--- a/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/stepfunctions-trust-policy.json
+++ b/skills/specialized-skills/serverless-skills/processing-s3-uploads-with-step-functions/scripts/stepfunctions-trust-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "states.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "ACCOUNT_ID"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add 2 new skills:

- **deploying-custom-domain-rest-api**: Deploys a Regional REST API with custom domain, Lambda authorizer, ACM cert, and Route 53 DNS
- **processing-s3-uploads-with-step-functions**: Step Functions workflow routing S3 uploads to Lambda or Fargate based on file size

Eval results: 46/54 (85%) across multiple models
Gamma verified: Both skills auto-retrieve and execute end-to-end