### PR TITLE
fix: Fix invalid YAML frontmatter in migrate-to-msk-express SKILL.md

### DIFF
--- a/skills/specialized-skills/analytics-skills/migrate-to-msk-express/SKILL.md
+++ b/skills/specialized-skills/analytics-skills/migrate-to-msk-express/SKILL.md
@@ -11,7 +11,6 @@ description: >-
   MSK, streaming migration, moving streaming workloads to AWS, MSK workload compatibility,
   MSK cluster sizing, choosing an MSK cluster type, or MSK Replicator.
 version: 1
-  workload: [streaming, messaging]
 ---
 
 # Migrating to MSK Express


### PR DESCRIPTION
The 'workload' key was indented under 'version: 1' but its parent 'metadata:' line was missing, producing a YAML parse error on GitHub. Removing unnecessary fields

## Description

<!-- Describe the changes in this PR -->

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [X] Other

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [X] My changes pass `python3 tools/validate.py`
- [X] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
