### PR TITLE
feat: add aws-lambda-microvms skill

### DIFF
--- a/plugins/aws-core/skills/aws-serverless/SKILL.md
+++ b/plugins/aws-core/skills/aws-serverless/SKILL.md
@@ -33,6 +33,7 @@ Domain expertise for building serverless applications on AWS. Covers Lambda conf
 | Starting with Powertools | Use [powertools-handler.py](assets/powertools-handler.py) as a template |
 | Lambda Managed Instances, LMI, capacity providers, EC2-backed Lambda, PerExecutionEnvironmentMaxConcurrency | Use the **aws-lambda-managed-instances** skill instead |
 | Durable functions, durable execution, checkpoint-and-replay | Use the **aws-lambda-durable-functions** skill instead |
+| Firecracker microVMs, strong tenant isolation, sandboxed/untrusted code execution, long-lived sessions, suspend/resume, port-listening servers, snapshot-resumable compute | Use the **aws-lambda-microvms** skill instead |
 | Spans multiple areas | Read the most specific reference first, then consult others as needed |
 
 ## Files

--- a/skills/core-skills/aws-serverless/SKILL.md
+++ b/skills/core-skills/aws-serverless/SKILL.md
@@ -33,6 +33,7 @@ Domain expertise for building serverless applications on AWS. Covers Lambda conf
 | Starting with Powertools | Use [powertools-handler.py](assets/powertools-handler.py) as a template |
 | Lambda Managed Instances, LMI, capacity providers, EC2-backed Lambda, PerExecutionEnvironmentMaxConcurrency | Use the **aws-lambda-managed-instances** skill instead |
 | Durable functions, durable execution, checkpoint-and-replay | Use the **aws-lambda-durable-functions** skill instead |
