### PR TITLE
fix: resolve aws-lambda-microvms example inconsistencies

### DIFF
--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/SKILL.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/SKILL.md
@@ -54,7 +54,7 @@ In general, Lambda MicroVMs are suited for long-lived sessions, real port-listen
 
 ## Typical workflow
 
-0. **Check regional availability** — confirm Lambda MicroVMs is available in your target region (use a `ListMicrovmImages` call). Your S3 artifact bucket and any network connectors must be in the same region as the image.
+0. **Check regional availability** — confirm Lambda MicroVMs is available in your target region (run `aws lambda-microvms list-managed-microvm-images`). Your S3 artifact bucket and any network connectors must be in the same region as the image.
 1. **Package** an app: zip with a `Dockerfile` at the root, upload to S3 (same region as the image).
 2. **Implement lifecycle hooks** (optional but recommended) — HTTP endpoints on a port you specify (commonly `9000`) for `/run`, `/resume`, `/suspend`, `/terminate`, `/ready`, `/validate`.
 3. **CreateMicrovmImage** — pointing at the S3 artifact, a managed base image, and a build role. Lambda compiles the Dockerfile into an OCI image, starts your app, calls `/ready`, snapshots disk + memory, optionally validates with `/validate`. Lambda will periodically release new managed image versions, and customers should re-build using the latest version to ensure they have up to date images.

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/getting-started.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/getting-started.md
@@ -148,7 +148,7 @@ Image state: `CREATING` → `CREATED`. Version state: `PENDING` → `IN_PROGRESS
 ```bash
 aws lambda-microvms list-microvm-image-builds \
   --image-identifier arn:aws:lambda:<region>:123456789012:microvm-image:my-first-image \
-  --image-version 1
+  --image-version 1.0
 ```
 
 If a build fails, `stateReason` carries an error code from [`troubleshooting.md`](troubleshooting.md).

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/iam-and-security.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/iam-and-security.md
@@ -25,7 +25,7 @@ The two **must be separate** ARNs in production. The build role usually needs S3
         "aws:SourceAccount": "<account-id>"
       },
       "ArnLike": {
-        "aws:SourceArn": "arn:aws:lambda:<region>:<account-id>:microvm-image/*"
+        "aws:SourceArn": "arn:aws:lambda:<region>:<account-id>:microvm-image:*"
       }
     }
   }]
@@ -118,7 +118,7 @@ Attach the `SHELL_INGRESS` network connector at run time:
 
 ```bash
 aws lambda-microvms run-microvm \
-  --image-identifier arn:aws:lambda:<region>:<account>:microvm-image/my-image \
+  --image-identifier arn:aws:lambda:<region>:<account>:microvm-image:my-image \
   --execution-role-arn ... \
   --ingress-network-connectors '["arn:aws:lambda:<region>:aws:network-connector:aws-network-connector:SHELL_INGRESS"]'
 ```

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/lifecycle-model.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/lifecycle-model.md
@@ -103,7 +103,7 @@ A hook left at its default `DISABLED` is not called even if the application impl
 
 ### Hook contract
 
-- Return **HTTP 200** when the hook has completed successfully. For `/ready` and `/validate`, return **503** if the application needs more time — the platform will retry until the configured timeout. Returning 503 quickly is preferred over blocking until ready, otherwise the platform may time out before the configured timeout.
+- Return **HTTP 200** when the hook has completed successfully. For `/ready` and `/validate`, return **503** if the application needs more time — the platform will keep retrying until the configured timeout elapses. Returning 503 quickly is preferred over blocking the request until ready: a blocked call holds the connection open and can consume the entire timeout window in one attempt instead of letting the platform poll.
   - During image build, a `/ready` failure (non-200/503 or timeout) fails the build.
   - At runtime, a hook failure may cause `RunMicrovm` to fail or transition the MicroVM through `TERMINATING` with `stateReason` set.
 - The `runHookPayload` you pass to `RunMicrovm` is delivered as the request body of `/run`.
@@ -137,13 +137,15 @@ TerminateMicrovm ─────▶│   POST /terminate           │
 
 ## Idle policy fields
 
+The `idlePolicy` block itself is **optional** on `RunMicrovm` — omit it to disable idle-based auto-suspend entirely. **If you supply the block, all three fields below are required:**
+
 | Field | Range | Notes |
 |---|---|---|
-| `maxIdleDurationSeconds` | ≥60 | Required. Idle threshold from last proxy traffic. |
-| `suspendedDurationSeconds` | ≥0 | Required. Time-to-terminate while suspended. `0` means "terminate immediately on suspend." |
-| `autoResumeEnabled` | bool | Required. If true, proxy resumes the VM transparently when traffic arrives at its endpoint. |
+| `maxIdleDurationSeconds` | ≥60 | Required if `idlePolicy` is supplied. Idle threshold from last proxy traffic. |
+| `suspendedDurationSeconds` | ≥0 | Required if `idlePolicy` is supplied. Time-to-terminate while suspended. `0` means "terminate immediately on suspend." |
+| `autoResumeEnabled` | bool | Required if `idlePolicy` is supplied. If true, proxy resumes the VM transparently when traffic arrives at its endpoint. |
 
-In `RunMicrovm` you can also set `maximumDurationInSeconds` (cap 28,800) — a hard wall-clock lifetime regardless of activity.
+`maximumDurationInSeconds` is **not** an `idlePolicy` field — it is a separate top-level `RunMicrovm` flag that sets a hard wall-clock lifetime regardless of activity.
 
 ## Hook implementation tips
 

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/networking.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/networking.md
@@ -15,7 +15,7 @@ How traffic gets in and out of a MicroVM, what protocols are supported, and how 
 
 > The proxy agent auto-detects whether the guest application speaks TLS.
 
-Each MicroVM gets a **dedicated, service-managed HTTPS endpoint** (`https://<microvm>.lambda-microvm.on.aws`).
+Each MicroVM gets a **dedicated, service-managed HTTPS endpoint** (`https://<microvm-id>.lambda-microvm.<region>.on.aws`).
 
 ## Ingress (inbound)
 
