### PR TITLE
docs: clarify --metadata AWS_REGION vs local region in Kiro MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Add the AWS MCP Server to your Kiro MCP configuration (`.kiro/settings/mcp.json`
 
 > **Note:** It is recommended to pin to a specific version (e.g., `@1.6.3`) to ensure reproducible behavior and protect against supply chain risks. We recommend regularly checking [PyPI](https://pypi.org/project/mcp-proxy-for-aws/) for new stable versions and updating accordingly.
 
+> **Region configuration:** `--metadata AWS_REGION=...` sets the default Region for AWS operations performed by the remote AWS MCP Server. The local `mcp-proxy-for-aws` process separately resolves a Region from the standard provider chain (`AWS_REGION`, `AWS_DEFAULT_REGION`, or the active profile's `region`) when refreshing credentials. If your active AWS profile has no `region` set — common with AWS CLI v2 SSO / `aws login` profiles — and you see a `NoRegionError` at MCP startup, set `AWS_REGION` in an `env` block on the MCP server config.
+
 Then install skills from this repository:
 
 ```


### PR DESCRIPTION
## Summary

- Adds a callout under the Kiro MCP setup example clarifying that `--metadata AWS_REGION=...` configures the **remote** AWS MCP Server's default Region, not the local Region used by `mcp-proxy-for-aws` during credential refresh.
- Tells users hitting `NoRegionError` at MCP startup — common with AWS CLI v2 SSO / `aws login` profiles that don't persist a `region = ...` line — to set `AWS_REGION` via the standard provider chain.

Fixes #63.

## Test plan

- [ ] Render `README.md` and confirm the new blockquote sits cleanly between the JSON example and the existing version-pin note.
- [ ] Confirm no markdownlint violations.