+| Firecracker microVMs, strong tenant isolation, sandboxed/untrusted code execution, long-lived sessions, suspend/resume, port-listening servers, snapshot-resumable compute | Use the **aws-lambda-microvms** skill instead |
 | Spans multiple areas | Read the most specific reference first, then consult others as needed |
 
 ## Files

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/SKILL.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: aws-lambda-microvms
+description: Builds, runs, debugs, and operates applications on AWS Lambda MicroVMs — Firecracker-isolated, snapshot-resumable serverless compute environments running inside a container with up to 8 hr lifetimes. Applicable when workloads need strong isolation between tenants, isolated serverless compute, sandbox compute, or secure multi-tenant execution. Also suited for AI/agent code-execution sandboxes, interactive code playgrounds and notebooks (Jupyter, REPLs, dev environments running user-supplied code), reinforcement-learning environments, multi-tenant CI executors and build runners, sessionful game or simulation servers, or isolated security scanners. Also applicable when the workload needs long-lived sessions, a real port-listening server (gRPC, WebSocket, custom TCP protocols), state preserved across periods of inactivity (suspend/resume), container-level access (FUSE, eBPF, custom syscalls), or session-affine routing.
+version: 1
+---
+
+# AWS Lambda MicroVMs
+
+> The AWS MCP server is recommended for sandboxed execution and audit logging.
+
+AWS Lambda MicroVMs are serverless compute environments that combine Firecracker VM isolation with container-like efficiency. Each MicroVM:
+
+- Runs your application as a **container inside a Firecracker microVM** — you can reproduce the environment locally.
+- Runs Amazon Linux 2023 as the base OS inside the MicroVM.
+- Boots from a **memory + disk snapshot** captured at image build time, so application init is skipped on run.
+- Has a dedicated, TLS-terminated HTTPS endpoint reachable with an auth token.
+- Can be **suspended and resumed** with state preserved; lives up to 8 hours.
+
+**Two-resource model:**
+
+- `MicrovmImage` — a versioned artifact built from `{S3 zip with Dockerfile} + baseImageArn`. Each version has per-architecture/chipset `Build`s.
+- `Microvm` — a running instance created (`RunMicrovm`) from an image version.
+
+**Two roles:**
+
+- `buildRoleArn` — used during image build (S3 read, CloudWatch logs, optional ECR).
+- `executionRoleArn` — assumed at runtime by the running MicroVM.
+
+## When to use
+
+### Choose Lambda MicroVMs when
+
+- **Analytics workloads** — isolated compute for data processing, ETL jobs, or query execution with strong tenant separation.
+- **AI / agent code execution sandboxes** — fresh, isolated environment per session, fast resume between turns.
+- **Interactive code playgrounds & notebooks** — Jupyter, REPLs, dev environments executing user code.
+- **Reinforcement-learning environments** — clean per-episode envs with tool access.
+- **Multi-tenant CI executors / build runners** — strong tenant isolation.
+- **Game / simulation servers** — sessionful, long-lived (up to 8 hr) workloads.
+- **Security scanning** — running untrusted analyzers in isolation.
+
+In general, Lambda MicroVMs are suited for long-lived sessions, real port-listening servers (gRPC, WebSocket, custom TCP protocols), state preserved across periods of inactivity (suspend/resume), container-level access (FUSE, eBPF, custom syscalls), or session-affine routing to a specific compute environment.
+
+### Choose AWS Lambda (functions) when
+
+- The workload fits in 15 minutes.
+- Per-invocation isolation is fine; no need for session state held in memory.
+- Fully automatic scaling is preferred (no `RunMicrovm` to manage).
+- Event-source integrations (S3, SQS, EventBridge, etc.) drive the function.
+
+### Choose something else when
+
+- Continuous compute beyond 8 hr → ECS / EKS / EC2.
+- Lift-and-shift workloads needing kernel modifications or a non-Linux OS → EC2.
+
+## Typical workflow
+
+0. **Check regional availability** — confirm Lambda MicroVMs is available in your target region (use a `ListMicrovmImages` call). Your S3 artifact bucket and any network connectors must be in the same region as the image.
+1. **Package** an app: zip with a `Dockerfile` at the root, upload to S3 (same region as the image).
+2. **Implement lifecycle hooks** (optional but recommended) — HTTP endpoints on a port you specify (commonly `9000`) for `/run`, `/resume`, `/suspend`, `/terminate`, `/ready`, `/validate`.
+3. **CreateMicrovmImage** — pointing at the S3 artifact, a managed base image, and a build role. Lambda compiles the Dockerfile into an OCI image, starts your app, calls `/ready`, snapshots disk + memory, optionally validates with `/validate`. Lambda will periodically release new managed image versions, and customers should re-build using the latest version to ensure they have up to date images.
+4. **RunMicrovm** — pick an image version, attach `executionRoleArn`, set `idlePolicy`, ingress/egress connectors, and (optionally) a `runHookPayload`. Receive an `endpoint` URL and `microvmId`.
+5. **CreateMicrovmAuthToken** — get an auth token (max 60 min) with `allowedPorts` specifying which ports the token grants access to. Send traffic to the endpoint with `X-aws-proxy-auth: <token>`.
+6. **Suspend / Resume / Terminate** — explicit APIs, or let the `idlePolicy` drive it (`maxIdleDurationSeconds`, `suspendedDurationSeconds`, `autoResumeEnabled`).
+
+### Core CLI commands
+
+```bash
+# Create an image (zip with Dockerfile at root in S3, plus a managed base image)
+aws lambda-microvms create-microvm-image \
+  --name my-image \
+  --base-image-arn arn:aws:lambda:<region>:aws:microvm-image:al2023-1 \
+  --build-role-arn arn:aws:iam::<acct>:role/MicroVMBuildRole \
+  --code-artifact '{"uri":"s3://<bucket>/<key>.zip"}'
+
+# Run a MicroVM (returns endpoint + microvmId). --image-identifier takes the
+# image ARN (the bare name is rejected); --image-version is the full major.minor string.
+aws lambda-microvms run-microvm \
+  --image-identifier arn:aws:lambda:<region>:<acct>:microvm-image:my-image \
+  --image-version 1.0 \
+  --execution-role-arn arn:aws:iam::<acct>:role/MicroVMExecutionRole \
+  --idle-policy '{"maxIdleDurationSeconds":900,"suspendedDurationSeconds":300,"autoResumeEnabled":true}'
+
+# Mint an auth token and call the endpoint
+TOKEN=$(aws lambda-microvms create-microvm-auth-token \
+  --microvm-identifier microvm-... --expiration-in-minutes 30 \
+  --allowed-ports '[{"port":8080}]' \
+  --query 'authToken."X-aws-proxy-auth"' --output text)
+curl "<endpoint>/" -H "X-aws-proxy-auth: $TOKEN"
+
+# Lifecycle
+aws lambda-microvms suspend-microvm   --microvm-identifier microvm-...
+aws lambda-microvms resume-microvm    --microvm-identifier microvm-...
+aws lambda-microvms terminate-microvm --microvm-identifier microvm-...
+```
+
+See [`references/getting-started.md`](references/getting-started.md) for the full walkthrough including `--hooks` config and lifecycle hooks.
+
+## Hook configuration
+
+Hooks are organized into two groups under the `--hooks` parameter:
+
+### `microvmImageHooks` (build-time)
+
+> **Recommendation:** Implement the image build hooks (`/ready` and `/validate`) for best performance. They enable the platform to capture a complete snapshot and prefetch the portions accessed at run time.
+
+| Hook | Purpose | Timeout range |
+|---|---|---|
+| `ready` | Called during application boot. When this hook returns a 200 status code, it signals to the platform that the application is ready to be snapshotted. Use this to ensure your application is fully booted before a snapshot is taken. If your application is not yet ready, return a 503 status code until it is ready for snapshotting. | 1–3600s (default 30s) |
+| `validate` | Called after running your application from the microVM snapshot. Use this hook to validate the application is ready to serve traffic. This hook additionally allows the platform to sample the portions of the snapshot that are used when your application is ran, allowing Lambda to prefetch those portions of the snapshot to reduce latency. To get the best performance, run mock payloads through the application during validate. When this hook returns a 200, it signals to the Lambda the MicroVM image is valid. If your application needs more time to run its validate workflow, return a 503 status code. | 1–3600s (default 30s) |
+
+> **Why implement `/ready`?** It signals the platform that your application has fully booted. Without it, the snapshot may be taken mid-initialization, meaning the cached state is incomplete and every run repeats part of the boot sequence.
+>
+> **Why implement `/validate`?** It lets the platform verify the snapshot is correct, and also samples which portions of the snapshot are accessed during `RunMicrovm`. This allows the platform to **prefetch** those portions on future launches, reducing cold-start times.
+
+### `microvmHooks` (runtime)
+
+| Hook | Purpose | Timeout range |
+|---|---|---|
+| `run` | Fires once after run from snapshot | 1–60s (default 1s) |
+| `resume` | Fires after SUSPENDED → RUNNING | 1–60s (default 1s) |
+| `suspend` | Fires before RUNNING → SUSPENDED | 1–60s (default 1s) |
+| `terminate` | Fires before termination | 1–60s (default 1s) |
+
+See [`references/getting-started.md`](references/getting-started.md) for a full example enabling all hooks.
+
+## Per-MicroVM size limits
+
+| Resource | Limit |
+|---|---|
+| Maximum vCPUs per MicroVM | 16 |
+| Maximum memory per MicroVM | 32 GB |
+
+> For all other quotas — concurrent MicroVMs per account, launch rate, image count, max execution duration, auth token TTL, Lambda Network Connector (LNC) limits, per-ENI bandwidth, etc. — **check the AWS docs / Service Quotas console.** Most are soft quotas, raisable through Service Quotas / Support.
+
+## Additional capabilities
+
+By default, the container runs with a restricted set of Linux capabilities. Set `--additional-os-capabilities '["ALL"]'` at image creation time only when required by your use case:
+
+- **Filesystem mounts** — EFS, FUSE-based filesystems.
+- **Nested containers** — running additional containers with containerd inside the MicroVM.
+- **eBPF programs** — tracing, profiling, or custom network policies.
+
+```bash
+aws lambda-microvms create-microvm-image \
+  --name my-image \
+  --base-image-arn arn:aws:lambda:<region>:aws:microvm-image:al2023-1 \
+  --build-role-arn arn:aws:iam::<acct>:role/MicroVMBuildRole \
+  --code-artifact '{"uri":"s3://<bucket>/<key>.zip"}' \
+  --additional-os-capabilities '["ALL"]'
+```
+
+## Shell ingress for agent use cases
+
+For programmatic shell access (agent workflows, remote command execution), use the `SHELL_INGRESS` network connector:
+
+```bash
+aws lambda-microvms run-microvm \
+  --image-identifier arn:aws:lambda:<region>:<acct>:microvm-image:my-image \
+  --image-version 1.0 \
+  --execution-role-arn arn:aws:iam::<acct>:role/MicroVMExecutionRole \
+  --ingress-network-connectors '["arn:aws:lambda:<region>:aws:network-connector:aws-network-connector:SHELL_INGRESS"]' \
+  --idle-policy '{"maxIdleDurationSeconds":900,"suspendedDurationSeconds":300,"autoResumeEnabled":true}'
+```
+
+This provides a WebSocket-based shell channel accessible from any client (terminal or browser), suitable for agent-driven workflows that need to execute commands inside the MicroVM.
+
+## Known constraints
+
+- **Image is single-size** — you can't ship multiple instance sizes from one image. Plan one image per size.
+- **Image versions incur storage cost** even when no MicroVMs are running on them. Use `delete-microvm-image-version` to clean up.
+- **Suspend → resume can't switch network connectors.** LNC is bound at run time.
+- **No self-suspend from inside the MicroVM.** Call `SuspendMicrovm` from outside (via the public API).
+- **Auth token max TTL is 60 min.** Refresh ahead of expiry for long-running clients.
+- **Runtime hooks (`/run`, `/resume`, `/suspend`, `/terminate`) are fast-notification only** (1–60s timeout). Don't use them for slow init.
+
+## Reference index
+
+Pick the reference that matches your task:
+
+- [`references/getting-started.md`](references/getting-started.md) — prerequisites (S3 bucket, build role trust policy), packaging, end-to-end CLI walkthrough, first run + token + curl.
+- [`references/lifecycle-model.md`](references/lifecycle-model.md) — image vs. MicroVM state machines, the six lifecycle hooks (paths, timeouts, what to do in each), idle/suspend/resume semantics, hook payloads.
+- [`references/snapshots-and-uniqueness.md`](references/snapshots-and-uniqueness.md) — what gets snapshotted, the uniqueness pitfall, CSPRNGs by language, env vars vs. run configuration, snapshot size inspection.
+- [`references/networking.md`](references/networking.md) — ingress vs. egress connectors, port routing, `X-aws-proxy-*` headers, WebSocket subprotocols, HTTP/2 / gRPC, VPC egress.
+- [`references/iam-and-security.md`](references/iam-and-security.md) — build role vs. execution role, trust policies, auth tokens (regular vs. shell), `lambda:PassNetworkConnector`.
+- [`references/troubleshooting.md`](references/troubleshooting.md) — image build error codes, run/connect failures, hook timeouts, network connector issues, debugging via shell access.
+
+## Conventions used in references
+
+- The runtime-side default proxy port is `8080`. Override per-request with `X-aws-proxy-port` or per-WebSocket with subprotocol `lambda-microvms.port.<n>`.
+
+## Security considerations
+
+- **Confused deputy prevention** — add `aws:SourceAccount` (or `aws:SourceArn`) condition keys to trust policies. See `references/iam-and-security.md`.
+- **Snapshot uniqueness** — snapshots share memory state. Reseed CSPRNGs and rotate secrets on resume. See `references/snapshots-and-uniqueness.md`.
+- **Network isolation** — use VPC egress connectors to restrict outbound traffic.
+- **Least-privilege execution roles** — scope IAM policies to specific regions, accounts, and resource prefixes.
+- **Logging** — enable CloudTrail for MicroVM lifecycle events.

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/getting-started.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/getting-started.md
@@ -1,0 +1,243 @@
+# Getting started
+
+End-to-end: prerequisites → package → create image → run MicroVM → authenticate → call.
+
+## Prerequisites
+
+0. **Check regional availability.** Confirm Lambda MicroVMs is available in your target region — check the Lambda MicroVMs documentation for supported regions. The S3 artifact bucket and any network connectors must be in the same region as the image.
+1. **S3 bucket** in the region you'll create the image in. Cross-region access is rejected (`S3_CROSS_REGION_ACCESS_DENIED`).
+2. **Build IAM role** that Lambda assumes during image build. Trust policy:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [{
+       "Effect": "Allow",
+       "Principal": { "Service": "lambda.amazonaws.com" },
+       "Action": "sts:AssumeRole",
+       "Condition": {
+         "StringEquals": {
+           "aws:SourceAccount": "<account-id>"
+         }
+       }
+     }]
+   }
+   ```
+
+   Permissions on the role:
+   - `s3:GetObject` on the artifact key, `s3:PutObject` for build outputs (if you write any).
+   - `logs:CreateLogGroup`, `logs:CreateLogStream`, `logs:PutLogEvents`.
+   - `ecr:GetAuthorizationToken` if your `Dockerfile` `FROM` references private ECR.
+3. **(Optional) Execution role** for runtime — Lambda uses this to ship logs and to expose AWS credentials inside the MicroVM via IMDSv2. Same trust policy as the build role. Without an execution role, application stdout is *not* shipped to CloudWatch.
+
+See [`iam-and-security.md`](iam-and-security.md) for the full breakdown.
+
+## Step 1 — Package the application
+
+A code artifact is a zip containing a `Dockerfile` at the **root** plus any files it references.
+
+```
+my-app.zip
+├── Dockerfile
+├── app.py
+└── requirements.txt
+```
+
+**Minimal Python example** (Flask app on port 8080, lifecycle hooks on port 9000):
+
+```python
+# app.py
+from flask import Flask
+import threading
+
+# Application port (default routed by proxy from external 80/443)
+app = Flask(__name__)
+@app.get("/") 
+def root(): return {"hello": "world"}
+
+# Lifecycle hooks port
+hooks = Flask("hooks")
+P = "/aws/lambda-microvms/runtime/v1"
+@hooks.post(f"{P}/ready")     
+def ready(): return "", 200
+@hooks.post(f"{P}/run")        
+def run(): return "", 200
+@hooks.post(f"{P}/resume")    
+def resume(): return "", 200
+@hooks.post(f"{P}/suspend")   
+def suspend(): return "", 200
+@hooks.post(f"{P}/terminate") 
+def terminate(): return "", 200
+
+if __name__ == "__main__":
+    threading.Thread(target=lambda: hooks.run(host="0.0.0.0", port=9000), daemon=True).start()
+    app.run(host="0.0.0.0", port=8080)
+```
+
+```dockerfile
+# Dockerfile
+FROM public.ecr.aws/lambda/microvms:al2023-minimal
+RUN dnf install -y python3 python3-pip && dnf clean all
+RUN pip install --no-cache-dir flask==3.0.3
+COPY app.py .
+EXPOSE 8080 9000
+CMD ["python", "app.py"]
+```
+
+Upload:
+
+```bash
+zip my-app.zip Dockerfile app.py
+aws s3 cp my-app.zip s3://${BUCKET}/microvm-images/my-first-image/code-artifact.zip
+```
+
+## Step 2 — List managed base images
+
+A custom image must be built *on top of* a Lambda-managed base image (Amazon Linux 2023 + service components).
+
+```bash
+aws lambda-microvms list-managed-microvm-images
+```
+
+Pick an `imageArn` from the output (e.g. `arn:aws:lambda:<region>:aws:microvm-image:al2023-1`).
+
+## Step 3 — Create the MicroVM image
+
+```bash
+aws lambda-microvms create-microvm-image \
+  --name my-first-image \
+  --description "Hello world Flask app" \
+  --base-image-arn arn:aws:lambda:<region>:aws:microvm-image:al2023-1 \
+  --build-role-arn arn:aws:iam::123456789012:role/MicroVMBuildRole \
+  --code-artifact '{"uri":"s3://my-bucket/microvm-images/my-first-image/code-artifact.zip"}' \
+  --hooks '{
+    "port": 9000,
+    "microvmImageHooks": {
+      "ready": "ENABLED",
+      "readyTimeoutInSeconds": 60
+    },
+    "microvmHooks": {
+      "run": "ENABLED",
+      "runTimeoutInSeconds": 2,
+      "resume": "ENABLED",
+      "resumeTimeoutInSeconds": 2,
+      "suspend": "ENABLED",
+      "suspendTimeoutInSeconds": 5,
+      "terminate": "ENABLED",
+      "terminateTimeoutInSeconds": 5
+    }
+  }'
+```
+
+Response includes the `imageArn` and a starting `state` of `CREATING`.
+
+Build proceeds: Lambda fetches the zip, compiles the Dockerfile into an OCI image, starts your app via `CMD`/`ENTRYPOINT`, calls `/ready`, captures the snapshot, then optionally calls `/validate` on a test run.
+
+## Step 4 — Wait for the build to succeed
+
+Pass the `imageArn` returned by `create-microvm-image` to `--image-identifier`. Image versions are `major.minor`; use the full string (e.g. `1.0`).
+
+```bash
+aws lambda-microvms get-microvm-image \
+  --image-identifier arn:aws:lambda:<region>:123456789012:microvm-image:my-first-image \
+  --query 'state'
+```
+
+Image state: `CREATING` → `CREATED`. Version state: `PENDING` → `IN_PROGRESS` → `SUCCESSFUL` (or `FAILED`). Inspect per-architecture builds:
+
+```bash
+aws lambda-microvms list-microvm-image-builds \
+  --image-identifier arn:aws:lambda:<region>:123456789012:microvm-image:my-first-image \
+  --image-version 1
+```
+
+If a build fails, `stateReason` carries an error code from [`troubleshooting.md`](troubleshooting.md).
+
+## Step 5 — Run a MicroVM
+
+`run-microvm` requires the **full `major.minor` version string** (`1.0`); Pass the image ARN as `--image-identifier`.
+
+```bash
+aws lambda-microvms run-microvm \
+  --image-identifier arn:aws:lambda:<region>:123456789012:microvm-image:my-first-image \
+  --image-version 1.0 \
+  --execution-role-arn arn:aws:iam::123456789012:role/MicroVMExecutionRole \
+  --idle-policy '{
+    "maxIdleDurationSeconds": 900,
+    "suspendedDurationSeconds": 300,
+    "autoResumeEnabled": true
+  }' \
+  --maximum-duration-in-seconds 28800 \
+  --logging '{"cloudWatch":{"logGroup":"/aws/lambda-microvms/my-first-image"}}'
+```
+
+Response:
+
+```json
+{
+  "microvmId": "microvm-...",
+  "state": "PENDING",
+  "endpoint": "<microvm-id>.lambda-microvm.<region>.on.aws",
+  "imageArn": "arn:aws:lambda:<region>:<account>:microvm-image:my-first-image",
+  "imageVersion": "1.0",
+  "maximumDurationInSeconds": 28800,
+  "startedAt": "2026-01-01T00:00:00Z"
+}
+```
+
+The MicroVM is ready when you can successfully ingress into it. Note that `get-microvm` state is eventually consistent and may lag behind reality — determine readiness by attempting to connect rather than polling the API.
+
+Typically ready within 1–10 s depending on snapshot size.
+
+## Step 6 — Authenticate and call
+
+Generate an auth token (max 60 min):
+
+```bash
+TOKEN=$(aws lambda-microvms create-microvm-auth-token \
+  --microvm-identifier microvm-... \
+  --expiration-in-minutes 30 \
+  --allowed-ports '[{"port":8080}]' \
+  --query 'authToken."X-aws-proxy-auth"' --output text)
+
+curl "https://<microvm-endpoint>/" \
+  -H "X-aws-proxy-auth: $TOKEN" \
+  -H "X-aws-proxy-port: 8080"
+```
+
+Default proxy target is **port 8080** inside the MicroVM. Override per-request with `X-aws-proxy-port`. For browsers / WebSockets see [`networking.md`](networking.md).
+
+## Step 7 — Suspend / resume / terminate
+
+```bash
+# Manual lifecycle control
+aws lambda-microvms suspend-microvm  --microvm-identifier microvm-...
+aws lambda-microvms resume-microvm   --microvm-identifier microvm-...
+aws lambda-microvms terminate-microvm --microvm-identifier microvm-...
+```
+
+If `autoResumeEnabled: true`, the proxy resumes a suspended MicroVM transparently when ingress traffic arrives.
+
+## Step 8 — Iterate (versions)
+
+To ship new code, **create a new version** of the image. Use:
+
+```bash
+aws lambda-microvms update-microvm-image \
+  --image-identifier arn:aws:lambda:<region>:123456789012:microvm-image:my-first-image \
+  --base-image-arn arn:aws:lambda:<region>:aws:microvm-image:al2023-1 \
+  --build-role-arn arn:aws:iam::<acct>:role/MicroVMBuildRole \
+  --code-artifact '{"uri":"s3://.../v2.zip"}'
+```
+
+Then `update-microvm-image-version --status ACTIVE|INACTIVE` to control which versions are usable, and `delete-microvm-image-version` to clean up.
+
+Note: image **versions incur storage cost** even when no MicroVMs are running on them — clean up old ones. `delete-microvm-image-version` cannot remove the **last remaining version** — use `delete-microvm-image` to remove the whole image instead.
+
+## Common pitfalls (quick list)
+
+- Forgetting to `EXPOSE <your application port>` in the Dockerfile — all apps run in a container, so the port your hooks and server bind to must be exposed.
+- Forgetting to bind hooks to `0.0.0.0` — Lambda calls hooks over the network namespace, so localhost-only listeners are unreachable.
+- Generating per-instance state in the Dockerfile — that state is **shared** across all MicroVMs from the snapshot. See [`snapshots-and-uniqueness.md`](snapshots-and-uniqueness.md).
+- We recommend using `public.ecr.aws/lambda/microvms:al2023-minimal` as the base registry. See [`snapshots-and-uniqueness.md`](snapshots-and-uniqueness.md).
+- Cross-region S3 artifact — must match the image's region.

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/iam-and-security.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/iam-and-security.md
@@ -1,0 +1,156 @@
+# IAM and security
+
+Lambda MicroVMs uses two IAM roles with a clean separation between **build time** and **runtime**, plus auth tokens for ingress traffic.
+
+## Two roles, two phases
+
+| Role | Required? | Used by | Used during |
+|---|---|---|---|
+| **Build role** (`buildRoleArn`) | Yes | `CreateMicrovmImage` / `UpdateMicrovmImage` | Image build (download artifact, run Dockerfile, ship build logs) |
+| **Execution role** (`executionRoleArn`) | Optional | `RunMicrovm` | Application runtime (assumed inside the guest, exposed via IMDSv2) |
+
+The two **must be separate** ARNs in production. The build role usually needs S3/ECR permissions you don't want exposed to running application code; the execution role usually needs application-specific perms (DynamoDB, Secrets Manager, etc.) the build doesn't.
+
+## Trust policy (both roles)
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Service": "lambda.amazonaws.com" },
+    "Action": "sts:AssumeRole",
+    "Condition": {
+      "StringEquals": {
+        "aws:SourceAccount": "<account-id>"
+      },
+      "ArnLike": {
+        "aws:SourceArn": "arn:aws:lambda:<region>:<account-id>:microvm-image/*"
+      }
+    }
+  }]
+}
+```
+
+The `Condition` block prevents the confused deputy problem by restricting which Lambda resources can assume these roles.
+
+## Build role — minimum permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ReadCodeArtifact",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::my-bucket/microvm-images/*"
+    },
+    {
+      "Sid": "WriteBuildLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:<region>:<account-id>:log-group:/aws/lambda-microvms/*"
+    }
+  ]
+}
+```
+
+Add as needed:
+
+- `ecr:GetAuthorizationToken`, `ecr:BatchGetImage`, `ecr:GetDownloadUrlForLayer` if your `Dockerfile`'s `FROM` references private ECR.
+
+## Execution role — minimum permissions
+
+The execution role is **optional**, but without it, application stdout is *not* forwarded to CloudWatch.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ],
+    "Resource": "arn:aws:logs:<region>:<account-id>:log-group:/aws/lambda-microvms/*"
+  }]
+}
+```
+
+Add scoped permissions for any AWS APIs your application calls (DynamoDB, S3, Secrets Manager, etc.).
+
+The credentials are exposed to the guest via IMDSv2 at:
+
+```
+http://169.254.169.254/latest/meta-data/iam/security-credentials/execution_role
+```
+
+> Most AWS SDKs pick this up automatically via the default credential chain. **No need to bake credentials into env vars.**
+
+The MicroVM ID is automatically provided in the `/run` hook request body as `microvmId`, alongside any `runHookPayload` you passed to `RunMicrovm`.
+
+## Auth tokens
+
+Lambda issues short-lived, opaque auth tokens for ingress traffic.
+
+| Field | Detail |
+|---|---|
+| TTL | `expirationInMinutes` ≤ 60 |
+| Header | `X-aws-proxy-auth: <token>` (or WebSocket subprotocol `lambda-microvms.authentication.<token>`) |
+| Scope | Restricted to a list of ports/ranges via `allowedPorts` on `CreateMicrovmAuthToken` (required) |
+
+### Two token operations
+
+| Operation | When to use |
+|---|---|
+| `create-microvm-auth-token` | Application traffic. Requires `allowedPorts`. |
+| `create-microvm-shell-auth-token` | Interactive shell access (browser or terminal). Only works when the MicroVM was run with the `SHELL_INGRESS` network connector attached. |
+
+## Shell access (debugging)
+
+Attach the `SHELL_INGRESS` network connector at run time:
+
+```bash
+aws lambda-microvms run-microvm \
+  --image-identifier arn:aws:lambda:<region>:<account>:microvm-image/my-image \
+  --execution-role-arn ... \
+  --ingress-network-connectors '["arn:aws:lambda:<region>:aws:network-connector:aws-network-connector:SHELL_INGRESS"]'
+```
+
+Then `create-microvm-shell-auth-token` and connect via the AWS console (Connect button on the MicroVM detail page) or a WebSocket client. The shell drops you into the container where your application runs.
+
+## SCP enforcement and IAM scoping
+
+Every `RunMicrovm` caller needs `lambda:PassNetworkConnector` — not just when attaching a custom VPC connector. MicroVMs default to the `HTTP_INGRESS` and `INTERNET_EGRESS` connectors, which are themselves passed at run time, so the permission is required even when you specify no connectors. Scope the `Resource` to the connector ARN(s) you actually pass.
+
+### Example: allow passing connectors
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "lambda:PassNetworkConnector",
+    "Resource": [
+      "arn:aws:lambda:<region>:aws:network-connector:aws-network-connector:*",
+      "arn:aws:lambda:<region>:<account>:network-connector:<connector-id>"
+    ]
+  }]
+}
+```
+
+The first ARN covers the AWS-managed default connectors; the second scopes to your own VPC connector.
+
+## PrivateLink
+
+VPC endpoints are supported for the `*.lambda-microvm.on.aws` domain (endpoint service: `com.amazonaws.<region>.lambda-microvm`) — clients in your VPC can reach MicroVM endpoints without traversing the public internet. Standard VPCE policy condition keys apply (`aws:SourceVpce`, `aws:SourceVpc`, `aws:ResourceAccount`, `aws:ResourceOrgID`). See the [AWS PrivateLink security best practices](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-access.html) for guidance on scoping VPCE policies.
+
+## CloudTrail
+
+Standard `lambda:*` data plane and management events show up in CloudTrail.

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/lifecycle-model.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/lifecycle-model.md
@@ -1,0 +1,159 @@
+# Lifecycle model
+
+Two state machines (image and MicroVM) plus the lifecycle hook contract your application can optionally implement.
+
+## Image state machine
+
+Image-level state:
+
+```
+CREATING ──▶ CREATED ──▶ DELETING
+```
+
+Version-level state (`state` + `status`):
+
+```
+state: PENDING ──▶ IN_PROGRESS ──▶ SUCCESSFUL
+                              └─▶ FAILED
+
+status: ACTIVE | INACTIVE
+```
+
+A single image version can produce multiple `Build` records — one per `(architecture, chipset, chipsetGeneration)`. Each build has its own `buildState`: `PENDING` → `IN_PROGRESS` → `SUCCESSFUL` | `FAILED`. List with `list-microvm-image-builds`.
+
+`UpdateMicrovmImageVersion` switches a version's `status` between `ACTIVE` and `INACTIVE` — `RunMicrovm` will only resolve `ACTIVE` versions when no explicit `imageVersion` is supplied.
+
+## MicroVM state machine
+
+```
+PENDING
+   │
+   ▼
+RUNNING ◀──── (auto-resume on ingress, or ResumeMicrovm)
+   │  ▲
+   ▼  │
+SUSPENDING ──▶ SUSPENDED
+                  │
+                  ▼ (after suspendedDurationSeconds, or TerminateMicrovm)
+              TERMINATING ──▶ TERMINATED
+```
+
+Triggers:
+
+- `RunMicrovm` → `PENDING` → `RUNNING`.
+- Idle for `maxIdleDurationSeconds` of no proxy traffic → `SUSPENDING` → `SUSPENDED`. Or call `SuspendMicrovm`.
+- Ingress traffic on the endpoint with `autoResumeEnabled: true`, or `ResumeMicrovm` → `RUNNING`.
+- `SUSPENDED` for `suspendedDurationSeconds` → terminated.
+- Maximum lifetime `maximumDurationInSeconds` (cap 28,800 s = 8 hr) reached → terminated.
+- `TerminateMicrovm` from anywhere.
+
+Idle is **measured by traffic through the proxy endpoint**. If your app does outbound work but receives no inbound traffic, the platform will count it as idle. For background workers, set high `maxIdleDurationSeconds` or disable auto-suspend by omitting `idlePolicy` in the request.
+
+## Lifecycle hooks
+
+Your application can implement HTTP endpoints that Lambda invokes at lifecycle transitions. Hooks are **opt-in per image** via the `--hooks` parameter. You must specify the `port` your hooks listen on (commonly `9000`).
+
+### Image build hooks
+
+| Hook | Path | When invoked | Timeout field | Use it for |
+|---|---|---|---|---|
+| **`/ready`** | `POST /aws/lambda-microvms/runtime/v1/ready` | During image build, before snapshot capture | `readyTimeoutInSeconds` (1–3600) | Confirm app initialized; fail the build if app is broken |
+| **`/validate`** | `POST /aws/lambda-microvms/runtime/v1/validate` | After build, on a test MicroVM run from the snapshot | `validateTimeoutInSeconds` (1–3600) | End-to-end smoke test of the snapshot |
+
+Implementing image build hooks is recommended for performance — they ensure your application is fully initialized before the snapshot is captured, resulting in faster runs.
+
+### MicroVM hooks
+
+| Hook | Path | When invoked | Timeout field | Use it for |
+|---|---|---|---|---|
+| **`/run`** | `POST /aws/lambda-microvms/runtime/v1/run` | Once, immediately after a MicroVM is run (resumed from snapshot) | `runTimeoutInSeconds` (1–60) | Create per-VM unique state, fetch secrets, register with discovery. **Should be quick** — not for long-running work |
+| **`/resume`** | `POST /aws/lambda-microvms/runtime/v1/resume` | After `SUSPENDED` → `RUNNING` | `resumeTimeoutInSeconds` (1–60) | Re-establish connections, generate new randomness if your application relies on non-CSPRNGs |
+| **`/suspend`** | `POST /aws/lambda-microvms/runtime/v1/suspend` | Just before `RUNNING` → `SUSPENDED` | `suspendTimeoutInSeconds` (1–60) | Return 200 only when the app is ready to be suspended. Customer decides the strategy: wait for in-flight work to drain within the timeout, or return immediately |
+| **`/terminate`** | `POST /aws/lambda-microvms/runtime/v1/terminate` | Just before termination | `terminateTimeoutInSeconds` (1–60) | Flush logs, persist state, deregister |
+
+> If you use microVM hooks, you must implement the `/ready` microVM image hook. This ensures your application has booted and can receive hook events.
+>
+> Always set explicit timeout values in `--hooks` when creating the image — especially for `/ready` (init) and `/run`/`/resume` (any per-VM init work).
+
+### Configuring hooks (image creation)
+
+```bash
+--hooks '{
+  "port": 9000,
+  "microvmImageHooks": {
+    "ready": "ENABLED",
+    "readyTimeoutInSeconds": 60,
+    "validate": "ENABLED",
+    "validateTimeoutInSeconds": 10
+  },
+  "microvmHooks": {
+    "run": "ENABLED",
+    "runTimeoutInSeconds": 2,
+    "resume": "ENABLED",
+    "resumeTimeoutInSeconds": 2,
+    "suspend": "ENABLED",
+    "suspendTimeoutInSeconds": 5,
+    "terminate": "ENABLED",
+    "terminateTimeoutInSeconds": 5
+  }
+}'
+```
+
+A hook left at its default `DISABLED` is not called even if the application implements the path.
+
+### Hook contract
+
+- Return **HTTP 200** when the hook has completed successfully. For `/ready` and `/validate`, return **503** if the application needs more time — the platform will retry until the configured timeout. Returning 503 quickly is preferred over blocking until ready, otherwise the platform may time out before the configured timeout.
+  - During image build, a `/ready` failure (non-200/503 or timeout) fails the build.
+  - At runtime, a hook failure may cause `RunMicrovm` to fail or transition the MicroVM through `TERMINATING` with `stateReason` set.
+- The `runHookPayload` you pass to `RunMicrovm` is delivered as the request body of `/run`.
+
+### Sequence: run + ingress + idle + resume + terminate
+
+```
+                    Lambda                       Your app
+                       │                             │
+RunMicrovm ───────────▶│                             │
+                       │   resume snapshot           │
+                       │   POST /run (runHookPayload)│
+                       │────────────────────────────▶│ 200
+                       │                             │
+                client ──── HTTPS ingress ──────────▶│ (request handled)
+                       │ ... no traffic for          │
+                       │   maxIdleDurationSeconds ...  │
+                       │   POST /suspend             │
+                       │────────────────────────────▶│ 200
+                       │   suspend (snapshot RAM+disk)
+                       │                             │
+                client ──── HTTPS ingress ──────────▶│ (auto-resume if enabled)
+                       │   resume                    │
+                       │   POST /resume              │
+                       │────────────────────────────▶│ 200
+                       │   ... eventually ...        │
+TerminateMicrovm ─────▶│   POST /terminate           │
+                       │────────────────────────────▶│ 200
+                       │   stop                      │
+```
+
+## Idle policy fields
+
+| Field | Range | Notes |
+|---|---|---|
+| `maxIdleDurationSeconds` | ≥60 | Required. Idle threshold from last proxy traffic. |
+| `suspendedDurationSeconds` | ≥0 | Required. Time-to-terminate while suspended. `0` means "terminate immediately on suspend." |
+| `autoResumeEnabled` | bool | Required. If true, proxy resumes the VM transparently when traffic arrives at its endpoint. |
+
+In `RunMicrovm` you can also set `maximumDurationInSeconds` (cap 28,800) — a hard wall-clock lifetime regardless of activity.
+
+## Hook implementation tips
+
+- **Bind to `0.0.0.0`** on the configured `port`. Lambda calls hooks over the guest's network namespace; localhost-only listeners are unreachable.
+- **Run hooks in a separate thread / event loop** from your application server. `/suspend` should still answer 200 even if your main worker pool is busy.
+- **Keep `/run` and `/resume` fast.** These hooks are notification mechanisms. If your application needs to run long-running workflows (> 60s) in response, do so asynchronously.
+- **Don't use `/run` for long-running init.** That work belongs at image build time so it's captured in the snapshot. Avoid generating random data at build time — if unique random state is needed, invalidate and re-generate using a CSPRNG on `/run`.
+- **Make hooks idempotent.** Lambda may retry `/suspend` or `/terminate` under failure conditions.
+
+## Where to go next
+
+- Per-VM uniqueness (entropy, secrets, env vars vs. `runHookPayload`): [`snapshots-and-uniqueness.md`](snapshots-and-uniqueness.md)
+- Hook-related failure modes: [`troubleshooting.md`](troubleshooting.md)

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/networking.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/networking.md
@@ -1,0 +1,184 @@
+# Networking
+
+How traffic gets in and out of a MicroVM, what protocols are supported, and how the proxy header conventions work.
+
+## Big picture
+
+```
+┌────────────┐  HTTPS / WSS    ┌─────────────────┐  TLS-PSK   ┌──────────────┐  TLS?  ┌─────────────────┐
+│   Client   │ ── auth token ─▶│  Service proxy  │ ──────────▶│  MicroVM     │ ──────▶│  Application    │
+│ (browser,  │                 │  (TLS terminate;│            │  Proxy Agent │        │  (any TCP-based │
+│  curl,     │                 │   port routing) │            │              │        │   server: HTTP, │
+│  app)      │                 │                 │            │              │        │   gRPC, WS)     │
+└────────────┘                 └─────────────────┘            └──────────────┘        └─────────────────┘
+```
+
+> The proxy agent auto-detects whether the guest application speaks TLS.
+
+Each MicroVM gets a **dedicated, service-managed HTTPS endpoint** (`https://<microvm>.lambda-microvm.on.aws`).
+
+## Ingress (inbound)
+
+### Default routing
+
+By default, traffic on the proxy's external **port 443** is forwarded to **port 8080** inside the MicroVM.
+
+### Choosing a different target port
+
+Per-request: include `X-aws-proxy-port: <port>` (HTTP) or the WebSocket subprotocol `lambda-microvms.port.<port>`.
+
+### Allowed ports inside the MicroVM
+
+HTTP/HTTP2/gRPC/WebSocket on **any port**. Your application just needs to expose the port its hooks and server bind to.
+
+### Ingress connector
+
+For most workloads the default ingress is enough. Ports are configured per auth token via `--allowed-ports` on `create-microvm-auth-token`, not by ingress connectors.
+
+### Per-token port restrictions
+
+When generating an auth token, you can scope it to specific ports:
+
+```bash
+aws lambda-microvms create-microvm-auth-token \
+  --microvm-identifier microvm-... \
+  --expiration-in-minutes 30 \
+  --allowed-ports '[{"port":8080},{"range":{"startPort":9000,"endPort":9001}}]'
+```
+
+The `allowedPorts` field is required. Each entry is one of: `{"port": N}` (single port), `{"range": {"startPort": N, "endPort": M}}` (range), or `{"allPorts": {}}` (unrestricted).
+
+## Authenticating requests
+
+The proxy expects a valid auth token in `X-aws-proxy-auth`. Tokens come from `CreateMicrovmAuthToken`. Max 60 min TTL.
+
+### Two token APIs
+
+| API | Purpose |
+|---|---|
+| `create-microvm-auth-token` | Application traffic. Requires `allowedPorts`. |
+| `create-microvm-shell-auth-token` | Shell access (only when the `SHELL_INGRESS` network connector is attached). Works from the AWS console or a terminal WebSocket client. |
+
+Both return a `TokenParts` map (multiple key/value entries) — typically you want the `X-aws-proxy-auth` value.
+
+### curl
+
+```bash
+curl 'https://<microvm-endpoint>/' \
+  -H "X-aws-proxy-auth: $TOKEN" \
+  -H 'X-aws-proxy-port: 8080'
+```
+
+### Python
+
+```python
+import requests
+r = requests.get(
+    "https://<microvm-endpoint>/",
+    headers={"X-aws-proxy-auth": TOKEN, "X-aws-proxy-port": "8080"},
+)
+```
+
+### Browser / WebSocket
+
+Browsers can't set arbitrary headers on WebSocket connections, so all proxy metadata travels via subprotocols:
+
+```js
+const protocols = [
+  "lambda-microvms",                                   // required base
+  `lambda-microvms.authentication.${authToken}`,        // auth
+  "lambda-microvms.port.9000",                          // target port
+];
+const ws = new WebSocket("wss://<microvm-endpoint>/path", protocols);
+```
+
+The `lambda-microvms.*` subprotocols are **stripped before forwarding** to your application; your server should not see them on the upgrade request.
+
+## Protocol support
+
+| Protocol | Notes |
+|---|---|
+| HTTP/1.1 | Default. |
+| HTTP/2 | Negotiated via ALPN on TLS (if supported), with HTTP/1.1 fallback. For plaintext connections, send `X-aws-proxy-force-h2: true` to force HTTP/2 over plaintext (H2C) to the upstream. |
+| gRPC | Just HTTP/2 — works as soon as your server is on HTTP/2. |
+| WebSockets | Standard upgrade flow. Use subprotocols for auth/port (above). |
+| TLS to upstream | Optional. The proxy auto-detects whether your server speaks TLS and adjusts (re-encrypt for end-to-end TLS, or terminate at proxy). |
+
+> Protocol negotiation in this table applies to proxy agent → guest application traffic inside the MicroVM. Client → proxy service traffic is always TLS-encrypted and negotiates HTTP/2 independently.
+
+### Bandwidth ("proxy bandwidth capability")
+
+Proxy throughput **scales with MicroVM size: ~1 MB/s per vCPU**. Exceeding the cap causes the in-guest proxy to apply backpressure (latency increases, no errors). Either reduce throughput or pick a larger MicroVM size.
+
+## Egress (outbound)
+
+### Public internet (default)
+
+By default a MicroVM can reach any public address. No connector configuration required. Consider using VPC egress connectors to restrict outbound traffic to only required destinations for production workloads handling sensitive data.
+
+### VPC egress (private resources)
+
+Attach an **egress network connector** of type `VPC_EGRESS` to reach RDS / Aurora, ElastiCache, internal NLBs, on-prem via Direct Connect / VPN, S3 via VPC endpoints, etc.
+
+Steps:
+
+1. Build a `NetworkConnectorOperatorRole` (trust `lambda.amazonaws.com`; permissions to manage ENIs in your VPC):
+   - `ec2:CreateNetworkInterface`, `ec2:CreateTags`.
+2. Create the connector:
+
+   ```bash
+   aws lambda-core create-network-connector \
+     --name my-vpc-egress \
+     --configuration '{"VpcEgressConfiguration":{"SubnetIds":["subnet-..."],"SecurityGroupIds":["sg-..."],"NetworkProtocol":"IPv4","AssociatedComputeResourceTypes":["MicroVm"]}}' \
+     --operator-role arn:aws:iam::<account>:role/NetworkConnectorOperatorRole
+   ```
+
+   States: `PENDING` (provisioning ENIs, up to ~10 min) → `ACTIVE` → `DELETING`. Failure → `FAILED` with `StateReason`.
+3. Pass the connector ARN returned by `create-network-connector` at run time:
+
+   ```bash
+   aws lambda-microvms run-microvm \
+     --image-identifier arn:aws:lambda:<region>:<account>:microvm-image/my-image \
+     --egress-network-connectors '["arn:aws:lambda:<region>:<account>:network-connector:<connector-id>"]'
+   ```
+
+Constraints:
+
+- All subnets in the connector must be in the same VPC.
+- Security groups must be in that VPC.
+- Connector must be in the same Region as the MicroVM image.
+- `NetworkProtocol` supports both `IPv4` and `DualStack`.
+- The connector is **bound at run time** — you can't swap connectors on suspend/resume.
+- For internet *and* VPC access, configure a **NAT gateway** in your VPC.
+
+## Reserved / stripped headers
+
+The proxy reserves the `x-aws-proxy-*` namespace. Specifically:
+
+- `X-aws-proxy-auth` — auth token (required).
+- `X-aws-proxy-port` — target port (overrides default 8080).
+- `X-aws-proxy-force-h2` — force HTTP/2 to upstream (`true`).
+
+Unrecognized `x-aws-proxy-*` headers are stripped before forwarding. Don't use that namespace in your own application headers.
+
+## Verifying connectivity
+
+After run:
+
+```bash
+# Endpoint comes from RunMicrovm response or get-microvm
+ENDPOINT=$(aws lambda-microvms get-microvm --microvm-identifier microvm-... --query 'endpoint' --output text)
+TOKEN=$(aws lambda-microvms create-microvm-auth-token \
+  --microvm-identifier microvm-... --expiration-in-minutes 5 \
+  --allowed-ports '[{"port":8080}]' \
+  --query 'authToken."X-aws-proxy-auth"' --output text)
+
+curl -i "$ENDPOINT/" -H "X-aws-proxy-auth: $TOKEN"
+```
+
+A 502 from the proxy with the MicroVM in `RUNNING` state generally points at:
+
+- App not listening on the target port (default 8080).
+- TLS mismatch (proxy expects plaintext upstream, app speaks TLS without ALPN advertising HTTP/1.1).
+
+See [`troubleshooting.md`](troubleshooting.md) for more.

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/snapshots-and-uniqueness.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/snapshots-and-uniqueness.md
@@ -1,0 +1,98 @@
+# Snapshots and uniqueness
+
+The single most important MicroVM-specific concept: every MicroVM launched from an image starts from **the same snapshot**. State generated during image build is replicated across all instances.
+
+## What gets snapshotted
+
+During image build, after your `Dockerfile` runs and your `CMD`/`ENTRYPOINT` starts the application, Lambda waits for `/ready` (if enabled), then captures the full OS snapshot:
+
+1. **Disk snapshot** — the rootfs after layer extraction + any files written during init.
+2. **Memory snapshot** — RAM image including kernel state, OS state, and every running process started by the entrypoint (including background daemons).
+
+When you `RunMicrovm`, Lambda restores both, and your processes are already running. No `python app.py` re-execution. No connection-pool warmup. No JIT cold-start.
+
+This is what makes fast runs possible — but it also means **anything in memory or on disk at snapshot time is shared**. Snapshots are not updated by the service. It's the customer's responsibility to update them.
+
+## The uniqueness problem
+
+If your build-phase code does any of these, it ends up in the snapshot and is identical across every MicroVM:
+
+- Generates UUIDs / instance IDs.
+- Seeds a PRNG with the current time.
+- Fetches a secret or token.
+- Reads `/dev/urandom` once and caches the bytes.
+- Establishes a TCP connection (the connection itself won't survive snapshot, but state derived from it will).
+
+### Fixes, in order of preference
+
+1. **Don't generate it at build time.** Generate at first use, after run.
+2. **Generate it in `/run`.** This hook fires once after run (post-snapshot resume) and is the canonical place to create per-VM unique state. Set `microvmHooks.run: "ENABLED"` in `--hooks`.
+3. **Read fresh entropy from a CSPRNG.** These are wired to the kernel RNG which Firecracker re-seeds across snapshot resume — see the language table below.
+4. **Inject per-VM data via `runHookPayload`.** The opaque blob you pass to `RunMicrovm` is delivered as the request body of `/run`, so you can include tenant IDs, signed URLs, parameter-store paths, etc.
+
+## CSPRNGs that are safe across snapshot resume
+
+| Language | Use | Don't use |
+|---|---|---|
+| Java | `java.security.SecureRandom` | `java.util.Random`, `Math.random()` seeded once |
+| Python | `secrets`, `random.SystemRandom` | `random.random()` with default seed |
+| .NET | `System.Security.Cryptography.RandomNumberGenerator` | `System.Random` instance reused across snapshot |
+| Node.js | `crypto.randomBytes`, `crypto.randomUUID` | `Math.random()` |
+| Go | `crypto/rand` | `math/rand` |
+| Rust | `rand::rngs::OsRng` | `rand::thread_rng()` if seeded once before snapshot |
+| C/C++ | `getrandom(2)`, `/dev/urandom` per-call | `rand()`, `srand(time(NULL))` once |
+
+The Lambda base ECR image (`public.ecr.aws/lambda/microvms:al2023-minimal`) ships an OpenSSL build that automatically re-seeds entropy on snapshot resume. If you bring your own base image, your OpenSSL version will **not** do this by default — use the Lambda base image or ensure your application reads fresh entropy per-call. Reading `/dev/urandom` per-call is safe — the kernel RNG reseeds on resume.
+
+## Connections and snapshot resume
+
+TCP connections opened in the entrypoint (e.g. an SDK client warming up) are captured in memory but not in any meaningful network sense — the underlying socket isn't valid after resume. **All outbound (non-local) connections are killed on run and resume.** Most AWS SDKs handle this transparently (they retry on `EBADF`/`ECONNRESET`). For other clients, ensure your connection libraries have timeouts and retries configured to re-establish connections automatically.
+
+## Configuration data: env vars vs. run payload vs. execution-role secrets
+
+You have three places to inject configuration:
+
+| Where | Set at | Same for all VMs? | Visible to | Use for |
+|---|---|---|---|---|
+| **Build env vars** (`--environment-variables`) | Image creation | Yes — burnt into the snapshot | Container env at build time and after resume | Static, non-sensitive: log level, app port, feature toggles |
+| **`runHookPayload`** | `RunMicrovm` | No — per-VM | Body of the `/run` POST | Per-VM: tenant ID, session ID, signed URLs, references to secrets |
+| **Execution role + AWS SDK** | At run | No — assumed credentials | IMDSv2 in the guest | Real secrets — fetch from Secrets Manager / SSM Parameter Store at runtime |
+
+## Inspecting snapshot sizes
+
+Each successful build records snapshot sizes. Use these to track image bloat over time:
+
+```bash
+BUILD_ID=$(aws lambda-microvms list-microvm-image-builds \
+  --image-identifier my-image \
+  --image-version 1 \
+  --query 'items[0].buildId' --output text)
+
+aws lambda-microvms get-microvm-image-build \
+  --image-identifier my-image \
+  --image-version 1 \
+  --build-id "$BUILD_ID"
+```
+
+Fields of interest (nested under `snapshotBuild`):
+
+- `snapshotBuild.memorySnapshotSizeInBytes` — RAM image. Dominated by your application's RSS plus kernel pages dirtied during boot. Big numbers usually mean the app over-eagerly preallocates buffers / loads big models in memory.
+- `snapshotBuild.codeInstallSizeInBytes` — size of the code artifact after it's compiled from the Dockerfile and installed in the filesystem. Dominated by the container image.
+- `snapshotBuild.diskSnapshotSizeInBytes` — bytes written by the OS or application during boot (does not include codeInstallSizeInBytes).
+
+Heuristics:
+
+- **Resume time scales with snapshot size accessed**, roughly 1 s per 500 MB. Trim aggressively.
+- A bloated `diskSnapshot` → audit the Dockerfile (multi-stage builds, `--no-install-recommends`, `dnf clean all`, remove `pip` caches).
+- A bloated `memorySnapshot` → check for over-eager warmup (loading every model variant at boot, opening millions of fds, etc.).
+
+## Disk-vs-memory restore behavior
+
+Memory is **eagerly restored** on run/resume, while block device (disk) content is **demand-paged**. This means a larger memory snapshot directly increases the time it takes for a snapshot to fully restore. Keep memory snapshots as small as possible for fast runs — avoid over-eager preallocation of buffers or loading large models entirely into RAM at build time.
+
+## If your app needs unique state at startup
+
+Common patterns:
+
+- **Listen for `/run` and receive the `microvmId` via `runHookPayload`.** `microvmId` is automatically injected in the request. Block your app's request handlers until `/run` returns.
+- **Pass it in `runHookPayload`**: the caller (your control plane) generates per-VM state and ships it in the `RunMicrovm` call.

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/troubleshooting.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/troubleshooting.md
@@ -1,0 +1,134 @@
+# Troubleshooting
+
+Failure modes by phase: image build, run, connect/auth, runtime/hooks, networking, lifecycle, shell.
+
+## Image build failures (`state: FAILED`)
+
+Inspect the per-build error:
+
+```bash
+aws lambda-microvms list-microvm-image-builds \
+  --image-identifier my-image \
+  --image-version 1 \
+  --query 'items[].[architecture,buildState,stateReason]' --output table
+```
+
+| `stateReason` | Cause | Fix |
+|---|---|---|
+| `S3_ACCESS_DENIED` | Build role can't read the artifact. | Add `s3:GetObject` for the artifact key to the build role. |
+| `S3_NO_SUCH_KEY` | Wrong path. | Verify `--code-artifact uri=s3://bucket/key` matches what's in S3. |
+| `S3_NO_SUCH_BUCKET` | Bucket doesn't exist. | Create the bucket; check spelling. |
+| `S3_INVALID_OBJECT` | Glacier or other non-instant storage class. | Move to Standard. |
+| `S3_CROSS_REGION_ACCESS_DENIED` | Artifact in different region than the image. | Re-upload to a bucket in the image's region. |
+| `ARCHIVE_DOCKERFILE_NOT_FOUND` | No `Dockerfile` at zip root. | Ensure `Dockerfile` is at the **top level** of the zip — `unzip -l my-app.zip` should show `Dockerfile` first, not `my-app/Dockerfile`. |
+| `ARCHIVE_INVALID` | Corrupt or non-zip archive. | Re-create with `zip -r`; verify with `unzip -t`. |
+| `CONTAINER_BUILD_FAILED` | Dockerfile error. | Reproduce locally with `docker build` against the same base image. Check the build logs in `/aws/lambda-microvms/<image-name>` in CloudWatch. |
+| `DISK_STORAGE_FULL` | Build exceeded disk. | Trim layers (multi-stage builds, `--no-install-recommends`, clean caches). |
+| `INTERNAL_PLATFORM_ERROR` | Service-side. | Retry. If persistent, contact support. |
+
+### `/ready` hook caused build failure
+
+The `/ready` and `/validate` hooks are asynchronous — return 503 until the application is ready/validated, and the platform will retry. If the application blocks instead of returning 503, the platform may time out before the configured timeout. If `/ready` never returns 200 (or times out), the build fails. Look at the application's CloudWatch logs (`/aws/lambda-microvms/<image-name>`) for stack traces from your hook server.
+
+### `/validate` hook caused build failure
+
+The validation phase launches a test MicroVM from the snapshot and calls `/validate`. This is an application-level check — use it to verify your app behaves correctly after resume (e.g., that connections are re-established, state is valid).
+
+## Run failures (`RunMicrovm`)
+
+| Error | Likely cause | Fix |
+|---|---|---|
+| `ResourceNotFoundException` | Image, version, or execution role doesn't exist. | Verify ARNs. For custom images use `imageVersion`; for managed images you can omit it. |
+| `ServiceQuotaExceededException` | Hit account-wide MicroVM concurrency or memory cap. | Wait for terminations, request a quota increase. |
+| `ValidationException` | Bad input (idle policy missing required fields, malformed connector ARN, etc.). | Check the `message` field — it's specific. |
+| `AccessDenied` | Caller can't `lambda:RunMicrovm`, or `iam:PassRole` for the execution role, or `lambda:PassNetworkConnector` (required on every `RunMicrovm`, even with the default connectors). | Add the missing IAM permission to the caller. |
+| `ConflictException` | `clientToken` reused with different parameters. | Use a fresh `clientToken` or replay the exact same request. |
+
+## Connect / auth failures
+
+### `401`/`403` from the proxy
+
+- Token expired (max 60 min). Mint a new one with `create-microvm-auth-token`.
+- Token was issued to a different MicroVM ID.
+- Token has `allowedPorts` and you're requesting a port outside the allowed ranges.
+
+### `502` from the proxy
+
+A 502 can be returned during the first few seconds after the MicroVM is run while the snapshot is being restored.
+
+- App not listening on the routed port (default 8080; use `X-aws-proxy-port` to redirect).
+- TLS mismatch — the app is speaking TLS without ALPN advertising HTTP/1.1, or speaking plaintext on a port the proxy thinks is TLS.
+- App crashed after run. Check CloudWatch logs.
+
+### `429` from the proxy
+
+Per-MicroVM or account-level rate limit. Back off and retry. Check the docs for the run-rate quota.
+
+### `5xx` while a run was in flight
+
+If the proxy receives traffic before `RunMicrovm` finishes, it may 5xx. Retry connections with backoff rather than polling `get-microvm` state (which is eventually consistent), or rely on `autoResumeEnabled` semantics if you're hitting a recently-suspended MicroVM.
+
+## Auto-resume not working
+
+- Confirm `idlePolicy.autoResumeEnabled: true` was set at run time.
+- Confirm the MicroVM's `state` is `SUSPENDED` (not `TERMINATED` — auto-resume doesn't revive terminated VMs).
+- The proxy invokes resume then retries connecting a few times with a delay between attempts. If your `/resume` hook is slow or the app doesn't respond in time, the proxy may return an error to the caller.
+
+## Hook timeouts at runtime
+
+| Hook | Symptom | Fix |
+|---|---|---|
+| `/run` | `RunMicrovm` returns success but VM goes to `TERMINATED` shortly after with `stateReason` mentioning hook failure. | Raise `runTimeoutInSeconds`; move long-running init out of `/run` (it should be quick). |
+| `/resume` | First request after resume hangs / 502s. | Raise `resumeTimeoutInSeconds`. Check resume hook for slow operations (DB reconnects, etc.). |
+| `/suspend` | VM doesn't actually suspend on idle. | Hook is hanging or returning non-200. Hook should return 200 when the app is ready to suspend. |
+| `/terminate` | Logs/state lost on shutdown. | Add a flush in `/terminate` and raise the timeout. |
+
+Hook server **must bind to `0.0.0.0`** on the configured `port` (commonly 9000). `127.0.0.1`-only listeners are unreachable from Lambda's hook caller.
+
+## Network connector troubleshooting
+
+| Issue | Cause | Fix |
+|---|---|---|
+| Connector stuck in `PENDING` >10 min | ENI provisioning failure (subnet full, missing IAM perms). | Check `StateReason` on `get-network-connector`. Verify the operator role has `ec2:CreateNetworkInterface` and `ec2:CreateTags`. |
+| `InvalidGroup.NotFound` | Subnet and SG in different VPCs / regions. | Both must share VPC and Region with the connector. |
+| `Unable to assume role` | Operator role trust policy doesn't allow `lambda.amazonaws.com`. | Fix trust policy, retry. |
+| `Invalid security token` | Caller's AWS creds are stale. | Refresh credentials. |
+
+## Snapshot / uniqueness symptoms
+
+- All MicroVMs serve the same instance ID / UUID. → Generation happened at build time. Move to `/run` or first-request init. See [`snapshots-and-uniqueness.md`](snapshots-and-uniqueness.md).
+- TLS handshakes intermittently fail across multiple VMs. → Predictable PRNG seeded once at build. Switch to a CSPRNG.
+- "AWS SDK calls fail with credentials errors after a few hours." → SDK client picked up creds at boot and didn't refresh. Most modern SDKs refresh; verify version.
+
+## Image storage costs growing
+
+Old image versions persist (and bill) even when unused.
+
+```bash
+aws lambda-microvms list-microvm-image-versions \
+  --image-identifier my-image
+
+aws lambda-microvms delete-microvm-image-version \
+  --image-identifier my-image \
+  --image-version <old-version>
+```
+
+Or mark old versions `INACTIVE` first if you want to keep them around for rollback. INACTIVE versions are still billed.
+
+## Where logs live
+
+| Log | Location |
+|---|---|
+| Image build logs | `/aws/lambda-microvms/<image-name>` (build role must have `logs:*` on this group) |
+| Application stdout / stderr | Same group at runtime, when `executionRoleArn` has `logs:*` |
+| Custom CloudWatch logging | Pass `--logging '{"cloudWatch":{"logGroup":"...","logStream":"..."}}'` to `RunMicrovm` |
+| CloudTrail | Standard `lambda:*` events in your trail |
+
+> Avoid logging secrets, tokens, or PII to stdout/stderr — application output is forwarded to CloudWatch.
+
+Custom CloudWatch metrics are **not** auto-emitted — publish from inside your application (or run the CloudWatch Agent inside the container). Set up CloudWatch Alarms on key metrics to catch operational issues early. Consider enabling CloudTrail data events for Lambda MicroVM API calls in production environments.
+
+## When all else fails
+
+1. Run with the `SHELL_INGRESS` network connector attached, get a shell auth token, connect via the console "Connect" button.
+2. The shell drops into the same container as the running app — same network namespace, same filesystem. You can inspect files, processes, and network state directly.


