### PR TITLE
feat(networking): add sitetositevpn skill

### DIFF
--- a/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/SKILL.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: sitetositevpn
+description: Configures AWS Site-to-Site VPN: creating an IPsec VPN connection between an on-premises network and a VPC, choosing the target gateway (virtual private gateway, transit gateway, or AWS Cloud WAN), choosing static or dynamic (BGP) routing, sizing tunnel bandwidth (Standard 1.25 Gbps or Large 5 Gbps), connecting many sites through a VPN Concentrator, applying the customer gateway device configuration, making a connection highly available, and monitoring tunnels with CloudWatch. Applicable when the user wants to connect a data center or branch office to AWS over an encrypted tunnel, choose how routes are exchanged, scale throughput, consolidate sites, or diagnose a down tunnel. Routes to the right per-task procedure in references. Not for AWS Direct Connect (its own service), Client VPN for individual remote users, the transit gateway side of a VPN attachment — route tables, propagation, or ECMP bandwidth aggregation across tunnels on the hub (transitgateway skill) — or Route 53 DNS work.
+version: 1
+---
+
+# AWS Site-to-Site VPN
+
+## Overview
+
+Domain expertise for configuring AWS Site-to-Site VPN, the managed service that builds an encrypted
+IP Security (IPsec) connection between an on-premises network and AWS. Covers the routing decision
+(static versus dynamic (BGP) routing), creating the connection and its dependent resources in the right order,
+sizing tunnel bandwidth, consolidating many sites through a VPN Concentrator, applying the customer
+gateway device configuration, building for high availability, and monitoring and troubleshooting
+tunnels.
+
+This skill is a router. Each customer task maps to a procedure file under `references/`. Read the
+matching reference in full before acting, then follow its constraints and steps. The reference
+files are self-contained: each carries its own decision tables, constraints, procedure, and
+troubleshooting.
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. Site-to-Site VPN is a regional service: pass
+`--region {region}` matching the VPC or transit gateway the connection terminates on.
+
+## Which Site-to-Site VPN task do you need?
+
+| Goal | Reference |
+| --- | --- |
+| Decide between static and dynamic (BGP) routing before creating a connection | [choosing static or dynamic routing](references/choosing-static-or-dynamic-routing.md) |
+| Create an encrypted VPN connection from on-premises to a VPC | [creating a site-to-site vpn connection](references/creating-a-site-to-site-vpn-connection.md) |
+| Size tunnel bandwidth at Standard (1.25 Gbps) or Large (5 Gbps) | [choosing tunnel bandwidth](references/choosing-tunnel-bandwidth-standard-or-large.md) |
+| Connect 25 or more low-bandwidth sites through one shared attachment | [connecting many sites with a vpn concentrator](references/connecting-many-sites-with-a-vpn-concentrator.md) |
+| Configure the on-premises customer gateway device | [applying the customer gateway device configuration](references/applying-the-customer-gateway-device-configuration.md) |
+| Make the connection survive tunnel maintenance and device failure | [making a connection highly available](references/making-a-connection-highly-available.md) |
+| Detect a down tunnel and find out why | [monitoring and troubleshooting tunnels](references/monitoring-and-troubleshooting-tunnels.md) |
+
+## Routing notes
+
+- **Decide routing before you build.** The static-versus-dynamic decision shapes the customer
+  gateway, the failover behavior, and whether the customer can control which routes enter their
+  network. Run the choosing-static-or-dynamic-routing reference before creating the connection so
+  the customer does not have to recreate it to change routing type.
+- **The target gateway gates almost everything.** A virtual private gateway terminates the VPN at
+  one VPC. A transit gateway fronts many VPCs and is the only target that supports Large (5 Gbps)
+  tunnels, equal-cost multi-path (ECMP) bandwidth aggregation, and the VPN Concentrator. The
+  gateway choice lives in the creating reference and is referenced again by the bandwidth and
+  concentrator references, because picking a virtual private gateway closes those doors.
+- **Bandwidth sizing vs the Concentrator.** Both scale capacity, in opposite directions. Large
+  tunnels give one connection more throughput (up to 5 Gbps per tunnel); the Concentrator gives
+  many low-bandwidth sites a shared 5 Gbps attachment so each site does not need its own
+  full-bandwidth connection. Match the reference to whether the customer has one high-throughput
+  site or many small ones.
+- **AWS side vs device side.** Creating the connection and downloading the configuration happen on
+  the AWS side; applying that configuration happens on the customer's on-premises device, which AWS
+  never touches. The applying-the-customer-gateway-device-configuration reference is device-side
+  education, not an AWS-side step.
+- **Monitoring is its own task.** Detecting and diagnosing a down tunnel (CloudWatch metrics,
+  alarms, and VPN logs) is the monitoring reference, separate from building the connection.
+
+## Additional Resources
+
+- [AWS Site-to-Site VPN User Guide](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html)
+- [AWS Site-to-Site VPN product page](https://aws.amazon.com/vpn/site-to-site-vpn/)
+- [AWS VPN pricing](https://aws.amazon.com/vpn/pricing/)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/applying-the-customer-gateway-device-configuration.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/applying-the-customer-gateway-device-configuration.md
@@ -1,0 +1,247 @@
+# Applying the Customer Gateway Device Configuration
+
+## Overview
+
+Domain expertise for configuring the on-premises customer gateway (CGW) device after an AWS
+Site-to-Site VPN connection is created, so the tunnels come up. Covers downloading the AWS-provided
+sample configuration file, choosing the recommended sample over the compatibility sample, treating
+the sample as a starting point rather than a finished config, the IAM permissions the download
+screen needs, configuring both tunnels, and handling an unlisted device.
+
+This reference educates the customer on what to configure on their own device; it does not hand them
+a ready-to-use configuration, because the right values depend on the device and security
+requirements the agent cannot see. The configuration is applied on the customer's device, not on the
+AWS side. Assumes the connection already exists (the creating-a-site-to-site-vpn-connection
+reference).
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. Pass `--region {region}` matching the connection.
+
+## Table of Contents
+
+- Overview
+- Workflow
+- Educate, do not prescribe
+- Recommended versus compatibility sample
+- IAM permissions for the download screen
+- Configure both tunnels
+- Unlisted device
+- Troubleshooting
+- Procedure
+- Security Considerations
+- Additional Resources
+
+## Workflow
+
+To get the device configured, download the matching sample file, review and adapt it, and apply it
+to both tunnels on the on-premises device. See the Procedure section below.
+
+The procedure covers:
+
+- Confirming the IAM permissions the download screen needs
+- Downloading the sample for the device vendor, platform, software version, and IKE version
+- Choosing the recommended sample where AWS offers one
+- Reviewing and adapting the sample, then applying both tunnels on the device
+
+## Educate, do not prescribe
+
+The configuration this workflow produces is applied on the customer's on-premises device, not on the
+AWS side. The skill's job is to explain what to configure, not to hand the customer a finished config
+to paste in, because the right values depend on the customer's device and security requirements.
+
+**Constraints:**
+
+- You MUST explain the settings the device needs and offer the AWS sample as a starting point the customer reviews and adapts
+- You MUST NOT present a single ready-to-use configuration as correct for the customer's device
+- You MUST state that the configuration goes on the customer's device, not the AWS side
+
+## Recommended versus compatibility sample
+
+For many devices AWS offers two sample types: a compatibility sample and a recommended sample that
+uses stronger settings. The sample specifies only minimum requirements (such as AES128, SHA1, and
+Diffie-Hellman group 2 in most Regions), so applying it as-is can leave the customer on the weakest
+acceptable settings.
+
+**Constraints:**
+
+- You MUST prefer the recommended sample where AWS offers one
+- You MUST flag the sample as a starting point and prompt the customer to adjust algorithms,
+  Diffie-Hellman groups, certificates, and IPv6 before applying it
+- You MUST set strong tunnel options (AES-256, SHA-256 or higher, Diffie-Hellman group 14 or higher) rather than the AES-128 / SHA-1 / DH group 2 minimums
+
+## IAM permissions for the download screen
+
+Loading the download configuration screen requires the IAM permissions
+`GetVpnConnectionDeviceTypes` and `GetVpnConnectionDeviceSampleConfiguration`. Without them the
+screen does not populate, with no obvious explanation that a missing permission is the cause.
+
+**Constraints:**
+
+- You MUST check for `GetVpnConnectionDeviceTypes` and `GetVpnConnectionDeviceSampleConfiguration` if the download screen is empty
+- You SHOULD name the missing permission so the customer is not stuck staring at a blank screen
+
+## Configure both tunnels
+
+The configuration covers both tunnels. Applying only the first leaves the connection without the
+redundancy AWS provides, so it drops during routine tunnel maintenance. Customers stop after the
+first tunnel because the connection appears to work.
+
+**Constraints:**
+
+- You MUST confirm both tunnels are configured on the device, not just one
+- You SHOULD explain that the second tunnel is what keeps the connection up during tunnel maintenance
+
+## Unlisted device
+
+When the customer's exact device is not in the vendor list they do not know how to proceed, and the
+supported algorithms and IKE versions vary by device.
+
+**Constraints:**
+
+- You MUST point the customer to the Generic configuration option for an unlisted device
+- You SHOULD help the customer pick the correct IKE version (IKEv1 or IKEv2) for their device
+
+## Troubleshooting
+
+### Tunnels stay down after applying the sample
+The sample is a starting point; algorithms or settings may not match the device's needs. Review and adapt it (Educate, do not prescribe).
+
+### Download configuration screen is empty
+Missing `GetVpnConnectionDeviceTypes` or `GetVpnConnectionDeviceSampleConfiguration`. Add the permissions (IAM permissions for the download screen).
+
+### Connection drops during maintenance
+Only one tunnel was configured. Configure both (Configure both tunnels).
+
+### Device is not in the vendor list
+Use the Generic configuration option and the correct IKE version (Unlisted device).
+
+## Procedure
+
+### Overview
+
+This procedure confirms the download permissions, downloads the matching sample (preferring the
+recommended type), guides the customer to review and adapt it, and confirms both tunnels are
+configured, then surfaces the console link to verify tunnel status.
+
+### Parameters
+
+- **region** (required): The AWS Region of the connection.
+- **vpn_connection_id** (required): The connection whose configuration to download.
+- **device_vendor** (required): The on-premises device vendor, platform, and software version.
+- **ike_version** (required): `ikev1` or `ikev2`, matching the device.
+- **sample_type** (optional): `recommended` (preferred) or `compatibility`.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask for the device vendor, platform, software version, and IKE version upfront
+- You SHOULD confirm whether the device is in the supported list or needs the Generic option
+
+### Steps
+
+#### 1. Confirm download permissions
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You SHOULD recommend ephemeral IAM role-based credentials (instance profile, SSO session, or assumed role) rather than long-lived IAM user access keys for running these commands
+- You MUST confirm the caller has `GetVpnConnectionDeviceTypes` and `GetVpnConnectionDeviceSampleConfiguration`
+
+#### 2. Resolve the device type ID
+
+**Constraints:**
+
+- You MUST resolve the vendor/platform/software version to a `{device_type_id}` first, since
+  `get-vpn-connection-device-sample-configuration` takes the numeric ID, not a human-readable name.
+  List the supported device types and match the customer's device (vendor, platform, software) to
+  its `DeviceTypeId`:
+
+  ```
+  aws ec2 get-vpn-connection-device-types --region {region}
+  # Find the entry whose Vendor/Platform/Software match the customer's device; use its DeviceTypeId
+  ```
+
+- You MUST use the Generic device type's ID when the customer's device is not in the returned list
+
+#### 3. Download the sample configuration
+
+**Constraints:**
+
+- You MUST download the sample for the resolved device type ID and IKE version, preferring the recommended sample:
+
+  ```
+  aws ec2 get-vpn-connection-device-sample-configuration \
+    --vpn-connection-id {vpn_connection_id} --vpn-connection-device-type-id {device_type_id} \
+    --internet-key-exchange-version {ike_version} --sample-type recommended --region {region}
+  ```
+
+#### 4. Review and adapt
+
+**Constraints:**
+
+- You MUST present the sample as a starting point and prompt the customer to adjust algorithms, Diffie-Hellman groups, certificates, and IPv6
+- You MUST NOT tell the customer to apply the sample unchanged as if it were correct for their device
+
+#### 5. Apply both tunnels and confirm
+
+**Constraints:**
+
+- You MUST confirm the customer configures both tunnels on the device, not just one
+- You MUST present the VPN connection console link, filling `{region}` and `{vpnConnectionId}` from
+  the request, and tell the customer to open it and confirm both tunnels report UP:
+
+  ```
+  https://console.aws.amazon.com/vpc/home?region={region}#VpnConnectionDetails:VpnConnectionId={vpnConnectionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "region": "us-east-1",
+  "vpn_connection_id": "vpn-0abc1234def567890",
+  "device_vendor": "Cisco ASA 9.x",
+  "ike_version": "ikev2",
+  "sample_type": "recommended"
+}
+```
+
+#### Example output
+
+```
+Confirmed download permissions. Downloaded the recommended IKEv2 sample for Cisco ASA 9.x.
+Flagged it as a starting point: adjust algorithms, DH group, certificates, and IPv6 before applying.
+Both tunnels configured on the device. Open the connection and confirm both tunnels report UP:
+https://console.aws.amazon.com/vpc/home?region=us-east-1#VpnConnectionDetails:VpnConnectionId=vpn-0abc1234def567890
+```
+
+### Troubleshooting
+
+#### Tunnels down after applying
+The sample needs adapting to the device. Review the algorithms and settings (Step 4).
+
+#### Download screen empty
+Missing IAM permissions. Add `GetVpnConnectionDeviceTypes` and `GetVpnConnectionDeviceSampleConfiguration` (Step 1).
+
+#### Connection drops during maintenance
+Only one tunnel configured. Configure both (Step 5).
+
+## Security Considerations
+
+The device configuration carries the authentication secret and the encryption settings the tunnels
+negotiate, so it is the most security-sensitive artifact the customer handles.
+
+**Constraints:**
+
+- You MUST set strong tunnel options (AES-256, SHA-256 or higher, Diffie-Hellman group 14 or higher) rather than the AES-128 / SHA-1 / DH group 2 minimums
+- You MUST treat tunnel pre-shared keys (PSKs) as secrets: never pass them on the command line or store them in plaintext, store them in AWS Secrets Manager, and rotate them periodically; where the device supports it, recommend certificate-based authentication with AWS Private Certificate Authority instead of a static PSK
+- You SHOULD remind the customer that the downloaded sample contains live tunnel secrets and should
+  be deleted from any temporary or download location once applied
+- You SHOULD enable Amazon CloudWatch tunnel-state alarms and Site-to-Site VPN logs, and confirm AWS CloudTrail is enabled so the API calls that create, modify, or delete the connection are audited (see the monitoring-and-troubleshooting-tunnels reference). You MUST enable encryption at rest on every log destination — KMS on the CloudWatch Logs log group holding the VPN/tunnel logs and SSE-S3 or SSE-KMS on the S3 bucket holding the CloudTrail logs — since these logs can carry tunnel and connection detail
+
+## Additional Resources
+
+- [Get started with AWS Site-to-Site VPN (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/SetUpVPNConnections.html)
+- [Static and dynamic configuration files for an AWS Site-to-Site VPN customer gateway device (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/example-configuration-files.html)
+- [AWS Site-to-Site VPN customer gateway devices (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/your-cgw.html)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/choosing-static-or-dynamic-routing.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/choosing-static-or-dynamic-routing.md
@@ -1,0 +1,226 @@
+# Choosing Static or Dynamic (BGP) Routing for a Site-to-Site VPN Connection
+
+## Overview
+
+Decision expertise for picking how routes are exchanged between an on-premises network and a VPC
+before creating an AWS Site-to-Site VPN connection. Covers the two routing types (static, where the
+customer enters on-premises prefixes by hand, and dynamic, where the customer gateway and the AWS
+gateway exchange routes over Border Gateway Protocol), the device capability that gates the choice,
+the failover difference, the deliberate use of static routing for route control, and the
+Autonomous System Number (ASN) that dynamic routing requires.
+
+This reference makes and explains a recommendation. It does not create the connection. Once the
+routing type is settled, the creating-a-site-to-site-vpn-connection reference covers the build. It
+does not cover tunnel bandwidth sizing or the customer gateway device configuration; those are
+separate references.
+
+## Table of Contents
+
+- Overview
+- Workflow
+- Decision: static or dynamic routing
+- BGP support gates the choice
+- Static routing as deliberate route control
+- Failover difference
+- ASN for dynamic routing
+- Troubleshooting
+- Procedure
+- Security Considerations
+- Additional Resources
+
+## Workflow
+
+To recommend a routing type, gather the customer's device capability and route-control needs, match
+them against the decision table, and explain the recommendation. See the Procedure section below.
+
+The procedure covers:
+
+- Confirming whether the on-premises device supports BGP
+- Establishing whether the customer needs to control which routes enter their network
+- Matching the requirements to static or dynamic routing
+- Explaining the failover and ASN consequences of the choice
+
+## Decision: static or dynamic routing
+
+| Choice | Use when |
+| --- | --- |
+| Dynamic (BGP) | The on-premises device supports BGP and the customer wants automatic route exchange and BGP-assisted failover between tunnels |
+| Static | The device does not support BGP, or the customer deliberately wants to control which on-premises routes enter the AWS network. On a BGP-capable device, dynamic routing with BGP prefix filtering is the other way to control which routes are admitted |
+
+**Constraints:**
+
+- You MUST confirm whether the on-premises device supports BGP before recommending a routing type.
+  The right answer depends on the customer's device and intent, not a fixed rule
+- You MUST NOT recommend dynamic routing for a device that does not support BGP
+- You SHOULD default to dynamic routing for a BGP-capable device unless the customer has a route-control reason to choose static
+
+## BGP support gates the choice
+
+Dynamic routing requires a BGP-capable customer gateway device. Recommending it for a device that
+does not support BGP leaves the customer stuck at the customer gateway step.
+
+**Constraints:**
+
+- You MUST verify BGP support on the on-premises device before offering dynamic routing
+- You SHOULD ask the customer for the device make and model if BGP support is unknown, rather than assuming
+
+## Static routing as deliberate route control
+
+Some customers choose static routing on a BGP-capable device on purpose. When connecting to a
+partner network, static routing lets the customer write only the specific partner prefixes they
+approve, rather than accepting everything the partner advertises over BGP. This is common in
+regulated industries such as banking and financial services.
+
+On a BGP-capable device, static routing is not the only way to control which routes are admitted:
+dynamic routing with BGP prefix filtering lets the customer accept only approved partner prefixes
+while keeping the automatic route exchange and BGP-assisted failover that dynamic routing provides.
+Static routing gives the simplest, most explicit control; BGP prefix filtering gives route control
+without giving up dynamic failover.
+
+**Constraints:**
+
+- You MUST treat static routing as a valid deliberate choice when the customer wants to control
+  which routes enter their network, not only as a fallback for devices without BGP
+- You MUST present dynamic routing with BGP prefix filtering as the alternative route-control option
+  on a BGP-capable device, so the customer chooses route control without necessarily giving up
+  dynamic failover
+- You SHOULD surface the route-control benefit when the customer is connecting to a partner or third-party network
+
+## Failover difference
+
+BGP offers liveness detection that assists failover to the second tunnel when the first goes down.
+Static routing does not get that, so a customer on static routing gives up the automatic failover
+benefit without always realizing it.
+
+**Constraints:**
+
+- You MUST name the failover difference so the customer makes the resilience tradeoff knowingly
+- You SHOULD pair this with the making-a-connection-highly-available reference when the customer depends on the connection for production
+
+## ASN for dynamic routing
+
+Dynamic routing requires a BGP ASN for the customer gateway. When the customer has no public ASN,
+they can use a private ASN.
+
+**Constraints:**
+
+- You MUST supply the private ASN ranges when the customer has no public ASN, so they are not
+  blocked at the customer gateway step. The 16-bit private range is 64512 to 65534 and the 32-bit
+  private range is 4200000000 to 4294967294
+- You SHOULD confirm the AWS-side ASN differs from the customer gateway ASN for a virtual private gateway target
+
+## Troubleshooting
+
+### Customer picked dynamic routing but the device has no BGP
+The device cannot run BGP. Recommend static routing and enter the on-premises prefixes by hand (Decision).
+
+### Partner routes the customer did not approve appear in the AWS route table
+BGP advertised everything from the partner. On a BGP-capable device, present both route-control options: dynamic routing with BGP prefix filtering (accept only approved prefixes, keeping automatic failover) or static routing (enter approved prefixes by hand). Recommend BGP prefix filtering when the customer wants to keep dynamic failover (Static routing as deliberate route control).
+
+### Customer is blocked creating the customer gateway because they have no ASN
+Dynamic routing needs a BGP ASN. Supply a private ASN from the allowed range (ASN for dynamic routing).
+
+## Procedure
+
+### Overview
+
+This procedure gathers the customer's device capability and route-control needs, matches them to a
+routing type, and explains the consequences. It is a decision procedure: there is no console-write
+step, because the output is a recommendation, not a deployed resource.
+
+### Parameters
+
+- **device_supports_bgp** (required): Whether the on-premises customer gateway device supports BGP.
+- **needs_route_control** (required): Whether the customer must control which on-premises routes
+  enter the AWS network (common for partner or regulated connections).
+- **has_public_asn** (optional): Whether the customer has a public BGP ASN, relevant only for dynamic routing.
+
+**Constraints for parameter acquisition:**
+
+- You MUST establish BGP support and route-control need upfront in a single prompt
+- You MUST NOT recommend a routing type before both are known
+
+### Steps
+
+#### 1. Establish device capability and intent
+
+**Constraints:**
+
+- You MUST confirm whether the on-premises device supports BGP
+- You MUST establish whether the customer needs to control which routes enter their network
+
+#### 2. Match to a routing type
+
+**Constraints:**
+
+- You MUST recommend static routing if the device does not support BGP
+- You MUST recommend static routing or dynamic routing with BGP prefix filtering if the customer needs to control which routes enter, even on a BGP-capable device
+- You SHOULD recommend dynamic routing otherwise, for automatic route exchange and BGP-assisted failover
+
+#### 3. Explain the consequences
+
+**Constraints:**
+
+- You MUST state the failover difference: dynamic routing gets BGP liveness detection that assists
+  tunnel failover; static routing does not
+- You MUST supply a private ASN range if the customer chooses dynamic routing and has no public ASN
+- You MUST NOT proceed to build; hand off to the creating-a-site-to-site-vpn-connection reference once the customer commits
+
+### Example
+
+#### Example input
+
+```json
+{
+  "device_supports_bgp": true,
+  "needs_route_control": true,
+  "has_public_asn": false
+}
+```
+
+#### Example output
+
+```
+The device supports BGP, so there are two ways to get the route control the customer wants:
+- Dynamic routing with BGP prefix filtering: advertise and accept only the approved partner
+  prefixes (filter the rest at the customer gateway). This keeps BGP liveness detection and
+  automatic tunnel failover while still controlling which routes enter the AWS route table.
+- Static routing: enter the approved prefixes by hand for the simplest, most explicit control.
+  Tradeoff: static routing does not get BGP liveness detection, so tunnel failover is not automatic.
+Recommendation: prefer dynamic routing with BGP prefix filtering here, since the device is
+BGP-capable and the customer keeps automatic failover; choose static routing only if they want the
+simplest explicit control and accept manual failover. Next: build it with the
+creating-a-site-to-site-vpn-connection reference.
+```
+
+### Troubleshooting
+
+#### Customer picked dynamic but the device cannot run BGP
+Recommend static routing and enter prefixes by hand (Step 2).
+
+#### Unwanted partner routes appear after choosing BGP
+On a BGP-capable device, present both route-control options: dynamic routing with BGP prefix filtering (accept only approved prefixes, keeping automatic failover) or static routing (enter approved prefixes by hand). Recommend BGP prefix filtering when the customer wants to keep dynamic failover (Step 2).
+
+#### Customer has no ASN for dynamic routing
+Supply a private ASN range (Step 3).
+
+## Security Considerations
+
+The routing choice is also a security boundary: it decides which on-premises prefixes can enter the
+AWS network and which AWS prefixes are advertised back.
+
+**Constraints:**
+
+- You MUST surface that static routing lets the customer admit only explicitly approved prefixes,
+  while dynamic (BGP) routing accepts whatever the peer advertises; recommend static routing or BGP
+  prefix filtering when connecting to a partner or untrusted network so unintended routes are not admitted
+- You SHOULD remind the customer that regardless of routing type, the security group and route table
+  still gate actual reachability, so they must be scoped to the intended CIDR blocks
+- You SHOULD note that the routing type does not change the tunnel's encryption posture; encryption
+  and authentication are set in the tunnel and device configuration
+
+## Additional Resources
+
+- [Static and dynamic routing in AWS Site-to-Site VPN (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/vpn-static-dynamic.html)
+- [AWS Site-to-Site VPN routing options (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPNRoutingTypes.html)
+- [Customer gateway options for your AWS Site-to-Site VPN connection (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/cgw-options.html)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/choosing-tunnel-bandwidth-standard-or-large.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/choosing-tunnel-bandwidth-standard-or-large.md
@@ -1,0 +1,255 @@
+# Choosing Standard (1.25 Gbps) or Large (5 Gbps) Tunnel Bandwidth
+
+## Overview
+
+Decision expertise for sizing the tunnel bandwidth of an AWS Site-to-Site VPN connection. Covers the
+two options (Standard, up to 1.25 Gbps per tunnel and the default; Large, up to 5 Gbps per tunnel),
+the target gateway that gates Large, the per-connection scope that covers both tunnels, the path
+requirements on the device and circuit, the in-place-modification limits, and the cost tradeoff
+versus equal-cost multi-path (ECMP) routing.
+
+This reference makes and explains a recommendation and applies the setting. It assumes the
+connection exists or is being created (the creating-a-site-to-site-vpn-connection reference). It
+does not cover the VPN Concentrator, which scales many small sites rather than one connection's
+throughput.
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. Pass `--region {region}` matching the connection.
+
+## Table of Contents
+
+- Overview
+- Workflow
+- Decision: Standard or Large
+- The target gateway gates Large
+- Per-connection scope
+- Path must support the bandwidth
+- Switching bandwidth later
+- Cost and ECMP
+- Troubleshooting
+- Procedure
+- Security Considerations
+- Additional Resources
+
+## Workflow
+
+To size tunnel bandwidth, gather the throughput need and the target gateway, match them to Standard
+or Large, confirm the path supports it, and apply the setting. See the Procedure section below.
+
+The procedure covers:
+
+- Establishing the throughput the workload needs
+- Confirming the target gateway supports Large
+- Confirming the on-premises device and circuit support the higher throughput
+- Setting Standard or Large at create or modify time
+
+## Decision: Standard or Large
+
+| Choice | Use when |
+| --- | --- |
+| Standard (1.25 Gbps per tunnel) | The workload needs no more than 1.25 Gbps per tunnel, or the connection is on a virtual private gateway |
+| Large (5 Gbps per tunnel) | The workload needs high throughput (bandwidth-intensive hybrid apps, big data migration, Direct Connect backup or overlay) and the connection is on a transit gateway or Cloud WAN |
+
+**Constraints:**
+
+- You MUST establish the throughput need before recommending, since Large carries a higher cost
+- You SHOULD recommend Large only when the workload genuinely needs more than 1.25 Gbps per tunnel
+
+## The target gateway gates Large
+
+Large (5 Gbps) tunnels are supported only on transit gateway and AWS Cloud WAN connections, not on a
+virtual private gateway. A customer who needs more than 1.25 Gbps but already built on a virtual
+private gateway cannot flip the setting; they must move to a transit gateway first.
+
+**Constraints:**
+
+- You MUST check the target gateway before offering Large; rule it out on a virtual private gateway
+- You MUST tell the customer that needing high throughput points them at a transit gateway
+
+## Per-connection scope
+
+The bandwidth setting is per connection, not per tunnel. Standard and Large cannot coexist in the
+same connection, and Large applies to both tunnels at once.
+
+**Constraints:**
+
+- You MUST state that the setting covers both tunnels and that one connection cannot mix Standard and Large
+- You SHOULD explain that a single traffic flow maps to one tunnel, so exceeding one tunnel's ceiling needs multiple flows
+
+## Path must support the bandwidth
+
+Large bandwidth only delivers if the on-premises customer gateway device and the internet circuit
+can handle the higher throughput. Otherwise the customer pays for 5 Gbps and never sees it.
+
+**Constraints:**
+
+- You MUST prompt the customer to confirm the device and circuit capacity before selecting Large
+- You SHOULD note that the throughput ceiling is the lowest-capacity hop on the path, not the tunnel setting alone
+
+## Switching bandwidth later
+
+Modifying the bandwidth is supported in place only in select Regions; elsewhere the customer must
+delete and recreate the connection. Any modification briefly interrupts the connection while it
+applies.
+
+**Constraints:**
+
+- You MUST surface the bandwidth decision at create time and warn that changing it later may mean a recreate
+- You MUST warn that any bandwidth modification briefly interrupts the connection
+
+## Cost and ECMP
+
+Large tunnels cost noticeably more per hour than Standard, so the choice is a real cost tradeoff.
+Customers who need more than a single tunnel's ceiling can bond multiple Standard tunnels with
+ECMP on a transit gateway; Large tunnels remove that ECMP complexity by raising the per-tunnel
+ceiling directly.
+
+**Constraints:**
+
+- You MUST frame Large as a higher-cost option that removes ECMP complexity, not a free upgrade
+- You SHOULD point customers needing more than 5 Gbps per tunnel at ECMP across multiple tunnels on a transit gateway
+
+## Troubleshooting
+
+### Large is not selectable
+The connection is on a virtual private gateway. Large needs a transit gateway or Cloud WAN (The target gateway gates Large).
+
+### Customer expects 10 Gbps from two 5 Gbps tunnels
+The setting is per connection and a single flow uses one tunnel. Aggregate across flows or use ECMP (Per-connection scope, Cost and ECMP).
+
+### Paid for Large but throughput is capped lower
+The device or circuit is the bottleneck. Confirm path capacity (Path must support the bandwidth).
+
+### Changing bandwidth caused an outage
+Any modification briefly interrupts the connection, and outside select Regions it requires recreate (Switching bandwidth later).
+
+## Procedure
+
+### Overview
+
+This procedure establishes the throughput need, confirms the target gateway and path support Large,
+and applies Standard or Large at create or modify time, then surfaces the console link to verify.
+
+### Parameters
+
+- **region** (required): The AWS Region of the connection.
+- **vpn_connection_id** (required for modify): The connection to modify.
+- **target_gateway_type** (required): `vgw`, `transit-gateway`, or `cloud-wan`.
+- **throughput_need** (required): The per-tunnel throughput the workload needs.
+- **bandwidth** (required): `Standard` or `Large`.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask for the throughput need and target gateway upfront
+- You MUST NOT offer Large on a virtual private gateway
+
+### Steps
+
+#### 1. Establish throughput and gateway
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You SHOULD recommend ephemeral IAM role-based credentials (instance profile, SSO session, or assumed role) rather than long-lived IAM user access keys for running these commands
+- You MUST establish the per-tunnel throughput the workload needs
+- You MUST confirm the target gateway is a transit gateway or Cloud WAN before offering Large
+
+#### 2. Confirm the path
+
+**Constraints:**
+
+- You MUST confirm the on-premises device and internet circuit support the chosen bandwidth before selecting Large
+
+#### 3. Apply the bandwidth setting
+
+**Constraints:**
+
+- You MUST set the bandwidth at create time on a new connection, alongside the strong tunnel options
+  (two `TunnelOptions` objects, one per tunnel, with AES-256, SHA2-256, and DH group 14):
+
+  ```
+  aws ec2 create-vpn-connection --type ipsec.1 --transit-gateway-id {tgw_id} \
+    --customer-gateway-id {cgw_id} \
+    --options "TunnelBandwidth=Large,TunnelOptions=[{Phase1EncryptionAlgorithms=[{Value=AES256}],Phase2EncryptionAlgorithms=[{Value=AES256}],Phase1IntegrityAlgorithms=[{Value=SHA2-256}],Phase2IntegrityAlgorithms=[{Value=SHA2-256}],Phase1DHGroupNumbers=[{Value=14}],Phase2DHGroupNumbers=[{Value=14}]},{Phase1EncryptionAlgorithms=[{Value=AES256}],Phase2EncryptionAlgorithms=[{Value=AES256}],Phase1IntegrityAlgorithms=[{Value=SHA2-256}],Phase2IntegrityAlgorithms=[{Value=SHA2-256}],Phase1DHGroupNumbers=[{Value=14}],Phase2DHGroupNumbers=[{Value=14}]}]" \
+    --region {region}
+  ```
+
+- You MUST warn before modifying an existing connection that it briefly interrupts connectivity and may require recreate outside select Regions:
+
+  ```
+  aws ec2 modify-vpn-connection-options --vpn-connection-id {vpn_connection_id} \
+    --tunnel-bandwidth Large --region {region}
+  ```
+
+#### 4. Confirm and surface the console link
+
+**Constraints:**
+
+- You MUST confirm the connection reports the chosen bandwidth:
+
+  ```
+  aws ec2 describe-vpn-connections --vpn-connection-ids {vpn_connection_id} --region {region}
+  ```
+
+- You MUST present the VPN connection console link, filling `{region}` and `{vpnConnectionId}` from the API response:
+
+  ```
+  https://console.aws.amazon.com/vpc/home?region={region}#VpnConnectionDetails:VpnConnectionId={vpnConnectionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "region": "us-east-1",
+  "target_gateway_type": "transit-gateway",
+  "throughput_need": "3 Gbps",
+  "bandwidth": "Large"
+}
+```
+
+#### Example output
+
+```
+Recommendation: Large (5 Gbps) tunnels. The workload needs 3 Gbps, above the 1.25 Gbps Standard
+ceiling, and the connection is on a transit gateway, which supports Large. Confirmed the on-premises
+device and circuit handle 3 Gbps+. Set TunnelBandwidth=Large at create time.
+Open the connection in the console to confirm bandwidth:
+https://console.aws.amazon.com/vpc/home?region=us-east-1#VpnConnectionDetails:VpnConnectionId=vpn-0abc1234def567890
+```
+
+### Troubleshooting
+
+#### Large not available
+The connection is on a virtual private gateway. Move to a transit gateway (Step 1).
+
+#### Throughput capped below Large
+The device or circuit is the bottleneck. Confirm path capacity (Step 2).
+
+#### Modify caused an interruption
+Any bandwidth modification briefly interrupts the connection (Step 3).
+
+## Security Considerations
+
+The bandwidth setting does not change the connection's authentication or encryption, but it is set on
+the same `create-vpn-connection` and `modify-vpn-connection-options` calls that carry the tunnel
+security options, so the security posture must not be dropped when sizing bandwidth.
+
+**Constraints:**
+
+- You MUST set strong tunnel options (AES-256, SHA-256 or higher, Diffie-Hellman group 14 or higher) rather than the AES-128 / SHA-1 / DH group 2 minimums
+- You MUST NOT let a bandwidth change reset tunnel options to weaker defaults; preserve them when modifying a connection
+- You MUST treat tunnel pre-shared keys (PSKs) as secrets: never pass them on the command line or store them in plaintext, store them in AWS Secrets Manager, and rotate them periodically; where the device supports it, recommend certificate-based authentication with AWS Private Certificate Authority instead of a static PSK
+- You SHOULD remind the customer that a bandwidth modification re-establishes the tunnels, so they
+  must confirm the encryption and authentication settings still match policy afterward
+- You SHOULD enable Amazon CloudWatch tunnel-state alarms and Site-to-Site VPN logs, and confirm AWS CloudTrail is enabled so the API calls that create, modify, or delete the connection are audited (see the monitoring-and-troubleshooting-tunnels reference). You MUST enable encryption at rest on every log destination — KMS on the CloudWatch Logs log group holding the VPN/tunnel logs and SSE-S3 or SSE-KMS on the S3 bucket holding the CloudTrail logs — since these logs can carry tunnel and connection detail
+
+## Additional Resources
+
+- [Tunnel options for your AWS Site-to-Site VPN connection (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPNTunnels.html)
+- [Modify AWS Site-to-Site VPN connection options (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/modify-vpn-connection-options.html)
+- [Introducing AWS Site-to-Site VPN 5 Gbps Tunnels to support high throughput workloads (AWS Networking & Content Delivery Blog)](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-aws-site-to-site-vpn-5-gbps-tunnels-to-support-high-throughput-workloads/)
+- [Scaling VPN throughput using AWS Transit Gateway (AWS Networking & Content Delivery Blog)](https://aws.amazon.com/blogs/networking-and-content-delivery/scaling-vpn-throughput-using-aws-transit-gateway/)
+- [AWS VPN Pricing](https://aws.amazon.com/vpn/pricing/)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/connecting-many-sites-with-a-vpn-concentrator.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/connecting-many-sites-with-a-vpn-concentrator.md
@@ -1,0 +1,235 @@
+# Connecting Many Sites Through a Site-to-Site VPN Concentrator
+
+## Overview
+
+Domain expertise for consolidating multi-site connectivity with an AWS Site-to-Site VPN
+Concentrator: a transit gateway attachment that gives 5 Gbps of aggregate bandwidth shared across
+many remote sites, with endpoints in two Availability Zones. Covers the deployment profile the
+Concentrator fits, the transit-gateway-only and BGP-only constraints, the per-site work that remains,
+and the cost comparison against per-site connections.
+
+Does not cover sizing one connection's throughput (the choosing-tunnel-bandwidth reference) or the
+general connection build (the creating-a-site-to-site-vpn-connection reference), though each site's
+connection follows that build. Use this reference when the customer has many low-bandwidth sites,
+not one high-throughput site.
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. Pass `--region {region}` matching the transit gateway.
+
+## Table of Contents
+
+- Overview
+- Workflow
+- Decision: is a Concentrator the right fit
+- Transit-gateway-only and BGP-only constraints
+- Per-site work remains
+- Cost comparison
+- Troubleshooting
+- Procedure
+- Security Considerations
+- Additional Resources
+
+## Workflow
+
+To consolidate many sites, confirm the deployment fits the Concentrator profile, create the
+Concentrator on a transit gateway, then create one VPN connection per site against it. See the
+Procedure section below.
+
+The procedure covers:
+
+- Checking the site count and per-site bandwidth against the Concentrator profile
+- Creating the Concentrator on an existing transit gateway
+- Creating one BGP VPN connection per site, each with a unique CIDR block
+- Surfacing the console link to verify
+
+## Decision: is a Concentrator the right fit
+
+| Choice | Use when |
+| --- | --- |
+| VPN Concentrator | 25 or more remote sites, each needing roughly 50 to 100 Mbps, sharing 5 Gbps aggregate bandwidth (retail chains, restaurant franchises, hotels, multi-site healthcare) |
+| Individual VPN connections | A handful of sites, or a single site that needs high throughput on its own |
+| Large (5 Gbps) tunnels | One site that needs high per-tunnel throughput (the choosing-tunnel-bandwidth reference) |
+
+**Constraints:**
+
+- You MUST check the site count and per-site bandwidth against the profile (25+ sites, 50 to 100 Mbps each) before recommending a Concentrator
+- You SHOULD recommend individual connections or Large tunnels when the customer has few sites or a single high-throughput site
+
+## Transit-gateway-only and BGP-only constraints
+
+The Concentrator is a transit gateway attachment only, so it does not work with a virtual private
+gateway, and connections on it must use BGP routing; static routing is not an option.
+
+**Constraints:**
+
+- You MUST confirm the customer has (or will create) a transit gateway; the Concentrator cannot attach to a virtual private gateway
+- You MUST state that connections on the Concentrator require BGP routing, so the customer's devices must support BGP
+- You SHOULD surface both constraints before the customer starts, so the gateway and routing decisions are made correctly the first time
+
+## Per-site work remains
+
+The Concentrator shares one attachment, but each remote site still needs its own VPN connection and
+its own customer gateway, and every site must use a unique CIDR block to avoid routing conflicts
+across the shared attachment.
+
+**Constraints:**
+
+- You MUST make clear the consolidation is at the attachment and bandwidth level, not "one connection to configure"
+- You MUST enforce a unique CIDR block per site to avoid routing conflicts
+- You SHOULD sequence the per-site connections so none is skipped
+
+## Cost comparison
+
+A Concentrator bills per hour for the attachment plus a smaller per-connection charge. It is cheaper
+than a full 1.25 Gbps connection per site only when there are enough low-bandwidth sites to amortize
+the attachment cost.
+
+**Constraints:**
+
+- You MUST walk the customer through the comparison against per-site connections, based on their actual site count
+- You SHOULD NOT assume consolidation is always cheaper; below the break-even site count, per-site connections cost less
+
+## Troubleshooting
+
+### Concentrator will not attach to the gateway
+The Concentrator is a transit gateway attachment only. It cannot use a virtual private gateway (Transit-gateway-only constraints).
+
+### A site's connection rejects static routing
+Concentrator connections require BGP. The device must support BGP (Transit-gateway-only and BGP-only constraints).
+
+### Routing breaks across sites
+Two sites use overlapping CIDR blocks. Give each site a unique CIDR block (Per-site work remains).
+
+### Concentrator costs more than expected for few sites
+Below the break-even site count, per-site connections are cheaper. Reconsider the fit (Cost comparison).
+
+## Procedure
+
+### Overview
+
+This procedure confirms the deployment fits the Concentrator profile, creates the Concentrator on a
+transit gateway, creates one BGP VPN connection per site with a unique CIDR block, then surfaces the
+console link to verify.
+
+### Parameters
+
+- **region** (required): The AWS Region of the transit gateway.
+- **transit_gateway_id** (required): The existing transit gateway to attach the Concentrator to.
+- **site_count** (required): The number of remote sites.
+- **per_site_bandwidth** (required): The bandwidth each site needs.
+- **sites** (required): Per site, the customer gateway IP, the customer gateway BGP ASN, and the unique CIDR block.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask for the site count and per-site bandwidth upfront to confirm the fit
+- You MUST confirm a transit gateway exists or will be created
+
+### Steps
+
+#### 1. Confirm the fit
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You SHOULD recommend ephemeral IAM role-based credentials (instance profile, SSO session, or assumed role) rather than long-lived IAM user access keys for running these commands
+- You MUST check site count and per-site bandwidth against the profile (25+ sites, 50 to 100 Mbps each)
+- You SHOULD recommend individual connections or Large tunnels instead if the deployment does not fit
+
+#### 2. Create the Concentrator
+
+**Constraints:**
+
+- You MUST create the Concentrator on the existing transit gateway. It provisions two endpoints, one per Availability Zone:
+
+  ```
+  aws ec2 create-vpn-concentrator --transit-gateway-id {transit_gateway_id} --region {region}
+  ```
+
+- You MUST capture the concentrator ID from the response
+
+#### 3. Create one VPN connection per site
+
+**Constraints:**
+
+- You MUST create each site's customer gateway and a BGP VPN connection against the Concentrator, with a unique CIDR block per site. Per site, create the customer gateway, then the connection against the transit gateway the Concentrator is on, supplying two `TunnelOptions` objects so both tunnels use strong options:
+
+  ```
+  aws ec2 create-customer-gateway --type ipsec.1 --public-ip {site_customer_gateway_ip} \
+    --bgp-asn {site_customer_gateway_asn} --region {region}
+  aws ec2 create-vpn-connection --type ipsec.1 --customer-gateway-id {site_customer_gateway_id} \
+    --transit-gateway-id {transit_gateway_id} \
+    --options "StaticRoutesOnly=false,TunnelOptions=[{Phase1EncryptionAlgorithms=[{Value=AES256}],Phase2EncryptionAlgorithms=[{Value=AES256}],Phase1IntegrityAlgorithms=[{Value=SHA2-256}],Phase2IntegrityAlgorithms=[{Value=SHA2-256}],Phase1DHGroupNumbers=[{Value=14}],Phase2DHGroupNumbers=[{Value=14}]},{Phase1EncryptionAlgorithms=[{Value=AES256}],Phase2EncryptionAlgorithms=[{Value=AES256}],Phase1IntegrityAlgorithms=[{Value=SHA2-256}],Phase2IntegrityAlgorithms=[{Value=SHA2-256}],Phase1DHGroupNumbers=[{Value=14}],Phase2DHGroupNumbers=[{Value=14}]}]" \
+    --region {region}
+  ```
+
+- You MUST set strong tunnel options (AES-256, SHA-256 or higher, Diffie-Hellman group 14 or higher) rather than the AES-128 / SHA-1 / DH group 2 minimums
+- You MUST supply two `TunnelOptions` objects, one per tunnel, since every connection has two tunnels; a single-element array leaves Tunnel 2 on the weak AES-128 / SHA-1 / DH group 2 defaults
+- You MUST NOT use static routing; Concentrator connections require BGP
+- You MUST confirm no two sites share a CIDR block
+
+#### 4. Confirm and surface the console link
+
+**Constraints:**
+
+- You MUST confirm the Concentrator and each site's connection report the expected state
+- You MUST present the VPN Concentrators console link, filling `{region}` from the request, and tell the customer to open it and confirm the Concentrator and attached connections:
+
+  ```
+  https://console.aws.amazon.com/vpc/home?region={region}#SiteToSiteVpnConcentrators:
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "region": "us-east-1",
+  "transit_gateway_id": "tgw-0abc1234",
+  "site_count": 40,
+  "per_site_bandwidth": "75 Mbps",
+  "sites": [
+    {"customer_gateway_ip": "203.0.113.10", "customer_gateway_asn": 65010, "ip_range": "10.20.1.0/24"},
+    {"customer_gateway_ip": "203.0.113.11", "customer_gateway_asn": 65011, "ip_range": "10.20.2.0/24"}
+  ]
+}
+```
+
+#### Example output
+
+```
+Fit confirmed: 40 sites at ~75 Mbps each share 5 Gbps aggregate, within the Concentrator profile.
+Created the Concentrator on tgw-0abc1234 (endpoints in two AZs) and one BGP VPN connection per site,
+each with a unique CIDR block. Open the Concentrators view to confirm:
+https://console.aws.amazon.com/vpc/home?region=us-east-1#SiteToSiteVpnConcentrators:
+```
+
+### Troubleshooting
+
+#### Concentrator will not attach
+It is a transit gateway attachment only (Step 2).
+
+#### A site rejects static routing
+Concentrator connections require BGP (Step 3).
+
+#### Routing breaks across sites
+Overlapping CIDR blocks. Give each site a unique CIDR block (Step 3).
+
+## Security Considerations
+
+A Concentrator multiplies the number of tunnels and secrets the customer manages on one shared
+attachment, so per-site authentication and isolation matter more than for a single connection.
+
+**Constraints:**
+
+- You MUST treat tunnel pre-shared keys (PSKs) as secrets: never pass them on the command line or store them in plaintext, store them in AWS Secrets Manager, and rotate them periodically; where the device supports it, recommend certificate-based authentication with AWS Private Certificate Authority instead of a static PSK. Use a distinct key per site rather than reusing one key across sites
+- You MUST enforce a unique, non-overlapping CIDR block per site, since overlapping CIDR blocks across the
+  shared attachment both break routing and let one site reach another's prefixes
+- You MUST set strong tunnel options (AES-256, SHA-256 or higher, Diffie-Hellman group 14 or higher) rather than the AES-128 / SHA-1 / DH group 2 minimums
+- You SHOULD enable Amazon CloudWatch tunnel-state alarms and Site-to-Site VPN logs, and confirm AWS CloudTrail is enabled so the API calls that create, modify, or delete the connection are audited (see the monitoring-and-troubleshooting-tunnels reference). You MUST enable encryption at rest on every log destination — KMS on the CloudWatch Logs log group holding the VPN/tunnel logs and SSE-S3 or SSE-KMS on the S3 bucket holding the CloudTrail logs — since these logs can carry tunnel and connection detail
+
+## Additional Resources
+
+- [Introducing AWS Site-to-Site VPN Concentrator for multi-site connectivity (AWS Networking & Content Delivery Blog)](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-aws-site-to-site-vpn-concentrator-for-multi-site-connectivity/)
+- [AWS Site-to-Site VPN quotas (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/vpn-limits.html)
+- [AWS VPN Pricing](https://aws.amazon.com/vpn/pricing/)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/creating-a-site-to-site-vpn-connection.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/creating-a-site-to-site-vpn-connection.md
@@ -1,0 +1,297 @@
+# Creating a Site-to-Site VPN Connection
+
+## Overview
+
+Domain expertise for building an AWS Site-to-Site VPN connection: an encrypted IP Security (IPsec)
+tunnel between an on-premises network and a VPC. Covers the target gateway decision (virtual private
+gateway, transit gateway, or AWS Cloud WAN), the fixed order of the dependent resources, the
+customer gateway as metadata only, the distinct-ASN rule for a virtual private gateway, and
+choosing tunnel options at create time.
+
+Does not cover the routing-type decision (the choosing-static-or-dynamic-routing reference), tunnel
+bandwidth sizing (the choosing-tunnel-bandwidth reference), the VPN Concentrator (its own
+reference), or applying the device configuration (the applying-the-customer-gateway-device-configuration
+reference). Settle routing type before running this procedure.
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. Site-to-Site VPN is regional; pass
+`--region {region}` matching the VPC or transit gateway the connection terminates on.
+
+## Table of Contents
+
+- Overview
+- Workflow
+- Decision: target gateway
+- Creation order
+- The customer gateway is metadata only
+- Distinct ASNs for a virtual private gateway
+- Tunnel options at create time
+- Troubleshooting
+- Procedure
+- Security Considerations
+- Additional Resources
+
+## Workflow
+
+To build the connection end to end, follow the procedure exactly. See the Procedure section below.
+
+The procedure covers:
+
+- Choosing the target gateway based on how many VPCs and how much throughput the customer needs
+- Creating the customer gateway resource that describes the on-premises device
+- Creating or selecting the target gateway and attaching it to the VPC
+- Enabling route propagation or adding routes, and updating the security group
+- Creating the VPN connection with the chosen routing and tunnel options
+- Surfacing the console link to verify status and download the device configuration
+
+## Decision: target gateway
+
+| Choice | Use when |
+| --- | --- |
+| Virtual private gateway (VGW) | The VPN terminates at a single VPC and the customer needs no more than 1.25 Gbps per tunnel |
+| Transit gateway | The VPN fronts many VPCs, needs Large (5 Gbps) tunnels, needs ECMP bandwidth aggregation, or will use a VPN Concentrator |
+| AWS Cloud WAN core network | The VPN attaches to a Cloud WAN global network |
+
+**Constraints:**
+
+- You MUST establish the target gateway first, tied to how many VPCs the customer must reach and
+  how much throughput they need. It is the most consequential choice and gates bandwidth and Concentrator options
+- You MUST tell the customer that a virtual private gateway cannot later be upgraded in place to
+  Large tunnels or a Concentrator; reaching those means rebuilding on a transit gateway
+- You SHOULD recommend a transit gateway when the customer needs more than one VPC or any feature a virtual private gateway does not support
+
+## Creation order
+
+The connection only works after several resources are in place in the right order. Creating the VPN
+connection first and stopping there leaves traffic with nowhere to flow, and no single error points
+at the missing piece.
+
+**Constraints:**
+
+- You MUST create the resources in this order: customer gateway, target gateway attached to the
+  VPC, route propagation or routes, security group rule, then the VPN connection
+- You MUST confirm each resource before moving to the next
+- You MUST confirm route propagation (or static routes) and the security group rule before declaring the connection ready
+
+## The customer gateway is metadata only
+
+The customer gateway resource in AWS is only metadata: it gives AWS the device's public IP address
+and routing details. Customers read "gateway" and assume creating it configures their device. It
+does not; the device configuration is a separate step the customer owns.
+
+**Constraints:**
+
+- You MUST make clear that the customer gateway resource does not configure the on-premises device
+- You SHOULD point the customer at the applying-the-customer-gateway-device-configuration reference for the device-side work
+
+## Distinct ASNs for a virtual private gateway
+
+When the target gateway is a virtual private gateway, the Autonomous System Number (ASN) on the AWS
+side must differ from the customer gateway ASN, and the gateway must be attached to the VPC before
+anything routes.
+
+**Constraints:**
+
+- You MUST set distinct ASNs on the AWS side and the customer gateway side for a virtual private gateway target
+- You MUST confirm the gateway is attached to the VPC before expecting routes to flow
+
+## Tunnel options at create time
+
+Customers accept the default tunnel options at creation, then later need stronger algorithms and
+discover that modifying tunnel or connection options replaces the tunnel endpoints and interrupts
+connectivity.
+
+**Constraints:**
+
+- You MUST set strong tunnel options (AES-256, SHA-256 or higher, Diffie-Hellman group 14 or higher) at create time, when changing them is free, rather than after the customer is in production
+- You MUST warn that modifying tunnel options later replaces the tunnel endpoints and briefly interrupts the connection
+
+## Troubleshooting
+
+### Connection created but traffic does not flow
+Route propagation or the security group rule is missing. Confirm both (Creation order).
+
+### Connection never establishes on a virtual private gateway
+The AWS-side and customer gateway ASNs match, or the gateway is not attached. Set distinct ASNs and attach (Distinct ASNs).
+
+### Customer waits for AWS to configure their device
+The customer gateway resource is metadata only. The device configuration is the customer's separate step (The customer gateway is metadata only).
+
+### Customer needs more than 1.25 Gbps but built on a virtual private gateway
+Large tunnels need a transit gateway. Rebuild the target gateway on a transit gateway (Decision).
+
+## Procedure
+
+### Overview
+
+This procedure creates the customer gateway, the target gateway, the routing and security group
+configuration, and the VPN connection in the required order, then surfaces the console link to
+verify status and download the device configuration.
+
+### Parameters
+
+- **region** (required): The AWS Region of the VPC or transit gateway.
+- **target_gateway_type** (required): `vgw`, `transit-gateway`, or `cloud-wan`.
+- **vpc_id** (required for a virtual private gateway or transit gateway target): The VPC the gateway attaches to.
+- **transit_gateway_id** (required if using an existing transit gateway): The transit gateway the connection terminates on. If creating a new transit gateway, this is captured from the `create-transit-gateway` response in Step 3.
+- **customer_gateway_ip** (required): The public IP address of the on-premises device.
+- **routing_type** (required): `static` or `dynamic`, settled in the choosing-static-or-dynamic-routing reference.
+- **customer_gateway_asn** (required): The BGP ASN of the customer gateway. `create-customer-gateway` always requires `--bgp-asn`. For dynamic routing, use the real ASN of the on-premises device. For static routing, supply a placeholder (for example, `65000`).
+- **aws_side_asn** (required when creating a new virtual private gateway or transit gateway): The BGP ASN for the AWS side, which must differ from `customer_gateway_asn`. If the customer does not specify one, use the AWS default `64512`.
+- **subnet_ids** (required for a transit gateway target): One subnet ID per Availability Zone for the transit gateway VPC attachment.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask for all required parameters upfront in a single prompt
+- You MUST confirm the routing type is already decided before building
+
+### Steps
+
+#### 1. Verify dependencies
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You SHOULD recommend ephemeral IAM role-based credentials (instance profile, SSO session, or assumed role) rather than long-lived IAM user access keys for running these commands
+- You MUST confirm the VPC (or transit gateway) and the on-premises device public IP exist before building
+
+#### 2. Create the customer gateway
+
+**Constraints:**
+
+- You MUST create the customer gateway describing the on-premises device:
+
+  ```
+  aws ec2 create-customer-gateway --type ipsec.1 --public-ip {customer_gateway_ip} \
+    --bgp-asn {customer_gateway_asn} --region {region}
+  ```
+
+- You MUST capture the `CustomerGatewayId` from the response
+
+#### 3. Create or select the target gateway and attach it
+
+**Constraints:**
+
+- You MUST create the chosen target gateway. For a virtual private gateway, create it and attach it to the VPC:
+
+  ```
+  aws ec2 create-vpn-gateway --type ipsec.1 --amazon-side-asn {aws_side_asn} --region {region}
+  aws ec2 attach-vpn-gateway --vpn-gateway-id {vpn_gateway_id} --vpc-id {vpc_id} --region {region}
+  ```
+
+- For a transit gateway, create it (or select an existing one) and attach it to the VPC. The VPN connection is associated with the transit gateway in Step 5; the VPC attachment carries VPN traffic into the VPC:
+
+  ```
+  aws ec2 create-transit-gateway --options AmazonSideAsn={aws_side_asn} --region {region}
+  aws ec2 create-transit-gateway-vpc-attachment --transit-gateway-id {transit_gateway_id} \
+    --vpc-id {vpc_id} --subnet-ids {subnet_ids} --region {region}
+  ```
+
+- You MUST set an AWS-side ASN distinct from the customer gateway ASN for a virtual private gateway
+
+#### 4. Enable routing and update the security group
+
+**Constraints:**
+
+- You MUST enable route propagation on the subnet route table (or add static routes) so the subnet can reach the on-premises network
+- You MUST update the security group to permit the on-premises traffic
+
+#### 5. Create the VPN connection
+
+**Constraints:**
+
+- You MUST create the connection against the target gateway and customer gateway, with the chosen routing type and tunnel options. For a virtual private gateway target, pass `--vpn-gateway-id`; for a transit gateway target, pass `--transit-gateway-id` instead:
+
+  ```
+  # Virtual private gateway target
+  aws ec2 create-vpn-connection --type ipsec.1 --customer-gateway-id {customer_gateway_id} \
+    --vpn-gateway-id {vpn_gateway_id} \
+    --options "StaticRoutesOnly={true_if_static},TunnelOptions=[{Phase1EncryptionAlgorithms=[{Value=AES256}],Phase2EncryptionAlgorithms=[{Value=AES256}],Phase1IntegrityAlgorithms=[{Value=SHA2-256}],Phase2IntegrityAlgorithms=[{Value=SHA2-256}],Phase1DHGroupNumbers=[{Value=14}],Phase2DHGroupNumbers=[{Value=14}]},{Phase1EncryptionAlgorithms=[{Value=AES256}],Phase2EncryptionAlgorithms=[{Value=AES256}],Phase1IntegrityAlgorithms=[{Value=SHA2-256}],Phase2IntegrityAlgorithms=[{Value=SHA2-256}],Phase1DHGroupNumbers=[{Value=14}],Phase2DHGroupNumbers=[{Value=14}]}]" \
+    --region {region}
+
+  # Transit gateway target
+  aws ec2 create-vpn-connection --type ipsec.1 --customer-gateway-id {customer_gateway_id} \
+    --transit-gateway-id {transit_gateway_id} \
+    --options "StaticRoutesOnly={true_if_static},TunnelOptions=[{Phase1EncryptionAlgorithms=[{Value=AES256}],Phase2EncryptionAlgorithms=[{Value=AES256}],Phase1IntegrityAlgorithms=[{Value=SHA2-256}],Phase2IntegrityAlgorithms=[{Value=SHA2-256}],Phase1DHGroupNumbers=[{Value=14}],Phase2DHGroupNumbers=[{Value=14}]},{Phase1EncryptionAlgorithms=[{Value=AES256}],Phase2EncryptionAlgorithms=[{Value=AES256}],Phase1IntegrityAlgorithms=[{Value=SHA2-256}],Phase2IntegrityAlgorithms=[{Value=SHA2-256}],Phase1DHGroupNumbers=[{Value=14}],Phase2DHGroupNumbers=[{Value=14}]}]" \
+    --region {region}
+  ```
+
+- You MUST set strong tunnel options (AES-256, SHA-256 or higher, Diffie-Hellman group 14 or higher) rather than the AES-128 / SHA-1 / DH group 2 minimums
+- You MUST supply two `TunnelOptions` objects, one per tunnel, since every connection has two tunnels; a single-element array leaves Tunnel 2 on the weak AES-128 / SHA-1 / DH group 2 defaults
+- You SHOULD enable Site-to-Site VPN logs at create time so tunnel establishment and BGP events are captured from the start; see the monitoring-and-troubleshooting-tunnels reference for setup
+
+#### 6. Confirm and surface the console link
+
+**Constraints:**
+
+- You MUST confirm the connection and its tunnels reach the expected state:
+
+  ```
+  aws ec2 describe-vpn-connections --vpn-connection-ids {vpn_connection_id} --region {region}
+  ```
+
+- You MUST present the VPN connection console link, filling `{region}` and `{vpnConnectionId}` from
+  the API response, and tell the customer to open it, confirm the connection, and download the
+  device configuration:
+
+  ```
+  https://console.aws.amazon.com/vpc/home?region={region}#VpnConnectionDetails:VpnConnectionId={vpnConnectionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "region": "us-east-1",
+  "target_gateway_type": "transit-gateway",
+  "vpc_id": "vpc-0abc1234def567890",
+  "subnet_ids": ["subnet-0abc1234def567890", "subnet-0fed9876cba543210"],
+  "aws_side_asn": 64512,
+  "customer_gateway_ip": "203.0.113.10",
+  "routing_type": "dynamic",
+  "customer_gateway_asn": 65010
+}
+```
+
+#### Example output
+
+```
+Created customer gateway (203.0.113.10, ASN 65010) and the VPN connection on the transit gateway,
+dynamic routing. Route propagation enabled and the security group updated.
+Open the VPN connection in the console, confirm both tunnels, and download the device configuration:
+https://console.aws.amazon.com/vpc/home?region=us-east-1#VpnConnectionDetails:VpnConnectionId=vpn-0abc1234def567890
+```
+
+### Troubleshooting
+
+#### Traffic does not flow after creation
+Route propagation or the security group rule is missing. Confirm both (Step 4).
+
+#### Connection never establishes on a virtual private gateway
+ASNs match or the gateway is not attached. Set distinct ASNs and attach (Step 3).
+
+#### Customer expects AWS to configure their device
+The customer gateway is metadata. Hand off to the applying-the-customer-gateway-device-configuration reference.
+
+## Security Considerations
+
+Creating the connection sets the authentication and encryption posture the tunnels run with, so the
+security choices belong at create time, when changing them is free.
+
+**Constraints:**
+
+- You MUST treat tunnel pre-shared keys (PSKs) as secrets: never pass them on the command line or store them in plaintext, store them in AWS Secrets Manager, and rotate them periodically; where the device supports it, recommend certificate-based authentication with AWS Private Certificate Authority instead of a static PSK
+- You MUST set strong tunnel options (AES-256, SHA-256 or higher, Diffie-Hellman group 14 or higher) rather than the AES-128 / SHA-1 / DH group 2 minimums
+- You MUST scope the security group rule to the specific on-premises CIDR blocks and protocols the
+  workload needs, not `0.0.0.0/0`
+- You SHOULD enable Amazon CloudWatch tunnel-state alarms and Site-to-Site VPN logs, and confirm AWS CloudTrail is enabled so the API calls that create, modify, or delete the connection are audited (see the monitoring-and-troubleshooting-tunnels reference). You MUST enable encryption at rest on every log destination — KMS on the CloudWatch Logs log group holding the VPN/tunnel logs and SSE-S3 or SSE-KMS on the S3 bucket holding the CloudTrail logs — since these logs can carry tunnel and connection detail
+
+## Additional Resources
+
+- [Get started with AWS Site-to-Site VPN (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/SetUpVPNConnections.html)
+- [Create an AWS Site-to-Site VPN connection (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/create-vpn-connection.html)
+- [AWS Site-to-Site VPN single and multiple VPN connection examples (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/Examples.html)
+- [AWS Site-to-Site VPN customer gateway devices (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/your-cgw.html)
+- [Tunnel options for your AWS Site-to-Site VPN connection (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPNTunnels.html)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/making-a-connection-highly-available.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/making-a-connection-highly-available.md
@@ -1,0 +1,214 @@
+# Making a Site-to-Site VPN Connection Highly Available
+
+## Overview
+
+Domain expertise for keeping an AWS Site-to-Site VPN connection up through tunnel maintenance and
+on-premises device failure. Covers configuring the on-premises device to use both tunnels (which is
+free), the BGP attribute settings that let AWS steer traffic to the healthy tunnel during endpoint
+updates, the second-connection-on-a-second-device pattern for surviving device failure (which adds
+cost), and the matching-advertisement requirement for clean failover.
+
+Does not cover the routing-type decision (the choosing-static-or-dynamic-routing reference) or
+monitoring (the monitoring-and-troubleshooting-tunnels reference). Assumes a connection exists (the
+creating-a-site-to-site-vpn-connection reference).
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. Pass `--region {region}` matching the connection.
+
+## Table of Contents
+
+- Overview
+- Workflow
+- Both tunnels first, at no extra cost
+- BGP attributes for tunnel-update steering
+- Second device for device failure, at added cost
+- Matching advertisements for clean failover
+- Troubleshooting
+- Procedure
+- Security Considerations
+- Additional Resources
+
+## Workflow
+
+To make the connection highly available, configure both tunnels on the device, set matching BGP
+attributes, and decide whether a second connection on a second device is warranted. See the
+Procedure section below.
+
+The procedure covers:
+
+- Confirming both tunnels are configured on the on-premises device
+- Setting matching Weight and Local Preference so AWS steering is honored
+- Deciding whether to add a second connection on a second device for device-failure resilience
+- Configuring both devices to advertise the same prefixes over BGP
+
+## Both tunnels first, at no extra cost
+
+Each connection provides two tunnels in different Availability Zones, but the redundancy only works
+if the device is configured to use both, and customers commonly configure only one. There is no
+added charge for using both tunnels: the VPN connection price covers both.
+
+**Constraints:**
+
+- You MUST treat configuring both tunnels as required, not optional
+- You SHOULD reassure the customer there is no extra cost for the second tunnel; the connection price covers both
+
+## BGP attributes for tunnel-update steering
+
+AWS applies tunnel endpoint updates one tunnel at a time and steers traffic to the healthy tunnel
+using a lower multi-exit discriminator (MED) value. That steering only takes effect if the device
+uses the same Weight and Local Preference for both tunnels; different values override the AWS
+preference and send traffic into the tunnel being updated.
+
+**Constraints:**
+
+- You MUST set matching Weight and Local Preference on both tunnels so the AWS failover signal is honored
+- You SHOULD explain that mismatched attributes send traffic into the tunnel AWS is taking down for maintenance
+
+## Second device for device failure, at added cost
+
+Two tunnels protect against an AWS-side device failure, but not against the customer's own gateway
+device failing. Surviving the loss of the on-premises device requires a second VPN connection on a
+separate customer gateway device. This is a real added cost: each connection bills per
+connection-hour, so a redundant pair roughly doubles the connection charge.
+
+**Constraints:**
+
+- You MUST explain what a single connection does and does not protect against before the customer relies on it for production
+- You MUST name the added cost of a second connection, in contrast to the free second tunnel
+- You SHOULD frame the second device as a deliberate cost-for-resilience tradeoff
+
+## Matching advertisements for clean failover
+
+A redundant pair only fails over cleanly when both devices advertise the same prefixes to the
+target gateway, and BGP is what detects the failure and reroutes. Mismatched prefixes or static
+routing produce a setup that does not fail over as expected.
+
+**Constraints:**
+
+- You MUST configure both devices to advertise the same prefixes to the target gateway
+- You SHOULD steer the customer toward BGP for the failure detection that drives failover
+
+## Troubleshooting
+
+### Connection drops during AWS maintenance
+Only one tunnel is configured. Configure both (Both tunnels first).
+
+### Traffic goes into the tunnel being updated
+Weight and Local Preference differ between tunnels. Set them equal (BGP attributes for tunnel-update steering).
+
+### Connection still drops when the on-premises device fails
+A single connection does not cover device failure. Add a second connection on a second device (Second device for device failure).
+
+### Redundant pair does not fail over cleanly
+The two devices advertise mismatched prefixes, or static routing is in use. Advertise the same prefixes over BGP (Matching advertisements).
+
+## Procedure
+
+### Overview
+
+This procedure confirms both tunnels are used, sets matching BGP attributes, and optionally adds a
+second connection on a second device with matching advertisements, then surfaces the console link to
+verify tunnel status.
+
+### Parameters
+
+- **region** (required): The AWS Region of the connection.
+- **vpn_connection_id** (required): The primary connection.
+- **needs_device_failover** (required): Whether the customer must survive the loss of the on-premises device.
+- **second_customer_gateway_ip** (required if needs_device_failover): The public IP of the second device.
+
+**Constraints for parameter acquisition:**
+
+- You MUST establish whether device-failure resilience is needed, since it changes the cost
+- You SHOULD confirm the connection uses BGP, since clean failover depends on it
+
+### Steps
+
+#### 1. Confirm both tunnels are used
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You SHOULD recommend ephemeral IAM role-based credentials (instance profile, SSO session, or assumed role) rather than long-lived IAM user access keys for running these commands
+- You MUST confirm the on-premises device is configured to use both tunnels, at no extra cost
+
+#### 2. Set matching BGP attributes
+
+**Constraints:**
+
+- You MUST set the same Weight and Local Preference on both tunnels so AWS steering during endpoint updates is honored
+
+#### 3. Decide on a second device
+
+**Constraints:**
+
+- You MUST explain that two tunnels do not cover device failure, and a second connection on a second device does, at roughly double the connection cost
+- You SHOULD proceed to add the second connection only if the customer accepts the cost for device-failure resilience
+
+#### 4. Configure matching advertisements and confirm
+
+**Constraints:**
+
+- You MUST configure both devices to advertise the same prefixes over BGP if a second connection is added
+- You MUST present the VPN connections console link, filling `{region}` from the request, and tell the customer to open it and confirm both connections and all tunnels:
+
+  ```
+  https://console.aws.amazon.com/vpc/home?region={region}#VpnConnections:
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "region": "us-east-1",
+  "vpn_connection_id": "vpn-0abc1234def567890",
+  "needs_device_failover": true,
+  "second_customer_gateway_ip": "203.0.113.20"
+}
+```
+
+#### Example output
+
+```
+Both tunnels configured on the primary device (no extra cost), with matching Weight and Local
+Preference so AWS steering is honored. Customer accepted the added cost for device-failure
+resilience: added a second connection on 203.0.113.20, both devices advertising the same prefixes over
+BGP. Open the connections list and confirm both connections and all tunnels:
+https://console.aws.amazon.com/vpc/home?region=us-east-1#VpnConnections:
+```
+
+### Troubleshooting
+
+#### Drops during maintenance
+Only one tunnel configured. Configure both (Step 1).
+
+#### Traffic enters the tunnel being updated
+Mismatched Weight and Local Preference. Set them equal (Step 2).
+
+#### Device failure takes the connection down
+Add a second connection on a second device (Step 3).
+
+#### Redundant pair fails over poorly
+Advertise the same prefixes over BGP on both devices (Step 4).
+
+## Security Considerations
+
+High availability adds tunnels and, with a second device, a second connection, each with its own
+authentication secrets, so the redundant path must hold the same security posture as the primary.
+
+**Constraints:**
+
+- You MUST set strong tunnel options (AES-256, SHA-256 or higher, Diffie-Hellman group 14 or higher) rather than the AES-128 / SHA-1 / DH group 2 minimums. Apply them to both tunnels and, where a second connection is added, to that connection too, so failover never lands on a weaker tunnel
+- You MUST treat tunnel pre-shared keys (PSKs) as secrets: never pass them on the command line or store them in plaintext, store them in AWS Secrets Manager, and rotate them periodically; where the device supports it, recommend certificate-based authentication with AWS Private Certificate Authority instead of a static PSK. Use a distinct key per tunnel and per connection rather than reusing one key across the redundant pair
+- You SHOULD enable Amazon CloudWatch tunnel-state alarms and Site-to-Site VPN logs, and confirm AWS CloudTrail is enabled so the API calls that create, modify, or delete the connection are audited (see the monitoring-and-troubleshooting-tunnels reference). You MUST enable encryption at rest on every log destination — KMS on the CloudWatch Logs log group holding the VPN/tunnel logs and SSE-S3 or SSE-KMS on the S3 bucket holding the CloudTrail logs — since these logs can carry tunnel and connection detail
+- You SHOULD confirm both devices advertise only the intended prefixes over BGP so a failover does not
+  expose prefixes the primary path would not
+
+## Additional Resources
+
+- [Resilience in AWS Site-to-Site VPN (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/disaster-recovery-resiliency.html)
+- [Redundant AWS Site-to-Site VPN connections for failover (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/vpn-redundant-connection.html)
+- [Routing during VPN tunnel endpoint updates (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/routing-vpn-tunnel-updates.html)
+- [AWS VPN Pricing](https://aws.amazon.com/vpn/pricing/)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/monitoring-and-troubleshooting-tunnels.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/sitetositevpn/references/monitoring-and-troubleshooting-tunnels.md
@@ -1,0 +1,282 @@
+# Monitoring Tunnel State and Troubleshooting a Down Tunnel
+
+## Overview
+
+Domain expertise for detecting and diagnosing AWS Site-to-Site VPN tunnel failures with Amazon
+CloudWatch. Covers the `TunnelState` metric and how it reads differently for static versus BGP
+connections, building alarms that notify an Amazon Simple Notification Service (SNS) topic, enabling
+and reading Site-to-Site VPN logs to find the cause, why the data metrics are not a liveness signal,
+and the CloudWatch cost consideration. This reference covers tunnel state and VPN logs; AWS CloudTrail
+captures the API-level events such as connection creation and modification.
+
+Does not cover building the connection or its high availability (other references). Assumes a
+connection exists (the creating-a-site-to-site-vpn-connection reference).
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. Pass `--region {region}` matching the connection.
+
+## Table of Contents
+
+- Overview
+- Workflow
+- TunnelState reads differently by routing type
+- Wiring a working alarm
+- VPN logs name the cause
+- Data metrics are not liveness
+- CloudWatch cost
+- Troubleshooting
+- Procedure
+- Security Considerations
+- Additional Resources
+
+## Workflow
+
+To detect and diagnose tunnel failures, set the right alarm against the connection's routing type,
+wire it to an SNS topic, and enable VPN logs to find the cause when a tunnel drops. See the
+Procedure section below.
+
+The procedure covers:
+
+- Determining the routing type so the `TunnelState` threshold is correct
+- Creating the alarm with the right metric, statistic, threshold, and SNS topic
+- Enabling Site-to-Site VPN logs to CloudWatch Logs
+- Reading the logs for the IKE or BGP detail that names the cause
+
+## TunnelState reads differently by routing type
+
+The `TunnelState` metric does not read the same way for both routing types. For static VPNs, 0 is
+DOWN and 1 is UP. For BGP VPNs, 1 means ESTABLISHED and values between 0 and 1 mean at least one
+tunnel is not up. An alarm threshold set without knowing this misfires or stays silent during a real
+outage.
+
+**Constraints:**
+
+- You MUST set the alarm threshold against the customer's actual routing type
+- You SHOULD confirm whether the connection is static or BGP before configuring the alarm
+
+## Wiring a working alarm
+
+A working alarm needs the right metric, statistic, threshold, and an SNS topic wired together, and
+the statistic depends on the alarm scope: alarming when any tunnel drops versus only when all
+tunnels are down versus watching one specific tunnel.
+
+**Constraints:**
+
+- You MUST sequence the alarm setup: metric, statistic, threshold, then SNS topic
+- You MUST pick the statistic that matches the scope: `Minimum` for any-tunnel-down, `Maximum` for all-tunnels-down, or the `TunnelIpAddress` dimension for a single tunnel
+- You SHOULD confirm the SNS topic has a confirmed subscription so the notification actually reaches someone
+- You MUST encrypt the CloudWatch Logs group that receives Site-to-Site VPN logs with an AWS KMS key and enable server-side encryption on the SNS topic, and MUST verify that all SNS topic subscribers are authorized operations personnel
+
+## VPN logs name the cause
+
+When a tunnel is down the metric says it is down but not why, and customers spend time guessing at
+IKE, dead peer detection, or BGP causes. Site-to-Site VPN logs published to CloudWatch Logs carry
+the tunnel establishment and BGP detail that names the cause, but they must be enabled first.
+
+**Constraints:**
+
+- You MUST enable the VPN logs and point the customer at the fields that explain the failure, rather than leaving them to guess
+- You SHOULD enable logs before an incident where possible, since they only capture events after they are turned on
+
+## Data metrics are not liveness
+
+The `TunnelDataIn` and `TunnelDataOut` metrics can report traffic even when a tunnel is down,
+because of periodic status checks and background BGP and ARP requests. Customers who watch data
+volume as a health signal conclude the tunnel is fine when it is not.
+
+**Constraints:**
+
+- You MUST rely on `TunnelState` for health and treat the data metrics as usage, not liveness
+- You SHOULD correct the customer if they propose alarming on data volume as a health signal
+
+## CloudWatch cost
+
+Site-to-Site VPN does not charge for metrics or logs, but the CloudWatch metrics, alarms, and logs
+themselves bill at standard CloudWatch rates. Turning on detailed monitoring and log delivery across
+every connection adds up.
+
+**Constraints:**
+
+- You MUST note the CloudWatch cost so the customer makes the tradeoff knowingly
+- You SHOULD suggest enabling full metrics, alarms, and logs for production VPNs while trimming them for test and development workloads
+
+## Troubleshooting
+
+### Alarm never fires during an outage, or fires constantly
+The threshold does not match the routing type. Set it against static (0/1) or BGP (1 = established) (TunnelState reads differently by routing type).
+
+### Alarm fires but no one is notified
+The SNS topic has no confirmed subscription. Confirm the subscription (Wiring a working alarm).
+
+### Tunnel is down and the cause is unknown
+VPN logs are not enabled. Enable them and read the IKE and BGP detail (VPN logs name the cause).
+
+### Tunnel looks healthy by data volume but is actually down
+Data metrics report background traffic. Use `TunnelState` for health (Data metrics are not liveness).
+
+## Procedure
+
+### Overview
+
+This procedure determines the routing type, creates a correctly-thresholded alarm wired to an SNS
+topic, and enables VPN logs, then surfaces the connection console link to verify tunnel status.
+
+### Parameters
+
+- **region** (required): The AWS Region of the connection.
+- **vpn_connection_id** (required): The connection to monitor.
+- **routing_type** (required): `static` or `dynamic` (BGP), to set the threshold correctly.
+- **scope** (required): one of `any-tunnel-down`, `all-tunnels-down`, or `single-tunnel`, to pick
+  the statistic and dimension (see Step 2). `any-tunnel-down` pages when either tunnel of the
+  connection drops (redundancy health); `all-tunnels-down` pages only when the whole connection is
+  lost; `single-tunnel` watches one specific tunnel by its outside IP.
+- **sns_topic_arn** (required): The SNS topic to notify.
+- **kms_key_arn** (required): The AWS KMS key ARN used to encrypt the CloudWatch Logs group that receives VPN logs.
+- **tunnel_outside_ips** (required): The outside IP addresses of the VPN tunnels (one per tunnel, obtained from `describe-vpn-connections`).
+- **environment** (optional): `staging` or `test`, to weigh the CloudWatch cost.
+
+**Constraints for parameter acquisition:**
+
+- You MUST establish the routing type and alarm scope upfront
+- You MUST verify that all SNS topic subscribers are authorized operations personnel
+- You SHOULD confirm the SNS topic exists and has a confirmed subscription
+
+### Steps
+
+#### 1. Determine routing type and threshold
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You SHOULD recommend ephemeral IAM role-based credentials (instance profile, SSO session, or assumed role) rather than long-lived IAM user access keys for running these commands
+- You MUST set the `TunnelState` threshold against the routing type: static is 0 DOWN / 1 UP; BGP is 1 ESTABLISHED, 0 to 1 means a tunnel is not up
+
+#### 2. Create the alarm
+
+**Constraints:**
+
+- You MUST create the alarm with the right metric, statistic for the scope, threshold, and SNS topic:
+
+  ```
+  aws cloudwatch put-metric-alarm --alarm-name s2s-vpn-tunnel-down-{vpn_connection_id}-{scope} \
+    --namespace AWS/VPN --metric-name TunnelState --dimensions Name=VpnId,Value={vpn_connection_id} \
+    --statistic Maximum --threshold 1 --comparison-operator LessThanThreshold \
+    --period 300 --evaluation-periods 1 --treat-missing-data breaching \
+    --alarm-actions {sns_topic_arn} --region {region}
+  ```
+
+- You MUST verify that all SNS topic subscribers are authorized operations personnel before wiring the topic to the alarm
+- You MUST verify the SNS topic has server-side encryption enabled before wiring it to the alarm, checking that `KmsMasterKeyId` is set on the topic:
+
+  ```
+  aws sns get-topic-attributes --topic-arn {sns_topic_arn} --region {region}
+  ```
+
+- You MUST set `--treat-missing-data breaching` so the alarm fires rather than going to INSUFFICIENT_DATA when a down tunnel stops reporting metrics
+- You MUST include both `{vpn_connection_id}` and `{scope}` in the alarm name so each
+  connection-and-scope alarm is unique; `put-metric-alarm` is an upsert, so a name without the scope
+  would let a second alarm on the same connection (for example an `any-tunnel-down` alarm added
+  alongside an `all-tunnels-down` alarm) silently overwrite the first, and a name without the
+  connection id would collide across connections (for example the second leg of an HA pair)
+- You MUST pick the statistic and dimension that match the requested `scope`. With the `Name=VpnId`
+  dimension, `TunnelState` aggregates across both tunnels of the connection, so the statistic
+  selects which aggregate you alarm on:
+
+  | `scope` | Intent | Statistic | Dimension |
+  | --- | --- | --- | --- |
+  | `any-tunnel-down` | Page when either tunnel drops (redundancy health) | `Minimum` (falls below 1 as soon as one tunnel is down) | `Name=VpnId` |
+  | `all-tunnels-down` | Page only when the whole connection is lost | `Maximum` (falls below 1 only when no tunnel is up) | `Name=VpnId` |
+  | `single-tunnel` | Watch one specific tunnel | statistic does not matter (already one tunnel) | `Name=VpnId` plus `Name=TunnelIpAddress,Value={tunnel_outside_ip}` |
+
+  The example below uses `Maximum` (the `all-tunnels-down` scope), which alarms only on full
+  connection loss; switch to `Minimum` for `any-tunnel-down` to be paged the moment either tunnel
+  drops, or add the `TunnelIpAddress` dimension for `single-tunnel`
+
+#### 3. Enable VPN logs
+
+**Constraints:**
+
+- You MUST create the CloudWatch Logs group with AWS KMS encryption, then enable log delivery to it on each tunnel so a future down tunnel can be diagnosed. `create-log-group` does not return an ARN, so construct the log group ARN as `arn:aws:logs:{region}:{account_id}:log-group:/aws/vpn/{vpn_connection_id}:*` (or retrieve it with `describe-log-groups`), and run `modify-vpn-tunnel-options` once per tunnel outside IP, since each connection has two tunnels:
+
+  ```
+  aws logs create-log-group --log-group-name /aws/vpn/{vpn_connection_id} \
+    --kms-key-id {kms_key_arn} --region {region}
+  # Repeat for each address in {tunnel_outside_ips}
+  aws ec2 modify-vpn-tunnel-options --vpn-connection-id {vpn_connection_id} \
+    --vpn-tunnel-outside-ip-address {tunnel_outside_ip} \
+    --tunnel-options "LogOptions={CloudwatchLogOptions={LogEnabled=true,LogGroupArn={log_group_arn},LogOutputFormat=json}}" \
+    --region {region}
+  ```
+
+- You MUST warn the customer that `modify-vpn-tunnel-options` briefly renegotiates and interrupts the affected tunnel while the change is applied; on a production connection, enable logs one tunnel at a time and confirm the first tunnel is back up before modifying the second, so the connection is never fully down
+- You SHOULD point the customer at the IKE and BGP fields that name the cause
+
+#### 4. Confirm and surface the console link
+
+**Constraints:**
+
+- You MUST present the VPN connection console link, filling `{region}` and `{vpnConnectionId}` from the request, and tell the customer to open it and confirm tunnel status:
+
+  ```
+  https://console.aws.amazon.com/vpc/home?region={region}#VpnConnectionDetails:VpnConnectionId={vpnConnectionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "region": "us-east-1",
+  "vpn_connection_id": "vpn-0abc1234def567890",
+  "routing_type": "dynamic",
+  "scope": "all-tunnels-down",
+  "sns_topic_arn": "arn:aws:sns:us-east-1:111122223333:vpn-alerts",
+  "kms_key_arn": "arn:aws:kms:us-east-1:111122223333:key/abcd1234-ef56-7890-abcd-1234567890ab",
+  "tunnel_outside_ips": ["198.51.100.10", "198.51.100.11"],
+  "environment": "staging"
+}
+```
+
+#### Example output
+
+```
+BGP connection: TunnelState threshold set to alarm below 1 (established). all-tunnels-down alarm
+(Maximum statistic, VpnId dimension) wired to the vpn-alerts SNS topic. VPN logs enabled to a KMS-encrypted CloudWatch Logs group on both
+tunnels (198.51.100.10, 198.51.100.11) for cause diagnosis. Noted CloudWatch cost is justified for
+the staging workload. Open the connection to confirm tunnel status:
+https://console.aws.amazon.com/vpc/home?region=us-east-1#VpnConnectionDetails:VpnConnectionId=vpn-0abc1234def567890
+```
+
+### Troubleshooting
+
+#### Alarm misfires or stays silent
+Threshold does not match routing type. Set it against static or BGP (Step 1).
+
+#### No notification on alarm
+SNS topic has no confirmed subscription. Confirm it (Step 2).
+
+#### Cause of a down tunnel is unknown
+Enable VPN logs and read the IKE and BGP fields (Step 3).
+
+#### Healthy by data volume but down
+Use `TunnelState`, not data metrics, for health (Data metrics are not liveness).
+
+## Security Considerations
+
+VPN logs and tunnel state changes expose infrastructure detail (peer IPs, BGP and IKE events), so the
+monitoring path is itself sensitive and must be access-controlled.
+
+**Constraints:**
+
+- You MUST encrypt the CloudWatch Logs group that receives Site-to-Site VPN logs with an AWS KMS key and enable server-side encryption on the SNS topic, and MUST verify that all SNS topic subscribers are authorized operations personnel
+- You SHOULD apply a least-privilege retention and access policy to the log group so only authorized
+  personnel can read tunnel and BGP detail
+
+## Additional Resources
+
+- [Monitor AWS Site-to-Site VPN tunnels using Amazon CloudWatch (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/monitoring-cloudwatch-vpn.html)
+- [Create Amazon CloudWatch alarms to monitor AWS Site-to-Site VPN tunnels (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/creating-alarms-vpn.html)
+- [AWS Site-to-Site VPN logs (AWS Site-to-Site VPN User Guide)](https://docs.aws.amazon.com/vpn/latest/s2svpn/monitoring-logs.html)
+- [AWS VPN Pricing](https://aws.amazon.com/vpn/pricing/)
+- [Setting up of AWS Site-to-Site VPN automated monitoring solution (AWS Networking & Content Delivery Blog)](https://aws.amazon.com/blogs/networking-and-content-delivery/setting-up-of-aws-site-to-site-vpn-automated-monitoring-solution/)


### PR DESCRIPTION
Adds the `sitetositevpn` specialized skill under `skills/specialized-skills/networking-and-content-delivery-skills/`.

Part of the AWS Networking Skills launch — promoting `sitetositevpn` to production. SKILL.md router + reference procedures, mirroring the version in the internal AWS MCP skills registry (AWSMCPSOPs). Public `name`/`description`/`version` frontmatter per repo convention.

Text-only skill (no executable code); security-reviewed (Guardian PASS).