### PR TITLE
docs: Add AWS CLI quick start section as the first entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Agent Toolkit for AWS gives AI coding agents the tools, knowledge, and guard
 Use the Agent Toolkit directly from your terminal with the AWS CLI:
 
 ```
-aws agent-toolkit chat
+aws configure agent-toolkit
 ```
 
 See the [AWS CLI integration guide](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/aws-cli.html) for setup, configuration, and usage instructions.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ The Agent Toolkit for AWS gives AI coding agents the tools, knowledge, and guard
 
 ## Quick start
 
+### AWS CLI
+
+Use the Agent Toolkit directly from your terminal with the AWS CLI:
+
+```
+aws agent-toolkit chat
+```
+
+See the [AWS CLI integration guide](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/aws-cli.html) for setup, configuration, and usage instructions.
+
 ### Claude Code
 
 The plugins are available on the official Anthropic marketplace (`claude-plugins-official`) which is added to your Claude Code installation by default.


### PR DESCRIPTION
## Description
Add AWS CLI as the first entry in the Quick start section. The AWS CLI is the simplest entry point (single command, no plugin setup), so it now leads the Quick start before the coding agent integrations.
  
## Type of Change
 - [ ] New plugin
 - [ ] New skill
 - [ ] Bug fix
  - [x] Documentation update
  - [ ] CI/CD change
  - [ ] Other
  
## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation
  
  *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*