### PR DESCRIPTION
## What

Adds the **aws-lambda-microvms** skill under `skills/specialized-skills/serverless-skills/`, and registers it in the `aws-serverless` core skill's routing table.

AWS Lambda MicroVMs are serverless compute environments that combine Firecracker VM isolation with container-like efficiency — snapshot-resumable, suspend/resume, dedicated HTTPS endpoint, up to 8-hour lifetimes. The skill covers building/running/debugging/operating MicroVM applications across seven references:

- `getting-started.md` — prerequisites, IAM roles, first image build + run
- `lifecycle-model.md` — state machine, idle/suspend/resume, image hooks
- `networking.md` — endpoints, auth tokens, ingress/egress network connectors, VPC egress
- `iam-and-security.md` — execution/build roles, SHELL_INGRESS, token handling
- `snapshots-and-uniqueness.md` — snapshot model, per-VM uniqueness, secrets handling
- `troubleshooting.md` — build/run failure codes and fixes

## Changes

- **New skill:** `skills/specialized-skills/serverless-skills/aws-lambda-microvms/` (SKILL.md + 6 references).
- **Routing:** added a MicroVMs row to the `aws-serverless` routing table in both copies that the repo keeps in sync — `skills/core-skills/aws-serverless/SKILL.md` and `plugins/aws-core/skills/aws-serverless/SKILL.md`.

## Notes

- All guidance uses standard AWS CLI syntax so it works with or without the AWS MCP server.

## Testing

- `python3 tools/validate.py` → all validations pass (new skill frontmatter recognized).
- `markdownlint-cli2 '**/*.md' '#node_modules'` → 0 errors.
