### PR TITLE
fix: remove TODO comment from aws-core README

### DIFF
--- a/plugins/aws-core/README.md
+++ b/plugins/aws-core/README.md
@@ -51,8 +51,6 @@ This plugin includes the following default skills:
 | storage | Store and manage data with AWS storage services |
 | aws-blocks | Build full-stack applications with AWS Blocks |
 
-<!-- [TODO] Confirm final skill list matches what ships in the plugin. deploy-to-aws status is RED in tracker. -->
-
 ### Rules files
 
 Recommended AWS rules files are available separately in the [`rules/`](../../rules/) directory of this repository.


### PR DESCRIPTION
## Description

Remove a TODO comment that was accidentally left in the published `plugins/aws-core/README.md`.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [x] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*