@@ -138,7 +138,7 @@ Steps:
 
    ```bash
    aws lambda-microvms run-microvm \
-     --image-identifier arn:aws:lambda:<region>:<account>:microvm-image/my-image \
+     --image-identifier arn:aws:lambda:<region>:<account>:microvm-image:my-image \
      --egress-network-connectors '["arn:aws:lambda:<region>:<account>:network-connector:<connector-id>"]'
    ```
 

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/snapshots-and-uniqueness.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/snapshots-and-uniqueness.md
@@ -64,13 +64,13 @@ Each successful build records snapshot sizes. Use these to track image bloat ove
 
 ```bash
 BUILD_ID=$(aws lambda-microvms list-microvm-image-builds \
-  --image-identifier my-image \
-  --image-version 1 \
+  --image-identifier arn:aws:lambda:<region>:<account>:microvm-image:my-image \
+  --image-version 1.0 \
   --query 'items[0].buildId' --output text)
 
 aws lambda-microvms get-microvm-image-build \
-  --image-identifier my-image \
-  --image-version 1 \
+  --image-identifier arn:aws:lambda:<region>:<account>:microvm-image:my-image \
+  --image-version 1.0 \
   --build-id "$BUILD_ID"
 ```
 

--- a/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/troubleshooting.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-microvms/references/troubleshooting.md
@@ -8,8 +8,8 @@ Inspect the per-build error:
 
 ```bash
 aws lambda-microvms list-microvm-image-builds \
-  --image-identifier my-image \
-  --image-version 1 \
+  --image-identifier arn:aws:lambda:<region>:<account>:microvm-image:my-image \
+  --image-version 1.0 \
   --query 'items[].[architecture,buildState,stateReason]' --output table
 ```
 
@@ -28,7 +28,7 @@ aws lambda-microvms list-microvm-image-builds \
 
 ### `/ready` hook caused build failure
 
-The `/ready` and `/validate` hooks are asynchronous — return 503 until the application is ready/validated, and the platform will retry. If the application blocks instead of returning 503, the platform may time out before the configured timeout. If `/ready` never returns 200 (or times out), the build fails. Look at the application's CloudWatch logs (`/aws/lambda-microvms/<image-name>`) for stack traces from your hook server.
+The `/ready` and `/validate` hooks are asynchronous — return 503 until the application is ready/validated, and the platform will retry. If the application blocks the request instead of returning 503 promptly, a single hung call can consume the whole hook timeout window before the platform gets a chance to retry. If `/ready` never returns 200 (or the timeout elapses), the build fails. Look at the application's CloudWatch logs (`/aws/lambda-microvms/<image-name>`) for stack traces from your hook server.
 
 ### `/validate` hook caused build failure
 
@@ -106,10 +106,10 @@ Old image versions persist (and bill) even when unused.
 
 ```bash
 aws lambda-microvms list-microvm-image-versions \
-  --image-identifier my-image
+  --image-identifier arn:aws:lambda:<region>:<account>:microvm-image:my-image
 
 aws lambda-microvms delete-microvm-image-version \
-  --image-identifier my-image \
+  --image-identifier arn:aws:lambda:<region>:<account>:microvm-image:my-image \
   --image-version <old-version>
 ```
 


### PR DESCRIPTION
## What

Follow-up cleanup to the `aws-lambda-microvms` skill, fixing internal inconsistencies in the CLI examples and reference docs.

## Changes

- **`--image-identifier`**: use the full image ARN everywhere (the bare name is rejected by the API); normalize to the colon form `microvm-image:name`, including the trust-policy `SourceArn`.
- **`--image-version`**: normalize to the full `major.minor` string (`1.0`).
- **Regional availability check**: point at the concrete `aws lambda-microvms list-managed-microvm-images` command instead of an op name that didn't match the rest of the docs.
- **Endpoint hostname**: use `<microvm-id>.lambda-microvm.<region>.on.aws` consistently.
- **idlePolicy**: clarify the block is optional but its fields are required when supplied, and that `maximumDurationInSeconds` is a separate top-level `RunMicrovm` flag (not an idlePolicy field).
- **Hook timeout guidance**: reword the self-contradictory "time out before the configured timeout" phrasing in `/ready`/`/validate` docs.

## Testing

- `python3 tools/validate.py` → passes.
- `markdownlint-cli2` on the skill → 0 errors.