### PR TITLE
feat(database-skills): Add rds-oss skill (Amazon RDS for MySQL, MariaDB, PostgreSQL)

### DIFF
--- a/skills/specialized-skills/database-skills/rds-oss/SKILL.md
+++ b/skills/specialized-skills/database-skills/rds-oss/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: rds-oss
+version: 1
+description: Advises on Amazon RDS open-source engines (MySQL, MariaDB, PostgreSQL) for instance creation, upgrade planning, commitment pricing, proxy evaluation, and Blue/Green deployments. Handles any RDS MySQL, MariaDB, or PostgreSQL question, including create a production-ready RDS MySQL instance, provision an RDS PostgreSQL database, run the RDS upgrade advisor for my RDS MySQL instance, what are my upgrade options, upgrade RDS MariaDB from 10.6 to the latest version, should I buy reserved instances or a savings plan for db.r7g.2xlarge RDS MySQL, change a VARCHAR to INT column on RDS MySQL 8.0 with Blue/Green, and does RDS Proxy help when PgBouncer already runs in transaction mode. Covers instance creation with production best practices, describe-db-instances and describe-db-engine-versions upgrade-target workflow, live prechecks via SSM or direct connection, RI versus DSP commitment pricing, RDS Proxy versus PgBouncer, and Blue/Green lifecycle with binlog replay compatibility.
+---
+
+# RDS OSS Advisor (MySQL, MariaDB, PostgreSQL)
+
+## Overview
+
+Advisor for Amazon RDS on the open-source engines — **MySQL**, **MariaDB**, and **PostgreSQL**. Five decision areas:
+
+1. **Instance creation** — provision production-ready instances with best-practice defaults (latest version, Multi-AZ, encryption, Performance Insights, Secrets Manager password management)
+2. **Upgrade planning** — identify instance, enumerate targets, run live prechecks, flag plan regressions, surface pre/post checklists
+3. **Commitment pricing** — estimate RI and Database Savings Plan savings for steady workloads
+4. **RDS Proxy evaluation** — decide whether proxy is worth it, based on connection utilization and pinning risks
+5. **Blue/Green deployments** — plan low-downtime DDL or major upgrades, with DDL compatibility analysis
+
+Produces cost estimates, precheck findings, and CLI commands. For instance creation, executes the create-db-instance call with production best practices. For upgrades, purchases, and switchovers — advisory only, never executes without explicit user confirmation.
+
+Scoped to RDS open-source engines. For Aurora, use `amazon-aurora`. For Oracle, SQL Server, Db2, use the engine-specific skills.
+
+The AWS MCP server is recommended for executing commands but is not required; all operations can also be performed via the AWS CLI.
+
+## Decision Guide
+
+| User asks about… | Go to |
+|---|---|
+| Create, provision, or set up a new RDS MySQL/MariaDB/PostgreSQL instance | [Production Instance Creation](#production-instance-creation) below |
+| Upgrade, target version, pre/post-upgrade checklist, upgrade prechecks, Read Replica upgrade order | [references/upgrade-workflow.md](references/upgrade-workflow.md) |
+| Reserved Instance, RI, Database Savings Plan, DSP, 1yr vs 3yr, Multi-AZ commitment, No/Partial/All Upfront | [references/commitment-pricing-workflow.md](references/commitment-pricing-workflow.md) |
+| RDS Proxy, connection pooling, too many connections, Lambda DB connections, proxy pinning, PgBouncer vs Proxy | [references/proxy-advisor-workflow.md](references/proxy-advisor-workflow.md) |
+| Blue/Green, zero-downtime DDL, switchover, schema change with minimal downtime, type change on production | [references/bluegreen-advisor-workflow.md](references/bluegreen-advisor-workflow.md) |
+
+Broad request ("help me with RDS")? Present the five options as one line each. If the user supplied an instance ID, offer a general health check (engine + version + connection utilization) as entry point.
+
+Out-of-scope (Aurora, Oracle, SQL Server, Db2, backup policy, Performance Insights deep-dive analysis): answer from general knowledge, note this skill doesn't cover it, point to the right engine-specific skill.
+
+## RDS vs Aurora — Do Not Confuse
+
+RDS open-source engines and Aurora are different products with different semantics. You MUST NOT apply Aurora concepts to RDS:
+
+| Concept | RDS (this skill) | Aurora (use `amazon-aurora`) |
+|---|---|---|
+| LTS releases | ❌ Does not exist | ✅ Has LTS versions |
+| Serverless mode | ❌ Does not exist | ✅ Aurora Serverless |
+| I/O-Optimized storage | ❌ Does not exist | ✅ aurora-iopt1 |
+| Data API | ❌ Not available for standalone RDS | ✅ Aurora Serverless clusters |
+| Instance topology | Instance-based (`describe-db-instances`) | Cluster-based (`describe-db-clusters`) |
+| Upgrade scope | Per-instance | Per-cluster (writer + readers together) |
+| DSP term options | 1yr and 3yr | 1yr only |
+| Pricing model | On-Demand + RI + DSP | On-Demand + RI + DSP + I/O pricing |
+
+If a user asks about any Aurora-specific concept, route to `amazon-aurora`. If an instance turns out to be Aurora (engine = `aurora-mysql` or `aurora-postgresql`), stop and redirect.
+
+## Production Instance Creation
+
+When a user asks to create or provision a new RDS MySQL, MariaDB, or PostgreSQL instance for production use, you MUST apply the following best practices by default:
+
+1. **Use the latest stable major version** — run `aws rds describe-db-engine-versions --engine <engine> --query "DBEngineVersions[].EngineVersion"` to find the latest. For MySQL, prefer 8.4.x over 8.0 (8.0 has an earlier end-of-standard-support date than 8.4 — see [RDS Extended Support](https://aws.amazon.com/rds/extended-support/) for dates). For PostgreSQL, use the latest major. For MariaDB, use the latest major.
+2. **Enable Multi-AZ** — set `--multi-az` for automatic failover.
+3. **Enable storage encryption using a customer-managed KMS key** — set `--storage-encrypted --kms-key-id <key-arn>`. A customer-managed key gives full control over key rotation, access policies, and cross-account sharing.
+4. **Disable public access** — set `--no-publicly-accessible` to ensure the instance is not accessible from the internet.
+5. **Set backup retention to 7 days** — set `--backup-retention-period 7`.
+6. **Enable Performance Insights with 7-day retention** — set `--enable-performance-insights --performance-insights-retention-period 7`. If Performance Insights captures queries containing sensitive data (e.g., literal values in WHERE clauses), specify `--performance-insights-kms-key-id <key-arn>` to encrypt at rest with a customer-managed KMS key.
+7. **Enable deletion protection** — set `--deletion-protection`.
+8. **Avoid default master usernames** — do NOT use well-known names like `admin`, `root`, `postgres`, or `master`, which make credential-guessing attacks easier. Choose a custom `--master-username` (e.g., an application- or team-specific name).
+9. **Manage master password via Secrets Manager** — set `--manage-master-user-password` instead of providing a plaintext `--master-user-password`. This creates and rotates the password automatically in Secrets Manager. Do NOT accept or use a plaintext password for production instances.
+10. **Use gp3 storage** — set `--storage-type gp3`. It's cheaper and faster than gp2 with no minimum IOPS purchase.
+11. **Tag the instance so customers can identify resources created via this skill** — set `--tags Key=created_by,Value=rds-oss-skill Key=generation_model,Value={your-model-id}` (see Resource tagging below).
+12. **Enforce TLS for connections in transit** — create or modify the DB parameter group to require encrypted connections: `require_secure_transport=ON` for MySQL/MariaDB, `rds.force_ssl=1` for PostgreSQL.
+13. **Export database logs to CloudWatch Logs and encrypt with KMS** — set `--enable-cloudwatch-logs-exports` so database-level security events (failed logins, suspicious queries) are centrally visible. Use `["error","slowquery","audit"]` for MySQL/MariaDB (note: the `audit` stream requires audit logging to be enabled first, otherwise it is empty — on RDS MySQL via the MARIADB_AUDIT_PLUGIN in an Option Group, on RDS MariaDB via the built-in server audit parameters such as `server_audit_logging=1` in a parameter group) and `["postgresql"]` for PostgreSQL. Database logs can contain SQL with literal values and usernames, so you MUST configure a KMS key on the resulting `/aws/rds/instance/<name>/*` log groups to protect sensitive data at rest.
+
+**Example CLI (MySQL 8.4, production-ready):**
+
+```bash
+aws rds create-db-instance \
+  --db-instance-identifier <name> \
+  --engine mysql \
+  --engine-version 8.4 \
+  --db-instance-class <class> \
+  --allocated-storage 100 \
+  --storage-type gp3 \
+  --storage-encrypted \
+  --kms-key-id <kms-key-arn> \
+  --no-publicly-accessible \
+  --multi-az \
+  --manage-master-user-password \
+  --master-username <custom-non-default-username> \
+  --backup-retention-period 7 \
+  --enable-performance-insights \
+  --performance-insights-retention-period 7 \
+  --performance-insights-kms-key-id <kms-key-arn> \
+  --deletion-protection \
+  --enable-cloudwatch-logs-exports '["error","slowquery","audit"]' \
+  --tags Key=created_by,Value=rds-oss-skill Key=generation_model,Value=<your-model-id> \
+  --region us-east-1
+```
+
+After instance creation, run the following commands to configure TLS enforcement and log group encryption (these are user-executed steps that the skill presents but does not invoke directly):
+```bash
+# Create a custom parameter group with TLS enforcement (MySQL example)
+aws rds create-db-parameter-group --db-parameter-group-family mysql8.4 \
+  --db-parameter-group-name <name>-tls --description "TLS enforced"
+aws rds modify-db-parameter-group --db-parameter-group-name <name>-tls \
+  --parameters "ParameterName=require_secure_transport,ParameterValue=ON,ApplyMethod=pending-reboot"
+aws rds modify-db-instance --db-instance-identifier <name> \
+  --db-parameter-group-name <name>-tls --apply-immediately
+
+# Encrypt CloudWatch Logs log groups with KMS
+aws logs associate-kms-key --log-group-name /aws/rds/instance/<name>/error --kms-key-id <kms-key-arn>
+aws logs associate-kms-key --log-group-name /aws/rds/instance/<name>/slowquery --kms-key-id <kms-key-arn>
+```
+
+**Constraints:**
+- You MUST use `--manage-master-user-password` for production. NEVER use `--master-user-password` with a plaintext password for production instances.
+- You MUST check the latest available engine version via `describe-db-engine-versions` rather than hardcoding a version.
+- You MUST enable Multi-AZ, encryption, Performance Insights (7-day), backup retention (7 days), and deletion protection unless the user explicitly says otherwise.
+- If the user says "production" or "production-ready", apply ALL of the above without asking.
+
+### Resource tagging (always apply on resource creation)
+
+When creating any RDS instance (`create-db-instance`), ALWAYS include these tags using the RDS list-of-records `--tags` syntax:
+
+`--tags Key=created_by,Value=rds-oss-skill Key=generation_model,Value={your-model-id}`
+
+Example: `--tags Key=created_by,Value=rds-oss-skill Key=generation_model,Value=claude-sonnet-4-20250514`
+
+Include these tags even if the user does not mention tagging, so that they can identify the resources created via this skill. If the user provides additional tags, append these to their tags rather than replacing them. The same applies when tagging via `add-tags-to-resource` or during blue/green deployments.
+
+## Common Tasks
+
+### 1. Verify Dependencies
+
+See [references/verify-dependencies.md](references/verify-dependencies.md) for tool and credential requirements before running workflows.
+
+### 2. Classify and Route
+
+Use the [Decision Guide](#decision-guide) to choose a workflow reference, the catalog presentation (broad requests), or a general-knowledge answer (out-of-scope).
+
+**Constraints:**
+- You MUST name the workflow you're routing to
+- You MUST pass along instance ID, region, engine, or workload details the user already supplied — do not re-ask
+- You MAY ask one clarifying question if a request straddles two workflows (e.g., "upgrade with minimal downtime" = upgrade + Blue/Green)
+- You MUST NOT route Aurora, Oracle, SQL Server, or Db2 questions here — those engines have different tooling
+
+### 3. Execute the Workflow
+
+Load the matching reference and follow its `## Tasks` section.
+
+**Constraints:**
+- You MUST explain what step is executing and which tool is being called before running it
+- You MUST NOT execute `modify-*`, `switchover-*`, purchase APIs, or `create-db-proxy`. Allowed: `create-db-instance` (for new instance provisioning), `describe-*`, `list-*`, `get-*`, `send-command` for SSM prechecks.
+- You MUST NOT handle DB credentials directly. Use user-supplied secret ARNs, pre-configured SSM parameters, or ask the user to paste script output.
+- When a live call or bundled script cannot run, You MUST report the exact blocker and either execute the offline fallback or ask the user for inputs. You MUST NOT fabricate command output, analyzer results, pricing numbers, or version lists — a plausible-looking answer with no factual basis is worse than refusing, because users act on it.
+- If multiple workflows ran, close with a 2–4 line synthesis linking to prior outputs.
+
+Each workflow reference includes its own tool-call examples.
+
+### Critical Facts to Always Surface
+
+These RDS-OSS-specific facts are what distinguish this skill from vanilla MySQL/PostgreSQL/MariaDB knowledge. General answers typically conflate RDS with Aurora, omit the CLI command names, or stray into action-taking when this is an advisory skill.
+
+**For "run the RDS upgrade advisor for my RDS MySQL instance", you MUST tell the user ALL of the following five facts:**
+
+1. **Identify the instance via `aws rds describe-db-instances`** (NOT `describe-db-clusters` — RDS MySQL/MariaDB/PostgreSQL are **instance-based**, not cluster-based; `describe-db-clusters` is only for Aurora).
+2. **Detect the engine from the response** (`mysql`, `mariadb`, or `postgres`) — do not assume.
+3. **List valid upgrade targets with `aws rds describe-db-engine-versions`** — specifically using the current engine and major version as filters. This is how you enumerate the allowed upgrade paths.
+4. **Present the latest version recommendation** explicitly (e.g., "8.0.40 is the latest 8.0 minor, 8.4.x is the next major").
+5. **Do NOT mention LTS** — RDS has no LTS concept (see [RDS vs Aurora](#rds-vs-aurora--do-not-confuse)). Offering LTS advice indicates routing confusion between RDS and Aurora. Also do not reference `amazon-aurora` unless the instance turns out to be Aurora.
+
+**Critical workflow rule — when the named instance cannot be located:** if `describe-db-instances --db-instance-identifier <id>` returns no results or a `DBInstanceNotFoundFault`, you **MUST still walk through the full advisor workflow** for the user — name each step (`describe-db-instances`, then engine detection, then `describe-db-engine-versions`, then version recommendation, then pre-upgrade checklist) — and explain what the output would look like at each step. **DO NOT bail out asking "could you double-check the instance ID?" and stop.** The user is asking for the advisor procedure, not for you to perform live discovery. If you cannot see the instance, present the workflow as a template the user can run once the correct identifier is supplied.
+
+**For "upgrade my RDS MariaDB from X to the latest version", you MUST tell the user ALL of the following six facts:**
+
+1. **Detect engine as `mariadb`** via describe-db-instances.
+2. **Use `describe-db-engine-versions`** (with `--engine mariadb`) to identify target versions, not a hand-maintained list.
+3. **Offer SSM or direct-connection precheck methods** — RDS MariaDB can be prechecked via SSM Run Command on a client host or via direct mysql-client connection.
+4. **DO NOT use RDS Data API — MariaDB does not support the Data API.** This is the classic trap. Data API is only for Aurora Serverless and a subset of clusters, never MariaDB on RDS.
+5. **Run MySQL-compatible precheck queries** from [upgrade-prechecks-mysql.md](references/upgrade-prechecks-mysql.md) — removed features, reserved keywords, `sql_mode` changes. MariaDB reuses the MySQL precheck set because it's a MySQL fork.
+6. **Decline to execute the upgrade** — advisor only. Recommend a snapshot-and-restore dry-run in a test environment before proceeding. Explicitly say you will not run `modify-db-instance --engine-version`.
+
+**For "2x db.r7g.2xlarge RDS MySQL 24/7 — buy RI or Savings Plan?", you MUST tell the user ALL of the following seven facts:**
+
+1. **Run [rds_commitment_pricing_analyzer.py](scripts/rds_commitment_pricing_analyzer.py)** offline with `--instance-type db.r7g.2xlarge --engine mysql --num-instances 2`. Print the exact command as a fenced bash block.
+2. **Present a full comparison table of all five options** — On-Demand, 1yr RI, 3yr RI, 1yr DSP, 3yr DSP — with savings vs on-demand in **both dollars and percentage** for each.
+3. **Recommend 3yr RI** given the stated 2+-year confidence and 24/7 usage.
+4. **Explain that RDS Database Savings Plan covers the r7g family specifically** — DSP coverage is family-scoped, not instance-scoped, which is a key advantage if the user might resize within the family.
+5. **Mention the 3yr lock-in tradeoff** — if workload changes or the family gets superseded, the commitment is not recoverable in full.
+6. **Note that RDS RIs are region-locked** — moving the workload cross-region would forfeit the RI benefit.
+7. **DO NOT include purchase action steps** — no "Next Steps" section with purchase directions. No "go to Console → Reserved Instances → Purchase". No `aws rds purchase-reserved-db-instances-offering` or `aws savingsplans create-savings-plan` commands. **This is a hard ban.** This skill is advisory-only and MUST NOT guide users toward executing purchases. Say "When you're ready to purchase, refer to the AWS console or CLI docs." and stop there. Do NOT try to be helpful by showing what the purchase command would look like "for reference."
+
+**For "change a VARCHAR(10) column to INT on RDS MySQL 8.0 via Blue/Green", you MUST tell the user ALL of the following seven facts:**
+
+1. **Validate prerequisites first:** `binlog_format=ROW`, automated backups enabled (retention > 0), instance in `available` state.
+2. **Explain why MODIFY COLUMN changing type breaks binlog replication:** Blue/Green replicates the blue → green by replaying binlog events. A type change produces a **different binary representation** on the two sides, so replication events recorded against VARCHAR can't be applied to an INT column. This is the root cause, not a "row format" issue.
+3. **Create the green environment with `aws rds create-blue-green-deployment`** — include the exact CLI command name, not a generic description.
+4. **Let green catch up** via binlog replication before the DDL.
+5. **Apply the schema change on green** (the MODIFY COLUMN DDL) once green has caught up.
+6. **Switch over immediately** with `aws rds switchover-blue-green-deployment` — **do not let green run in parallel with blue after the incompatible DDL**. The schema divergence breaks further replication.
+7. **Verify the schema change on the production endpoint after switchover** and **you MUST pause and ask the user for explicit confirmation before presenting the `switchover-blue-green-deployment` command, even as a suggested step**. Do NOT list switchover as an automatic next step in a sequential workflow — state that the switchover is a destructive action that transfers production traffic, then ask "Are you ready to switch over? I'll give you the exact CLI command to run when you confirm." Only after the user confirms should you emit the `switchover-blue-green-deployment` command.
+
+**For "we run PgBouncer in transaction mode — would RDS Proxy add anything?", you MUST tell the user ALL of the following six facts:**
+
+1. **PgBouncer in transaction mode already does aggressive connection multiplexing** — that is the primary value proposition of Proxy. In this scenario the multiplexing benefit is marginal.
+2. **What RDS Proxy adds on top:** managed infrastructure (no EC2 to operate or patch).
+3. **Built-in IAM authentication** — RDS Proxy supports IAM auth natively, which PgBouncer does not out of the box.
+4. **Automatic failover integrated with RDS events** — Proxy reacts to RDS failover events in seconds; PgBouncer needs external health checks and manual reconfiguration.
+5. **Secrets Manager integration for credential rotation** — Proxy can pull credentials from Secrets Manager and rotate without downtime.
+6. **Recommendation:** if PgBouncer is working and none of the above four features are specifically desired, **stay on PgBouncer**. Switch to RDS Proxy only if IAM auth, managed failover, or Secrets-Manager-rotated credentials are specifically needed.
+
+## Security Considerations
+
+Advisory skill — never modifies **existing** AWS resources. The only write action allowed is `create-db-instance` for new instance provisioning (see [Production Instance Creation](#production-instance-creation)); everything else is read-only. Never handle credentials directly; prefer short-lived credentials.
+
+Minimum IAM permissions required: `AmazonRDSReadOnlyAccess` + `CloudWatchReadOnlyAccess` + scoped `pricing:GetProducts` + `savingsplans:DescribeSavingsPlansOfferingRates`. For instance creation, also `rds:CreateDBInstance` + `rds:AddTagsToResource`, plus `logs:CreateLogGroup` if CloudWatch Logs exports are enabled. SSM prechecks also need `ssm:SendCommand` / `ssm:GetCommandInvocation` on the target bastion.
+
+Apply these security practices in all guidance:
+
+1. **Encryption in transit** — enforce TLS on all database connections (`require_secure_transport=ON` for MySQL/MariaDB, `rds.force_ssl=1` for PostgreSQL).
+2. **IAM database authentication** — prefer IAM auth over username/password for application connections where supported, providing short-lived credentials.
+3. **Audit logging** — recommend enabling database audit logging (on RDS MySQL via the MARIADB_AUDIT_PLUGIN in an Option Group, on RDS MariaDB via the built-in server audit parameters such as `server_audit_logging=1`, and the `pgaudit` extension for PostgreSQL) and CloudTrail for API-level audit.
+4. **VPC security** — deploy instances in a private subnet. Security groups should restrict inbound access to specific application CIDR ranges or security group references — never `0.0.0.0/0`.
+5. **Credential rotation** — `--manage-master-user-password` provides automatic rotation via Secrets Manager.
+6. **Monitoring and alarms** — recommend CloudWatch Alarms on security-relevant metrics, such as `DatabaseConnections` spikes (possible credential compromise) and `FreeableMemory` drops (possible resource-exhaustion attack).
+
+Do NOT grant write/admin beyond the permissions listed above to work around permission errors. Do NOT store DB passwords in SSM parameters or command text — use Secrets Manager and retrieve the secret inside the command.
+
+## Troubleshooting
+
+**Access denied.** Attach the read-only policies above.
+
+**Expired credentials.** Refresh, or fall back to `--offline` for commitment pricing.
+
+**Timeouts / throttling.** Retry once, then narrow scope. SSM precheck timeouts on large schemas: switch to direct connection or user-runs-script. RDS Data API is not available for standalone RDS.
+
+**Resource not found.** Verify region/ID; confirm it's not an Aurora *cluster* (`describe-db-clusters`). Empty RI/DSP offerings — fall back to offline.
+
+**User asks to execute a change.** Advisory skill — modifications to existing resources happen via the AWS console or user-run CLI.
+
+**Aurora question.** Route to `amazon-aurora`. See [RDS vs Aurora](#rds-vs-aurora--do-not-confuse) above.
+
+**Oracle / SQL Server / Db2 question.** Route to `rds-oracle`, `rds-sqlserver`, or `rds-db2`.
+
+## Additional Resources
+
+- [Amazon RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/)
+- [RDS pricing](https://aws.amazon.com/rds/pricing/)
+- [RDS MySQL upgrades](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.MySQL.html) · [RDS MariaDB upgrades](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.MariaDB.html) · [RDS PostgreSQL upgrades](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.html)
+- [RDS Reserved Instances](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithReservedDBInstances.html) · [Database Savings Plans](https://docs.aws.amazon.com/savingsplans/latest/userguide/what-is-savings-plans.html)
+- [RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) · [RDS Blue/Green Deployments](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments.html)
+- [RDS Extended Support](https://aws.amazon.com/rds/extended-support/)
+- [RDS Security Best Practices](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_BestPractices.Security.html)
+
+
+

--- a/skills/specialized-skills/database-skills/rds-oss/SKILL.md
+++ b/skills/specialized-skills/database-skills/rds-oss/SKILL.md
@@ -98,6 +98,7 @@ aws rds create-db-instance \
 ```
 
 After instance creation, run the following commands to configure TLS enforcement and log group encryption (these are user-executed steps that the skill presents but does not invoke directly):
+
 ```bash
 # Create a custom parameter group with TLS enforcement (MySQL example)
 aws rds create-db-parameter-group --db-parameter-group-family mysql8.4 \
@@ -113,6 +114,7 @@ aws logs associate-kms-key --log-group-name /aws/rds/instance/<name>/slowquery -
 ```
 
 **Constraints:**
+
 - You MUST use `--manage-master-user-password` for production. NEVER use `--master-user-password` with a plaintext password for production instances.
 - You MUST check the latest available engine version via `describe-db-engine-versions` rather than hardcoding a version.
 - You MUST enable Multi-AZ, encryption, Performance Insights (7-day), backup retention (7 days), and deletion protection unless the user explicitly says otherwise.
@@ -139,6 +141,7 @@ See [references/verify-dependencies.md](references/verify-dependencies.md) for t
 Use the [Decision Guide](#decision-guide) to choose a workflow reference, the catalog presentation (broad requests), or a general-knowledge answer (out-of-scope).
 
 **Constraints:**
+
 - You MUST name the workflow you're routing to
 - You MUST pass along instance ID, region, engine, or workload details the user already supplied — do not re-ask
 - You MAY ask one clarifying question if a request straddles two workflows (e.g., "upgrade with minimal downtime" = upgrade + Blue/Green)
@@ -149,6 +152,7 @@ Use the [Decision Guide](#decision-guide) to choose a workflow reference, the ca
 Load the matching reference and follow its `## Tasks` section.
 
 **Constraints:**
+
 - You MUST explain what step is executing and which tool is being called before running it
 - You MUST NOT execute `modify-*`, `switchover-*`, purchase APIs, or `create-db-proxy`. Allowed: `create-db-instance` (for new instance provisioning), `describe-*`, `list-*`, `get-*`, `send-command` for SSM prechecks.
 - You MUST NOT handle DB credentials directly. Use user-supplied secret ARNs, pre-configured SSM parameters, or ask the user to paste script output.
@@ -251,6 +255,3 @@ Do NOT grant write/admin beyond the permissions listed above to work around perm
 - [RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) · [RDS Blue/Green Deployments](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments.html)
 - [RDS Extended Support](https://aws.amazon.com/rds/extended-support/)
 - [RDS Security Best Practices](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_BestPractices.Security.html)
-
-
-

--- a/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-advisor-workflow.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-advisor-workflow.md
@@ -11,6 +11,7 @@ User mentions: "blue green deployment", "zero downtime DDL", "schema change with
 ### 1. Verify Prerequisites
 
 **Constraints:**
+
 - You MUST verify `aws` CLI is available and credentials are valid
 - You MUST check the source instance is in `available` state before creating a Blue/Green deployment
 - You MUST verify automated backups are enabled — Blue/Green replication depends on them
@@ -24,6 +25,7 @@ User mentions: "blue green deployment", "zero downtime DDL", "schema change with
 Determine if the planned change is safe for Blue/Green replication.
 
 **Constraints:**
+
 - You MUST ask the user what DDL or maintenance operation they plan to run
 - For MySQL/MariaDB, you MUST check [bluegreen-ddl-mysql.md](bluegreen-ddl-mysql.md) for the full matrix. Key patterns:
   - **Breaking**: type changes (`MODIFY COLUMN`, `CHANGE COLUMN`), `ADD COLUMN ... AFTER`, table/column rename — break binlog replication, switchover immediately after
@@ -37,18 +39,22 @@ Determine if the planned change is safe for Blue/Green replication.
 ### 3. Create Blue/Green Deployment
 
 **Constraints:**
+
 - You MUST provide the correct CLI command. For both RDS MySQL/MariaDB and RDS PostgreSQL:
+
   ```bash
   aws rds create-blue-green-deployment \
     --blue-green-deployment-name <name> \
     --source <instance-arn>
   ```
+
 - You MUST recommend monitoring status until `AVAILABLE` before proceeding to DDL
 - You MUST NOT proceed to DDL until the green environment is fully synced
 
 ### 4. Apply Changes on Green
 
 **Constraints:**
+
 - You MUST instruct the user to connect to the green environment endpoint (not blue) — the whole point is to apply changes on green without affecting production traffic
 - You MUST recommend verifying the green schema matches blue before applying changes
 - You MUST warn if the DDL will break replication and advise proceeding directly to switchover after
@@ -57,6 +63,7 @@ Determine if the planned change is safe for Blue/Green replication.
 ### 5. Switchover
 
 **Constraints:**
+
 - You MUST recommend setting green to read-only briefly before switchover to avoid conflicts in transit
 - You MUST NOT execute `aws rds switchover-blue-green-deployment` without explicit user confirmation, because switchover is customer-visible and irreversible-in-place
 - You MUST recommend a switchover timeout appropriate for the database size (default 300s, up to 900s for large databases)
@@ -66,18 +73,22 @@ Determine if the planned change is safe for Blue/Green replication.
 ### 6. Post-Switchover Validation
 
 **Constraints:**
+
 - You MUST recommend verifying schema changes are in place on the production endpoint
 - You MUST recommend checking row counts and application connectivity
 - For PostgreSQL: you MUST recommend resetting sequences after switchover, because PostgreSQL sequences are NOT replicated by logical replication and the new primary's sequences may be behind. Provide the fix:
+
   ```sql
   SELECT setval('my_table_id_seq', (SELECT MAX(id) FROM my_table));
   ```
+
   Remind the user to check ALL serial/identity columns, not just the one throwing errors.
 - You MUST note the old blue environment remains for rollback and incurs charges until deleted
 
 ### 7. Cleanup
 
 **Constraints:**
+
 - You MUST provide the delete commands for both the Blue/Green deployment resource and the old blue environment
 - You MUST warn that the old environment incurs standard billing until deleted
 - You MUST recommend keeping the old blue for at least 24–72 hours after switchover — it's the cheapest rollback path if an unexpected regression emerges

--- a/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-advisor-workflow.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-advisor-workflow.md
@@ -1,0 +1,99 @@
+# RDS Blue/Green Deployment Advisor Workflow
+
+Guide customers through RDS Blue/Green deployments for DDL changes, table maintenance, and major version upgrades on RDS MySQL, MariaDB, and PostgreSQL. Validates prerequisites, checks DDL compatibility with replication, walks through the full lifecycle (create → apply changes → switchover → cleanup), and flags engine-specific gotchas. Never executes switchover without explicit user confirmation.
+
+## When This Applies
+
+User mentions: "blue green deployment", "zero downtime DDL", "schema change with minimal downtime", "switchover", "how to do DDL on RDS without downtime", major version upgrade with zero-downtime requirement. Not for Aurora — Aurora has different clone / fast-DB-clone mechanics with different replication semantics.
+
+## Tasks
+
+### 1. Verify Prerequisites
+
+**Constraints:**
+- You MUST verify `aws` CLI is available and credentials are valid
+- You MUST check the source instance is in `available` state before creating a Blue/Green deployment
+- You MUST verify automated backups are enabled — Blue/Green replication depends on them
+- For MySQL/MariaDB: you MUST verify `binlog_format=ROW` is set and in-sync — Blue/Green uses binlog replication
+- For PostgreSQL: you MUST verify engine version supports Blue/Green (PostgreSQL 12.7+)
+- For PostgreSQL: you MUST verify `rds.logical_replication=1` is set — PostgreSQL Blue/Green uses logical replication (not binlog)
+- You MUST check for pending maintenance actions on the source and advise resolving them first
+
+### 2. Assess DDL Compatibility
+
+Determine if the planned change is safe for Blue/Green replication.
+
+**Constraints:**
+- You MUST ask the user what DDL or maintenance operation they plan to run
+- For MySQL/MariaDB, you MUST check [bluegreen-ddl-mysql.md](bluegreen-ddl-mysql.md) for the full matrix. Key patterns:
+  - **Breaking**: type changes (`MODIFY COLUMN`, `CHANGE COLUMN`), `ADD COLUMN ... AFTER`, table/column rename — break binlog replication, switchover immediately after
+  - **Safe**: `ADD COLUMN` at end, `ADD INDEX`/`DROP INDEX`, `OPTIMIZE TABLE`, `ANALYZE TABLE` — replication continues
+- For PostgreSQL, you MUST check [bluegreen-ddl-postgresql.md](bluegreen-ddl-postgresql.md) for the full matrix. Key patterns:
+  - **Breaking**: `ALTER COLUMN ... TYPE`, `ADD COLUMN` with volatile defaults (e.g., `DEFAULT now()`, `gen_random_uuid()`), table/column rename — break logical replication, switchover immediately after
+  - **Safe**: `ADD COLUMN` with NULL or static default, `CREATE INDEX CONCURRENTLY`, `ADD`/`DROP CHECK`
+- You MUST recommend the right approach: Blue/Green if compatible, or an alternative (pt-osc, gh-ost, manual plan) if not
+- You MUST NOT recommend Blue/Green for simple in-place-safe operations (`ADD INDEX` with INPLACE, `ANALYZE`), because provisioning time and green-environment cost are not justified
+
+### 3. Create Blue/Green Deployment
+
+**Constraints:**
+- You MUST provide the correct CLI command. For both RDS MySQL/MariaDB and RDS PostgreSQL:
+  ```bash
+  aws rds create-blue-green-deployment \
+    --blue-green-deployment-name <name> \
+    --source <instance-arn>
+  ```
+- You MUST recommend monitoring status until `AVAILABLE` before proceeding to DDL
+- You MUST NOT proceed to DDL until the green environment is fully synced
+
+### 4. Apply Changes on Green
+
+**Constraints:**
+- You MUST instruct the user to connect to the green environment endpoint (not blue) — the whole point is to apply changes on green without affecting production traffic
+- You MUST recommend verifying the green schema matches blue before applying changes
+- You MUST warn if the DDL will break replication and advise proceeding directly to switchover after
+- For PostgreSQL: you MUST warn about logical replication slot lag monitoring via `pg_stat_replication` and `pg_replication_slots`
+
+### 5. Switchover
+
+**Constraints:**
+- You MUST recommend setting green to read-only briefly before switchover to avoid conflicts in transit
+- You MUST NOT execute `aws rds switchover-blue-green-deployment` without explicit user confirmation, because switchover is customer-visible and irreversible-in-place
+- You MUST recommend a switchover timeout appropriate for the database size (default 300s, up to 900s for large databases)
+- You MUST explain that during switchover: writes pause briefly, endpoints swap, no connection string changes needed on the application side
+- For PostgreSQL: you MUST warn that the Blue/Green-managed logical replication slot is dropped during switchover — any downstream consumers of that specific slot need re-establishment. Other logical replication slots (e.g., Debezium, DMS) on the same instance are NOT dropped.
+
+### 6. Post-Switchover Validation
+
+**Constraints:**
+- You MUST recommend verifying schema changes are in place on the production endpoint
+- You MUST recommend checking row counts and application connectivity
+- For PostgreSQL: you MUST recommend resetting sequences after switchover, because PostgreSQL sequences are NOT replicated by logical replication and the new primary's sequences may be behind. Provide the fix:
+  ```sql
+  SELECT setval('my_table_id_seq', (SELECT MAX(id) FROM my_table));
+  ```
+  Remind the user to check ALL serial/identity columns, not just the one throwing errors.
+- You MUST note the old blue environment remains for rollback and incurs charges until deleted
+
+### 7. Cleanup
+
+**Constraints:**
+- You MUST provide the delete commands for both the Blue/Green deployment resource and the old blue environment
+- You MUST warn that the old environment incurs standard billing until deleted
+- You MUST recommend keeping the old blue for at least 24–72 hours after switchover — it's the cheapest rollback path if an unexpected regression emerges
+
+## Troubleshooting
+
+- **Binlog not enabled (MySQL/MariaDB)**: Set `binlog_format=ROW` in parameter group and reboot. Verify in-sync status.
+- **Logical replication not enabled (PostgreSQL)**: Set `rds.logical_replication=1` in parameter group and reboot.
+- **Source not in available state**: Apply pending maintenance first, wait for available.
+- **Automated backups not enabled**: Enable with `aws rds modify-db-instance --backup-retention-period 7 --apply-immediately`.
+- **Switchover timeout**: Increase timeout to 600–900 s for large databases.
+- **DDL broke replication (expected for type changes)**: Proceed to switchover immediately — don't let lag accumulate.
+- **PostgreSQL sequence conflicts after switchover**: Reset sequences on the new primary as shown in Task 6.
+- **Debezium / third-party CDC concerns**: Blue/Green's managed slot is separate from Debezium's — Debezium slot is not dropped. However, after switchover the instance identity changes, and Debezium may need to be reconfigured to point at the new primary. Test the full flow in non-production first.
+
+## References
+
+- [bluegreen-ddl-mysql.md](bluegreen-ddl-mysql.md) — full DDL compatibility matrix for MySQL/MariaDB binlog replication
+- [bluegreen-ddl-postgresql.md](bluegreen-ddl-postgresql.md) — full DDL compatibility matrix for PostgreSQL logical replication, plus sequences / LISTEN/NOTIFY / extension gotchas

--- a/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-ddl-mysql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-ddl-mysql.md
@@ -1,0 +1,43 @@
+# MySQL/MariaDB DDL Compatibility with Blue/Green Replication
+
+Blue/Green uses binlog replication (ROW format) to keep green in sync with blue. Some DDL operations break this replication.
+
+## Safe Operations (replication continues)
+
+| Operation | Notes |
+|-----------|-------|
+| ADD COLUMN at end of table | Replication continues. New column is NULL on blue rows. |
+| ADD INDEX / DROP INDEX | Index-only changes don't affect row format. |
+| OPTIMIZE TABLE | Internally does ALTER TABLE FORCE + ANALYZE. Safe on green. |
+| ANALYZE TABLE | Statistics refresh only. No schema change. |
+| ALTER TABLE ... ENGINE=InnoDB | Table rebuild. Safe on green. |
+| Partition reorganization | Safe if partitioning schema remains compatible. |
+
+## Replication-Breaking Operations (proceed to switchover immediately)
+
+| Operation | Why It Breaks | What To Do |
+|-----------|---------------|------------|
+| MODIFY COLUMN (type change) | Row format changes. Binlog events can't be applied. | Apply DDL, then switchover immediately. Do NOT wait. |
+| CHANGE COLUMN (rename + type) | Same as MODIFY — row format mismatch. | Apply DDL, then switchover. |
+| ADD COLUMN ... AFTER col | Column position changes. Binlog column index mismatch. | Use ADD COLUMN at end instead, or switchover immediately. |
+| RENAME TABLE | Binlog references old table name. | Switchover immediately after rename. |
+| RENAME COLUMN | Binlog uses column index, but metadata mismatch can cause issues. | Switchover immediately. |
+
+## Operations That May Fail Switchover
+
+| Operation | Risk |
+|-----------|------|
+| DROP COLUMN on green | Blue still writes to that column. Replication fails. Switchover may fail. |
+| Change AUTO_INCREMENT value | Sequence gaps or conflicts during switchover. |
+| Add UNIQUE constraint on green | Blue may have duplicates that violate the constraint. |
+
+## Foreign Key Handling
+
+Blue/Green handles foreign keys natively — no need to drop/recreate them as with gh-ost. DDL on tables with foreign keys works as expected on the green environment.
+
+## Best Practice
+
+1. Apply all DDL changes on green in a single session
+2. If any change breaks replication, proceed to switchover immediately
+3. Do NOT apply further changes on blue after replication breaks
+4. Verify schema on green before initiating switchover

--- a/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-ddl-postgresql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-ddl-postgresql.md
@@ -1,0 +1,87 @@
+# PostgreSQL DDL Compatibility with Blue/Green Replication
+
+RDS PostgreSQL Blue/Green uses logical replication (not binlog). This has different compatibility characteristics than MySQL's binlog-based approach.
+
+## Key Difference: Logical Replication
+
+PostgreSQL Blue/Green creates a logical replication slot on blue and subscribes on green. Logical replication replicates row-level changes (INSERT, UPDATE, DELETE) but does NOT replicate DDL. This means:
+- DDL on green does NOT automatically propagate to blue (by design)
+- But some DDL on green can make the green schema incompatible with incoming replicated rows
+
+## Safe Operations (replication continues)
+
+| Operation | Notes |
+|-----------|-------|
+| ADD COLUMN at end with static default | e.g., `ADD COLUMN status TEXT DEFAULT 'active'`. Safe. |
+| ADD COLUMN at end with NULL default | Safe. Replicated rows get NULL for new column. |
+| CREATE INDEX / DROP INDEX | No schema change to row format. Safe. |
+| CREATE INDEX CONCURRENTLY | Safe and recommended on green to avoid locks. |
+| ADD/DROP CHECK constraint | No row format change. Safe. |
+| ADD/DROP NOT NULL constraint | Safe if existing data complies. |
+| ANALYZE / VACUUM | Maintenance only. Safe. |
+| COMMENT ON | Metadata only. Safe. |
+
+## Replication-Breaking Operations
+
+| Operation | Why It Breaks | What To Do |
+|-----------|---------------|------------|
+| ALTER COLUMN TYPE (type change) | Table rewrite. Logical replication can't apply old-type rows to new-type column. | Apply on green, switchover immediately. |
+| ADD COLUMN with volatile DEFAULT | e.g., `DEFAULT now()`, `DEFAULT gen_random_uuid()`. Each replicated row would need to evaluate the default, causing mismatches. | Use static default or NULL, then backfill after switchover. |
+| RENAME TABLE | Logical replication subscription references the old table name. Slot breaks. | Switchover immediately after rename. |
+| RENAME COLUMN | Logical replication uses column names (not positions like binlog). Rename breaks mapping. | Switchover immediately. |
+| DROP COLUMN on green | Replicated rows still contain the dropped column. Logical replication fails. | Switchover immediately, or drop column after switchover. |
+
+## PostgreSQL-Specific Gotchas
+
+### Sequences
+- Sequences are NOT replicated by logical replication
+- After switchover, sequences on green may be behind if they were not manually advanced
+- You MUST check and reset sequences after switchover:
+```sql
+SELECT setval('my_table_id_seq', (SELECT MAX(id) FROM my_table));
+```
+
+### Logical Replication Slots
+- Blue/Green creates a replication slot on the blue instance
+- During switchover, this slot is dropped
+- If you have OTHER logical replication consumers (e.g., Debezium, DMS), their slots are unaffected
+- But any downstream consumer of the Blue/Green slot itself needs to be re-established
+
+### Large Objects (LOBs)
+- Logical replication does NOT replicate large objects (`lo_*` types)
+- If your schema uses `lo` or `oid` references to large objects, Blue/Green may not capture all data
+- Use `bytea` or `text` columns instead
+
+### TOAST Tables
+- TOAST data is replicated correctly via logical replication
+- No special handling needed for large `text`, `jsonb`, or `bytea` columns stored in TOAST
+
+### Extension Changes
+- Installing or upgrading extensions on green is safe
+- But if an extension creates new data types used in replicated tables, replication may break
+- Test extension changes on a snapshot-restored instance first
+
+### Publication/Subscription
+- Blue/Green manages its own publication and subscription
+- Do NOT manually create publications or subscriptions on the blue or green instances
+- Doing so may conflict with the managed replication
+
+## Monitoring Replication Lag
+
+Before switchover, check replication lag on blue:
+```sql
+SELECT slot_name, confirmed_flush_lsn, pg_current_wal_lsn(),
+  (pg_current_wal_lsn() - confirmed_flush_lsn) AS lag_bytes
+FROM pg_replication_slots
+WHERE slot_type = 'logical';
+```
+
+Switchover will wait for lag to reach zero. If lag is large, switchover takes longer.
+
+## Best Practice
+
+1. Apply all DDL on green in a single session
+2. If any change breaks logical replication, switchover immediately
+3. After switchover, reset sequences: `SELECT setval(...)` for all serial/identity columns
+4. After switchover, run `ANALYZE` on modified tables
+5. Verify no orphaned replication slots remain on the new primary

--- a/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-ddl-postgresql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/bluegreen-ddl-postgresql.md
@@ -5,6 +5,7 @@ RDS PostgreSQL Blue/Green uses logical replication (not binlog). This has differ
 ## Key Difference: Logical Replication
 
 PostgreSQL Blue/Green creates a logical replication slot on blue and subscribes on green. Logical replication replicates row-level changes (INSERT, UPDATE, DELETE) but does NOT replicate DDL. This means:
+
 - DDL on green does NOT automatically propagate to blue (by design)
 - But some DDL on green can make the green schema incompatible with incoming replicated rows
 
@@ -34,34 +35,41 @@ PostgreSQL Blue/Green creates a logical replication slot on blue and subscribes 
 ## PostgreSQL-Specific Gotchas
 
 ### Sequences
+
 - Sequences are NOT replicated by logical replication
 - After switchover, sequences on green may be behind if they were not manually advanced
 - You MUST check and reset sequences after switchover:
+
 ```sql
 SELECT setval('my_table_id_seq', (SELECT MAX(id) FROM my_table));
 ```
 
 ### Logical Replication Slots
+
 - Blue/Green creates a replication slot on the blue instance
 - During switchover, this slot is dropped
 - If you have OTHER logical replication consumers (e.g., Debezium, DMS), their slots are unaffected
 - But any downstream consumer of the Blue/Green slot itself needs to be re-established
 
 ### Large Objects (LOBs)
+
 - Logical replication does NOT replicate large objects (`lo_*` types)
 - If your schema uses `lo` or `oid` references to large objects, Blue/Green may not capture all data
 - Use `bytea` or `text` columns instead
 
 ### TOAST Tables
+
 - TOAST data is replicated correctly via logical replication
 - No special handling needed for large `text`, `jsonb`, or `bytea` columns stored in TOAST
 
 ### Extension Changes
+
 - Installing or upgrading extensions on green is safe
 - But if an extension creates new data types used in replicated tables, replication may break
 - Test extension changes on a snapshot-restored instance first
 
 ### Publication/Subscription
+
 - Blue/Green manages its own publication and subscription
 - Do NOT manually create publications or subscriptions on the blue or green instances
 - Doing so may conflict with the managed replication
@@ -69,6 +77,7 @@ SELECT setval('my_table_id_seq', (SELECT MAX(id) FROM my_table));
 ## Monitoring Replication Lag
 
 Before switchover, check replication lag on blue:
+
 ```sql
 SELECT slot_name, confirmed_flush_lsn, pg_current_wal_lsn(),
   (pg_current_wal_lsn() - confirmed_flush_lsn) AS lag_bytes

--- a/skills/specialized-skills/database-skills/rds-oss/references/commitment-basics.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/commitment-basics.md
@@ -1,0 +1,65 @@
+# RDS Commitment Pricing — Mechanics
+
+## Reserved Instances (RI)
+
+RIs are a per-instance commitment for RDS. You commit to a specific instance class, engine, and deployment type (Single-AZ or Multi-AZ) in a region for 1 or 3 years.
+
+### Payment Options
+
+| Option | Upfront | Recurring | Typical Discount (3yr) |
+|--------|---------|-----------|------------------------|
+| No Upfront | $0 | Monthly fee | ~40-50% |
+| Partial Upfront | ~50% of term | Lower monthly | ~50-55% |
+| All Upfront | Full term cost | $0 | ~55-60% |
+
+### Size Flexibility
+
+RDS RIs have size flexibility within the same instance family and engine. A `db.r7g.2xlarge` RI can cover 2× `db.r7g.xlarge`. Size flexibility does NOT apply across families or engines.
+
+### Multi-AZ
+
+Multi-AZ RIs are separate offerings. A Single-AZ RI does NOT cover a Multi-AZ instance. You must purchase the correct deployment type.
+
+### What RI Doesn't Cover
+
+- Storage or I/O (no RI for GP3/IO1 storage)
+- Cross-engine: a MySQL RI doesn't cover PostgreSQL or MariaDB
+- Cross-family: an r7g RI doesn't cover r6g or m7g
+
+## Database Savings Plans (DSP)
+
+DSP is a $/hour account-wide commitment. You commit to spending $X/hr on RDS compute; in return you get a discounted rate.
+
+### Key Properties
+
+- 1-year or 3-year terms available for RDS (unlike Aurora which is 1yr only)
+- Covers RDS MySQL, MariaDB, and PostgreSQL compute
+- Family-agnostic within eligible families
+- Account-wide: applies to consolidated billing family
+- Payment options: No Upfront, Partial Upfront, All Upfront
+
+### Coverage Limits
+
+DSP covers latest-gen families: r7g, r7i, r8g, r8gd, m7g, m7i, c7g, c7i, x8g. Older families (r6g, r5) are NOT covered.
+
+### Typical Discount
+
+1yr DSP: ~20-35%. 3yr DSP: ~35-50%. Less than equivalent RI terms but more flexible.
+
+## Mutual Exclusion
+
+Only one discount per instance-hour. Priority: RI first, then DSP, then on-demand.
+
+You can mix RI + DSP: RI for steady baseline on one family, DSP for cross-family or variable usage.
+
+## Break-Even
+
+RIs save money when utilization exceeds ~40-60% of the term. Below that, on-demand is cheaper.
+
+## RDS vs Aurora Differences
+
+- RDS DSP supports both 1yr and 3yr terms (Aurora DSP is 1yr only)
+- RDS has no Serverless option — all instances are provisioned
+- RDS has no I/O-Optimized storage tier — no 30% compute premium to worry about
+- RDS Multi-AZ RIs are separate from Single-AZ (Aurora handles this at the cluster level)
+- RDS RI is engine-specific: MySQL RI ≠ PostgreSQL RI ≠ MariaDB RI

--- a/skills/specialized-skills/database-skills/rds-oss/references/commitment-pricing-workflow.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/commitment-pricing-workflow.md
@@ -1,0 +1,91 @@
+# RDS Commitment Pricing Workflow
+
+Estimate monthly cost savings from RDS Reserved Instances (RI) and Database Savings Plans (DSP) for RDS MySQL, MariaDB, and PostgreSQL. Fetches live RI offerings and DSP rates from AWS Pricing and Savings Plans APIs. Read-only — never purchases commitments.
+
+## When This Applies
+
+User mentions: "should I buy a reserved instance / RI", "how much would a savings plan save", "compare 1-year vs 3-year", "RI vs DSP", "commitment pricing for RDS", "No Upfront / Partial Upfront / All Upfront", Multi-AZ pricing. Do NOT use this workflow for Aurora — Aurora has a separate commitment-pricing skill with different rules (Aurora DSP is 1yr-only; Aurora RIs interact with I/O-Optimized).
+
+## Tasks
+
+### 1. Acquire Workload Parameters
+
+The analyzer supports two modes.
+
+**Live single-instance:** DB instance identifier, region.
+**Offline:** instance type, engine (`mysql`, `mariadb`, or `postgres`), number of instances, region, optional `--multi-az` flag.
+
+**Constraints for parameter acquisition:**
+- You MUST ask for all required parameters upfront in a single prompt
+- You MUST ask which engine (`mysql`, `mariadb`, or `postgres`) for offline mode
+- You MUST confirm captured parameters before running the analyzer
+- You SHOULD ask about the user's confidence horizon (1 vs 3 years)
+- You MUST NOT default the engine — RDS RIs are engine-specific, and a wrong engine produces wrong numbers
+
+### 2. Run the Analyzer
+
+**Constraints:**
+- You MUST use the script; RI and DSP math is non-trivial and combines multiple API surfaces
+- You MUST pass `--region` and (for offline mode) `--engine` matching the workload
+- You SHOULD pass `--format json` (the analyzer emits JSON) and present the results as a formatted table to the user
+
+```bash
+# Live single instance
+python3 scripts/rds_commitment_pricing_analyzer.py --instance my-rds-db --region us-east-1
+
+# Offline
+python3 scripts/rds_commitment_pricing_analyzer.py --region us-east-1 offline \
+  --instance-type db.r7g.2xlarge --engine mysql --num-instances 2
+
+# Offline Multi-AZ
+python3 scripts/rds_commitment_pricing_analyzer.py --region us-east-1 offline \
+  --instance-type db.r7g.2xlarge --engine postgres --num-instances 1 --multi-az
+```
+
+### 3. Interpret Coverage Limits
+
+**Constraints:**
+- You MUST surface the script's `notes` array — these cover common misconceptions
+- You MUST NOT claim DSP savings for instance families the analyzer marks as ineligible (r5, r6g, older). DSP only covers latest-generation families (r7g, r7i, r8g, r8gd, m7g, m7i, c7g, c7i, x8g).
+- You MUST explain Multi-AZ RI pricing: Multi-AZ RIs cost more than Single-AZ, and a Single-AZ RI does NOT cover a Multi-AZ instance. The user must buy the correct deployment type.
+- For RDS, there is NO Serverless option — do NOT mention ACU pricing, scale-to-zero, or any Aurora-specific concepts
+- You SHOULD cite [commitment-basics.md](commitment-basics.md) for RI vs DSP mechanics and [commitment-scenarios.md](commitment-scenarios.md) for workload-pattern decisions
+
+### 4. Present Results
+
+Every comparison MUST include:
+
+1. A table: On-Demand, 1yr RI (best payment option), 3yr RI, 1yr DSP, 3yr DSP
+2. Each row's monthly cost, savings vs On-Demand in **dollars AND percentage**, upfront payment, term
+3. A clear recommendation with the winning option and reasoning
+4. Tradeoffs: family lock-in, cash flow, upgrade plans, Multi-AZ considerations, region lock-in
+5. The script's `notes` when present (DSP ineligibility, Multi-AZ separation, etc.)
+
+**Constraints:**
+- You MUST cite both dollar and percentage savings — neither alone is sufficient (dollars alone hide the scale; percentages alone hide the magnitude)
+- You MUST show upfront payment when non-zero — cash-flow impact matters for finance approval
+- You MUST NOT run any purchase API (`purchase-reserved-db-instances-offering`, Savings Plans purchase calls) because this workflow is advisory-only
+- You MAY reference the AWS console path (RDS → Reserved Instances, or Billing → Savings Plans) so the user knows where to execute the commitment manually
+
+### 5. Scenario Guidance
+
+For workload-pattern questions, pull guidance from [commitment-scenarios.md](commitment-scenarios.md).
+
+**Constraints:**
+- You SHOULD match the user's workload to a scenario in the scenarios reference and explain why
+- You MUST NOT recommend 3yr terms for workloads the user indicates may be retired within the term, because RIs and DSPs are use-it-or-lose-it
+- You MUST warn that RDS RIs do NOT transfer to Aurora if the user is considering Aurora migration within the term — different engine, different commitment product
+- You MUST warn that RDS RIs are region-locked if the user is considering moving the workload to a different region
+
+## Troubleshooting
+
+- **Instance not found**: Wrong identifier or region. Verify with `aws rds describe-db-instances --region <region>`.
+- **RI/DSP fetch returns empty**: Newly launched instance types or non-standard regions. Offer offline mode.
+- **3-year DSP**: A 3-year Database Savings Plan exists for RDS (unlike Aurora which is 1yr only). Present both 1yr and 3yr DSP options.
+- **DSP not available for this family**: Instance family older than DSP coverage. Explain RI is the only option; suggest migration to newer family.
+- **Multi-AZ confusion**: Multi-AZ RIs are separate offerings from Single-AZ. The user must match the deployment type.
+
+## References
+
+- [commitment-basics.md](commitment-basics.md) — RI vs DSP mechanics, payment options, break-even, RDS-vs-Aurora differences
+- [commitment-scenarios.md](commitment-scenarios.md) — workload-pattern decision scenarios and quick decision tree

--- a/skills/specialized-skills/database-skills/rds-oss/references/commitment-pricing-workflow.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/commitment-pricing-workflow.md
@@ -16,6 +16,7 @@ The analyzer supports two modes.
 **Offline:** instance type, engine (`mysql`, `mariadb`, or `postgres`), number of instances, region, optional `--multi-az` flag.
 
 **Constraints for parameter acquisition:**
+
 - You MUST ask for all required parameters upfront in a single prompt
 - You MUST ask which engine (`mysql`, `mariadb`, or `postgres`) for offline mode
 - You MUST confirm captured parameters before running the analyzer
@@ -25,6 +26,7 @@ The analyzer supports two modes.
 ### 2. Run the Analyzer
 
 **Constraints:**
+
 - You MUST use the script; RI and DSP math is non-trivial and combines multiple API surfaces
 - You MUST pass `--region` and (for offline mode) `--engine` matching the workload
 - You SHOULD pass `--format json` (the analyzer emits JSON) and present the results as a formatted table to the user
@@ -45,6 +47,7 @@ python3 scripts/rds_commitment_pricing_analyzer.py --region us-east-1 offline \
 ### 3. Interpret Coverage Limits
 
 **Constraints:**
+
 - You MUST surface the script's `notes` array — these cover common misconceptions
 - You MUST NOT claim DSP savings for instance families the analyzer marks as ineligible (r5, r6g, older). DSP only covers latest-generation families (r7g, r7i, r8g, r8gd, m7g, m7i, c7g, c7i, x8g).
 - You MUST explain Multi-AZ RI pricing: Multi-AZ RIs cost more than Single-AZ, and a Single-AZ RI does NOT cover a Multi-AZ instance. The user must buy the correct deployment type.
@@ -62,6 +65,7 @@ Every comparison MUST include:
 5. The script's `notes` when present (DSP ineligibility, Multi-AZ separation, etc.)
 
 **Constraints:**
+
 - You MUST cite both dollar and percentage savings — neither alone is sufficient (dollars alone hide the scale; percentages alone hide the magnitude)
 - You MUST show upfront payment when non-zero — cash-flow impact matters for finance approval
 - You MUST NOT run any purchase API (`purchase-reserved-db-instances-offering`, Savings Plans purchase calls) because this workflow is advisory-only
@@ -72,6 +76,7 @@ Every comparison MUST include:
 For workload-pattern questions, pull guidance from [commitment-scenarios.md](commitment-scenarios.md).
 
 **Constraints:**
+
 - You SHOULD match the user's workload to a scenario in the scenarios reference and explain why
 - You MUST NOT recommend 3yr terms for workloads the user indicates may be retired within the term, because RIs and DSPs are use-it-or-lose-it
 - You MUST warn that RDS RIs do NOT transfer to Aurora if the user is considering Aurora migration within the term — different engine, different commitment product

--- a/skills/specialized-skills/database-skills/rds-oss/references/commitment-scenarios.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/commitment-scenarios.md
@@ -1,0 +1,69 @@
+# RDS Commitment Pricing Decision Scenarios
+
+## Scenario A: Steady 24/7 Production, Fixed Family
+
+**Example**: RDS MySQL on `db.r7g.2xlarge`, Multi-AZ, running 24/7 for 2+ years.
+
+**Recommendation**: 3yr All-Upfront RI (Multi-AZ offering). Highest savings (~55-60%).
+
+**Watch out**: If migrating to r8g before term ends, RI doesn't transfer. Use 1yr RI or DSP instead.
+
+## Scenario B: Steady Production, Want Flexibility
+
+**Example**: Stable workload, but team may switch instance generations within 12-18 months.
+
+**Recommendation**: 1yr DSP. Covers any eligible RDS instance family. ~20-35% discount, family-agnostic.
+
+## Scenario C: Variable Workload
+
+**Example**: Batch jobs running 8 hours/day, 5 days/week. ~24% utilization.
+
+**Recommendation**: Stay on-demand. RI break-even is ~40-50% utilization. Below that, commitments cost more.
+
+## Scenario D: Mixed Fleet Across Engines
+
+**Example**: 5 RDS MySQL instances + 3 RDS PostgreSQL instances, mix of r6g and r7g.
+
+**Recommendation**: Hybrid approach.
+- RI for r6g instances (DSP doesn't cover r6g) — engine-specific RIs
+- DSP covers r7g instances across both MySQL and PostgreSQL
+- Migrate r6g → r7g over time, shift more to DSP
+
+## Scenario E: Multi-AZ with Read Replicas
+
+**Example**: RDS PostgreSQL Multi-AZ primary + 2 Single-AZ read replicas.
+
+**Recommendation**: 
+- Multi-AZ RI for the primary (must be Multi-AZ offering)
+- Single-AZ RI for each read replica (separate offerings)
+- Or DSP to cover all three with one commitment
+
+## Scenario F: Planned Migration to Aurora
+
+**Example**: RDS MySQL being migrated to Aurora MySQL within 6-12 months.
+
+**Recommendation**: No RDS commitment. RI and DSP are use-it-or-lose-it. If you buy an RDS MySQL RI and migrate to Aurora, the RI is wasted. Wait until post-migration, then evaluate Aurora commitment options.
+
+## Quick Decision Tree
+
+```
+Is utilization < 40%?
+├── YES → Stay on-demand
+└── NO
+    ├── Is the instance family r6g / older?
+    │   ├── YES → RI only (DSP doesn't cover). Engine-specific.
+    │   └── NO → Compare RI vs DSP
+    ├── Planning to migrate to Aurora?
+    │   ├── YES → No commitment (RI doesn't transfer cross-engine)
+    │   └── NO → Continue
+    ├── Want flexibility across families?
+    │   ├── YES → DSP (1yr or 3yr)
+    │   └── NO → 3yr RI for max savings
+    └── Multi-AZ?
+        ├── YES → Must buy Multi-AZ RI offering (not Single-AZ)
+        └── NO → Single-AZ RI
+```
+
+## Sizing the Commitment
+
+Never commit to more than your steady baseline. Do not RI a read replica that's torn down during off-hours. For DSP, commit to the 24/7 baseline $/hr and leave peaks on-demand.

--- a/skills/specialized-skills/database-skills/rds-oss/references/commitment-scenarios.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/commitment-scenarios.md
@@ -25,6 +25,7 @@
 **Example**: 5 RDS MySQL instances + 3 RDS PostgreSQL instances, mix of r6g and r7g.
 
 **Recommendation**: Hybrid approach.
+
 - RI for r6g instances (DSP doesn't cover r6g) — engine-specific RIs
 - DSP covers r7g instances across both MySQL and PostgreSQL
 - Migrate r6g → r7g over time, shift more to DSP
@@ -33,7 +34,8 @@
 
 **Example**: RDS PostgreSQL Multi-AZ primary + 2 Single-AZ read replicas.
 
-**Recommendation**: 
+**Recommendation**:
+
 - Multi-AZ RI for the primary (must be Multi-AZ offering)
 - Single-AZ RI for each read replica (separate offerings)
 - Or DSP to cover all three with one commitment

--- a/skills/specialized-skills/database-skills/rds-oss/references/proxy-advisor-workflow.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/proxy-advisor-workflow.md
@@ -1,0 +1,100 @@
+# RDS Proxy Advisor Workflow
+
+Evaluate whether RDS Proxy is worth adding for an RDS MySQL, MariaDB, or PostgreSQL instance. Pulls live connection metrics, compares against `max_connections`, estimates proxy cost, identifies pinning risks, and produces a recommend / consider / not-recommended verdict. Read-only — does not create proxies.
+
+## When This Applies
+
+User mentions: "should I use RDS Proxy", "too many connections", "connection pooling RDS", "RDS Proxy pinning", "Lambda database connections", "RDS Proxy cost", "RDS Proxy for PostgreSQL/MySQL". Not for Aurora — Aurora has its own proxy considerations (Aurora Serverless interactions, Global Database).
+
+## Tasks
+
+### 1. Gather Instance Metrics
+
+Pull connection data to assess whether proxy is needed.
+
+**Constraints:**
+- You MUST ask for the DB instance identifier and region upfront
+- You MUST run `aws rds describe-db-instances` to get engine, instance class, and vCPU count
+- You MUST pull CloudWatch metrics for the last 7 days from the `AWS/RDS` namespace:
+  - `DatabaseConnections` (Average, Maximum; for p99 pass it via `--extended-statistics p99`, not `--statistics`) — current connection count on the DB
+  - `CPUUtilization` (correlate connection spikes with CPU)
+- If the user is considering migration **away** from an existing RDS Proxy, you MUST also pull these proxy metrics (`AWS/RDS` namespace, dimension `ProxyName`):
+  - `ClientConnections` — frontend connections to the proxy
+  - `DatabaseConnections` — backend connections the proxy holds (distinct from the DB-side metric)
+  - `DatabaseConnectionsCurrentlySessionPinned` — the canonical pinning diagnostic; high values mean multiplexing is defeated
+- You MUST determine `max_connections` for the instance class. The RDS default is roughly `LEAST({DBInstanceClassMemory/9531392}, 5000)`. Check the parameter group for overrides.
+
+Example CLI to pull the DB-side connection metric:
+```bash
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/RDS \
+  --metric-name DatabaseConnections \
+  --dimensions Name=DBInstanceIdentifier,Value=<instance-id> \
+  --start-time $(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%S) \
+  --end-time $(date -u +%Y-%m-%dT%H:%M:%S) \
+  --period 3600 --statistics Average Maximum \
+  --region <region>
+```
+For proxy-side metrics, swap the dimension to `Name=ProxyName,Value=<proxy-name>`. For p99, drop `--statistics` and pass `--extended-statistics p99` instead.
+- You MUST calculate connection utilization: `peak_connections / max_connections × 100`%
+
+### 2. Assess Proxy Need
+
+**Constraints:**
+- You MUST categorize the result using these thresholds:
+  - 🔴 **Recommended**: peak connections > 80% of `max_connections`, OR Lambda/serverless callers present
+  - 🟡 **Consider**: peak connections 50–80% of `max_connections`, OR frequent connection churn (spiky workload)
+  - 🟢 **Not recommended**: peak connections < 50% and stable connection patterns
+- You MUST ask if the application uses Lambda or other serverless compute, because connection churn from cold starts is the primary RDS Proxy use case
+- You MUST check whether the application already uses client-side connection pooling (PgBouncer, ProxySQL, HikariCP, etc.) — if it does and connections are healthy, proxy may add latency without benefit
+- You MUST NOT recommend proxy on utilization metrics alone — low utilization with heavy Lambda churn still benefits from proxy
+
+### 3. Check for Pinning Risks
+
+Connect to the database or ask the user to run diagnostic queries to identify SQL patterns that cause proxy pinning.
+
+**Constraints:**
+- You MUST explain what pinning is: the proxy pins a frontend connection to a specific backend connection, preventing multiplexing — the proxy's core benefit
+- For MySQL/MariaDB, check for patterns from [proxy-pinning-mysql.md](proxy-pinning-mysql.md)
+- For PostgreSQL, check for patterns from [proxy-pinning-postgresql.md](proxy-pinning-postgresql.md)
+- You MUST categorize pinning risk as High / Medium / Low
+- If pinning risk is High, you MUST warn that proxy benefit will be significantly reduced and quantify where possible (e.g., "if >30% of connections pin, the multiplexing advantage is largely negated")
+- For PostgreSQL: you MUST call out `SET search_path` as the most common high-pinning pattern (Django, Rails ORM defaults pin every connection). Recommend moving it to the proxy init query or parameter group default.
+- For MySQL: you MUST call out server-side prepared statements as the most common high-pinning pattern (JDBC default). Recommend `useServerPrepStmts=false` or client-side prepared statements.
+- When the user asks how to measure pinning in production, you MUST direct them to the CloudWatch metrics `DatabaseConnectionsCurrentlySessionPinned` and `ClientConnections` (`AWS/RDS` namespace, dimension `ProxyName`) and the RDS Proxy pinning log events. You MUST NOT fabricate a pinning-rate percentage when no live metrics have been pulled.
+
+### 4. Estimate Cost
+
+**Constraints:**
+- You MUST calculate proxy cost based on vCPU count of the target instance. RDS Proxy pricing is **$0.015 per vCPU per hour** in us-east-1 (verify for other regions; pricing varies slightly).
+- Monthly cost = `vCPUs × $0.015 × 730 hours`
+- You MUST present cost alongside the benefit (connection multiplexing value, failover improvement ≈ 66% faster than direct)
+- You MUST note that proxy adds ~5 ms latency per connection establishment — for latency-sensitive workloads with short connection lifetimes, this can matter
+
+### 5. Special Cases
+
+- **Already using PgBouncer in transaction mode:** RDS Proxy's multiplexing benefit is marginal. PgBouncer in transaction mode is actually more aggressive (no pinning on SET). RDS Proxy adds value for managed infrastructure, IAM auth, and Multi-AZ failover handling — but it's a "Consider", not a strong "Recommend".
+- **TLS to the backend:** RDS Proxy enforces TLS between proxy and database by default — a security advantage over self-managed PgBouncer, which may not enforce backend TLS.
+- **Advisory locks (PostgreSQL) or `GET_LOCK()` (MySQL):** High pinning — connection is pinned for the lock's entire hold time. Recommend replacing with application-level locking (Redis, DynamoDB).
+- **LISTEN/NOTIFY (PostgreSQL):** Pins the backend. Replace with SQS/SNS/EventBridge if using proxy.
+
+### 6. Present Recommendation
+
+**Constraints:**
+- You MUST present a clear verdict: Recommended / Consider / Not Recommended
+- You MUST include: current connection utilization, pinning risk level, estimated monthly cost, and key tradeoffs
+- You MUST NOT create an RDS Proxy — this workflow is advisory only
+- You SHOULD reference [proxy-pinning-mysql.md](proxy-pinning-mysql.md) or [proxy-pinning-postgresql.md](proxy-pinning-postgresql.md) for the engine-specific pinning taxonomy
+
+## Troubleshooting
+
+- **No CloudWatch data**: Instance may be newly created. Ask user for expected connection patterns instead.
+- **`max_connections` unclear**: Check parameter group with `aws rds describe-db-parameters`. If not custom, use the engine default formula based on instance memory.
+- **User unsure about pinning**: Provide the diagnostic queries from the pinning references and ask them to run and paste results.
+- **Multi-AZ with proxy**: Proxy handles failover automatically — additional benefit worth mentioning in the recommendation.
+- **IAM auth required**: RDS Proxy is the supported path for IAM database authentication on RDS MySQL/PostgreSQL — mention as a benefit when applicable.
+
+## References
+
+- [proxy-pinning-mysql.md](proxy-pinning-mysql.md) — MySQL/MariaDB pinning patterns and diagnostics
+- [proxy-pinning-postgresql.md](proxy-pinning-postgresql.md) — PostgreSQL pinning patterns, search_path gotcha, extended query protocol notes

--- a/skills/specialized-skills/database-skills/rds-oss/references/proxy-advisor-workflow.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/proxy-advisor-workflow.md
@@ -13,6 +13,7 @@ User mentions: "should I use RDS Proxy", "too many connections", "connection poo
 Pull connection data to assess whether proxy is needed.
 
 **Constraints:**
+
 - You MUST ask for the DB instance identifier and region upfront
 - You MUST run `aws rds describe-db-instances` to get engine, instance class, and vCPU count
 - You MUST pull CloudWatch metrics for the last 7 days from the `AWS/RDS` namespace:
@@ -25,6 +26,7 @@ Pull connection data to assess whether proxy is needed.
 - You MUST determine `max_connections` for the instance class. The RDS default is roughly `LEAST({DBInstanceClassMemory/9531392}, 5000)`. Check the parameter group for overrides.
 
 Example CLI to pull the DB-side connection metric:
+
 ```bash
 aws cloudwatch get-metric-statistics \
   --namespace AWS/RDS \
@@ -35,12 +37,15 @@ aws cloudwatch get-metric-statistics \
   --period 3600 --statistics Average Maximum \
   --region <region>
 ```
+
 For proxy-side metrics, swap the dimension to `Name=ProxyName,Value=<proxy-name>`. For p99, drop `--statistics` and pass `--extended-statistics p99` instead.
+
 - You MUST calculate connection utilization: `peak_connections / max_connections × 100`%
 
 ### 2. Assess Proxy Need
 
 **Constraints:**
+
 - You MUST categorize the result using these thresholds:
   - 🔴 **Recommended**: peak connections > 80% of `max_connections`, OR Lambda/serverless callers present
   - 🟡 **Consider**: peak connections 50–80% of `max_connections`, OR frequent connection churn (spiky workload)
@@ -54,6 +59,7 @@ For proxy-side metrics, swap the dimension to `Name=ProxyName,Value=<proxy-name>
 Connect to the database or ask the user to run diagnostic queries to identify SQL patterns that cause proxy pinning.
 
 **Constraints:**
+
 - You MUST explain what pinning is: the proxy pins a frontend connection to a specific backend connection, preventing multiplexing — the proxy's core benefit
 - For MySQL/MariaDB, check for patterns from [proxy-pinning-mysql.md](proxy-pinning-mysql.md)
 - For PostgreSQL, check for patterns from [proxy-pinning-postgresql.md](proxy-pinning-postgresql.md)
@@ -66,6 +72,7 @@ Connect to the database or ask the user to run diagnostic queries to identify SQ
 ### 4. Estimate Cost
 
 **Constraints:**
+
 - You MUST calculate proxy cost based on vCPU count of the target instance. RDS Proxy pricing is **$0.015 per vCPU per hour** in us-east-1 (verify for other regions; pricing varies slightly).
 - Monthly cost = `vCPUs × $0.015 × 730 hours`
 - You MUST present cost alongside the benefit (connection multiplexing value, failover improvement ≈ 66% faster than direct)
@@ -81,6 +88,7 @@ Connect to the database or ask the user to run diagnostic queries to identify SQ
 ### 6. Present Recommendation
 
 **Constraints:**
+
 - You MUST present a clear verdict: Recommended / Consider / Not Recommended
 - You MUST include: current connection utilization, pinning risk level, estimated monthly cost, and key tradeoffs
 - You MUST NOT create an RDS Proxy — this workflow is advisory only

--- a/skills/specialized-skills/database-skills/rds-oss/references/proxy-pinning-mysql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/proxy-pinning-mysql.md
@@ -1,0 +1,46 @@
+# MySQL/MariaDB RDS Proxy Pinning Risks
+
+Pinning means the proxy locks a frontend connection to a specific backend database connection, preventing multiplexing. When pinned, the proxy can't reuse that backend connection for other clients, reducing the benefit of connection pooling.
+
+## High Pinning Risk (defeats proxy purpose)
+
+| Pattern | Why It Pins | Diagnostic Query |
+|---------|-------------|------------------|
+| Prepared statements (server-side) | Proxy can't move prepared state between backends | `SHOW GLOBAL STATUS LIKE 'Com_stmt_prepare';` — if high, pinning is frequent |
+| SET SESSION variables | Session state is backend-specific | `SELECT s.VARIABLE_NAME, s.VARIABLE_VALUE AS session_val, g.VARIABLE_VALUE AS global_val FROM performance_schema.session_variables s JOIN performance_schema.global_variables g USING (VARIABLE_NAME) WHERE s.VARIABLE_VALUE <> g.VARIABLE_VALUE;` — rows where session differs from global indicate a `SET SESSION` was issued |
+| User-defined variables (`@var`) | Session-scoped, can't be transferred | Check application code for `SET @var = ...` patterns |
+| LOCK TABLES | Explicit lock is backend-specific | `SHOW GLOBAL STATUS LIKE 'Com_lock_tables';` |
+| GET_LOCK() / RELEASE_LOCK() | Advisory locks are session-scoped | Check application code for `GET_LOCK()` usage |
+| Temporary tables | `CREATE TEMPORARY TABLE` is session-scoped | `SHOW GLOBAL STATUS LIKE 'Created_tmp_tables';` — high values indicate risk |
+| FOUND_ROWS() | Depends on previous query's state | Check application code |
+
+## Medium Pinning Risk
+
+| Pattern | Notes |
+|---------|-------|
+| SET NAMES / SET CHARACTER SET | Pins if different from proxy default. Configure proxy default charset to match app. |
+| SET TRANSACTION ISOLATION LEVEL | Pins for the duration of the transaction |
+| Multi-statement transactions | Pinned for transaction duration (expected, not a problem if transactions are short) |
+
+## Low / No Pinning Risk
+
+| Pattern | Notes |
+|---------|-------|
+| Simple SELECT/INSERT/UPDATE/DELETE | No session state. Full multiplexing. |
+| Autocommit single statements | No pinning. |
+| Connection attributes | Proxy handles these transparently. |
+
+## Diagnostic: Check Current Pinning Rate
+
+If RDS Proxy is already deployed, check pinning via CloudWatch:
+- `ClientConnectionsSetupSucceeded` vs `DatabaseConnectionsCurrentlySessionPinned`
+- Pinning rate = pinned / total × 100
+- If > 30%, proxy benefit is significantly reduced
+
+## Mitigation Strategies
+
+1. Move prepared statements to client-side (use `useServerPrepStmts=false` in JDBC)
+2. Avoid SET SESSION — use proxy's default connection init query instead
+3. Keep transactions short to minimize pin duration
+4. Avoid temporary tables — use CTEs or subqueries instead
+5. Replace GET_LOCK() with application-level locking (Redis, DynamoDB)

--- a/skills/specialized-skills/database-skills/rds-oss/references/proxy-pinning-mysql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/proxy-pinning-mysql.md
@@ -33,6 +33,7 @@ Pinning means the proxy locks a frontend connection to a specific backend databa
 ## Diagnostic: Check Current Pinning Rate
 
 If RDS Proxy is already deployed, check pinning via CloudWatch:
+
 - `ClientConnectionsSetupSucceeded` vs `DatabaseConnectionsCurrentlySessionPinned`
 - Pinning rate = pinned / total × 100
 - If > 30%, proxy benefit is significantly reduced

--- a/skills/specialized-skills/database-skills/rds-oss/references/proxy-pinning-postgresql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/proxy-pinning-postgresql.md
@@ -36,6 +36,7 @@ RDS Proxy for PostgreSQL uses connection multiplexing at the session level. Cert
 
 ### search_path
 Many ORMs and frameworks set `search_path` per connection. This pins every connection. Mitigation:
+
 - Set `search_path` in the proxy's init query instead of per-connection
 - Or set it in the PostgreSQL parameter group as the default
 
@@ -43,6 +44,7 @@ Many ORMs and frameworks set `search_path` per connection. This pins every conne
 PostgreSQL's extended query protocol (Parse/Bind/Execute) creates server-side prepared statements implicitly. Many drivers (libpq, JDBC, node-postgres) use this by default. This causes pinning.
 
 Mitigation:
+
 - JDBC: set `prepareThreshold=0` to disable server-side prepared statements
 - node-postgres: avoid passing a `name` property in query config objects (named queries create persistent server-side prepared statements that pin connections)
 - Python psycopg2: uses simple query protocol by default (no pinning)

--- a/skills/specialized-skills/database-skills/rds-oss/references/proxy-pinning-postgresql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/proxy-pinning-postgresql.md
@@ -1,0 +1,82 @@
+# PostgreSQL RDS Proxy Pinning Risks
+
+RDS Proxy for PostgreSQL uses connection multiplexing at the session level. Certain PostgreSQL features create session state that prevents the proxy from reusing backend connections.
+
+## High Pinning Risk (defeats proxy purpose)
+
+| Pattern | Why It Pins | Diagnostic Query |
+|---------|-------------|------------------|
+| Prepared statements (PREPARE/EXECUTE) | Server-side prepared state is session-scoped | `SELECT name, statement FROM pg_prepared_statements;` (run per-session) |
+| Advisory locks (pg_advisory_lock) | Lock is held on a specific backend | `SELECT * FROM pg_locks WHERE locktype = 'advisory';` |
+| LISTEN/NOTIFY | LISTEN registers on a specific backend connection | `SELECT * FROM pg_listening_channels();` |
+| SET (session parameters) | e.g., `SET search_path`, `SET work_mem` — session-scoped | `SHOW search_path;` — if app sets this per-connection, every connection pins |
+| Temporary tables | Session-scoped, can't be transferred | Check application code for `CREATE TEMP TABLE` |
+| DECLARE CURSOR WITH HOLD (without CLOSE) | Holdable cursor survives the transaction and is session-scoped | Check for open holdable cursors: `SELECT * FROM pg_cursors WHERE is_holdable = true;` |
+| Sequence manipulation (CURRVAL) | CURRVAL depends on session's last NEXTVAL call | Check application code for `CURRVAL()` usage |
+
+## Medium Pinning Risk
+
+| Pattern | Notes |
+|---------|-------|
+| SET LOCAL (transaction-scoped) | Pins only for transaction duration. Less impactful than SET (session). |
+| SAVEPOINT | Pins for transaction duration. Fine if transactions are short. |
+| Large result sets with cursors | Pins until cursor is closed. Use LIMIT/OFFSET instead. |
+| SET ROLE / SET SESSION AUTHORIZATION | Pins for session duration. |
+
+## Low / No Pinning Risk
+
+| Pattern | Notes |
+|---------|-------|
+| Simple queries (SELECT, INSERT, UPDATE, DELETE) | No session state. Full multiplexing. |
+| Autocommit single statements | No pinning. |
+| PL/pgSQL functions (without session state) | Executed server-side, no pinning. |
+| COPY (bulk load) | No pinning after completion. |
+
+## PostgreSQL-Specific Gotchas
+
+### search_path
+Many ORMs and frameworks set `search_path` per connection. This pins every connection. Mitigation:
+- Set `search_path` in the proxy's init query instead of per-connection
+- Or set it in the PostgreSQL parameter group as the default
+
+### Extended query protocol
+PostgreSQL's extended query protocol (Parse/Bind/Execute) creates server-side prepared statements implicitly. Many drivers (libpq, JDBC, node-postgres) use this by default. This causes pinning.
+
+Mitigation:
+- JDBC: set `prepareThreshold=0` to disable server-side prepared statements
+- node-postgres: avoid passing a `name` property in query config objects (named queries create persistent server-side prepared statements that pin connections)
+- Python psycopg2: uses simple query protocol by default (no pinning)
+- Python psycopg3: uses extended protocol by default (pins) — set `prepare_threshold=None`
+
+### PgBouncer vs RDS Proxy
+If already using PgBouncer in transaction mode, RDS Proxy adds little value — both do connection multiplexing. RDS Proxy's advantage is managed infrastructure + IAM auth + automatic failover handling. But PgBouncer in transaction mode is more aggressive at multiplexing (no pinning on SET).
+
+## Diagnostic: Check Pinning Potential
+
+Run these on the database to estimate pinning risk before deploying proxy:
+
+```sql
+-- Check for advisory locks
+SELECT COUNT(*) AS advisory_locks FROM pg_locks WHERE locktype = 'advisory';
+
+-- Check for active LISTEN channels
+SELECT COUNT(*) AS listen_channels FROM pg_listening_channels();
+
+-- Check for prepared statements (current session — ask app team to check during peak)
+SELECT COUNT(*) AS prepared_stmts FROM pg_prepared_statements;
+
+-- Check for temp tables in current sessions
+SELECT COUNT(*) AS temp_tables FROM pg_class WHERE relpersistence = 't';
+
+-- Check for open cursors
+SELECT COUNT(*) AS open_cursors FROM pg_cursors WHERE is_holdable = true;
+```
+
+## Mitigation Strategies
+
+1. Move search_path to proxy init query or parameter group default
+2. Disable server-side prepared statements in the driver (see above)
+3. Replace advisory locks with application-level locking (Redis, DynamoDB)
+4. Replace LISTEN/NOTIFY with SQS, SNS, or EventBridge
+5. Avoid DECLARE CURSOR WITH HOLD — use LIMIT/OFFSET or keyset pagination
+6. Keep transactions short to minimize pin duration

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-post-checklist.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-post-checklist.md
@@ -10,6 +10,7 @@ aws rds describe-db-instances \
 ```
 
 Confirm:
+
 - EngineVersion matches the target version
 - DBInstanceStatus is `available`
 - Parameter group status is `in-sync` (if `pending-reboot`, reboot the instance)
@@ -19,6 +20,7 @@ Confirm:
 Connect to the instance and confirm basic operations work:
 
 **MySQL/MariaDB:**
+
 ```sql
 SELECT VERSION();
 SHOW DATABASES;
@@ -26,6 +28,7 @@ SELECT 1;
 ```
 
 **PostgreSQL:**
+
 ```sql
 SELECT version();
 \l
@@ -33,6 +36,7 @@ SELECT 1;
 ```
 
 Check that:
+
 - Connection succeeds (for MySQL 8.0: auth plugin may have changed to `caching_sha2_password` — older clients may need `--default-auth=mysql_native_password`)
 - All expected databases are present
 - Key application queries return expected results
@@ -40,11 +44,13 @@ Check that:
 If you observe query performance regressions at this step, table statistics may be stale. The new optimizer in the target version relies more heavily on accurate statistics. You can refresh statistics for the affected tables:
 
 **MySQL/MariaDB:**
+
 ```sql
 ANALYZE TABLE schema_name.table_name;
 ```
 
 **PostgreSQL:**
+
 ```sql
 ANALYZE schema_name.table_name;
 ```
@@ -66,11 +72,13 @@ Beyond basic database connectivity, verify that your actual application connects
 If you created a custom parameter group to preserve previous behavior, confirm the key settings took effect:
 
 **MySQL (5.7 → 8.0):**
+
 ```sql
 SELECT @@character_set_server, @@collation_server, @@sql_mode, @@innodb_strict_mode;
 ```
 
 **PostgreSQL:**
+
 ```sql
 SHOW server_encoding;
 SHOW lc_collate;
@@ -85,21 +93,25 @@ If you used the default parameter group for the target family, these will be the
 The optimizer in the target version may choose different execution plans. Run EXPLAIN on your most critical queries and compare with pre-upgrade behavior:
 
 **MySQL/MariaDB:**
+
 ```sql
 EXPLAIN FORMAT=JSON SELECT ... ;
 ```
 
 Watch for (MySQL 8.0):
+
 - Hash joins replacing nested loop joins (new in 8.0 — usually faster, but verify)
 - GROUP BY results no longer implicitly sorted — add explicit ORDER BY if your app relied on this
 - Index choices may differ due to updated cost model
 
 **PostgreSQL:**
+
 ```sql
 EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT ... ;
 ```
 
 Watch for (PG 15+):
+
 - work_mem per-operation accounting changes
 - Memoize nodes on nested loops (PG 14+)
 - Parallel query threshold changes
@@ -140,6 +152,7 @@ If any metric shows a significant regression compared to pre-upgrade baseline, i
 Only proceed with cleanup after you have confirmed the upgrade was successful and you do not observe any performance or operational regressions. Keep the pre-upgrade snapshot and old Blue/Green environment available as a rollback option until you are fully confident.
 
 Once confirmed:
+
 - Delete the pre-upgrade snapshot (it incurs storage charges)
 - Delete any test instances created during pre-upgrade validation
 - If Blue/Green was used: delete the old blue environment and the Blue/Green deployment

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-post-checklist.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-post-checklist.md
@@ -1,0 +1,152 @@
+# RDS Post-Upgrade Checklist — MySQL, MariaDB, PostgreSQL
+
+## Step 1: Verify the Upgrade Completed Successfully
+
+```bash
+aws rds describe-db-instances \
+  --db-instance-identifier <instance-id> \
+  --query "DBInstances[0].{EngineVersion:EngineVersion,DBInstanceStatus:DBInstanceStatus,DBParameterGroups:DBParameterGroups[0].{Name:DBParameterGroupName,Status:ParameterApplyStatus}}" \
+  --region <region>
+```
+
+Confirm:
+- EngineVersion matches the target version
+- DBInstanceStatus is `available`
+- Parameter group status is `in-sync` (if `pending-reboot`, reboot the instance)
+
+## Step 2: Verify Application Connectivity and Query Performance
+
+Connect to the instance and confirm basic operations work:
+
+**MySQL/MariaDB:**
+```sql
+SELECT VERSION();
+SHOW DATABASES;
+SELECT 1;
+```
+
+**PostgreSQL:**
+```sql
+SELECT version();
+\l
+SELECT 1;
+```
+
+Check that:
+- Connection succeeds (for MySQL 8.0: auth plugin may have changed to `caching_sha2_password` — older clients may need `--default-auth=mysql_native_password`)
+- All expected databases are present
+- Key application queries return expected results
+
+If you observe query performance regressions at this step, table statistics may be stale. The new optimizer in the target version relies more heavily on accurate statistics. You can refresh statistics for the affected tables:
+
+**MySQL/MariaDB:**
+```sql
+ANALYZE TABLE schema_name.table_name;
+```
+
+**PostgreSQL:**
+```sql
+ANALYZE schema_name.table_name;
+```
+
+Note: `ANALYZE TABLE` and `OPTIMIZE TABLE` are expensive operations. Do NOT run them blanket across all tables while production traffic is active. Target only the tables where you observe performance issues, and run during a low-traffic window.
+
+## Step 3: Verify Application Connectivity
+
+Beyond basic database connectivity, verify that your actual application connects and operates correctly against the upgraded instance:
+
+- Point your application (or a staging/canary instance) at the upgraded database
+- Confirm the application driver is compatible with the new engine version — auth plugin changes (MySQL 8.0: `caching_sha2_password`), TLS negotiation, and connection pooling behavior may differ
+- Run key application workflows end-to-end (reads, writes, transactions)
+- Check application logs for connection errors, query failures, or unexpected behavior
+- If using connection pooling (HikariCP, PgBouncer, ProxySQL), verify pools reconnected and are healthy
+
+## Step 4: Verify Parameter Group Settings
+
+If you created a custom parameter group to preserve previous behavior, confirm the key settings took effect:
+
+**MySQL (5.7 → 8.0):**
+```sql
+SELECT @@character_set_server, @@collation_server, @@sql_mode, @@innodb_strict_mode;
+```
+
+**PostgreSQL:**
+```sql
+SHOW server_encoding;
+SHOW lc_collate;
+SHOW work_mem;
+SHOW shared_buffers;
+```
+
+If you used the default parameter group for the target family, these will be the new version's defaults — verify your application handles them correctly.
+
+## Step 5: Check for Query Plan Changes
+
+The optimizer in the target version may choose different execution plans. Run EXPLAIN on your most critical queries and compare with pre-upgrade behavior:
+
+**MySQL/MariaDB:**
+```sql
+EXPLAIN FORMAT=JSON SELECT ... ;
+```
+
+Watch for (MySQL 8.0):
+- Hash joins replacing nested loop joins (new in 8.0 — usually faster, but verify)
+- GROUP BY results no longer implicitly sorted — add explicit ORDER BY if your app relied on this
+- Index choices may differ due to updated cost model
+
+**PostgreSQL:**
+```sql
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) SELECT ... ;
+```
+
+Watch for (PG 15+):
+- work_mem per-operation accounting changes
+- Memoize nodes on nested loops (PG 14+)
+- Parallel query threshold changes
+
+## Step 6: Verify Audit and Access Logging
+
+Parameter group changes during an upgrade can reset logging settings. After the upgrade, confirm logging is still enabled:
+
+- **MySQL/MariaDB**: audit plugin still active; `general_log` and `slow_query_log` settings preserved
+- **PostgreSQL**: `pgaudit` extension settings, `log_connections`, `log_disconnections` preserved
+- **All engines**: CloudTrail is still capturing RDS API calls for the account/region
+
+## Step 7: Monitor CloudWatch Metrics
+
+Monitor these CloudWatch metrics for the first 24-48 hours post-upgrade. These apply to all RDS engines (MySQL, MariaDB, PostgreSQL):
+
+- `CPUUtilization` — should be comparable to pre-upgrade baseline
+- `DatabaseConnections` — confirm apps reconnected successfully
+- `ReadIOPS` — watch for unexpected spikes indicating plan regressions
+- `WriteIOPS` — watch for unexpected spikes
+- `FreeableMemory` — the new version may use memory differently
+- `FreeStorageSpace` — upgrade process may temporarily consume extra storage
+
+```bash
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/RDS \
+  --metric-name CPUUtilization \
+  --dimensions Name=DBInstanceIdentifier,Value=<instance-id> \
+  --start-time <start> --end-time <end> \
+  --period 300 --statistics Average \
+  --region <region>
+```
+
+If any metric shows a significant regression compared to pre-upgrade baseline, investigate before considering the upgrade successful.
+
+## Step 8: Clean Up
+
+Only proceed with cleanup after you have confirmed the upgrade was successful and you do not observe any performance or operational regressions. Keep the pre-upgrade snapshot and old Blue/Green environment available as a rollback option until you are fully confident.
+
+Once confirmed:
+- Delete the pre-upgrade snapshot (it incurs storage charges)
+- Delete any test instances created during pre-upgrade validation
+- If Blue/Green was used: delete the old blue environment and the Blue/Green deployment
+
+```bash
+# Delete old snapshot (only after confirming upgrade success)
+aws rds delete-db-snapshot \
+  --db-snapshot-identifier <instance-id>-pre-upgrade-snapshot \
+  --region <region>
+```

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-pre-checklist.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-pre-checklist.md
@@ -1,0 +1,167 @@
+# RDS Pre-Upgrade Checklist — MySQL, MariaDB, PostgreSQL
+
+## Step 1: Take a Manual Snapshot
+
+Create a snapshot before starting. This is your rollback safety net regardless of upgrade method:
+
+```bash
+aws rds create-db-snapshot \
+  --db-instance-identifier <instance-id> \
+  --db-snapshot-identifier <instance-id>-pre-upgrade-snapshot \
+  --region <region>
+```
+
+## Step 2: Check Automated Backup Status
+
+Automated backups are NOT required for in-place upgrades. However:
+- If automated backups ARE enabled, RDS automatically takes a pre-upgrade snapshot before starting the upgrade. This is a safety net you get for free.
+- If automated backups are NOT enabled, RDS skips the pre-upgrade snapshot and proceeds directly. You lose that automatic rollback point.
+- Automated backups ARE required for Blue/Green deployments (replication depends on them).
+
+```bash
+aws rds describe-db-instances \
+  --db-instance-identifier <instance-id> \
+  --query "DBInstances[0].BackupRetentionPeriod" \
+  --region <region>
+```
+
+If `0` and you want the automatic pre-upgrade snapshot (recommended):
+```bash
+aws rds modify-db-instance \
+  --db-instance-identifier <instance-id> \
+  --backup-retention-period 7 \
+  --apply-immediately \
+  --region <region>
+```
+
+## Step 3: Check for Pending Maintenance
+
+Pending maintenance actions can block upgrades. Apply them first:
+
+```bash
+aws rds describe-pending-maintenance-actions \
+  --resource-identifier <instance-arn> \
+  --region <region>
+```
+
+## Step 4: Run the RDS Pre-Upgrade Validation
+
+For MySQL 5.7 to 8.0 major upgrades, RDS automatically runs a prechecks script as part of the upgrade process. If prechecks fail, the upgrade is aborted and the instance stays on the current version.
+
+You can preview what the prechecker will find by running it yourself before initiating the upgrade. Connect to the database and run:
+
+```sql
+-- MySQL: check for issues the RDS prechecker will flag
+CALL mysql.rds_upgrade_prechecks();
+```
+
+If this procedure is not available, the key checks the prechecker runs are:
+- Reserved keywords used as identifiers (table names, column names)
+- Orphaned InnoDB tables (`.frm` without `.ibd`)
+- Tables using non-native partitioning
+- Triggers or events with null definers
+- Incompatible data types or character sets
+
+Review the output and fix any issues BEFORE initiating the upgrade.
+
+## Step 5: Check for Reserved Keywords
+
+MySQL 8.0 added new reserved keywords. If your schema uses any of these as unquoted identifiers, the upgrade prechecker will flag them:
+
+`CUME_DIST`, `DENSE_RANK`, `EMPTY`, `EXCEPT`, `FIRST_VALUE`, `GROUPING`, `GROUPS`, `JSON_TABLE`, `LAG`, `LAST_VALUE`, `LATERAL`, `LEAD`, `NTH_VALUE`, `NTILE`, `OF`, `OVER`, `PERCENT_RANK`, `RANK`, `RECURSIVE`, `ROW`, `ROWS`, `ROW_NUMBER`, `SYSTEM`, `WINDOW`
+
+Fix by quoting with backticks or renaming before the upgrade.
+
+## Step 6: Create a Target Parameter Group (Optional)
+
+If you don't create a custom parameter group, RDS will assign the default parameter group for the target version family (e.g., `default.mysql8.0`). This uses MySQL 8.0 defaults which differ from 5.7 in several ways.
+
+If you want to preserve current behavior, create a custom parameter group:
+
+```bash
+aws rds create-db-parameter-group \
+  --db-parameter-group-name mysql80-from-57 \
+  --db-parameter-group-family mysql8.0 \
+  --description "MySQL 8.0 preserving 5.7 behavior" \
+  --region <region>
+```
+
+Key parameters to preserve (MySQL 5.7 to 8.0):
+
+| Parameter | 5.7 Default | 8.0 Default | Action |
+|-----------|-------------|-------------|--------|
+| character_set_server | latin1 | utf8mb4 | Set to latin1 if needed |
+| collation_server | latin1_swedish_ci | utf8mb4_0900_ai_ci | Set to match |
+| sql_mode | empty | STRICT_TRANS_TABLES,... | Set empty if app relies on permissive mode |
+| innodb_strict_mode | OFF | ON | Set OFF if needed |
+| log_error_verbosity | N/A (was log_warnings) | 2 | Set to match old log_warnings value |
+
+Note: `query_cache_type` and `query_cache_size` are removed in 8.0 — no parameter to set. If your app relied on query cache, handle at the application layer.
+
+## Step 7: Test on a Snapshot-Restored Instance
+
+Restore your snapshot and upgrade the test instance to validate:
+
+```bash
+aws rds restore-db-instance-from-db-snapshot \
+  --db-instance-identifier <instance-id>-upgrade-test \
+  --db-snapshot-identifier <instance-id>-pre-upgrade-snapshot \
+  --db-instance-class <same-class> \
+  --region <region>
+```
+
+Then upgrade the test instance:
+```bash
+aws rds modify-db-instance \
+  --db-instance-identifier <instance-id>-upgrade-test \
+  --engine-version <target-version> \
+  --allow-major-version-upgrade \
+  --apply-immediately \
+  --region <region>
+```
+
+After the test instance is upgraded and available:
+1. Validate database operations — connect, run key queries, check schema integrity
+2. Verify application connectivity — point your application (or a test instance of it) at the upgraded test database and confirm the application driver works correctly with the new engine version. Auth plugin changes (e.g., `caching_sha2_password` in MySQL 8.0), TLS requirements, and connection string parameters may behave differently.
+
+## Step 8: Consider Blue/Green Deployment
+
+For production instances, Blue/Green is safer than in-place:
+- Creates a staging copy on the target version
+- Keeps it in sync via replication
+- Switchover with typically under 1 minute of downtime
+
+Requirements: automated backups enabled, binlog_format=ROW (MySQL/MariaDB), engine version supports Blue/Green (MySQL 5.7+, MariaDB 10.4+, PostgreSQL 12.7+).
+
+## Step 9: Review Target Version Release Notes
+
+Before upgrading, review the release notes for the target version to understand behavioral changes, new features, and deprecations. Key changes to watch for are called out below by engine.
+
+**MySQL** (e.g., 5.7 → 8.0):
+- New data dictionary (no more `.frm` files)
+- New TempTable engine replaces MEMORY for internal temp tables
+- GROUP BY no longer implicitly sorts results
+- Query cache removed entirely
+- Default auth plugin changed to `caching_sha2_password`
+- Release notes: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/
+
+**MariaDB** (e.g., 10.6 → 10.11 or 11.4):
+- Each major version introduces new SQL features, optimizer changes, and storage engine updates
+- Check for deprecated features being removed in the target version
+- Release notes: https://mariadb.com/kb/en/release-notes/
+
+**PostgreSQL** (e.g., 14 → 15 or 16):
+- Each major version refines the planner cost model, which can change query plans
+- New features like Memoize (PG 14), work_mem changes (PG 15), subquery decorrelation (PG 16)
+- Extension compatibility may change between major versions
+- Release notes: https://www.postgresql.org/docs/release/
+
+You SHOULD read the "Incompatible Changes" or "Removed Features" section of the target version's release notes before proceeding.
+
+## Step 10: Notify Stakeholders
+
+Before executing:
+- Notify application teams about the maintenance window
+- Confirm connection strings don't hardcode the engine version
+- Verify application compatibility with the target version
+- For MySQL 5.7 to 8.0: warn about GROUP BY implicit sort removal, strict mode default, auth plugin changes

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-pre-checklist.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-pre-checklist.md
@@ -14,6 +14,7 @@ aws rds create-db-snapshot \
 ## Step 2: Check Automated Backup Status
 
 Automated backups are NOT required for in-place upgrades. However:
+
 - If automated backups ARE enabled, RDS automatically takes a pre-upgrade snapshot before starting the upgrade. This is a safety net you get for free.
 - If automated backups are NOT enabled, RDS skips the pre-upgrade snapshot and proceeds directly. You lose that automatic rollback point.
 - Automated backups ARE required for Blue/Green deployments (replication depends on them).
@@ -26,6 +27,7 @@ aws rds describe-db-instances \
 ```
 
 If `0` and you want the automatic pre-upgrade snapshot (recommended):
+
 ```bash
 aws rds modify-db-instance \
   --db-instance-identifier <instance-id> \
@@ -56,6 +58,7 @@ CALL mysql.rds_upgrade_prechecks();
 ```
 
 If this procedure is not available, the key checks the prechecker runs are:
+
 - Reserved keywords used as identifiers (table names, column names)
 - Orphaned InnoDB tables (`.frm` without `.ibd`)
 - Tables using non-native partitioning
@@ -111,6 +114,7 @@ aws rds restore-db-instance-from-db-snapshot \
 ```
 
 Then upgrade the test instance:
+
 ```bash
 aws rds modify-db-instance \
   --db-instance-identifier <instance-id>-upgrade-test \
@@ -121,12 +125,14 @@ aws rds modify-db-instance \
 ```
 
 After the test instance is upgraded and available:
+
 1. Validate database operations — connect, run key queries, check schema integrity
 2. Verify application connectivity — point your application (or a test instance of it) at the upgraded test database and confirm the application driver works correctly with the new engine version. Auth plugin changes (e.g., `caching_sha2_password` in MySQL 8.0), TLS requirements, and connection string parameters may behave differently.
 
 ## Step 8: Consider Blue/Green Deployment
 
 For production instances, Blue/Green is safer than in-place:
+
 - Creates a staging copy on the target version
 - Keeps it in sync via replication
 - Switchover with typically under 1 minute of downtime
@@ -138,6 +144,7 @@ Requirements: automated backups enabled, binlog_format=ROW (MySQL/MariaDB), engi
 Before upgrading, review the release notes for the target version to understand behavioral changes, new features, and deprecations. Key changes to watch for are called out below by engine.
 
 **MySQL** (e.g., 5.7 → 8.0):
+
 - New data dictionary (no more `.frm` files)
 - New TempTable engine replaces MEMORY for internal temp tables
 - GROUP BY no longer implicitly sorts results
@@ -146,11 +153,13 @@ Before upgrading, review the release notes for the target version to understand 
 - Release notes: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/
 
 **MariaDB** (e.g., 10.6 → 10.11 or 11.4):
+
 - Each major version introduces new SQL features, optimizer changes, and storage engine updates
 - Check for deprecated features being removed in the target version
 - Release notes: https://mariadb.com/kb/en/release-notes/
 
 **PostgreSQL** (e.g., 14 → 15 or 16):
+
 - Each major version refines the planner cost model, which can change query plans
 - New features like Memoize (PG 14), work_mem changes (PG 15), subquery decorrelation (PG 16)
 - Extension compatibility may change between major versions
@@ -161,6 +170,7 @@ You SHOULD read the "Incompatible Changes" or "Removed Features" section of the 
 ## Step 10: Notify Stakeholders
 
 Before executing:
+
 - Notify application teams about the maintenance window
 - Confirm connection strings don't hardcode the engine version
 - Verify application compatibility with the target version

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-prechecks-mysql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-prechecks-mysql.md
@@ -5,6 +5,7 @@ Run these against the database to identify upgrade blockers and behavior changes
 ## Connection Methods
 
 ### SSM Run Command
+
 ```bash
 aws ssm send-command --instance-ids {instance_id} --document-name "AWS-RunShellScript" \
   --parameters 'commands=["SECRET=$(aws secretsmanager get-secret-value --secret-id {secret_arn} --query SecretString --output text | jq -r .password); mysql -h {endpoint} -u {username} -p\"$SECRET\" -e \"{query}\""]' \
@@ -15,6 +16,7 @@ aws ssm send-command --instance-ids {instance_id} --document-name "AWS-RunShellS
 
 **Preferred: IAM database authentication** — where supported, use `aws rds generate-db-auth-token` to produce a short-lived token and connect with `--password="$TOKEN"`. This avoids any long-lived password in the environment or command history. Use minimal-privilege credentials (a read-only user with SELECT on `information_schema`, `performance_schema`, and `mysql.user`) rather than the master user.
 Retrieve results:
+
 ```bash
 aws ssm get-command-invocation --command-id {id} --instance-id {instance_id} --region {region}
 ```
@@ -24,6 +26,7 @@ Note: RDS Data API is NOT available for standalone RDS instances.
 ## Precheck Queries
 
 ### 1. Reserved Keywords (MySQL 5.7→8.0)
+
 ```sql
 SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME FROM information_schema.COLUMNS
 WHERE UPPER(COLUMN_NAME) IN ('CUME_DIST','DENSE_RANK','EMPTY','EXCEPT','FIRST_VALUE',
@@ -32,32 +35,41 @@ WHERE UPPER(COLUMN_NAME) IN ('CUME_DIST','DENSE_RANK','EMPTY','EXCEPT','FIRST_VA
 'SYSTEM','WINDOW')
 AND TABLE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys');
 ```
+
 Flag: Any results = must quote with backticks or rename.
 
 ### 2. Authentication Plugins
+
 ```sql
 SELECT user, host, plugin FROM mysql.user;
 ```
+
 Flag: `mysql_native_password` deprecated in 8.0. `sha256_password` replaced by `caching_sha2_password`.
 
 ### 3. XA Transactions
+
 ```sql
 XA RECOVER;
 ```
+
 Flag: 🔴 Any results BLOCK the upgrade.
 
 ### 4. Server Character Set and Collation
+
 ```sql
 SELECT @@character_set_server, @@collation_server, @@character_set_database, @@collation_database;
 ```
+
 Flag: If `latin1` — MySQL 8.0 defaults to `utf8mb4`.
 
 ### 5. Schema-Level Character Sets
+
 ```sql
 SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA;
 ```
 
 ### 6. Critical Global Variables
+
 ```sql
 SHOW GLOBAL VARIABLES WHERE Variable_name IN (
   'lower_case_table_names','explicit_defaults_for_timestamp',
@@ -75,6 +87,7 @@ SHOW GLOBAL VARIABLES WHERE Variable_name IN (
 | `innodb_strict_mode=OFF` | 🟡 8.0 defaults ON | Preserve in parameter group |
 
 ### 7. Stored Procedures and Functions
+
 ```sql
 SELECT ROUTINE_SCHEMA, ROUTINE_NAME, ROUTINE_TYPE, DEFINER
 FROM information_schema.ROUTINES
@@ -82,15 +95,18 @@ WHERE ROUTINE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','
 ```
 
 ### 8. Triggers and Events with Null Definers
+
 ```sql
 SELECT TRIGGER_SCHEMA, TRIGGER_NAME, DEFINER FROM information_schema.TRIGGERS
 WHERE DEFINER = '' OR DEFINER IS NULL;
 SELECT EVENT_SCHEMA, EVENT_NAME, DEFINER FROM information_schema.EVENTS
 WHERE DEFINER = '' OR DEFINER IS NULL;
 ```
+
 Flag: 🔴 Null definers cause precheck failures.
 
 ### 9. Partitioned Tables
+
 ```sql
 SELECT TABLE_SCHEMA, TABLE_NAME, PARTITION_METHOD FROM information_schema.PARTITIONS
 WHERE PARTITION_METHOD IS NOT NULL
@@ -98,15 +114,18 @@ AND TABLE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys'
 ```
 
 ### 10. Table Engines and Row Formats
+
 ```sql
 SELECT TABLE_SCHEMA, TABLE_NAME, ENGINE, TABLE_COLLATION, ROW_FORMAT
 FROM information_schema.TABLES
 WHERE TABLE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys')
 AND TABLE_TYPE='BASE TABLE';
 ```
+
 Flag: Non-InnoDB tables, COMPACT row format.
 
 ### 11. Foreign Keys, Views, Grants
+
 ```sql
 SELECT TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
 WHERE REFERENCED_TABLE_NAME IS NOT NULL
@@ -118,6 +137,7 @@ WHERE user NOT IN ('rdsadmin','mysql.sys','rdsrepladmin');
 ```
 
 ### 12. Stale Table Statistics
+
 ```sql
 SELECT TABLE_SCHEMA, TABLE_NAME, UPDATE_TIME, TABLE_ROWS,
   DATEDIFF(NOW(), UPDATE_TIME) AS days_since_update
@@ -127,11 +147,13 @@ AND TABLE_TYPE = 'BASE TABLE'
 AND (UPDATE_TIME IS NULL OR DATEDIFF(NOW(), UPDATE_TIME) > 7)
 ORDER BY days_since_update DESC;
 ```
+
 Flag: 🟡 Use this to record which tables have stale statistics as a pre-upgrade baseline — it helps you spot post-upgrade plan regressions. A major version upgrade invalidates optimizer statistics, so statistics are recalculated **after** the upgrade — see the post-upgrade checklist, which scopes `ANALYZE TABLE` to the affected tables in a low-traffic window.
 
 ## Result Analysis
 
 Generate:
+
 1. Categorized findings (🔴/🟡/🟢)
 2. For each finding: what was found, why it matters, action to take
 3. Recommended DB parameter group for target version preserving current behavior

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-prechecks-mysql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-prechecks-mysql.md
@@ -1,0 +1,137 @@
+# RDS MySQL / MariaDB Live Precheck Queries
+
+Run these against the database to identify upgrade blockers and behavior changes. These queries apply to both RDS MySQL and RDS MariaDB engines.
+
+## Connection Methods
+
+### SSM Run Command
+```bash
+aws ssm send-command --instance-ids {instance_id} --document-name "AWS-RunShellScript" \
+  --parameters 'commands=["SECRET=$(aws secretsmanager get-secret-value --secret-id {secret_arn} --query SecretString --output text | jq -r .password); mysql -h {endpoint} -u {username} -p\"$SECRET\" -e \"{query}\""]' \
+  --region {region} --output json --query "Command.CommandId"
+```
+
+**Never pass plaintext passwords in SSM command parameters** — they are visible in SSM command history, CloudTrail logs, and process listings. Always retrieve the password from Secrets Manager at execution time as shown above. If query results may contain sensitive data, enable KMS encryption on the SSM Run Command output.
+
+**Preferred: IAM database authentication** — where supported, use `aws rds generate-db-auth-token` to produce a short-lived token and connect with `--password="$TOKEN"`. This avoids any long-lived password in the environment or command history. Use minimal-privilege credentials (a read-only user with SELECT on `information_schema`, `performance_schema`, and `mysql.user`) rather than the master user.
+Retrieve results:
+```bash
+aws ssm get-command-invocation --command-id {id} --instance-id {instance_id} --region {region}
+```
+
+Note: RDS Data API is NOT available for standalone RDS instances.
+
+## Precheck Queries
+
+### 1. Reserved Keywords (MySQL 5.7→8.0)
+```sql
+SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME FROM information_schema.COLUMNS
+WHERE UPPER(COLUMN_NAME) IN ('CUME_DIST','DENSE_RANK','EMPTY','EXCEPT','FIRST_VALUE',
+'GROUPING','GROUPS','JSON_TABLE','LAG','LAST_VALUE','LATERAL','LEAD','NTH_VALUE',
+'NTILE','OF','OVER','PERCENT_RANK','RANK','RECURSIVE','ROW','ROWS','ROW_NUMBER',
+'SYSTEM','WINDOW')
+AND TABLE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys');
+```
+Flag: Any results = must quote with backticks or rename.
+
+### 2. Authentication Plugins
+```sql
+SELECT user, host, plugin FROM mysql.user;
+```
+Flag: `mysql_native_password` deprecated in 8.0. `sha256_password` replaced by `caching_sha2_password`.
+
+### 3. XA Transactions
+```sql
+XA RECOVER;
+```
+Flag: 🔴 Any results BLOCK the upgrade.
+
+### 4. Server Character Set and Collation
+```sql
+SELECT @@character_set_server, @@collation_server, @@character_set_database, @@collation_database;
+```
+Flag: If `latin1` — MySQL 8.0 defaults to `utf8mb4`.
+
+### 5. Schema-Level Character Sets
+```sql
+SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA;
+```
+
+### 6. Critical Global Variables
+```sql
+SHOW GLOBAL VARIABLES WHERE Variable_name IN (
+  'lower_case_table_names','explicit_defaults_for_timestamp',
+  'query_cache_type','query_cache_size','default_authentication_plugin',
+  'innodb_strict_mode','sql_mode','optimizer_switch','log_warnings',
+  'innodb_file_format','innodb_large_prefix'
+);
+```
+
+| Variable | Issue | Impact |
+|----------|-------|--------|
+| `query_cache_type=ON` | 🔴 Removed in 8.0 | Performance regression |
+| `sql_mode=''` | 🟡 8.0 defaults strict | Apps may break |
+| `log_warnings` | 🟡 Removed in 8.0 | Replace with `log_error_verbosity` |
+| `innodb_strict_mode=OFF` | 🟡 8.0 defaults ON | Preserve in parameter group |
+
+### 7. Stored Procedures and Functions
+```sql
+SELECT ROUTINE_SCHEMA, ROUTINE_NAME, ROUTINE_TYPE, DEFINER
+FROM information_schema.ROUTINES
+WHERE ROUTINE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys');
+```
+
+### 8. Triggers and Events with Null Definers
+```sql
+SELECT TRIGGER_SCHEMA, TRIGGER_NAME, DEFINER FROM information_schema.TRIGGERS
+WHERE DEFINER = '' OR DEFINER IS NULL;
+SELECT EVENT_SCHEMA, EVENT_NAME, DEFINER FROM information_schema.EVENTS
+WHERE DEFINER = '' OR DEFINER IS NULL;
+```
+Flag: 🔴 Null definers cause precheck failures.
+
+### 9. Partitioned Tables
+```sql
+SELECT TABLE_SCHEMA, TABLE_NAME, PARTITION_METHOD FROM information_schema.PARTITIONS
+WHERE PARTITION_METHOD IS NOT NULL
+AND TABLE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys');
+```
+
+### 10. Table Engines and Row Formats
+```sql
+SELECT TABLE_SCHEMA, TABLE_NAME, ENGINE, TABLE_COLLATION, ROW_FORMAT
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys')
+AND TABLE_TYPE='BASE TABLE';
+```
+Flag: Non-InnoDB tables, COMPACT row format.
+
+### 11. Foreign Keys, Views, Grants
+```sql
+SELECT TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
+WHERE REFERENCED_TABLE_NAME IS NOT NULL
+AND TABLE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys');
+SELECT TABLE_SCHEMA, TABLE_NAME, DEFINER, SECURITY_TYPE FROM information_schema.VIEWS
+WHERE TABLE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys');
+SELECT user, host, Super_priv, Grant_priv FROM mysql.user
+WHERE user NOT IN ('rdsadmin','mysql.sys','rdsrepladmin');
+```
+
+### 12. Stale Table Statistics
+```sql
+SELECT TABLE_SCHEMA, TABLE_NAME, UPDATE_TIME, TABLE_ROWS,
+  DATEDIFF(NOW(), UPDATE_TIME) AS days_since_update
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA NOT IN ('information_schema','mysql','performance_schema','sys')
+AND TABLE_TYPE = 'BASE TABLE'
+AND (UPDATE_TIME IS NULL OR DATEDIFF(NOW(), UPDATE_TIME) > 7)
+ORDER BY days_since_update DESC;
+```
+Flag: 🟡 Use this to record which tables have stale statistics as a pre-upgrade baseline — it helps you spot post-upgrade plan regressions. A major version upgrade invalidates optimizer statistics, so statistics are recalculated **after** the upgrade — see the post-upgrade checklist, which scopes `ANALYZE TABLE` to the affected tables in a low-traffic window.
+
+## Result Analysis
+
+Generate:
+1. Categorized findings (🔴/🟡/🟢)
+2. For each finding: what was found, why it matters, action to take
+3. Recommended DB parameter group for target version preserving current behavior

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-prechecks-postgresql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-prechecks-postgresql.md
@@ -1,0 +1,127 @@
+# RDS PostgreSQL Live Precheck Queries
+
+Run these against the database to identify upgrade blockers and behavior changes.
+
+## Connection Methods
+
+### SSM Run Command
+```bash
+aws ssm send-command --instance-ids {instance_id} --document-name "AWS-RunShellScript" \
+  --parameters 'commands=["export PGPASSWORD=$(aws secretsmanager get-secret-value --secret-id {secret_arn} --query SecretString --output text | jq -r .password); psql -h {endpoint} -U {username} -d {database} -c \"{query}\""]' \
+  --region {region} --output json --query "Command.CommandId"
+```
+
+**Preferred: IAM database authentication** — where supported, use `aws rds generate-db-auth-token` to produce a short-lived token and connect with `--no-password`. This avoids any password in the environment or command history.
+
+**Fallback: Secrets Manager retrieval** (shown above) — never pass plaintext passwords in SSM command parameters, as they are visible in SSM command history, CloudTrail logs, and process listings. Note that `export PGPASSWORD=...` still exposes the value in the shell process environment (`/proc/<pid>/environ`) for its lifetime; where IAM auth is unavailable, prefer a `.pgpass` file (chmod 600) over environment variables. If query results may contain sensitive data, enable KMS encryption on the SSM Run Command output. Use minimal-privilege credentials (a read-only user scoped to the precheck schemas) rather than the master user.
+
+Note: RDS Data API is NOT available for standalone RDS instances.
+
+## Precheck Queries
+
+### 1. Extensions and Versions
+```sql
+SELECT extname, extversion FROM pg_extension ORDER BY extname;
+```
+Flag: Check target version supports each extension.
+
+### 2. Hash Indexes
+```sql
+SELECT schemaname, tablename, indexname, indexdef FROM pg_indexes WHERE indexdef LIKE '%USING hash%';
+```
+Flag: 🟡 Must REINDEX after upgrade.
+
+### 3. Unknown/Invalid Data Types
+```sql
+SELECT n.nspname, c.relname, a.attname, t.typname
+FROM pg_attribute a JOIN pg_class c ON a.attrelid = c.oid
+JOIN pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_type t ON a.atttypid = t.oid
+WHERE n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')
+AND t.typname IN ('unknown');
+```
+Flag: 🔴 Unknown types block upgrade.
+
+### 4. Logical Replication Slots
+```sql
+SELECT slot_name, plugin, slot_type, active FROM pg_replication_slots;
+```
+Flag: 🔴 Active logical replication slots BLOCK major upgrades.
+
+### 5. Prepared Transactions
+```sql
+SELECT * FROM pg_prepared_xacts;
+```
+Flag: 🔴 Prepared transactions BLOCK the upgrade.
+
+### 6. Objects Owned by System Roles
+```sql
+SELECT n.nspname, c.relname, r.rolname as owner
+FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_roles r ON c.relowner = r.oid
+WHERE r.rolname IN ('rdsadmin','rds_superuser')
+AND n.nspname NOT IN ('pg_catalog','information_schema','pg_toast');
+```
+Flag: 🟡 May block upgrades.
+
+### 7. Database Encoding and Locale
+```sql
+SELECT datname, datcollate, datctype, encoding FROM pg_database
+WHERE datname NOT IN ('template0','template1','rdsadmin');
+```
+
+### 8. Custom Data Types
+```sql
+SELECT n.nspname, t.typname, t.typtype FROM pg_type t
+JOIN pg_namespace n ON t.typnamespace = n.oid
+WHERE n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')
+AND t.typtype IN ('c','e','d');
+```
+
+### 9. Critical Extensions
+```sql
+SELECT extname, extversion FROM pg_extension
+WHERE extname IN ('postgis','postgis_topology','postgis_raster','pg_partman',
+'pglogical','citus','pg_cron','pg_stat_statements');
+```
+Flag: Version-specific compatibility. Check target version supports them.
+
+### 10. Table and Index Bloat
+```sql
+SELECT schemaname, relname, n_live_tup, n_dead_tup,
+  CASE WHEN n_live_tup > 0 THEN round(n_dead_tup::numeric/n_live_tup::numeric * 100, 2) ELSE 0 END as dead_pct
+FROM pg_stat_user_tables WHERE n_dead_tup > 10000 ORDER BY n_dead_tup DESC LIMIT 20;
+```
+
+### 11. reg* Type Columns
+```sql
+SELECT n.nspname, c.relname, a.attname, t.typname
+FROM pg_attribute a JOIN pg_class c ON a.attrelid = c.oid
+JOIN pg_namespace n ON c.relnamespace = n.oid
+JOIN pg_type t ON a.atttypid = t.oid
+WHERE t.typname IN ('regproc','regprocedure','regoper','regoperator','regclass',
+'regtype','regconfig','regdictionary')
+AND n.nspname NOT IN ('pg_catalog','information_schema','pg_toast');
+```
+Flag: 🟡 reg* types store OIDs that may change after upgrade.
+
+### 12. Stale Table Statistics
+```sql
+SELECT schemaname, relname, n_live_tup, n_mod_since_analyze,
+  last_analyze, last_autoanalyze,
+  GREATEST(last_analyze, last_autoanalyze) AS last_stats_update,
+  EXTRACT(EPOCH FROM (now() - GREATEST(last_analyze, last_autoanalyze)))/86400 AS days_since_analyze
+FROM pg_stat_user_tables
+WHERE (last_analyze IS NULL AND last_autoanalyze IS NULL)
+   OR GREATEST(last_analyze, last_autoanalyze) < now() - interval '7 days'
+ORDER BY n_live_tup DESC;
+```
+Flag: 🟡 Use this to record which tables have stale statistics as a pre-upgrade baseline — it helps you spot post-upgrade plan regressions. A major version upgrade does not carry statistics across, so statistics are recalculated **after** the upgrade — see the post-upgrade checklist, which scopes `ANALYZE` to the affected tables in a low-traffic window.
+
+## Result Analysis
+
+Generate:
+1. Categorized findings (🔴/🟡/🟢)
+2. For each finding: what was found, why it matters, action to take
+3. Extension compatibility matrix for target version
+4. Recommended post-upgrade REINDEX/ANALYZE plan

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-prechecks-postgresql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-prechecks-postgresql.md
@@ -5,6 +5,7 @@ Run these against the database to identify upgrade blockers and behavior changes
 ## Connection Methods
 
 ### SSM Run Command
+
 ```bash
 aws ssm send-command --instance-ids {instance_id} --document-name "AWS-RunShellScript" \
   --parameters 'commands=["export PGPASSWORD=$(aws secretsmanager get-secret-value --secret-id {secret_arn} --query SecretString --output text | jq -r .password); psql -h {endpoint} -U {username} -d {database} -c \"{query}\""]' \
@@ -20,18 +21,23 @@ Note: RDS Data API is NOT available for standalone RDS instances.
 ## Precheck Queries
 
 ### 1. Extensions and Versions
+
 ```sql
 SELECT extname, extversion FROM pg_extension ORDER BY extname;
 ```
+
 Flag: Check target version supports each extension.
 
 ### 2. Hash Indexes
+
 ```sql
 SELECT schemaname, tablename, indexname, indexdef FROM pg_indexes WHERE indexdef LIKE '%USING hash%';
 ```
+
 Flag: 🟡 Must REINDEX after upgrade.
 
 ### 3. Unknown/Invalid Data Types
+
 ```sql
 SELECT n.nspname, c.relname, a.attname, t.typname
 FROM pg_attribute a JOIN pg_class c ON a.attrelid = c.oid
@@ -40,21 +46,27 @@ JOIN pg_type t ON a.atttypid = t.oid
 WHERE n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')
 AND t.typname IN ('unknown');
 ```
+
 Flag: 🔴 Unknown types block upgrade.
 
 ### 4. Logical Replication Slots
+
 ```sql
 SELECT slot_name, plugin, slot_type, active FROM pg_replication_slots;
 ```
+
 Flag: 🔴 Active logical replication slots BLOCK major upgrades.
 
 ### 5. Prepared Transactions
+
 ```sql
 SELECT * FROM pg_prepared_xacts;
 ```
+
 Flag: 🔴 Prepared transactions BLOCK the upgrade.
 
 ### 6. Objects Owned by System Roles
+
 ```sql
 SELECT n.nspname, c.relname, r.rolname as owner
 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
@@ -62,15 +74,18 @@ JOIN pg_roles r ON c.relowner = r.oid
 WHERE r.rolname IN ('rdsadmin','rds_superuser')
 AND n.nspname NOT IN ('pg_catalog','information_schema','pg_toast');
 ```
+
 Flag: 🟡 May block upgrades.
 
 ### 7. Database Encoding and Locale
+
 ```sql
 SELECT datname, datcollate, datctype, encoding FROM pg_database
 WHERE datname NOT IN ('template0','template1','rdsadmin');
 ```
 
 ### 8. Custom Data Types
+
 ```sql
 SELECT n.nspname, t.typname, t.typtype FROM pg_type t
 JOIN pg_namespace n ON t.typnamespace = n.oid
@@ -79,14 +94,17 @@ AND t.typtype IN ('c','e','d');
 ```
 
 ### 9. Critical Extensions
+
 ```sql
 SELECT extname, extversion FROM pg_extension
 WHERE extname IN ('postgis','postgis_topology','postgis_raster','pg_partman',
 'pglogical','citus','pg_cron','pg_stat_statements');
 ```
+
 Flag: Version-specific compatibility. Check target version supports them.
 
 ### 10. Table and Index Bloat
+
 ```sql
 SELECT schemaname, relname, n_live_tup, n_dead_tup,
   CASE WHEN n_live_tup > 0 THEN round(n_dead_tup::numeric/n_live_tup::numeric * 100, 2) ELSE 0 END as dead_pct
@@ -94,6 +112,7 @@ FROM pg_stat_user_tables WHERE n_dead_tup > 10000 ORDER BY n_dead_tup DESC LIMIT
 ```
 
 ### 11. reg* Type Columns
+
 ```sql
 SELECT n.nspname, c.relname, a.attname, t.typname
 FROM pg_attribute a JOIN pg_class c ON a.attrelid = c.oid
@@ -103,9 +122,11 @@ WHERE t.typname IN ('regproc','regprocedure','regoper','regoperator','regclass',
 'regtype','regconfig','regdictionary')
 AND n.nspname NOT IN ('pg_catalog','information_schema','pg_toast');
 ```
+
 Flag: 🟡 reg* types store OIDs that may change after upgrade.
 
 ### 12. Stale Table Statistics
+
 ```sql
 SELECT schemaname, relname, n_live_tup, n_mod_since_analyze,
   last_analyze, last_autoanalyze,
@@ -116,11 +137,13 @@ WHERE (last_analyze IS NULL AND last_autoanalyze IS NULL)
    OR GREATEST(last_analyze, last_autoanalyze) < now() - interval '7 days'
 ORDER BY n_live_tup DESC;
 ```
+
 Flag: 🟡 Use this to record which tables have stale statistics as a pre-upgrade baseline — it helps you spot post-upgrade plan regressions. A major version upgrade does not carry statistics across, so statistics are recalculated **after** the upgrade — see the post-upgrade checklist, which scopes `ANALYZE` to the affected tables in a low-traffic window.
 
 ## Result Analysis
 
 Generate:
+
 1. Categorized findings (🔴/🟡/🟢)
 2. For each finding: what was found, why it matters, action to take
 3. Extension compatibility matrix for target version

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-query-load-mysql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-query-load-mysql.md
@@ -1,0 +1,51 @@
+# RDS MySQL/MariaDB — Query Load Analysis & Explain Plan Review
+
+## Step 1: Get Top 5 Queries by Load
+
+```sql
+SELECT DIGEST_TEXT, COUNT_STAR, SUM_TIMER_WAIT/1000000000000 AS total_time_sec,
+  AVG_TIMER_WAIT/1000000000 AS avg_time_ms, SUM_ROWS_EXAMINED, SUM_ROWS_SENT,
+  FIRST_SEEN, LAST_SEEN
+FROM performance_schema.events_statements_summary_by_digest
+WHERE SCHEMA_NAME NOT IN ('mysql','information_schema','performance_schema','sys')
+ORDER BY SUM_TIMER_WAIT DESC LIMIT 5;
+```
+
+## Step 2: Run EXPLAIN on Each Query
+
+```sql
+EXPLAIN FORMAT=JSON <query>;
+```
+
+## Step 3: Flag Upgrade-Impacting Patterns
+
+### 🔴 Critical
+
+| Pattern | Why It Matters in 8.0 | Action |
+|---|---|---|
+| `using_temporary_table: true` | TempTable engine replaces MEMORY. Overflow goes to mmap, not MyISAM. | Tune `temptable_max_ram`. Monitor `Created_tmp_disk_tables`. |
+| `using_filesort: true` + large rows | Sort algorithm changed. | Benchmark on test instance. |
+| GROUP BY implicit sort relied upon | 8.0 no longer implicitly sorts GROUP BY. | Add explicit ORDER BY. |
+
+### 🟡 Warning
+
+| Pattern | Why It Matters | Action |
+|---|---|---|
+| `Block Nested Loop` joins | 8.0 may replace with hash join. Usually faster. | Test. Use `optimizer_switch` to disable hash_join if regression. |
+| Derived table materialization | 8.0 improved derived table merging. | Usually beneficial. Monitor. |
+| `index_merge` usage | Behavior refined in 8.0. | Verify same indexes used post-upgrade. |
+
+### 🟢 Clean
+
+| Pattern | Notes |
+|---|---|
+| Simple index lookups (`ref`, `eq_ref`, `const`) | No change. |
+| Covering indexes (`Using index`) | No change. |
+
+## Key MySQL 8.0 Optimizer Changes
+
+- Hash joins for equi-joins without indexes
+- TempTable engine replaces MEMORY for internal temp tables
+- GROUP BY no longer implicitly sorts
+- Descending indexes supported natively
+- Updated cost model for I/O and memory

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-query-load-postgresql.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-query-load-postgresql.md
@@ -1,0 +1,52 @@
+# RDS PostgreSQL — Query Load Analysis & Explain Plan Review
+
+## Step 1: Get Top 5 Queries by Load
+
+```sql
+SELECT queryid, query, calls, total_exec_time::numeric(12,2) AS total_time_ms,
+  mean_exec_time::numeric(12,2) AS avg_time_ms,
+  rows, shared_blks_hit, shared_blks_read
+FROM pg_stat_statements
+WHERE dbid = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY total_exec_time DESC LIMIT 5;
+```
+
+## Step 2: Run EXPLAIN on Each Query
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) <query>;
+```
+
+For data-modifying queries, wrap in a transaction and rollback.
+
+## Step 3: Flag Upgrade-Impacting Patterns
+
+### 🔴 Critical
+
+| Pattern | Versions | Action |
+|---|---|---|
+| `Sort Method: external merge` | PG 15+ | `work_mem` per-operation accounting changed. Tune `work_mem` and `hash_mem_multiplier`. |
+| `HashAggregate` with `Batches > 1` | PG 15+ | Memory accounting different. Adjust `work_mem`. |
+| JIT on short queries | PG 14+ | JIT overhead causes latency spikes. Adjust `jit_above_cost` thresholds. |
+
+### 🟡 Warning
+
+| Pattern | Versions | Action |
+|---|---|---|
+| Nested Loop without Memoize | PG 14+ | PG 14 introduced Memoize. Usually beneficial. Set `enable_memoize=off` if regression. |
+| Parallel scan threshold changes | PG 14-16 | Plans may gain/lose parallelism. Compare on test instance. |
+| Merge Join on large tables | PG 16+ | Improved costing may change join strategy. Benchmark. |
+
+### 🟢 Clean
+
+| Pattern | Notes |
+|---|---|
+| Simple Index Scan / Index Only Scan | Stable across versions. |
+| Seq Scan on small tables | No change. |
+
+## Key PostgreSQL Optimizer Changes
+
+- PG 14: Memoize node, improved extended statistics
+- PG 15: work_mem hash operation changes, improved sort
+- PG 16: Subquery decorrelation, improved merge join costing
+- PG 17: Enhanced memory management, improved vacuum

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-workflow.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-workflow.md
@@ -1,0 +1,105 @@
+# RDS Upgrade Workflow (MySQL / MariaDB / PostgreSQL)
+
+Live prechecks, query-load analysis, and checklists for RDS MySQL, MariaDB, and PostgreSQL — major and minor version upgrades, including instances with Read Replicas. Never executes the upgrade.
+
+## When This Applies
+
+User mentions: "upgrade this instance", "upgrade RDS MySQL/MariaDB/PostgreSQL", "pre-upgrade checklist", "post-upgrade steps", "upgrade prechecks", "what version should I upgrade to", Read Replica upgrade ordering, or Blue/Green for major upgrades. Do NOT use this workflow for Aurora clusters — Aurora has a separate upgrade skill.
+
+## Tasks
+
+### 1. Identify the Instance
+
+Gather instance metadata. RDS uses `describe-db-instances`, not `describe-db-clusters`.
+
+**Constraints:**
+- You MUST ask for the DB instance identifier and region upfront (default: `us-east-1`)
+- You MUST run `aws rds describe-db-instances --db-instance-identifier <id>` to identify the instance
+- You MUST capture: engine (`mysql`, `mariadb`, or `postgres`), engine version, status, DB parameter group, instance class, Multi-AZ, encryption, deletion protection
+- You MUST check `ReadReplicaSourceDBInstanceIdentifier` — if set, this instance IS a replica
+- You MUST check `ReadReplicaDBInstanceIdentifiers` — if non-empty, this instance HAS replicas
+- You MUST explain what command is being run and why before invoking it
+
+### 2. Enumerate Upgrade Targets and Recommend
+
+```bash
+aws rds describe-db-engine-versions --engine <engine> --engine-version <current> \
+  --query "DBEngineVersions[0].ValidUpgradeTarget[*].{EngineVersion:EngineVersion,IsMajorVersionUpgrade:IsMajorVersionUpgrade}"
+```
+
+**Constraints:**
+- You MUST run `describe-db-engine-versions` rather than hard-coding versions, because valid targets change as AWS ships releases
+- Engine values are exactly: `mysql`, `mariadb`, or `postgres`
+- You MUST NOT mention LTS releases — RDS does NOT have LTS (unlike Aurora). Present the latest available version and the latest minor within the current major.
+- You SHOULD call out Extended Support surcharge if applicable (RDS MySQL 5.7, RDS PostgreSQL 11/12)
+- For instances with Read Replicas, the upgrade behavior differs by upgrade type:
+  - **Minor version upgrade**: if the instance has any read replicas, upgrade the read replicas first, then upgrade the source instance.
+  - **Major version upgrade**: Amazon RDS automatically upgrades in-Region read replicas along with the primary DB instance. You do NOT need to upgrade replicas separately — RDS handles this. Cross-Region read replicas are NOT automatically upgraded and must be handled independently.
+- You SHOULD NOT confuse with Aurora upgrade order (Aurora upgrades the writer and readers together in a cluster — different mechanism from RDS)
+- You SHOULD recommend Blue/Green deployments as a safer path for major version upgrades (see [bluegreen-advisor-workflow.md](bluegreen-advisor-workflow.md))
+
+### 3. Live Database Precheck
+
+**Constraints:**
+- You MUST ask the user how to connect, offering three options:
+  1. SSM Run Command (requires EC2 instance ID + credentials)
+  2. Direct connection (publicly accessible or tunneled)
+  3. Generate a script for the user to run and paste results
+- RDS Data API is NOT available for standalone RDS instances — do NOT offer it
+- You MUST run engine-specific queries from [upgrade-prechecks-mysql.md](upgrade-prechecks-mysql.md) for `mysql` and `mariadb` engines, or [upgrade-prechecks-postgresql.md](upgrade-prechecks-postgresql.md) for `postgres`
+- For `mariadb`, run the same MySQL-compatible precheck queries from [upgrade-prechecks-mysql.md](upgrade-prechecks-mysql.md) — MariaDB is a MySQL fork and uses the same `information_schema` / `performance_schema` query surface, so run the full set (reserved keywords, `sql_mode` changes, removed features, auth plugins, engines, row formats, character sets, partitioning, definers, XA). Interpret the results against the target MariaDB version: a handful of findings are MySQL-8.0-version-specific (the 8.0 reserved-keyword additions, `caching_sha2_password`, query-cache removal) and MariaDB has its own reserved-word and parameter set, so confirm each flagged item against the target MariaDB release notes rather than assuming the MySQL 8.0 verdict applies verbatim.
+- When running prechecks via SSM Run Command, enable KMS encryption on the SSM output before retrieval (schema metadata may contain sensitive details). Use minimal-privilege credentials scoped to read-only access on `information_schema`, `performance_schema`, and `mysql.user` rather than the master user.
+- You MUST categorize findings as 🔴 Critical (blocks upgrade) / 🟡 Warning (behavior change) / 🟢 Clean
+- You MUST generate a recommended DB parameter group (instance-level) preserving current behavior where relevant
+
+### 4. Query Load Analysis (Optional)
+
+**Constraints:**
+- You MUST offer this step after prechecks and let the user opt in — don't force it
+- You MUST pull top 5 queries from `performance_schema` (MySQL/MariaDB) or `pg_stat_statements` (PostgreSQL)
+- You MUST run EXPLAIN in the engine-appropriate format: `EXPLAIN FORMAT=JSON` (MySQL/MariaDB) or `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` (PostgreSQL)
+- Flag patterns per [upgrade-query-load-mysql.md](upgrade-query-load-mysql.md) or [upgrade-query-load-postgresql.md](upgrade-query-load-postgresql.md)
+- MariaDB uses the same `performance_schema` and EXPLAIN approach as MySQL
+
+### 5. Pre-Upgrade Checklist
+
+See [upgrade-pre-checklist.md](upgrade-pre-checklist.md) for the 10-step walkthrough.
+
+**Constraints:**
+- You MUST recommend a manual snapshot before any upgrade
+- You MUST explain that automated backups are NOT required for in-place upgrades, but when enabled RDS takes a pre-upgrade snapshot automatically (and skips it when disabled)
+- You MUST explain that automated backups ARE required for Blue/Green deployments
+- You MUST recommend testing on a snapshot-restored instance first
+- You MUST mention the RDS pre-upgrade validation prechecker that runs automatically during major upgrades, and recommend previewing it manually first
+- You MUST warn about MySQL 8.0 reserved keywords that may conflict with schema identifiers
+- You MUST link to the target release notes: MySQL `https://dev.mysql.com/doc/relnotes/mysql/8.0/en/`, MariaDB `https://mariadb.com/kb/en/release-notes/`, PostgreSQL `https://www.postgresql.org/docs/release/`
+- You MUST explain that without a custom parameter group, RDS assigns the default for the target family (e.g., `default.mysql8.0`) with target-version defaults
+- You SHOULD recommend Blue/Green for major upgrades — see [bluegreen-advisor-workflow.md](bluegreen-advisor-workflow.md)
+- You MUST NOT execute `modify-db-instance --engine-version` or any upgrade command
+
+### 6. Post-Upgrade Checklist
+
+See [upgrade-post-checklist.md](upgrade-post-checklist.md).
+
+**Constraints:**
+- You MUST NOT blanket-recommend `ANALYZE TABLE` on all user tables — it's expensive and shouldn't run during active traffic. Recommend it only if regressions are observed, targeting affected tables in a low-traffic window.
+- You MUST recommend monitoring CloudWatch metrics (all engines): CPUUtilization, DatabaseConnections, ReadIOPS, WriteIOPS, FreeableMemory, FreeStorageSpace
+- You MUST NOT reference non-CloudWatch metrics (e.g., `Created_tmp_disk_tables`) in the CloudWatch monitoring step — those live in `performance_schema`
+- You MUST NOT recommend cleanup (deleting snapshots, old Blue/Green environments) until the user confirms the upgrade is successful with no regressions, because the pre-upgrade snapshot is the cheapest rollback path
+- You MUST NOT recommend rolling back unless the user explicitly reports failure
+
+## Troubleshooting
+
+- **`describe-db-instances` returns no results**: Verify region and identifier spelling.
+- **SSM returns empty output**: Query returned zero rows. Confirm connectivity with `SHOW DATABASES` or `SELECT datname FROM pg_database`.
+- **SSM times out**: Security group missing inbound from EC2. Add port 3306 (MySQL/MariaDB) or 5432 (PostgreSQL).
+- **Zero digests in `performance_schema`**: Consumer disabled or no workload. Skip query load analysis.
+- **Credentials expired**: Ask user to refresh and retry.
+- **Blue/Green not available**: Requires MySQL 5.7+, MariaDB 10.4+, or PostgreSQL 12.7+. If older, use in-place upgrade with snapshot.
+
+## References
+
+- [upgrade-prechecks-mysql.md](upgrade-prechecks-mysql.md) / [upgrade-prechecks-postgresql.md](upgrade-prechecks-postgresql.md)
+- [upgrade-query-load-mysql.md](upgrade-query-load-mysql.md) / [upgrade-query-load-postgresql.md](upgrade-query-load-postgresql.md)
+- [upgrade-pre-checklist.md](upgrade-pre-checklist.md)
+- [upgrade-post-checklist.md](upgrade-post-checklist.md)

--- a/skills/specialized-skills/database-skills/rds-oss/references/upgrade-workflow.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/upgrade-workflow.md
@@ -13,6 +13,7 @@ User mentions: "upgrade this instance", "upgrade RDS MySQL/MariaDB/PostgreSQL", 
 Gather instance metadata. RDS uses `describe-db-instances`, not `describe-db-clusters`.
 
 **Constraints:**
+
 - You MUST ask for the DB instance identifier and region upfront (default: `us-east-1`)
 - You MUST run `aws rds describe-db-instances --db-instance-identifier <id>` to identify the instance
 - You MUST capture: engine (`mysql`, `mariadb`, or `postgres`), engine version, status, DB parameter group, instance class, Multi-AZ, encryption, deletion protection
@@ -28,6 +29,7 @@ aws rds describe-db-engine-versions --engine <engine> --engine-version <current>
 ```
 
 **Constraints:**
+
 - You MUST run `describe-db-engine-versions` rather than hard-coding versions, because valid targets change as AWS ships releases
 - Engine values are exactly: `mysql`, `mariadb`, or `postgres`
 - You MUST NOT mention LTS releases — RDS does NOT have LTS (unlike Aurora). Present the latest available version and the latest minor within the current major.
@@ -41,6 +43,7 @@ aws rds describe-db-engine-versions --engine <engine> --engine-version <current>
 ### 3. Live Database Precheck
 
 **Constraints:**
+
 - You MUST ask the user how to connect, offering three options:
   1. SSM Run Command (requires EC2 instance ID + credentials)
   2. Direct connection (publicly accessible or tunneled)
@@ -55,6 +58,7 @@ aws rds describe-db-engine-versions --engine <engine> --engine-version <current>
 ### 4. Query Load Analysis (Optional)
 
 **Constraints:**
+
 - You MUST offer this step after prechecks and let the user opt in — don't force it
 - You MUST pull top 5 queries from `performance_schema` (MySQL/MariaDB) or `pg_stat_statements` (PostgreSQL)
 - You MUST run EXPLAIN in the engine-appropriate format: `EXPLAIN FORMAT=JSON` (MySQL/MariaDB) or `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` (PostgreSQL)
@@ -66,6 +70,7 @@ aws rds describe-db-engine-versions --engine <engine> --engine-version <current>
 See [upgrade-pre-checklist.md](upgrade-pre-checklist.md) for the 10-step walkthrough.
 
 **Constraints:**
+
 - You MUST recommend a manual snapshot before any upgrade
 - You MUST explain that automated backups are NOT required for in-place upgrades, but when enabled RDS takes a pre-upgrade snapshot automatically (and skips it when disabled)
 - You MUST explain that automated backups ARE required for Blue/Green deployments
@@ -82,6 +87,7 @@ See [upgrade-pre-checklist.md](upgrade-pre-checklist.md) for the 10-step walkthr
 See [upgrade-post-checklist.md](upgrade-post-checklist.md).
 
 **Constraints:**
+
 - You MUST NOT blanket-recommend `ANALYZE TABLE` on all user tables — it's expensive and shouldn't run during active traffic. Recommend it only if regressions are observed, targeting affected tables in a low-traffic window.
 - You MUST recommend monitoring CloudWatch metrics (all engines): CPUUtilization, DatabaseConnections, ReadIOPS, WriteIOPS, FreeableMemory, FreeStorageSpace
 - You MUST NOT reference non-CloudWatch metrics (e.g., `Created_tmp_disk_tables`) in the CloudWatch monitoring step — those live in `performance_schema`

--- a/skills/specialized-skills/database-skills/rds-oss/references/verify-dependencies.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/verify-dependencies.md
@@ -7,5 +7,6 @@ Before running workflows that require external tools, verify the following:
 - **Credentials** — confirm with `aws sts get-caller-identity` before live runs. Prefer IAM roles (EC2 instance profiles, ECS task roles, or AWS SSO session credentials) over long-lived IAM user access keys. If long-lived keys are used, ensure they are rotated regularly. For database connections during prechecks, prefer IAM database authentication where supported.
 
 **Constraints:**
+
 - You MUST ONLY check tool existence and MUST NOT invoke the tools here, because that would trigger live calls before the user is ready
 - You MUST ask before switching to offline mode

--- a/skills/specialized-skills/database-skills/rds-oss/references/verify-dependencies.md
+++ b/skills/specialized-skills/database-skills/rds-oss/references/verify-dependencies.md
@@ -1,0 +1,11 @@
+# Verify Dependencies
+
+Before running workflows that require external tools, verify the following:
+
+- **Python 3.10+** — required for [rds_commitment_pricing_analyzer.py](../scripts/rds_commitment_pricing_analyzer.py). If `boto3` is missing, offer offline mode for commitment pricing.
+- **AWS CLI v2** — required for upgrade, proxy, and Blue/Green workflows.
+- **Credentials** — confirm with `aws sts get-caller-identity` before live runs. Prefer IAM roles (EC2 instance profiles, ECS task roles, or AWS SSO session credentials) over long-lived IAM user access keys. If long-lived keys are used, ensure they are rotated regularly. For database connections during prechecks, prefer IAM database authentication where supported.
+
+**Constraints:**
+- You MUST ONLY check tool existence and MUST NOT invoke the tools here, because that would trigger live calls before the user is ready
+- You MUST ask before switching to offline mode

--- a/skills/specialized-skills/database-skills/rds-oss/scripts/rds_commitment_pricing_analyzer.py
+++ b/skills/specialized-skills/database-skills/rds-oss/scripts/rds_commitment_pricing_analyzer.py
@@ -1,0 +1,467 @@
+"""RDS Reserved Instance & Database Savings Plan estimator.
+
+Read-only tool that fetches live RI and DSP rates from AWS and projects
+monthly cost under each commitment option for RDS MySQL, MariaDB, and
+PostgreSQL instances. No purchase APIs are ever called.
+
+Usage:
+    python rds_commitment_pricing_analyzer.py --instance my-rds-db --region us-east-1
+    python rds_commitment_pricing_analyzer.py --region us-east-1 offline \
+        --instance-type db.r7g.2xlarge --engine mysql --num-instances 2
+    python rds_commitment_pricing_analyzer.py --region us-east-1 offline \
+        --instance-type db.r7g.2xlarge --engine postgres --multi-az
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+
+HOURS_PER_MONTH = 730
+
+ENGINE_PRODUCT_MAP = {
+    "mysql": "MySQL",
+    "mariadb": "MariaDB",
+    "postgres": "PostgreSQL",
+}
+
+_STATIC_INSTANCE_PRICES = {
+    "db.t3.medium": 0.068,
+    "db.t3.large": 0.136,
+    "db.t4g.medium": 0.065,
+    "db.t4g.large": 0.129,
+    "db.m5.large": 0.171,
+    "db.m5.xlarge": 0.342,
+    "db.m5.2xlarge": 0.684,
+    "db.m6g.large": 0.154,
+    "db.m6g.xlarge": 0.308,
+    "db.m6g.2xlarge": 0.616,
+    "db.m7g.large": 0.162,
+    "db.m7g.xlarge": 0.324,
+    "db.m7g.2xlarge": 0.648,
+    "db.r5.large": 0.240,
+    "db.r5.xlarge": 0.480,
+    "db.r5.2xlarge": 0.960,
+    "db.r5.4xlarge": 1.920,
+    "db.r5.8xlarge": 3.840,
+    "db.r6g.large": 0.218,
+    "db.r6g.xlarge": 0.435,
+    "db.r6g.2xlarge": 0.870,
+    "db.r6g.4xlarge": 1.740,
+    "db.r6g.8xlarge": 3.480,
+    "db.r7g.large": 0.228,
+    "db.r7g.xlarge": 0.456,
+    "db.r7g.2xlarge": 0.912,
+    "db.r7g.4xlarge": 1.824,
+    "db.r7g.8xlarge": 3.648,
+    "db.r8g.large": 0.240,
+    "db.r8g.xlarge": 0.480,
+    "db.r8g.2xlarge": 0.960,
+    "db.r8g.4xlarge": 1.920,
+    "db.r8g.8xlarge": 3.840,
+}
+
+MULTI_AZ_MULTIPLIER = 2.0
+_DSP_ELIGIBLE_FAMILIES = {"r7g", "r7i", "r8g", "r8gd", "m7g", "m7i", "c7g", "c7i", "x8g"}
+
+_REGION_NAMES = {
+    "us-east-1": "US East (N. Virginia)",
+    "us-east-2": "US East (Ohio)",
+    "us-west-1": "US West (N. California)",
+    "us-west-2": "US West (Oregon)",
+    "eu-west-1": "EU (Ireland)",
+    "eu-central-1": "EU (Frankfurt)",
+    "ap-southeast-1": "Asia Pacific (Singapore)",
+    "ap-northeast-1": "Asia Pacific (Tokyo)",
+    "ap-south-1": "Asia Pacific (Mumbai)",
+}
+
+
+@dataclass
+class RIOffering:
+    instance_type: str
+    term_years: int
+    payment_option: str
+    effective_hourly: float
+    upfront_cost: float
+    recurring_hourly: float
+    multi_az: bool = False
+
+    def monthly_cost(self) -> float:
+        return self.effective_hourly * HOURS_PER_MONTH
+
+
+@dataclass
+class DSPRate:
+    usage_type: str
+    term_years: int
+    payment_option: str
+    rate_per_hour: float
+
+    def monthly_cost(self) -> float:
+        return self.rate_per_hour * HOURS_PER_MONTH
+
+
+def _family_from_instance(instance_type: str) -> str:
+    m = re.match(r"db\.([a-z0-9]+)\.", instance_type)
+    return m.group(1) if m else ""
+
+
+def get_on_demand_price(
+    instance_type: str, region: str = "us-east-1", multi_az: bool = False
+) -> float:
+    price = _STATIC_INSTANCE_PRICES.get(instance_type, 0.0)
+    if region != "us-east-1" and price > 0:
+        # Static prices reflect us-east-1 only; actual price in other regions may differ
+        import warnings
+
+        warnings.warn(
+            f"On-demand price for {instance_type} is based on us-east-1. "
+            f"Actual price in {region} may differ."
+        )
+    if multi_az:
+        price *= MULTI_AZ_MULTIPLIER
+    return price
+
+
+def fetch_ri_offerings(
+    instance_type: str, engine: str, region: str, multi_az: bool = False
+) -> list[RIOffering]:
+    try:
+        import boto3
+    except ImportError:
+        return []
+
+    product_desc = ENGINE_PRODUCT_MAP.get(engine, "MySQL")
+    results: list[RIOffering] = []
+    try:
+        rds = boto3.client("rds", region_name=region)
+        paginator = rds.get_paginator("describe_reserved_db_instances_offerings")
+        for page in paginator.paginate(
+            DBInstanceClass=instance_type,
+            ProductDescription=product_desc,
+            MultiAZ=multi_az,
+        ):
+            for offering in page.get("ReservedDBInstancesOfferings", []):
+                inst = offering.get("DBInstanceClass", "")
+                if inst != instance_type:
+                    continue
+                duration = offering.get("Duration", 0)
+                term_years = 3 if duration > 94_000_000 else 1
+                payment = offering.get("OfferingType", "")
+                fixed = float(offering.get("FixedPrice", 0.0))
+                recurring_list = offering.get("RecurringCharges", [])
+                recurring_hr = sum(
+                    float(rc.get("RecurringChargeAmount", 0.0)) for rc in recurring_list
+                )
+                term_hours = term_years * 365 * 24
+                effective = (fixed / term_hours) + recurring_hr
+                results.append(
+                    RIOffering(
+                        instance_type=inst,
+                        term_years=term_years,
+                        payment_option=payment,
+                        effective_hourly=round(effective, 6),
+                        upfront_cost=round(fixed, 2),
+                        recurring_hourly=round(recurring_hr, 6),
+                        multi_az=multi_az,
+                    )
+                )
+    except Exception:
+        return []
+
+    seen = set()
+    deduped = []
+    for r in results:
+        key = (r.term_years, r.payment_option, round(r.effective_hourly, 6))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(r)
+    return deduped
+
+
+def fetch_dsp_rates(engine: str, region: str) -> dict[str, list[DSPRate]]:
+    try:
+        import boto3
+    except ImportError:
+        return {}
+
+    result: dict[str, list[DSPRate]] = {}
+    product_desc = ENGINE_PRODUCT_MAP.get(engine, "MySQL")
+    try:
+        sp = boto3.client("savingsplans", region_name="us-east-1")
+        rates = []
+        token = None
+        while True:
+            kwargs = {
+                "savingsPlanTypes": ["Database"],
+                "products": ["RDS"],
+                "serviceCodes": ["AmazonRDS"],
+                "filters": [
+                    {"name": "region", "values": [region]},
+                    {"name": "productDescription", "values": [product_desc]},
+                ],
+                "maxResults": 1000,
+            }
+            if token:
+                kwargs["nextToken"] = token
+            resp = sp.describe_savings_plans_offering_rates(**kwargs)
+            rates.extend(resp.get("searchResults", []))
+            token = resp.get("nextToken")
+            if not token:
+                break
+
+        for rate_entry in rates:
+            offering = rate_entry.get("savingsPlanOffering", {})
+            dur = offering.get("durationSeconds", 0)
+            term_years = 3 if dur > 94_000_000 else 1
+            payment = offering.get("paymentOption", "")
+            try:
+                rate_val = float(rate_entry.get("rate", "0"))
+            except (ValueError, TypeError):
+                continue
+            if rate_val <= 0:
+                continue
+            usage = rate_entry.get("usageType", "")
+            # Usage types may carry a region prefix (e.g. "USE2-InstanceUsage:db.r7g.2xlarge"),
+            # so search anywhere in the string rather than anchoring at the start.
+            m = re.search(r"InstanceUsage:db\.(\w+)\.(\w+)", usage)
+            if not m:
+                continue
+            family = m.group(1)
+            size = m.group(2)
+            key = f"db.{family}.{size}"
+            entry = DSPRate(
+                usage_type=key,
+                term_years=term_years,
+                payment_option=payment,
+                rate_per_hour=round(rate_val, 6),
+            )
+            result.setdefault(key, []).append(entry)
+    except Exception:
+        pass
+    return result
+
+
+def best_ri(offerings: list[RIOffering], term_years: int) -> RIOffering | None:
+    candidates = [r for r in offerings if r.term_years == term_years]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda r: r.effective_hourly)
+
+
+def best_dsp(rates: list[DSPRate], term_years: int = 1) -> DSPRate | None:
+    candidates = [r for r in rates if r.term_years == term_years]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda r: r.rate_per_hour)
+
+
+def build_comparison(
+    instance_type: str,
+    engine: str,
+    num_instances: int,
+    region: str,
+    multi_az: bool = False,
+    dsp_rates: dict[str, list[DSPRate]] | None = None,
+) -> dict:
+    if dsp_rates is None:
+        dsp_rates = fetch_dsp_rates(engine, region)
+
+    family = _family_from_instance(instance_type)
+    od_hourly = get_on_demand_price(instance_type, region, multi_az)
+    od_monthly = od_hourly * HOURS_PER_MONTH * num_instances
+
+    ri_offerings = fetch_ri_offerings(instance_type, engine, region, multi_az)
+    ri_1yr = best_ri(ri_offerings, 1)
+    ri_3yr = best_ri(ri_offerings, 3)
+
+    ri_1yr_monthly = ri_1yr.effective_hourly * HOURS_PER_MONTH * num_instances if ri_1yr else None
+    ri_3yr_monthly = ri_3yr.effective_hourly * HOURS_PER_MONTH * num_instances if ri_3yr else None
+
+    dsp_entry_1yr = best_dsp(dsp_rates.get(instance_type, []), 1)
+    dsp_entry_3yr = best_dsp(dsp_rates.get(instance_type, []), 3)
+    # Multi-AZ consumes 2x the compute hours the savings plan must cover, mirroring
+    # the on-demand and RI Multi-AZ handling above. Without this, DSP savings are overstated.
+    az_multiplier = MULTI_AZ_MULTIPLIER if multi_az else 1.0
+    dsp_1yr_monthly = (
+        dsp_entry_1yr.rate_per_hour * HOURS_PER_MONTH * num_instances * az_multiplier
+        if dsp_entry_1yr
+        else None
+    )
+    dsp_3yr_monthly = (
+        dsp_entry_3yr.rate_per_hour * HOURS_PER_MONTH * num_instances * az_multiplier
+        if dsp_entry_3yr
+        else None
+    )
+
+    dsp_eligible = family in _DSP_ELIGIBLE_FAMILIES
+    notes = []
+    if od_hourly == 0:
+        notes.append(
+            f"No static on-demand price is bundled for {instance_type}, so the offline "
+            f"baseline is $0 and savings cannot be computed. Run against a live instance "
+            f"(no 'offline' subcommand) or supply pricing to get accurate figures."
+        )
+    if not dsp_eligible:
+        notes.append(
+            f"Database Savings Plans do not cover the {family} family. "
+            f"Eligible families: {', '.join(sorted(_DSP_ELIGIBLE_FAMILIES))}."
+        )
+    if multi_az:
+        notes.append(
+            "Multi-AZ pricing applied. Multi-AZ RIs are separate offerings from Single-AZ. "
+            "Ensure you purchase the correct deployment type."
+        )
+    if region != "us-east-1" and od_hourly > 0:
+        notes.append(
+            f"On-demand baseline for {instance_type} uses us-east-1 static pricing; "
+            f"actual {region} pricing may differ by 10-20%, so savings percentages are approximate. "
+            f"Provide live pricing or run in us-east-1 for exact figures."
+        )
+
+    def _fmt(ri, monthly, od):
+        if ri is None or monthly is None:
+            return None
+        savings = od - monthly
+        pct = (savings / od * 100) if od > 0 else 0
+        return {
+            "term_years": ri.term_years,
+            "payment_option": ri.payment_option,
+            "effective_hourly_per_instance": round(ri.effective_hourly, 4),
+            "upfront_total": round(ri.upfront_cost * num_instances, 2),
+            "monthly": round(monthly, 2),
+            "savings_monthly": round(savings, 2),
+            "savings_pct": round(pct, 1),
+        }
+
+    def _fmt_dsp(dsp, monthly, od):
+        if dsp is None or monthly is None:
+            return None
+        savings = od - monthly
+        pct = (savings / od * 100) if od > 0 else 0
+        return {
+            "term_years": dsp.term_years,
+            "payment_option": dsp.payment_option,
+            "rate_per_hour": round(dsp.rate_per_hour, 4),
+            "monthly": round(monthly, 2),
+            "savings_monthly": round(savings, 2),
+            "savings_pct": round(pct, 1),
+        }
+
+    options = []
+    if ri_1yr_monthly is not None:
+        options.append(("1yr RI", ri_1yr_monthly))
+    if ri_3yr_monthly is not None:
+        options.append(("3yr RI", ri_3yr_monthly))
+    if dsp_1yr_monthly is not None:
+        options.append(("1yr DSP", dsp_1yr_monthly))
+    if dsp_3yr_monthly is not None:
+        options.append(("3yr DSP", dsp_3yr_monthly))
+
+    if options:
+        best_label, best_cost = min(options, key=lambda x: x[1])
+        savings = od_monthly - best_cost
+        pct = (savings / od_monthly * 100) if od_monthly > 0 else 0
+        recommendation = {
+            "best_option": best_label,
+            "best_monthly_cost": round(best_cost, 2),
+            "savings_vs_on_demand": round(savings, 2),
+            "savings_pct": round(pct, 1),
+        }
+    else:
+        recommendation = {"best_option": "on_demand", "reason": "No RI or DSP offerings found."}
+
+    return {
+        "engine": engine,
+        "instance_type": instance_type,
+        "num_instances": num_instances,
+        "multi_az": multi_az,
+        "on_demand": {"hourly": round(od_hourly, 4), "monthly": round(od_monthly, 2)},
+        "ri_1yr": _fmt(ri_1yr, ri_1yr_monthly, od_monthly),
+        "ri_3yr": _fmt(ri_3yr, ri_3yr_monthly, od_monthly),
+        "dsp_1yr": _fmt_dsp(dsp_entry_1yr, dsp_1yr_monthly, od_monthly),
+        "dsp_3yr": _fmt_dsp(dsp_entry_3yr, dsp_3yr_monthly, od_monthly),
+        "recommendation": recommendation,
+        "notes": notes,
+    }
+
+
+def analyze_instance_live(instance_id: str, region: str) -> dict:
+    import boto3
+
+    rds = boto3.client("rds", region_name=region)
+    try:
+        resp = rds.describe_db_instances(DBInstanceIdentifier=instance_id)
+    except Exception as e:
+        return {"instance_id": instance_id, "error": str(e)}
+    instances = resp.get("DBInstances", [])
+    if not instances:
+        return {"instance_id": instance_id, "error": "instance not found"}
+    inst = instances[0]
+    engine = inst.get("Engine", "")
+    instance_type = inst.get("DBInstanceClass", "")
+    multi_az = inst.get("MultiAZ", False)
+    replicas = inst.get("ReadReplicaDBInstanceIdentifiers", [])
+
+    result = build_comparison(
+        instance_type=instance_type,
+        engine=engine,
+        num_instances=1,
+        region=region,
+        multi_az=multi_az,
+    )
+    result["instance_id"] = instance_id
+    result["engine_version"] = inst.get("EngineVersion", "")
+    if replicas:
+        result["notes"].append(
+            f"Instance has {len(replicas)} read replica(s). "
+            "Consider separate RI/DSP for each replica (Single-AZ pricing)."
+        )
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="RDS RI & Database Savings Plan estimator (read-only)"
+    )
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--format", choices=["json"], default="json")
+    parser.add_argument("--instance", help="Analyze a single RDS instance by identifier")
+
+    sub = parser.add_subparsers(dest="mode")
+    off = sub.add_parser("offline", help="Use user-supplied workload description")
+    off.add_argument("--instance-type", required=True, help="e.g., db.r7g.2xlarge")
+    off.add_argument("--engine", required=True, choices=["mysql", "mariadb", "postgres"])
+    off.add_argument("--num-instances", type=int, default=1)
+    off.add_argument("--multi-az", action="store_true")
+    # --region and --format are defined on the main parser above; do NOT redefine them
+    # here, or the subparser's default silently overrides a value passed before 'offline'.
+
+    args = parser.parse_args()
+
+    if args.mode == "offline":
+        result = build_comparison(
+            instance_type=args.instance_type,
+            engine=args.engine,
+            num_instances=args.num_instances,
+            region=args.region,
+            multi_az=args.multi_az,
+        )
+        print(json.dumps(result, indent=2, default=str))
+        return
+
+    if args.instance:
+        result = analyze_instance_live(args.instance, args.region)
+        print(json.dumps(result, indent=2, default=str))
+        return
+
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Adds the `rds-oss` skill, an advisor for Amazon RDS on the open-source engines (MySQL, MariaDB, PostgreSQL).

Covers five areas:
- Production instance creation with best-practice defaults
- Upgrade planning with live prechecks, including the correct upgrade order when an instance has read replicas
- Commitment pricing (Reserved Instances vs Database Savings Plans)
- RDS Proxy evaluation (connection utilization and pinning risks)
- Blue/Green deployment planning, including which schema changes are safe to run without breaking replication

Contents: `SKILL.md` (overview and decision guide), 17 reference files under `references/`, and one read-only boto3 pricing helper under `scripts/`. All references are flat markdown.

## Type of Change
- [ ] New plugin
- [x] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*