### PR TITLE
feat(aws-cloudformation): add Express mode SOP and expand pre-deployment validation

### DIFF
--- a/plugins/aws-core/skills/aws-cloudformation/SKILL.md
+++ b/plugins/aws-core/skills/aws-cloudformation/SKILL.md
@@ -27,6 +27,7 @@ Domain expertise for the full CloudFormation lifecycle: authoring templates, val
 Follow the [authoring best-practices SOP](references/author-cloudformation-best-practices.script.md) as a review checklist. When unsure about property names or types, use the [resource property lookup SOP](references/lookup-resource-properties.script.md) to verify against authoritative documentation rather than guessing.
 
 Key defaults to apply unless there is a clear reason not to:
+
 - S3 buckets: `PublicAccessBlockConfiguration` (all four true), `BucketEncryption`, `VersioningConfiguration`
 - Stateful resources: `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain`
 - Avoid hardcoded physical resource names — use `!Sub "${AWS::StackName}-..."` for uniqueness
@@ -47,6 +48,7 @@ Run three validation layers in order — each catches different classes of error
 Use [deploy-with-express-mode SOP](references/deploy-with-express-mode.script.md) when the user wants faster deployment feedback during development iteration. Express mode completes stack operations as soon as resource configuration is applied — resources continue stabilizing in the background.
 
 Key points:
+
 - Activate with `--deployment-config '{"mode": "EXPRESS"}'` on `create-stack`, `update-stack`, or `delete-stack`
 - CDK: `cdk deploy --express`
 - Rollback is disabled by default; re-enable with `"disableRollback": false`
@@ -58,6 +60,7 @@ Key points:
 When a stack is in a failed state (`CREATE_FAILED`, `ROLLBACK_COMPLETE`, `UPDATE_ROLLBACK_FAILED`, etc.), follow the [troubleshoot-deployment SOP](references/troubleshoot-deployment.script.md).
 
 Key points:
+
 - Use `aws cloudformation describe-events --stack-name <name> --filters FailedEvents=true --region <region>` to get only failure events. Do NOT use `describe-stack-events` — that API does not support the `--filters` parameter. Do NOT use `--query` JMESPath filters as a substitute — use the `--filters` parameter directly.
 - Examine EVERY failed event's `ResourceStatusReason`. If a failure has a specific error message (e.g., "not authorized to perform", "already exists"), it is a real failure. If a failure says "Resource creation cancelled" with no specific error, it is a cascade caused by rollback — it does not tell you what would have gone wrong.
 - When multiple resources have their own specific errors, they are parallel failures from a shared root cause (e.g., an IAM role missing permissions for multiple services). Enumerate ALL the specific permission gaps, not just the first one, so the developer can fix everything in one pass.

--- a/plugins/aws-core/skills/aws-cloudformation/SKILL.md
+++ b/plugins/aws-core/skills/aws-cloudformation/SKILL.md
@@ -1,16 +1,7 @@
 ---
 name: aws-cloudformation
 description: Author, validate, and troubleshoot AWS CloudFormation templates. Covers template authoring with secure defaults, pre-deployment validation (cfn-lint, cfn-guard, change sets), and root-cause diagnosis of failed stacks using CloudFormation events and CloudTrail correlation.
-owner_team: CloudFormation
-owner_cti: AWS/CloudFormation/AWS IAC MCP Server
-stages: [preprod, prod]
-categories: [aws-core]
 version: 1
-metadata:
-  service: [cloudformation, cloudtrail, iam]
-  task: [author, validate, deploy, debug, troubleshoot]
-  persona: [developer, devops, architect]
-  workload: [infrastructure-as-code]
 ---
 # CloudFormation
 

--- a/plugins/aws-core/skills/aws-cloudformation/SKILL.md
+++ b/plugins/aws-core/skills/aws-cloudformation/SKILL.md
@@ -1,7 +1,16 @@
 ---
 name: aws-cloudformation
 description: Author, validate, and troubleshoot AWS CloudFormation templates. Covers template authoring with secure defaults, pre-deployment validation (cfn-lint, cfn-guard, change sets), and root-cause diagnosis of failed stacks using CloudFormation events and CloudTrail correlation.
+owner_team: CloudFormation
+owner_cti: AWS/CloudFormation/AWS IAC MCP Server
+stages: [preprod, prod]
+categories: [aws-core]
 version: 1
+metadata:
+  service: [cloudformation, cloudtrail, iam]
+  task: [author, validate, deploy, debug, troubleshoot]
+  persona: [developer, devops, architect]
+  workload: [infrastructure-as-code]
 ---
 # CloudFormation
 
@@ -18,7 +27,6 @@ Domain expertise for the full CloudFormation lifecycle: authoring templates, val
 Follow the [authoring best-practices SOP](references/author-cloudformation-best-practices.script.md) as a review checklist. When unsure about property names or types, use the [resource property lookup SOP](references/lookup-resource-properties.script.md) to verify against authoritative documentation rather than guessing.
 
 Key defaults to apply unless there is a clear reason not to:
-
 - S3 buckets: `PublicAccessBlockConfiguration` (all four true), `BucketEncryption`, `VersioningConfiguration`
 - Stateful resources: `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain`
 - Avoid hardcoded physical resource names — use `!Sub "${AWS::StackName}-..."` for uniqueness
@@ -30,16 +38,26 @@ Run three validation layers in order — each catches different classes of error
 
 1. **Syntax and schema** — [validate-cloudformation-template SOP](references/validate-cloudformation-template.script.md) (cfn-lint)
 2. **Security and compliance** — [check-cloudformation-template-compliance SOP](references/check-cloudformation-template-compliance.script.md) (cfn-guard)
-3. **Pre-deployment** — [cloudformation-pre-deploy-validation SOP](references/cloudformation-pre-deploy-validation.script.md) (change set + `describe-events` API)
+3. **Pre-deployment** — [cloudformation-pre-deploy-validation SOP](references/cloudformation-pre-deploy-validation.script.md) (`describe-events` API)
 
-**Critical:** Pre-deployment validation errors are retrieved via `aws cloudformation describe-events --change-set-name <arn> --region <region>`. Do NOT use `describe-stack-events` — that API does not return validation errors. Note: `describe-events` is a newer API — if the command is not recognized, upgrade the AWS CLI to the latest version.
+**Critical:** Pre-deployment validation is enabled by default on Create Stack, Update Stack, and change set creation. Retrieve results via `aws cloudformation describe-events` (see [SOP](references/cloudformation-pre-deploy-validation.script.md) for scoping options). Do NOT use `describe-stack-events`.
+
+### Deploy faster with Express mode
+
+Use [deploy-with-express-mode SOP](references/deploy-with-express-mode.script.md) when the user wants faster deployment feedback during development iteration. Express mode completes stack operations as soon as resource configuration is applied — resources continue stabilizing in the background.
+
+Key points:
+- Activate with `--deployment-config '{"mode": "EXPRESS"}'` on `create-stack`, `update-stack`, or `delete-stack`
+- CDK: `cdk deploy --express`
+- Rollback is disabled by default; re-enable with `"disableRollback": false`
+- NOT for production workflows that require resources to serve traffic immediately after stack completion
+- `aws cloudformation deploy` does NOT support Express mode — use `create-stack`/`update-stack`
 
 ### Troubleshoot a failed deployment
 
 When a stack is in a failed state (`CREATE_FAILED`, `ROLLBACK_COMPLETE`, `UPDATE_ROLLBACK_FAILED`, etc.), follow the [troubleshoot-deployment SOP](references/troubleshoot-deployment.script.md).
 
 Key points:
-
 - Use `aws cloudformation describe-events --stack-name <name> --filters FailedEvents=true --region <region>` to get only failure events. Do NOT use `describe-stack-events` — that API does not support the `--filters` parameter. Do NOT use `--query` JMESPath filters as a substitute — use the `--filters` parameter directly.
 - Examine EVERY failed event's `ResourceStatusReason`. If a failure has a specific error message (e.g., "not authorized to perform", "already exists"), it is a real failure. If a failure says "Resource creation cancelled" with no specific error, it is a cascade caused by rollback — it does not tell you what would have gone wrong.
 - When multiple resources have their own specific errors, they are parallel failures from a shared root cause (e.g., an IAM role missing permissions for multiple services). Enumerate ALL the specific permission gaps, not just the first one, so the developer can fix everything in one pass.
@@ -52,6 +70,7 @@ Key points:
 |-------------|--------|
 | Write or modify a template | Author task + best-practices checklist |
 | Check a template before deploying | Validation pipeline (3 layers) |
+| Deploy faster during development | Deploy-with-express-mode SOP |
 | Stack failed or is stuck | Troubleshoot-deployment SOP |
 | Unsure about a resource property | Resource property lookup SOP |
 

--- a/plugins/aws-core/skills/aws-cloudformation/references/cloudformation-pre-deploy-validation.script.md
+++ b/plugins/aws-core/skills/aws-cloudformation/references/cloudformation-pre-deploy-validation.script.md
@@ -25,6 +25,7 @@ Validation errors are exposed through the `describe-events` API scoped to the ch
 - **capabilities** (optional): CloudFormation capabilities (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`) if the template creates IAM resources.
 
 **Constraints for parameter acquisition:**
+
 - You MUST ask for all required parameters upfront in a single prompt
 - You MUST support multiple input methods for the template (direct input, file path, S3 URL)
 - You MUST confirm successful acquisition of all parameters before proceeding
@@ -36,6 +37,7 @@ Validation errors are exposed through the `describe-events` API scoped to the ch
 Check which mechanism is available to invoke AWS APIs.
 
 **Constraints:**
+
 - You MUST check in this order of preference:
   1. `call_aws` tool from the AWS MCP Server (preferred for sandboxed execution, audit logging, and observability)
   2. AWS CLI (`aws`) available on the user's system (verify with `which aws` or `aws --version`)
@@ -51,6 +53,7 @@ Check which mechanism is available to invoke AWS APIs.
 Catch issues locally before consuming CloudFormation API quota.
 
 **Constraints:**
+
 - You SHOULD recommend running the `validate-cloudformation-template` SOP first to catch cfn-lint syntax and schema errors locally
 - You SHOULD recommend running the `check-cloudformation-template-compliance` SOP to catch security violations locally
 - If the user has already run these checks or explicitly skips them, You MUST proceed to the next step
@@ -60,6 +63,7 @@ Catch issues locally before consuming CloudFormation API quota.
 Prepare the template for the change set.
 
 **Constraints:**
+
 - If the template is small (≤ 51,200 bytes) and provided as content or a local file, You MAY pass it inline via `--template-body`
 - If the template exceeds 51,200 bytes, You MUST upload it to S3 and use `--template-url` because `--template-body` has a size limit
 - If the template is already at an S3 URL, You MUST use `--template-url` directly
@@ -69,10 +73,12 @@ Prepare the template for the change set.
 Create the change set to trigger pre-deployment validation. Validation runs automatically during change set creation — no opt-in is required.
 
 **Constraints:**
+
 - You MUST use a unique, descriptive change set name (e.g., `pre-deploy-validation-<timestamp>`)
 - You MUST use the appropriate `--change-set-type` (`CREATE` for new stacks, `UPDATE` for existing)
 - You MUST include `--capabilities` if the template creates IAM resources (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`)
 - You MUST invoke via `call_aws` (preferred) or the AWS CLI. Example CLI form:
+
   ```
   aws cloudformation create-change-set \
     --stack-name <stack_name> \
@@ -82,6 +88,7 @@ Create the change set to trigger pre-deployment validation. Validation runs auto
     --region <region> \
     --capabilities CAPABILITY_IAM
   ```
+
   > **Notes:** Use `--template-url s3://...` instead of `--template-body` for templates exceeding 51,200 bytes. Include `--capabilities` only if the template creates IAM resources.
 - You MUST capture the returned change set ARN (Id) for the next step
 - You MUST explain to the user that creating a change set does NOT modify any resources because it only plans the changes and runs validation
@@ -92,6 +99,7 @@ Create the change set to trigger pre-deployment validation. Validation runs auto
 Fetch validation results from the `describe-events` API.
 
 **Constraints:**
+
 - You MUST use `aws cloudformation describe-events --change-set-name <arn> --region <region>` (via `call_aws` or CLI)
 - You MUST NOT use `describe-stack-events` because the legacy stack events API does NOT return validation errors — it only surfaces resource provisioning events after execution
 - You MUST filter events where `EventType` equals `VALIDATION_ERROR` because these are the validation findings
@@ -108,6 +116,7 @@ Fetch validation results from the `describe-events` API.
 Report validation findings grouped by type and help the user fix issues.
 
 **Constraints:**
+
 - You MUST present results grouped by `ValidationName`:
   - **Property syntax validation** — invalid property values or formats
   - **Resource name conflict validation** — resources that conflict with existing resources
@@ -124,6 +133,7 @@ Report validation findings grouped by type and help the user fix issues.
 Guide the user on next steps after validation.
 
 **Constraints:**
+
 - If all validations passed (or only `WARN`-mode issues that the user accepts), You MUST ask the user for explicit approval before executing the change set
 - You MUST NOT execute the change set without explicit user approval because this will modify live infrastructure
 - You MUST NOT delete a stack without explicit user approval. Before deleting, You MUST verify the stack status is `REVIEW_IN_PROGRESS` by calling `describe-stacks`
@@ -137,6 +147,7 @@ Guide the user on next steps after validation.
 ## Examples
 
 ### Example: Successful Validation
+
 ```
 Change set "pre-deploy-validation-1713580000" created for stack "my-app-stack".
 
@@ -151,6 +162,7 @@ The change set is ready to execute. Would you like to execute it now?
 ```
 
 ### Example: Failed Validation
+
 ```
 Change set "pre-deploy-validation-1713580000" created for stack "my-app-stack".
 

--- a/plugins/aws-core/skills/aws-cloudformation/references/cloudformation-pre-deploy-validation.script.md
+++ b/plugins/aws-core/skills/aws-cloudformation/references/cloudformation-pre-deploy-validation.script.md
@@ -8,7 +8,7 @@ Deterministic procedure for running CloudFormation's pre-deployment validation f
 2. **Resource name conflict validation** (FAIL) — Detects naming conflicts with existing resources in the account.
 3. **S3 bucket emptiness validation** (WARN) — Warns when deleting S3 buckets that contain objects.
 
-Validation errors are exposed through the **new `describe-events` API** scoped to the change set. This procedure uses `call_aws` (preferred) or the AWS CLI to invoke these APIs directly.
+Validation errors are exposed through the `describe-events` API scoped to the change set. This procedure uses `call_aws` (preferred) or the AWS CLI to invoke these APIs directly. Note: The AWS MCP server is recommended for streamlined API invocation, but all steps can be performed using the AWS CLI alone.
 
 **Important:** The legacy `describe-stack-events` API does NOT return validation errors. You MUST use `describe-events --change-set-name <arn>` to retrieve validation results.
 
@@ -25,7 +25,6 @@ Validation errors are exposed through the **new `describe-events` API** scoped t
 - **capabilities** (optional): CloudFormation capabilities (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`) if the template creates IAM resources.
 
 **Constraints for parameter acquisition:**
-
 - You MUST ask for all required parameters upfront in a single prompt
 - You MUST support multiple input methods for the template (direct input, file path, S3 URL)
 - You MUST confirm successful acquisition of all parameters before proceeding
@@ -37,7 +36,6 @@ Validation errors are exposed through the **new `describe-events` API** scoped t
 Check which mechanism is available to invoke AWS APIs.
 
 **Constraints:**
-
 - You MUST check in this order of preference:
   1. `call_aws` tool from the AWS MCP Server (preferred for sandboxed execution, audit logging, and observability)
   2. AWS CLI (`aws`) available on the user's system (verify with `which aws` or `aws --version`)
@@ -53,7 +51,6 @@ Check which mechanism is available to invoke AWS APIs.
 Catch issues locally before consuming CloudFormation API quota.
 
 **Constraints:**
-
 - You SHOULD recommend running the `validate-cloudformation-template` SOP first to catch cfn-lint syntax and schema errors locally
 - You SHOULD recommend running the `check-cloudformation-template-compliance` SOP to catch security violations locally
 - If the user has already run these checks or explicitly skips them, You MUST proceed to the next step
@@ -63,7 +60,6 @@ Catch issues locally before consuming CloudFormation API quota.
 Prepare the template for the change set.
 
 **Constraints:**
-
 - If the template is small (≤ 51,200 bytes) and provided as content or a local file, You MAY pass it inline via `--template-body`
 - If the template exceeds 51,200 bytes, You MUST upload it to S3 and use `--template-url` because `--template-body` has a size limit
 - If the template is already at an S3 URL, You MUST use `--template-url` directly
@@ -73,12 +69,10 @@ Prepare the template for the change set.
 Create the change set to trigger pre-deployment validation. Validation runs automatically during change set creation — no opt-in is required.
 
 **Constraints:**
-
 - You MUST use a unique, descriptive change set name (e.g., `pre-deploy-validation-<timestamp>`)
 - You MUST use the appropriate `--change-set-type` (`CREATE` for new stacks, `UPDATE` for existing)
 - You MUST include `--capabilities` if the template creates IAM resources (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`)
 - You MUST invoke via `call_aws` (preferred) or the AWS CLI. Example CLI form:
-
   ```
   aws cloudformation create-change-set \
     --stack-name <stack_name> \
@@ -88,7 +82,6 @@ Create the change set to trigger pre-deployment validation. Validation runs auto
     --region <region> \
     --capabilities CAPABILITY_IAM
   ```
-
   > **Notes:** Use `--template-url s3://...` instead of `--template-body` for templates exceeding 51,200 bytes. Include `--capabilities` only if the template creates IAM resources.
 - You MUST capture the returned change set ARN (Id) for the next step
 - You MUST explain to the user that creating a change set does NOT modify any resources because it only plans the changes and runs validation
@@ -96,10 +89,9 @@ Create the change set to trigger pre-deployment validation. Validation runs auto
 
 ### 5. Retrieve Validation Results via describe-events
 
-Fetch validation results from the **new `describe-events` API**.
+Fetch validation results from the `describe-events` API.
 
 **Constraints:**
-
 - You MUST use `aws cloudformation describe-events --change-set-name <arn> --region <region>` (via `call_aws` or CLI)
 - You MUST NOT use `describe-stack-events` because the legacy stack events API does NOT return validation errors — it only surfaces resource provisioning events after execution
 - You MUST filter events where `EventType` equals `VALIDATION_ERROR` because these are the validation findings
@@ -116,7 +108,6 @@ Fetch validation results from the **new `describe-events` API**.
 Report validation findings grouped by type and help the user fix issues.
 
 **Constraints:**
-
 - You MUST present results grouped by `ValidationName`:
   - **Property syntax validation** — invalid property values or formats
   - **Resource name conflict validation** — resources that conflict with existing resources
@@ -133,7 +124,6 @@ Report validation findings grouped by type and help the user fix issues.
 Guide the user on next steps after validation.
 
 **Constraints:**
-
 - If all validations passed (or only `WARN`-mode issues that the user accepts), You MUST ask the user for explicit approval before executing the change set
 - You MUST NOT execute the change set without explicit user approval because this will modify live infrastructure
 - You MUST NOT delete a stack without explicit user approval. Before deleting, You MUST verify the stack status is `REVIEW_IN_PROGRESS` by calling `describe-stacks`
@@ -147,7 +137,6 @@ Guide the user on next steps after validation.
 ## Examples
 
 ### Example: Successful Validation
-
 ```
 Change set "pre-deploy-validation-1713580000" created for stack "my-app-stack".
 
@@ -162,7 +151,6 @@ The change set is ready to execute. Would you like to execute it now?
 ```
 
 ### Example: Failed Validation
-
 ```
 Change set "pre-deploy-validation-1713580000" created for stack "my-app-stack".
 
@@ -199,7 +187,7 @@ Fix the template and create a new change set.
 ## Troubleshooting
 
 ### describe-events returns empty or unknown command
-The `describe-events` API (scoped to change sets with validation errors) is the newer API. If the installed AWS CLI is outdated, update it: `pip install --upgrade awscli` or `brew upgrade awscli`. If the command still returns nothing, confirm the change set ARN is correct and the change set has finished creating.
+The `describe-events` API (scoped to change sets) requires AWS CLI support for the command. If it is not recognized, update the AWS CLI: `pip install --upgrade awscli` or `brew upgrade awscli`. If the command still returns nothing, confirm the change set ARN is correct and the change set has finished creating.
 
 ### User calls describe-stack-events instead
 `describe-stack-events` returns events after the stack begins provisioning. It does NOT include pre-deployment validation errors. You MUST redirect the user to `describe-events --change-set-name <arn>`.

--- a/plugins/aws-core/skills/aws-cloudformation/references/deploy-with-express-mode.script.md
+++ b/plugins/aws-core/skills/aws-cloudformation/references/deploy-with-express-mode.script.md
@@ -1,0 +1,250 @@
+# Deploy with Express Mode
+
+## Overview
+
+Deterministic procedure for deploying CloudFormation stacks using **Express mode** — a deployment mode that completes stack operations as soon as resource configuration is applied, giving immediate confirmation to proceed to the next iteration. Resources continue becoming ready to serve traffic in the background.
+
+Express mode works with all existing CloudFormation templates and requires no template changes. It is recommended for development workflows where you iterate frequently and need fast deployment confirmation.
+
+**When to use Express mode:**
+- Iterating on infrastructure configurations during development
+- Deploying individual components of your application
+- Deploying dependent stacks that only need resource outputs (VPC IDs, endpoints, ARNs) to proceed
+- Building with AI agents that need fast feedback loops to validate and refine infrastructure
+- Prototyping and experimenting with new architectures
+
+**When NOT to use Express mode:**
+- Production workflows that require resources to serve traffic immediately after stack completion
+- Deployments where downstream consumers immediately hit endpoints (load balancers, CloudFront distributions, ECS services) after the operation completes
+
+**What Express mode skips:**
+1. Traffic readiness (e.g., EC2 instance reaching `running` state)
+2. Region propagation (e.g., CloudFront propagating to all edge locations, 5-10 minutes)
+3. Cleanup (e.g., network interface removal before Lambda function deletion)
+
+**What does NOT change:**
+- CloudFormation still processes all resources in dependency order
+- CloudFormation still retries dependent resources that encounter transient failures
+- CloudFormation still handles dependent resource failures
+
+## Parameters
+
+- **stack_name** (required): The CloudFormation stack name.
+- **template_source** (required): The template to deploy. One of:
+  - File path to a local template
+  - S3 URL of an uploaded template
+  - Template content provided directly
+- **operation** (required): One of `CREATE`, `UPDATE`, or `DELETE`.
+- **region** (required): AWS region for deployment.
+- **enable_rollback** (optional): Whether to enable rollback. Express mode disables rollback by default for fastest iteration. Set to `true` if the user wants rollback on failure.
+- **parameters** (optional): Stack parameters as key-value pairs.
+- **capabilities** (optional): CloudFormation capabilities (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`) if the template creates IAM resources.
+
+**Constraints for parameter acquisition:**
+- You MUST ask for all required parameters upfront in a single prompt
+- You MUST support multiple input methods for the template (direct input, file path, S3 URL)
+- You MUST confirm successful acquisition of all parameters before proceeding
+
+## Steps
+
+### 1. Verify Dependencies
+
+Check which mechanism is available to invoke AWS APIs.
+
+**Constraints:**
+- You MUST check in this order of preference:
+  1. `call_aws` tool from the AWS MCP Server (preferred for sandboxed execution, audit logging, and observability)
+  2. AWS CLI (`aws`) available on the user's system (verify with `which aws` or `aws --version`)
+- You MUST verify the user has valid AWS credentials configured for the target account/region (e.g., `aws sts get-caller-identity --region <region>`). This read-only call is acceptable during verification because it does not modify any resources
+- You MUST ONLY check for availability and credential validity. You MUST NOT create or modify stacks or install missing dependencies during this step
+- If the AWS CLI is missing, You MUST ask the user explicitly before running any install command
+- You MUST NOT run install commands without the user's explicit approval
+- If credentials are missing or invalid, You MUST ask the user to configure credentials and MUST NOT proceed until credentials are confirmed
+
+### 2. Confirm Express Mode is Appropriate
+
+Verify with the user that Express mode is the right choice for their use case.
+
+**Constraints:**
+- You MUST inform the user that Express mode completes when resource configuration is applied, and resources continue stabilizing in the background
+- You MUST ask whether the user's workflow requires resources to serve traffic immediately after the stack operation completes
+- If the user's workflow DOES require immediate traffic readiness (production serving, endpoint availability), You MUST recommend using the default deployment behavior instead
+- If the user is in a development/iteration workflow, You SHOULD proceed with Express mode
+- You MUST inform the user that rollback is disabled by default with Express mode. If the user wants rollback protection, You MUST include `"disableRollback": false` in the deployment configuration
+
+### 3. Upload Template (if needed)
+
+Prepare the template for the operation.
+
+**Constraints:**
+- If the template is small (≤ 51,200 bytes) and provided as content or a local file, You MAY pass it inline via `--template-body`
+- If the template exceeds 51,200 bytes, You MUST upload it to S3 and use `--template-url` because `--template-body` has a size limit
+- If the template is already at an S3 URL, You MUST use `--template-url` directly
+- This step does not apply to `DELETE` operations
+
+### 4. Execute Stack Operation with Express Mode
+
+Run the stack operation with the `--deployment-config` parameter set to Express mode.
+
+**Constraints:**
+- You MUST obtain explicit user approval before executing the operation because it creates, modifies, or deletes live infrastructure
+- You MUST use `--deployment-config '{"mode": "EXPRESS"}'` on the stack operation
+- If the user requested rollback, You MUST use `--deployment-config '{"mode": "EXPRESS", "disableRollback": false}'`
+- You MUST include `--capabilities` if the template creates IAM resources
+- You MUST NOT use `aws cloudformation deploy` because it does not support `--deployment-config`. Use `create-stack`, `update-stack`, or `delete-stack` instead.
+
+> **Note:** When using `call_aws`, pass the template content inline in the `TemplateBody` parameter — the `file://` syntax is AWS CLI-specific and does not work with `call_aws`.
+
+**Create a stack:**
+```
+aws cloudformation create-stack \
+  --stack-name <stack_name> \
+  --template-body file://<path> \
+  --region <region> \
+  --deployment-config '{"mode": "EXPRESS"}' \
+  --capabilities CAPABILITY_IAM
+```
+
+**Update a stack:**
+```
+aws cloudformation update-stack \
+  --stack-name <stack_name> \
+  --template-body file://<path> \
+  --region <region> \
+  --deployment-config '{"mode": "EXPRESS"}' \
+  --capabilities CAPABILITY_IAM
+```
+
+**Delete a stack:**
+```
+aws cloudformation delete-stack \
+  --stack-name <stack_name> \
+  --region <region> \
+  --deployment-config '{"mode": "EXPRESS"}'
+```
+
+**With rollback enabled:**
+```
+aws cloudformation create-stack \
+  --stack-name <stack_name> \
+  --template-body file://<path> \
+  --region <region> \
+  --deployment-config '{"mode": "EXPRESS", "disableRollback": false}' \
+  --capabilities CAPABILITY_IAM
+```
+
+### 5. Express Mode with Change Sets
+
+Express mode also works with change sets. The deployment configuration is stored with the change set and applied when executed.
+
+**Constraints:**
+- To use Express mode with a change set, supply `--deployment-config` at `create-change-set` time:
+  ```
+  aws cloudformation create-change-set \
+    --stack-name <stack_name> \
+    --template-body file://<path> \
+    --change-set-name <change_set_name> \
+    --deployment-config '{"mode": "EXPRESS"}' \
+    --region <region> \
+    --capabilities CAPABILITY_IAM
+  ```
+- You MUST NOT specify `--deployment-config` again at `execute-change-set` time because it is already stored with the change set
+- You SHOULD recommend the change set path when the user also wants pre-deployment validation before deploying with Express mode (change set creation runs all validation checks before execution)
+
+### 6. CDK Express Mode
+
+When the user is deploying with the AWS CDK, Express mode is activated with the `--express` flag.
+
+**Constraints:**
+- You MUST use `cdk deploy --express` to deploy with Express mode
+- To re-enable rollback: `cdk deploy --express --rollback`
+- Express mode applies to all CloudFormation deployments triggered by CDK, including multi-stack deployments
+- You MUST NOT recommend `cdk deploy --hotswap` as a substitute for Express mode — they are different capabilities:
+  - Express mode: full infrastructure changes through CloudFormation, no drift introduced
+  - CDK hotswap: code-only changes via direct service APIs, introduces drift (bypasses CloudFormation)
+
+### 7. Monitor Resource Readiness After Completion
+
+Guide the user on what to expect after Express mode completes.
+
+**Constraints:**
+- You MUST inform the user that resources continue stabilizing in the background after the operation reports complete
+- You SHOULD provide guidance on typical background stabilization timelines:
+  - CloudFront distribution: propagation to all edge locations (5-10 minutes)
+  - EC2 instance: health checks, reaching `running` state
+  - Lambda function delete: network interface cleanup
+  - ECS service: containers reaching desired capacity
+- You SHOULD recommend monitoring resource readiness through existing mechanisms: CloudWatch alarms, health checks, or service-specific dashboards
+- If a resource does not stabilize as expected, You SHOULD recommend redeploying the stack to retry the affected resources
+
+## Unsupported Features
+
+The following are NOT supported with Express mode. You MUST inform the user if their scenario involves any of these:
+
+- **Custom resources** (`AWS::CloudFormation::CustomResource` and `Custom::*`) — these follow default completion behavior even when Express mode is active
+- **StackSets** — Express mode is not supported for StackSet operations
+- **AWS SAM** — not supported
+- **`aws cloudformation deploy` CLI command** — does not support `--deployment-config`; use `create-stack` or `update-stack` instead
+- **Account-level default** — Express mode is activated per stack operation; there is no account-wide setting
+
+## Examples
+
+### Example: Create a stack with Express mode
+```
+$ aws cloudformation create-stack \
+    --stack-name my-dev-vpc \
+    --template-body file://vpc.yaml \
+    --region us-west-2 \
+    --deployment-config '{"mode": "EXPRESS"}'
+
+{
+  "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/my-dev-vpc/abc123"
+}
+
+Stack "my-dev-vpc" creation completed (Express mode).
+Resources are configured. VPC ID, subnet IDs, and other outputs are available.
+Background stabilization (route propagation, NAT gateway activation) continues.
+```
+
+### Example: CDK deploy with Express mode
+```
+$ cdk deploy --express
+
+ ✅  MyDevStack
+
+Express mode: stack completed when resource configuration was applied.
+Outputs:
+  MyDevStack.VpcId = vpc-0abc123def456
+  MyDevStack.ApiEndpoint = https://abc123.execute-api.us-west-2.amazonaws.com
+
+Resources continue stabilizing in the background.
+```
+
+### Example: Express mode with rollback enabled
+```
+$ aws cloudformation update-stack \
+    --stack-name my-dev-vpc \
+    --template-body file://vpc-v2.yaml \
+    --region us-west-2 \
+    --deployment-config '{"mode": "EXPRESS", "disableRollback": false}'
+```
+
+## Troubleshooting
+
+### Resources not ready to serve traffic after stack completes
+This is expected behavior with Express mode. Resources receive their configuration immediately but may still be starting up, propagating, or cleaning up. Monitor resource-specific readiness through CloudWatch, health checks, or service dashboards. If a resource does not stabilize, redeploy the stack to retry.
+
+### `--deployment-config` not recognized
+The `--deployment-config` parameter requires a CLI version that supports Express mode. Update the AWS CLI to the latest version. If using CDK, use `--express` instead.
+
+### `deploy` command does not accept `--deployment-config`
+The `aws cloudformation deploy` command does not support `--deployment-config`. Use `create-stack` or `update-stack` directly. In CDK, use `cdk deploy --express`.
+
+### Custom resources do not complete faster
+Custom resources always follow default completion behavior regardless of Express mode. This is by design — custom resources define their own completion logic.
+
+### StackSets error with Express mode
+Express mode is not supported for StackSet operations. Remove `--deployment-config` when working with StackSets.
+
+### Rollback not happening on failure
+Express mode disables rollback by default. To re-enable, add `"disableRollback": false` to the deployment configuration JSON, or use `cdk deploy --express --rollback` in CDK.

--- a/plugins/aws-core/skills/aws-cloudformation/references/deploy-with-express-mode.script.md
+++ b/plugins/aws-core/skills/aws-cloudformation/references/deploy-with-express-mode.script.md
@@ -7,6 +7,7 @@ Deterministic procedure for deploying CloudFormation stacks using **Express mode
 Express mode works with all existing CloudFormation templates and requires no template changes. It is recommended for development workflows where you iterate frequently and need fast deployment confirmation.
 
 **When to use Express mode:**
+
 - Iterating on infrastructure configurations during development
 - Deploying individual components of your application
 - Deploying dependent stacks that only need resource outputs (VPC IDs, endpoints, ARNs) to proceed
@@ -14,15 +15,18 @@ Express mode works with all existing CloudFormation templates and requires no te
 - Prototyping and experimenting with new architectures
 
 **When NOT to use Express mode:**
+
 - Production workflows that require resources to serve traffic immediately after stack completion
 - Deployments where downstream consumers immediately hit endpoints (load balancers, CloudFront distributions, ECS services) after the operation completes
 
 **What Express mode skips:**
+
 1. Traffic readiness (e.g., EC2 instance reaching `running` state)
 2. Region propagation (e.g., CloudFront propagating to all edge locations, 5-10 minutes)
 3. Cleanup (e.g., network interface removal before Lambda function deletion)
 
 **What does NOT change:**
+
 - CloudFormation still processes all resources in dependency order
 - CloudFormation still retries dependent resources that encounter transient failures
 - CloudFormation still handles dependent resource failures
@@ -41,6 +45,7 @@ Express mode works with all existing CloudFormation templates and requires no te
 - **capabilities** (optional): CloudFormation capabilities (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`) if the template creates IAM resources.
 
 **Constraints for parameter acquisition:**
+
 - You MUST ask for all required parameters upfront in a single prompt
 - You MUST support multiple input methods for the template (direct input, file path, S3 URL)
 - You MUST confirm successful acquisition of all parameters before proceeding
@@ -52,6 +57,7 @@ Express mode works with all existing CloudFormation templates and requires no te
 Check which mechanism is available to invoke AWS APIs.
 
 **Constraints:**
+
 - You MUST check in this order of preference:
   1. `call_aws` tool from the AWS MCP Server (preferred for sandboxed execution, audit logging, and observability)
   2. AWS CLI (`aws`) available on the user's system (verify with `which aws` or `aws --version`)
@@ -66,6 +72,7 @@ Check which mechanism is available to invoke AWS APIs.
 Verify with the user that Express mode is the right choice for their use case.
 
 **Constraints:**
+
 - You MUST inform the user that Express mode completes when resource configuration is applied, and resources continue stabilizing in the background
 - You MUST ask whether the user's workflow requires resources to serve traffic immediately after the stack operation completes
 - If the user's workflow DOES require immediate traffic readiness (production serving, endpoint availability), You MUST recommend using the default deployment behavior instead
@@ -77,6 +84,7 @@ Verify with the user that Express mode is the right choice for their use case.
 Prepare the template for the operation.
 
 **Constraints:**
+
 - If the template is small (≤ 51,200 bytes) and provided as content or a local file, You MAY pass it inline via `--template-body`
 - If the template exceeds 51,200 bytes, You MUST upload it to S3 and use `--template-url` because `--template-body` has a size limit
 - If the template is already at an S3 URL, You MUST use `--template-url` directly
@@ -87,6 +95,7 @@ Prepare the template for the operation.
 Run the stack operation with the `--deployment-config` parameter set to Express mode.
 
 **Constraints:**
+
 - You MUST obtain explicit user approval before executing the operation because it creates, modifies, or deletes live infrastructure
 - You MUST use `--deployment-config '{"mode": "EXPRESS"}'` on the stack operation
 - If the user requested rollback, You MUST use `--deployment-config '{"mode": "EXPRESS", "disableRollback": false}'`
@@ -96,6 +105,7 @@ Run the stack operation with the `--deployment-config` parameter set to Express 
 > **Note:** When using `call_aws`, pass the template content inline in the `TemplateBody` parameter — the `file://` syntax is AWS CLI-specific and does not work with `call_aws`.
 
 **Create a stack:**
+
 ```
 aws cloudformation create-stack \
   --stack-name <stack_name> \
@@ -106,6 +116,7 @@ aws cloudformation create-stack \
 ```
 
 **Update a stack:**
+
 ```
 aws cloudformation update-stack \
   --stack-name <stack_name> \
@@ -116,6 +127,7 @@ aws cloudformation update-stack \
 ```
 
 **Delete a stack:**
+
 ```
 aws cloudformation delete-stack \
   --stack-name <stack_name> \
@@ -124,6 +136,7 @@ aws cloudformation delete-stack \
 ```
 
 **With rollback enabled:**
+
 ```
 aws cloudformation create-stack \
   --stack-name <stack_name> \
@@ -138,7 +151,9 @@ aws cloudformation create-stack \
 Express mode also works with change sets. The deployment configuration is stored with the change set and applied when executed.
 
 **Constraints:**
+
 - To use Express mode with a change set, supply `--deployment-config` at `create-change-set` time:
+
   ```
   aws cloudformation create-change-set \
     --stack-name <stack_name> \
@@ -148,6 +163,7 @@ Express mode also works with change sets. The deployment configuration is stored
     --region <region> \
     --capabilities CAPABILITY_IAM
   ```
+
 - You MUST NOT specify `--deployment-config` again at `execute-change-set` time because it is already stored with the change set
 - You SHOULD recommend the change set path when the user also wants pre-deployment validation before deploying with Express mode (change set creation runs all validation checks before execution)
 
@@ -156,6 +172,7 @@ Express mode also works with change sets. The deployment configuration is stored
 When the user is deploying with the AWS CDK, Express mode is activated with the `--express` flag.
 
 **Constraints:**
+
 - You MUST use `cdk deploy --express` to deploy with Express mode
 - To re-enable rollback: `cdk deploy --express --rollback`
 - Express mode applies to all CloudFormation deployments triggered by CDK, including multi-stack deployments
@@ -168,6 +185,7 @@ When the user is deploying with the AWS CDK, Express mode is activated with the 
 Guide the user on what to expect after Express mode completes.
 
 **Constraints:**
+
 - You MUST inform the user that resources continue stabilizing in the background after the operation reports complete
 - You SHOULD provide guidance on typical background stabilization timelines:
   - CloudFront distribution: propagation to all edge locations (5-10 minutes)
@@ -190,6 +208,7 @@ The following are NOT supported with Express mode. You MUST inform the user if t
 ## Examples
 
 ### Example: Create a stack with Express mode
+
 ```
 $ aws cloudformation create-stack \
     --stack-name my-dev-vpc \
@@ -207,6 +226,7 @@ Background stabilization (route propagation, NAT gateway activation) continues.
 ```
 
 ### Example: CDK deploy with Express mode
+
 ```
 $ cdk deploy --express
 
@@ -221,6 +241,7 @@ Resources continue stabilizing in the background.
 ```
 
 ### Example: Express mode with rollback enabled
+
 ```
 $ aws cloudformation update-stack \
     --stack-name my-dev-vpc \

--- a/skills/core-skills/aws-cloudformation/SKILL.md
+++ b/skills/core-skills/aws-cloudformation/SKILL.md
@@ -27,6 +27,7 @@ Domain expertise for the full CloudFormation lifecycle: authoring templates, val
 Follow the [authoring best-practices SOP](references/author-cloudformation-best-practices.script.md) as a review checklist. When unsure about property names or types, use the [resource property lookup SOP](references/lookup-resource-properties.script.md) to verify against authoritative documentation rather than guessing.
 
 Key defaults to apply unless there is a clear reason not to:
+
 - S3 buckets: `PublicAccessBlockConfiguration` (all four true), `BucketEncryption`, `VersioningConfiguration`
 - Stateful resources: `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain`
 - Avoid hardcoded physical resource names — use `!Sub "${AWS::StackName}-..."` for uniqueness
@@ -47,6 +48,7 @@ Run three validation layers in order — each catches different classes of error
 Use [deploy-with-express-mode SOP](references/deploy-with-express-mode.script.md) when the user wants faster deployment feedback during development iteration. Express mode completes stack operations as soon as resource configuration is applied — resources continue stabilizing in the background.
 
 Key points:
+
 - Activate with `--deployment-config '{"mode": "EXPRESS"}'` on `create-stack`, `update-stack`, or `delete-stack`
 - CDK: `cdk deploy --express`
 - Rollback is disabled by default; re-enable with `"disableRollback": false`
@@ -58,6 +60,7 @@ Key points:
 When a stack is in a failed state (`CREATE_FAILED`, `ROLLBACK_COMPLETE`, `UPDATE_ROLLBACK_FAILED`, etc.), follow the [troubleshoot-deployment SOP](references/troubleshoot-deployment.script.md).
 
 Key points:
+
 - Use `aws cloudformation describe-events --stack-name <name> --filters FailedEvents=true --region <region>` to get only failure events. Do NOT use `describe-stack-events` — that API does not support the `--filters` parameter. Do NOT use `--query` JMESPath filters as a substitute — use the `--filters` parameter directly.
 - Examine EVERY failed event's `ResourceStatusReason`. If a failure has a specific error message (e.g., "not authorized to perform", "already exists"), it is a real failure. If a failure says "Resource creation cancelled" with no specific error, it is a cascade caused by rollback — it does not tell you what would have gone wrong.
 - When multiple resources have their own specific errors, they are parallel failures from a shared root cause (e.g., an IAM role missing permissions for multiple services). Enumerate ALL the specific permission gaps, not just the first one, so the developer can fix everything in one pass.

--- a/skills/core-skills/aws-cloudformation/SKILL.md
+++ b/skills/core-skills/aws-cloudformation/SKILL.md
@@ -1,16 +1,7 @@
 ---
 name: aws-cloudformation
 description: Author, validate, and troubleshoot AWS CloudFormation templates. Covers template authoring with secure defaults, pre-deployment validation (cfn-lint, cfn-guard, change sets), and root-cause diagnosis of failed stacks using CloudFormation events and CloudTrail correlation.
-owner_team: CloudFormation
-owner_cti: AWS/CloudFormation/AWS IAC MCP Server
-stages: [preprod, prod]
-categories: [aws-core]
 version: 1
-metadata:
-  service: [cloudformation, cloudtrail, iam]
-  task: [author, validate, deploy, debug, troubleshoot]
-  persona: [developer, devops, architect]
-  workload: [infrastructure-as-code]
 ---
 # CloudFormation
 

--- a/skills/core-skills/aws-cloudformation/SKILL.md
+++ b/skills/core-skills/aws-cloudformation/SKILL.md
@@ -1,7 +1,16 @@
 ---
 name: aws-cloudformation
 description: Author, validate, and troubleshoot AWS CloudFormation templates. Covers template authoring with secure defaults, pre-deployment validation (cfn-lint, cfn-guard, change sets), and root-cause diagnosis of failed stacks using CloudFormation events and CloudTrail correlation.
+owner_team: CloudFormation
+owner_cti: AWS/CloudFormation/AWS IAC MCP Server
+stages: [preprod, prod]
+categories: [aws-core]
 version: 1
+metadata:
+  service: [cloudformation, cloudtrail, iam]
+  task: [author, validate, deploy, debug, troubleshoot]
+  persona: [developer, devops, architect]
+  workload: [infrastructure-as-code]
 ---
 # CloudFormation
 
@@ -18,7 +27,6 @@ Domain expertise for the full CloudFormation lifecycle: authoring templates, val
 Follow the [authoring best-practices SOP](references/author-cloudformation-best-practices.script.md) as a review checklist. When unsure about property names or types, use the [resource property lookup SOP](references/lookup-resource-properties.script.md) to verify against authoritative documentation rather than guessing.
 
 Key defaults to apply unless there is a clear reason not to:
-
 - S3 buckets: `PublicAccessBlockConfiguration` (all four true), `BucketEncryption`, `VersioningConfiguration`
 - Stateful resources: `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain`
 - Avoid hardcoded physical resource names — use `!Sub "${AWS::StackName}-..."` for uniqueness
@@ -30,16 +38,26 @@ Run three validation layers in order — each catches different classes of error
 
 1. **Syntax and schema** — [validate-cloudformation-template SOP](references/validate-cloudformation-template.script.md) (cfn-lint)
 2. **Security and compliance** — [check-cloudformation-template-compliance SOP](references/check-cloudformation-template-compliance.script.md) (cfn-guard)
-3. **Pre-deployment** — [cloudformation-pre-deploy-validation SOP](references/cloudformation-pre-deploy-validation.script.md) (change set + `describe-events` API)
+3. **Pre-deployment** — [cloudformation-pre-deploy-validation SOP](references/cloudformation-pre-deploy-validation.script.md) (`describe-events` API)
 
-**Critical:** Pre-deployment validation errors are retrieved via `aws cloudformation describe-events --change-set-name <arn> --region <region>`. Do NOT use `describe-stack-events` — that API does not return validation errors. Note: `describe-events` is a newer API — if the command is not recognized, upgrade the AWS CLI to the latest version.
+**Critical:** Pre-deployment validation is enabled by default on Create Stack, Update Stack, and change set creation. Retrieve results via `aws cloudformation describe-events` (see [SOP](references/cloudformation-pre-deploy-validation.script.md) for scoping options). Do NOT use `describe-stack-events`.
+
+### Deploy faster with Express mode
+
+Use [deploy-with-express-mode SOP](references/deploy-with-express-mode.script.md) when the user wants faster deployment feedback during development iteration. Express mode completes stack operations as soon as resource configuration is applied — resources continue stabilizing in the background.
+
+Key points:
+- Activate with `--deployment-config '{"mode": "EXPRESS"}'` on `create-stack`, `update-stack`, or `delete-stack`
+- CDK: `cdk deploy --express`
+- Rollback is disabled by default; re-enable with `"disableRollback": false`
+- NOT for production workflows that require resources to serve traffic immediately after stack completion
+- `aws cloudformation deploy` does NOT support Express mode — use `create-stack`/`update-stack`
 
 ### Troubleshoot a failed deployment
 
 When a stack is in a failed state (`CREATE_FAILED`, `ROLLBACK_COMPLETE`, `UPDATE_ROLLBACK_FAILED`, etc.), follow the [troubleshoot-deployment SOP](references/troubleshoot-deployment.script.md).
 
 Key points:
-
 - Use `aws cloudformation describe-events --stack-name <name> --filters FailedEvents=true --region <region>` to get only failure events. Do NOT use `describe-stack-events` — that API does not support the `--filters` parameter. Do NOT use `--query` JMESPath filters as a substitute — use the `--filters` parameter directly.
 - Examine EVERY failed event's `ResourceStatusReason`. If a failure has a specific error message (e.g., "not authorized to perform", "already exists"), it is a real failure. If a failure says "Resource creation cancelled" with no specific error, it is a cascade caused by rollback — it does not tell you what would have gone wrong.
 - When multiple resources have their own specific errors, they are parallel failures from a shared root cause (e.g., an IAM role missing permissions for multiple services). Enumerate ALL the specific permission gaps, not just the first one, so the developer can fix everything in one pass.
@@ -52,6 +70,7 @@ Key points:
 |-------------|--------|
 | Write or modify a template | Author task + best-practices checklist |
 | Check a template before deploying | Validation pipeline (3 layers) |
+| Deploy faster during development | Deploy-with-express-mode SOP |
 | Stack failed or is stuck | Troubleshoot-deployment SOP |
 | Unsure about a resource property | Resource property lookup SOP |
 

--- a/skills/core-skills/aws-cloudformation/references/cloudformation-pre-deploy-validation.script.md
+++ b/skills/core-skills/aws-cloudformation/references/cloudformation-pre-deploy-validation.script.md
@@ -25,6 +25,7 @@ Validation errors are exposed through the `describe-events` API scoped to the ch
 - **capabilities** (optional): CloudFormation capabilities (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`) if the template creates IAM resources.
 
 **Constraints for parameter acquisition:**
+
 - You MUST ask for all required parameters upfront in a single prompt
 - You MUST support multiple input methods for the template (direct input, file path, S3 URL)
 - You MUST confirm successful acquisition of all parameters before proceeding
@@ -36,6 +37,7 @@ Validation errors are exposed through the `describe-events` API scoped to the ch
 Check which mechanism is available to invoke AWS APIs.
 
 **Constraints:**
+
 - You MUST check in this order of preference:
   1. `call_aws` tool from the AWS MCP Server (preferred for sandboxed execution, audit logging, and observability)
   2. AWS CLI (`aws`) available on the user's system (verify with `which aws` or `aws --version`)
@@ -51,6 +53,7 @@ Check which mechanism is available to invoke AWS APIs.
 Catch issues locally before consuming CloudFormation API quota.
 
 **Constraints:**
+
 - You SHOULD recommend running the `validate-cloudformation-template` SOP first to catch cfn-lint syntax and schema errors locally
 - You SHOULD recommend running the `check-cloudformation-template-compliance` SOP to catch security violations locally
 - If the user has already run these checks or explicitly skips them, You MUST proceed to the next step
@@ -60,6 +63,7 @@ Catch issues locally before consuming CloudFormation API quota.
 Prepare the template for the change set.
 
 **Constraints:**
+
 - If the template is small (≤ 51,200 bytes) and provided as content or a local file, You MAY pass it inline via `--template-body`
 - If the template exceeds 51,200 bytes, You MUST upload it to S3 and use `--template-url` because `--template-body` has a size limit
 - If the template is already at an S3 URL, You MUST use `--template-url` directly
@@ -69,10 +73,12 @@ Prepare the template for the change set.
 Create the change set to trigger pre-deployment validation. Validation runs automatically during change set creation — no opt-in is required.
 
 **Constraints:**
+
 - You MUST use a unique, descriptive change set name (e.g., `pre-deploy-validation-<timestamp>`)
 - You MUST use the appropriate `--change-set-type` (`CREATE` for new stacks, `UPDATE` for existing)
 - You MUST include `--capabilities` if the template creates IAM resources (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`)
 - You MUST invoke via `call_aws` (preferred) or the AWS CLI. Example CLI form:
+
   ```
   aws cloudformation create-change-set \
     --stack-name <stack_name> \
@@ -82,6 +88,7 @@ Create the change set to trigger pre-deployment validation. Validation runs auto
     --region <region> \
     --capabilities CAPABILITY_IAM
   ```
+
   > **Notes:** Use `--template-url s3://...` instead of `--template-body` for templates exceeding 51,200 bytes. Include `--capabilities` only if the template creates IAM resources.
 - You MUST capture the returned change set ARN (Id) for the next step
 - You MUST explain to the user that creating a change set does NOT modify any resources because it only plans the changes and runs validation
@@ -92,6 +99,7 @@ Create the change set to trigger pre-deployment validation. Validation runs auto
 Fetch validation results from the `describe-events` API.
 
 **Constraints:**
+
 - You MUST use `aws cloudformation describe-events --change-set-name <arn> --region <region>` (via `call_aws` or CLI)
 - You MUST NOT use `describe-stack-events` because the legacy stack events API does NOT return validation errors — it only surfaces resource provisioning events after execution
 - You MUST filter events where `EventType` equals `VALIDATION_ERROR` because these are the validation findings
@@ -108,6 +116,7 @@ Fetch validation results from the `describe-events` API.
 Report validation findings grouped by type and help the user fix issues.
 
 **Constraints:**
+
 - You MUST present results grouped by `ValidationName`:
   - **Property syntax validation** — invalid property values or formats
   - **Resource name conflict validation** — resources that conflict with existing resources
@@ -124,6 +133,7 @@ Report validation findings grouped by type and help the user fix issues.
 Guide the user on next steps after validation.
 
 **Constraints:**
+
 - If all validations passed (or only `WARN`-mode issues that the user accepts), You MUST ask the user for explicit approval before executing the change set
 - You MUST NOT execute the change set without explicit user approval because this will modify live infrastructure
 - You MUST NOT delete a stack without explicit user approval. Before deleting, You MUST verify the stack status is `REVIEW_IN_PROGRESS` by calling `describe-stacks`
@@ -137,6 +147,7 @@ Guide the user on next steps after validation.
 ## Examples
 
 ### Example: Successful Validation
+
 ```
 Change set "pre-deploy-validation-1713580000" created for stack "my-app-stack".
 
@@ -151,6 +162,7 @@ The change set is ready to execute. Would you like to execute it now?
 ```
 
 ### Example: Failed Validation
+
 ```
 Change set "pre-deploy-validation-1713580000" created for stack "my-app-stack".
 

--- a/skills/core-skills/aws-cloudformation/references/cloudformation-pre-deploy-validation.script.md
+++ b/skills/core-skills/aws-cloudformation/references/cloudformation-pre-deploy-validation.script.md
@@ -8,7 +8,7 @@ Deterministic procedure for running CloudFormation's pre-deployment validation f
 2. **Resource name conflict validation** (FAIL) — Detects naming conflicts with existing resources in the account.
 3. **S3 bucket emptiness validation** (WARN) — Warns when deleting S3 buckets that contain objects.
 
-Validation errors are exposed through the **new `describe-events` API** scoped to the change set. This procedure uses `call_aws` (preferred) or the AWS CLI to invoke these APIs directly.
+Validation errors are exposed through the `describe-events` API scoped to the change set. This procedure uses `call_aws` (preferred) or the AWS CLI to invoke these APIs directly. Note: The AWS MCP server is recommended for streamlined API invocation, but all steps can be performed using the AWS CLI alone.
 
 **Important:** The legacy `describe-stack-events` API does NOT return validation errors. You MUST use `describe-events --change-set-name <arn>` to retrieve validation results.
 
@@ -25,7 +25,6 @@ Validation errors are exposed through the **new `describe-events` API** scoped t
 - **capabilities** (optional): CloudFormation capabilities (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`) if the template creates IAM resources.
 
 **Constraints for parameter acquisition:**
-
 - You MUST ask for all required parameters upfront in a single prompt
 - You MUST support multiple input methods for the template (direct input, file path, S3 URL)
 - You MUST confirm successful acquisition of all parameters before proceeding
@@ -37,7 +36,6 @@ Validation errors are exposed through the **new `describe-events` API** scoped t
 Check which mechanism is available to invoke AWS APIs.
 
 **Constraints:**
-
 - You MUST check in this order of preference:
   1. `call_aws` tool from the AWS MCP Server (preferred for sandboxed execution, audit logging, and observability)
   2. AWS CLI (`aws`) available on the user's system (verify with `which aws` or `aws --version`)
@@ -53,7 +51,6 @@ Check which mechanism is available to invoke AWS APIs.
 Catch issues locally before consuming CloudFormation API quota.
 
 **Constraints:**
-
 - You SHOULD recommend running the `validate-cloudformation-template` SOP first to catch cfn-lint syntax and schema errors locally
 - You SHOULD recommend running the `check-cloudformation-template-compliance` SOP to catch security violations locally
 - If the user has already run these checks or explicitly skips them, You MUST proceed to the next step
@@ -63,7 +60,6 @@ Catch issues locally before consuming CloudFormation API quota.
 Prepare the template for the change set.
 
 **Constraints:**
-
 - If the template is small (≤ 51,200 bytes) and provided as content or a local file, You MAY pass it inline via `--template-body`
 - If the template exceeds 51,200 bytes, You MUST upload it to S3 and use `--template-url` because `--template-body` has a size limit
 - If the template is already at an S3 URL, You MUST use `--template-url` directly
@@ -73,12 +69,10 @@ Prepare the template for the change set.
 Create the change set to trigger pre-deployment validation. Validation runs automatically during change set creation — no opt-in is required.
 
 **Constraints:**
-
 - You MUST use a unique, descriptive change set name (e.g., `pre-deploy-validation-<timestamp>`)
 - You MUST use the appropriate `--change-set-type` (`CREATE` for new stacks, `UPDATE` for existing)
 - You MUST include `--capabilities` if the template creates IAM resources (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`)
 - You MUST invoke via `call_aws` (preferred) or the AWS CLI. Example CLI form:
-
   ```
   aws cloudformation create-change-set \
     --stack-name <stack_name> \
@@ -88,7 +82,6 @@ Create the change set to trigger pre-deployment validation. Validation runs auto
     --region <region> \
     --capabilities CAPABILITY_IAM
   ```
-
   > **Notes:** Use `--template-url s3://...` instead of `--template-body` for templates exceeding 51,200 bytes. Include `--capabilities` only if the template creates IAM resources.
 - You MUST capture the returned change set ARN (Id) for the next step
 - You MUST explain to the user that creating a change set does NOT modify any resources because it only plans the changes and runs validation
@@ -96,10 +89,9 @@ Create the change set to trigger pre-deployment validation. Validation runs auto
 
 ### 5. Retrieve Validation Results via describe-events
 
-Fetch validation results from the **new `describe-events` API**.
+Fetch validation results from the `describe-events` API.
 
 **Constraints:**
-
 - You MUST use `aws cloudformation describe-events --change-set-name <arn> --region <region>` (via `call_aws` or CLI)
 - You MUST NOT use `describe-stack-events` because the legacy stack events API does NOT return validation errors — it only surfaces resource provisioning events after execution
 - You MUST filter events where `EventType` equals `VALIDATION_ERROR` because these are the validation findings
@@ -116,7 +108,6 @@ Fetch validation results from the **new `describe-events` API**.
 Report validation findings grouped by type and help the user fix issues.
 
 **Constraints:**
-
 - You MUST present results grouped by `ValidationName`:
   - **Property syntax validation** — invalid property values or formats
   - **Resource name conflict validation** — resources that conflict with existing resources
@@ -133,7 +124,6 @@ Report validation findings grouped by type and help the user fix issues.
 Guide the user on next steps after validation.
 
 **Constraints:**
-
 - If all validations passed (or only `WARN`-mode issues that the user accepts), You MUST ask the user for explicit approval before executing the change set
 - You MUST NOT execute the change set without explicit user approval because this will modify live infrastructure
 - You MUST NOT delete a stack without explicit user approval. Before deleting, You MUST verify the stack status is `REVIEW_IN_PROGRESS` by calling `describe-stacks`
@@ -147,7 +137,6 @@ Guide the user on next steps after validation.
 ## Examples
 
 ### Example: Successful Validation
-
 ```
 Change set "pre-deploy-validation-1713580000" created for stack "my-app-stack".
 
@@ -162,7 +151,6 @@ The change set is ready to execute. Would you like to execute it now?
 ```
 
 ### Example: Failed Validation
-
 ```
 Change set "pre-deploy-validation-1713580000" created for stack "my-app-stack".
 
@@ -199,7 +187,7 @@ Fix the template and create a new change set.
 ## Troubleshooting
 
 ### describe-events returns empty or unknown command
-The `describe-events` API (scoped to change sets with validation errors) is the newer API. If the installed AWS CLI is outdated, update it: `pip install --upgrade awscli` or `brew upgrade awscli`. If the command still returns nothing, confirm the change set ARN is correct and the change set has finished creating.
+The `describe-events` API (scoped to change sets) requires AWS CLI support for the command. If it is not recognized, update the AWS CLI: `pip install --upgrade awscli` or `brew upgrade awscli`. If the command still returns nothing, confirm the change set ARN is correct and the change set has finished creating.
 
 ### User calls describe-stack-events instead
 `describe-stack-events` returns events after the stack begins provisioning. It does NOT include pre-deployment validation errors. You MUST redirect the user to `describe-events --change-set-name <arn>`.

--- a/skills/core-skills/aws-cloudformation/references/deploy-with-express-mode.script.md
+++ b/skills/core-skills/aws-cloudformation/references/deploy-with-express-mode.script.md
@@ -1,0 +1,250 @@
+# Deploy with Express Mode
+
+## Overview
+
+Deterministic procedure for deploying CloudFormation stacks using **Express mode** — a deployment mode that completes stack operations as soon as resource configuration is applied, giving immediate confirmation to proceed to the next iteration. Resources continue becoming ready to serve traffic in the background.
+
+Express mode works with all existing CloudFormation templates and requires no template changes. It is recommended for development workflows where you iterate frequently and need fast deployment confirmation.
+
+**When to use Express mode:**
+- Iterating on infrastructure configurations during development
+- Deploying individual components of your application
+- Deploying dependent stacks that only need resource outputs (VPC IDs, endpoints, ARNs) to proceed
+- Building with AI agents that need fast feedback loops to validate and refine infrastructure
+- Prototyping and experimenting with new architectures
+
+**When NOT to use Express mode:**
+- Production workflows that require resources to serve traffic immediately after stack completion
+- Deployments where downstream consumers immediately hit endpoints (load balancers, CloudFront distributions, ECS services) after the operation completes
+
+**What Express mode skips:**
+1. Traffic readiness (e.g., EC2 instance reaching `running` state)
+2. Region propagation (e.g., CloudFront propagating to all edge locations, 5-10 minutes)
+3. Cleanup (e.g., network interface removal before Lambda function deletion)
+
+**What does NOT change:**
+- CloudFormation still processes all resources in dependency order
+- CloudFormation still retries dependent resources that encounter transient failures
+- CloudFormation still handles dependent resource failures
+
+## Parameters
+
+- **stack_name** (required): The CloudFormation stack name.
+- **template_source** (required): The template to deploy. One of:
+  - File path to a local template
+  - S3 URL of an uploaded template
+  - Template content provided directly
+- **operation** (required): One of `CREATE`, `UPDATE`, or `DELETE`.
+- **region** (required): AWS region for deployment.
+- **enable_rollback** (optional): Whether to enable rollback. Express mode disables rollback by default for fastest iteration. Set to `true` if the user wants rollback on failure.
+- **parameters** (optional): Stack parameters as key-value pairs.
+- **capabilities** (optional): CloudFormation capabilities (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`) if the template creates IAM resources.
+
+**Constraints for parameter acquisition:**
+- You MUST ask for all required parameters upfront in a single prompt
+- You MUST support multiple input methods for the template (direct input, file path, S3 URL)
+- You MUST confirm successful acquisition of all parameters before proceeding
+
+## Steps
+
+### 1. Verify Dependencies
+
+Check which mechanism is available to invoke AWS APIs.
+
+**Constraints:**
+- You MUST check in this order of preference:
+  1. `call_aws` tool from the AWS MCP Server (preferred for sandboxed execution, audit logging, and observability)
+  2. AWS CLI (`aws`) available on the user's system (verify with `which aws` or `aws --version`)
+- You MUST verify the user has valid AWS credentials configured for the target account/region (e.g., `aws sts get-caller-identity --region <region>`). This read-only call is acceptable during verification because it does not modify any resources
+- You MUST ONLY check for availability and credential validity. You MUST NOT create or modify stacks or install missing dependencies during this step
+- If the AWS CLI is missing, You MUST ask the user explicitly before running any install command
+- You MUST NOT run install commands without the user's explicit approval
+- If credentials are missing or invalid, You MUST ask the user to configure credentials and MUST NOT proceed until credentials are confirmed
+
+### 2. Confirm Express Mode is Appropriate
+
+Verify with the user that Express mode is the right choice for their use case.
+
+**Constraints:**
+- You MUST inform the user that Express mode completes when resource configuration is applied, and resources continue stabilizing in the background
+- You MUST ask whether the user's workflow requires resources to serve traffic immediately after the stack operation completes
+- If the user's workflow DOES require immediate traffic readiness (production serving, endpoint availability), You MUST recommend using the default deployment behavior instead
+- If the user is in a development/iteration workflow, You SHOULD proceed with Express mode
+- You MUST inform the user that rollback is disabled by default with Express mode. If the user wants rollback protection, You MUST include `"disableRollback": false` in the deployment configuration
+
+### 3. Upload Template (if needed)
+
+Prepare the template for the operation.
+
+**Constraints:**
+- If the template is small (≤ 51,200 bytes) and provided as content or a local file, You MAY pass it inline via `--template-body`
+- If the template exceeds 51,200 bytes, You MUST upload it to S3 and use `--template-url` because `--template-body` has a size limit
+- If the template is already at an S3 URL, You MUST use `--template-url` directly
+- This step does not apply to `DELETE` operations
+
+### 4. Execute Stack Operation with Express Mode
+
+Run the stack operation with the `--deployment-config` parameter set to Express mode.
+
+**Constraints:**
+- You MUST obtain explicit user approval before executing the operation because it creates, modifies, or deletes live infrastructure
+- You MUST use `--deployment-config '{"mode": "EXPRESS"}'` on the stack operation
+- If the user requested rollback, You MUST use `--deployment-config '{"mode": "EXPRESS", "disableRollback": false}'`
+- You MUST include `--capabilities` if the template creates IAM resources
+- You MUST NOT use `aws cloudformation deploy` because it does not support `--deployment-config`. Use `create-stack`, `update-stack`, or `delete-stack` instead.
+
+> **Note:** When using `call_aws`, pass the template content inline in the `TemplateBody` parameter — the `file://` syntax is AWS CLI-specific and does not work with `call_aws`.
+
+**Create a stack:**
+```
+aws cloudformation create-stack \
+  --stack-name <stack_name> \
+  --template-body file://<path> \
+  --region <region> \
+  --deployment-config '{"mode": "EXPRESS"}' \
+  --capabilities CAPABILITY_IAM
+```
+
+**Update a stack:**
+```
+aws cloudformation update-stack \
+  --stack-name <stack_name> \
+  --template-body file://<path> \
+  --region <region> \
+  --deployment-config '{"mode": "EXPRESS"}' \
+  --capabilities CAPABILITY_IAM
+```
+
+**Delete a stack:**
+```
+aws cloudformation delete-stack \
+  --stack-name <stack_name> \
+  --region <region> \
+  --deployment-config '{"mode": "EXPRESS"}'
+```
+
+**With rollback enabled:**
+```
+aws cloudformation create-stack \
+  --stack-name <stack_name> \
+  --template-body file://<path> \
+  --region <region> \
+  --deployment-config '{"mode": "EXPRESS", "disableRollback": false}' \
+  --capabilities CAPABILITY_IAM
+```
+
+### 5. Express Mode with Change Sets
+
+Express mode also works with change sets. The deployment configuration is stored with the change set and applied when executed.
+
+**Constraints:**
+- To use Express mode with a change set, supply `--deployment-config` at `create-change-set` time:
+  ```
+  aws cloudformation create-change-set \
+    --stack-name <stack_name> \
+    --template-body file://<path> \
+    --change-set-name <change_set_name> \
+    --deployment-config '{"mode": "EXPRESS"}' \
+    --region <region> \
+    --capabilities CAPABILITY_IAM
+  ```
+- You MUST NOT specify `--deployment-config` again at `execute-change-set` time because it is already stored with the change set
+- You SHOULD recommend the change set path when the user also wants pre-deployment validation before deploying with Express mode (change set creation runs all validation checks before execution)
+
+### 6. CDK Express Mode
+
+When the user is deploying with the AWS CDK, Express mode is activated with the `--express` flag.
+
+**Constraints:**
+- You MUST use `cdk deploy --express` to deploy with Express mode
+- To re-enable rollback: `cdk deploy --express --rollback`
+- Express mode applies to all CloudFormation deployments triggered by CDK, including multi-stack deployments
+- You MUST NOT recommend `cdk deploy --hotswap` as a substitute for Express mode — they are different capabilities:
+  - Express mode: full infrastructure changes through CloudFormation, no drift introduced
+  - CDK hotswap: code-only changes via direct service APIs, introduces drift (bypasses CloudFormation)
+
+### 7. Monitor Resource Readiness After Completion
+
+Guide the user on what to expect after Express mode completes.
+
+**Constraints:**
+- You MUST inform the user that resources continue stabilizing in the background after the operation reports complete
+- You SHOULD provide guidance on typical background stabilization timelines:
+  - CloudFront distribution: propagation to all edge locations (5-10 minutes)
+  - EC2 instance: health checks, reaching `running` state
+  - Lambda function delete: network interface cleanup
+  - ECS service: containers reaching desired capacity
+- You SHOULD recommend monitoring resource readiness through existing mechanisms: CloudWatch alarms, health checks, or service-specific dashboards
+- If a resource does not stabilize as expected, You SHOULD recommend redeploying the stack to retry the affected resources
+
+## Unsupported Features
+
+The following are NOT supported with Express mode. You MUST inform the user if their scenario involves any of these:
+
+- **Custom resources** (`AWS::CloudFormation::CustomResource` and `Custom::*`) — these follow default completion behavior even when Express mode is active
+- **StackSets** — Express mode is not supported for StackSet operations
+- **AWS SAM** — not supported
+- **`aws cloudformation deploy` CLI command** — does not support `--deployment-config`; use `create-stack` or `update-stack` instead
+- **Account-level default** — Express mode is activated per stack operation; there is no account-wide setting
+
+## Examples
+
+### Example: Create a stack with Express mode
+```
+$ aws cloudformation create-stack \
+    --stack-name my-dev-vpc \
+    --template-body file://vpc.yaml \
+    --region us-west-2 \
+    --deployment-config '{"mode": "EXPRESS"}'
+
+{
+  "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/my-dev-vpc/abc123"
+}
+
+Stack "my-dev-vpc" creation completed (Express mode).
+Resources are configured. VPC ID, subnet IDs, and other outputs are available.
+Background stabilization (route propagation, NAT gateway activation) continues.
+```
+
+### Example: CDK deploy with Express mode
+```
+$ cdk deploy --express
+
+ ✅  MyDevStack
+
+Express mode: stack completed when resource configuration was applied.
+Outputs:
+  MyDevStack.VpcId = vpc-0abc123def456
+  MyDevStack.ApiEndpoint = https://abc123.execute-api.us-west-2.amazonaws.com
+
+Resources continue stabilizing in the background.
+```
+
+### Example: Express mode with rollback enabled
+```
+$ aws cloudformation update-stack \
+    --stack-name my-dev-vpc \
+    --template-body file://vpc-v2.yaml \
+    --region us-west-2 \
+    --deployment-config '{"mode": "EXPRESS", "disableRollback": false}'
+```
+
+## Troubleshooting
+
+### Resources not ready to serve traffic after stack completes
+This is expected behavior with Express mode. Resources receive their configuration immediately but may still be starting up, propagating, or cleaning up. Monitor resource-specific readiness through CloudWatch, health checks, or service dashboards. If a resource does not stabilize, redeploy the stack to retry.
+
+### `--deployment-config` not recognized
+The `--deployment-config` parameter requires a CLI version that supports Express mode. Update the AWS CLI to the latest version. If using CDK, use `--express` instead.
+
+### `deploy` command does not accept `--deployment-config`
+The `aws cloudformation deploy` command does not support `--deployment-config`. Use `create-stack` or `update-stack` directly. In CDK, use `cdk deploy --express`.
+
+### Custom resources do not complete faster
+Custom resources always follow default completion behavior regardless of Express mode. This is by design — custom resources define their own completion logic.
+
+### StackSets error with Express mode
+Express mode is not supported for StackSet operations. Remove `--deployment-config` when working with StackSets.
+
+### Rollback not happening on failure
+Express mode disables rollback by default. To re-enable, add `"disableRollback": false` to the deployment configuration JSON, or use `cdk deploy --express --rollback` in CDK.

--- a/skills/core-skills/aws-cloudformation/references/deploy-with-express-mode.script.md
+++ b/skills/core-skills/aws-cloudformation/references/deploy-with-express-mode.script.md
@@ -7,6 +7,7 @@ Deterministic procedure for deploying CloudFormation stacks using **Express mode
 Express mode works with all existing CloudFormation templates and requires no template changes. It is recommended for development workflows where you iterate frequently and need fast deployment confirmation.
 
 **When to use Express mode:**
+
 - Iterating on infrastructure configurations during development
 - Deploying individual components of your application
 - Deploying dependent stacks that only need resource outputs (VPC IDs, endpoints, ARNs) to proceed
@@ -14,15 +15,18 @@ Express mode works with all existing CloudFormation templates and requires no te
 - Prototyping and experimenting with new architectures
 
 **When NOT to use Express mode:**
+
 - Production workflows that require resources to serve traffic immediately after stack completion
 - Deployments where downstream consumers immediately hit endpoints (load balancers, CloudFront distributions, ECS services) after the operation completes
 
 **What Express mode skips:**
+
 1. Traffic readiness (e.g., EC2 instance reaching `running` state)
 2. Region propagation (e.g., CloudFront propagating to all edge locations, 5-10 minutes)
 3. Cleanup (e.g., network interface removal before Lambda function deletion)
 
 **What does NOT change:**
+
 - CloudFormation still processes all resources in dependency order
 - CloudFormation still retries dependent resources that encounter transient failures
 - CloudFormation still handles dependent resource failures
@@ -41,6 +45,7 @@ Express mode works with all existing CloudFormation templates and requires no te
 - **capabilities** (optional): CloudFormation capabilities (e.g., `CAPABILITY_IAM`, `CAPABILITY_NAMED_IAM`) if the template creates IAM resources.
 
 **Constraints for parameter acquisition:**
+
 - You MUST ask for all required parameters upfront in a single prompt
 - You MUST support multiple input methods for the template (direct input, file path, S3 URL)
 - You MUST confirm successful acquisition of all parameters before proceeding
@@ -52,6 +57,7 @@ Express mode works with all existing CloudFormation templates and requires no te
 Check which mechanism is available to invoke AWS APIs.
 
 **Constraints:**
+
 - You MUST check in this order of preference:
   1. `call_aws` tool from the AWS MCP Server (preferred for sandboxed execution, audit logging, and observability)
   2. AWS CLI (`aws`) available on the user's system (verify with `which aws` or `aws --version`)
@@ -66,6 +72,7 @@ Check which mechanism is available to invoke AWS APIs.
 Verify with the user that Express mode is the right choice for their use case.
 
 **Constraints:**
+
 - You MUST inform the user that Express mode completes when resource configuration is applied, and resources continue stabilizing in the background
 - You MUST ask whether the user's workflow requires resources to serve traffic immediately after the stack operation completes
 - If the user's workflow DOES require immediate traffic readiness (production serving, endpoint availability), You MUST recommend using the default deployment behavior instead
@@ -77,6 +84,7 @@ Verify with the user that Express mode is the right choice for their use case.
 Prepare the template for the operation.
 
 **Constraints:**
+
 - If the template is small (≤ 51,200 bytes) and provided as content or a local file, You MAY pass it inline via `--template-body`
 - If the template exceeds 51,200 bytes, You MUST upload it to S3 and use `--template-url` because `--template-body` has a size limit
 - If the template is already at an S3 URL, You MUST use `--template-url` directly
@@ -87,6 +95,7 @@ Prepare the template for the operation.
 Run the stack operation with the `--deployment-config` parameter set to Express mode.
 
 **Constraints:**
+
 - You MUST obtain explicit user approval before executing the operation because it creates, modifies, or deletes live infrastructure
 - You MUST use `--deployment-config '{"mode": "EXPRESS"}'` on the stack operation
 - If the user requested rollback, You MUST use `--deployment-config '{"mode": "EXPRESS", "disableRollback": false}'`
@@ -96,6 +105,7 @@ Run the stack operation with the `--deployment-config` parameter set to Express 
 > **Note:** When using `call_aws`, pass the template content inline in the `TemplateBody` parameter — the `file://` syntax is AWS CLI-specific and does not work with `call_aws`.
 
 **Create a stack:**
+
 ```
 aws cloudformation create-stack \
   --stack-name <stack_name> \
@@ -106,6 +116,7 @@ aws cloudformation create-stack \
 ```
 
 **Update a stack:**
+
 ```
 aws cloudformation update-stack \
   --stack-name <stack_name> \
@@ -116,6 +127,7 @@ aws cloudformation update-stack \
 ```
 
 **Delete a stack:**
+
 ```
 aws cloudformation delete-stack \
   --stack-name <stack_name> \
@@ -124,6 +136,7 @@ aws cloudformation delete-stack \
 ```
 
 **With rollback enabled:**
+
 ```
 aws cloudformation create-stack \
   --stack-name <stack_name> \
@@ -138,7 +151,9 @@ aws cloudformation create-stack \
 Express mode also works with change sets. The deployment configuration is stored with the change set and applied when executed.
 
 **Constraints:**
+
 - To use Express mode with a change set, supply `--deployment-config` at `create-change-set` time:
+
   ```
   aws cloudformation create-change-set \
     --stack-name <stack_name> \
@@ -148,6 +163,7 @@ Express mode also works with change sets. The deployment configuration is stored
     --region <region> \
     --capabilities CAPABILITY_IAM
   ```
+
 - You MUST NOT specify `--deployment-config` again at `execute-change-set` time because it is already stored with the change set
 - You SHOULD recommend the change set path when the user also wants pre-deployment validation before deploying with Express mode (change set creation runs all validation checks before execution)
 
@@ -156,6 +172,7 @@ Express mode also works with change sets. The deployment configuration is stored
 When the user is deploying with the AWS CDK, Express mode is activated with the `--express` flag.
 
 **Constraints:**
+
 - You MUST use `cdk deploy --express` to deploy with Express mode
 - To re-enable rollback: `cdk deploy --express --rollback`
 - Express mode applies to all CloudFormation deployments triggered by CDK, including multi-stack deployments
@@ -168,6 +185,7 @@ When the user is deploying with the AWS CDK, Express mode is activated with the 
 Guide the user on what to expect after Express mode completes.
 
 **Constraints:**
+
 - You MUST inform the user that resources continue stabilizing in the background after the operation reports complete
 - You SHOULD provide guidance on typical background stabilization timelines:
   - CloudFront distribution: propagation to all edge locations (5-10 minutes)
@@ -190,6 +208,7 @@ The following are NOT supported with Express mode. You MUST inform the user if t
 ## Examples
 
 ### Example: Create a stack with Express mode
+
 ```
 $ aws cloudformation create-stack \
     --stack-name my-dev-vpc \
@@ -207,6 +226,7 @@ Background stabilization (route propagation, NAT gateway activation) continues.
 ```
 
 ### Example: CDK deploy with Express mode
+
 ```
 $ cdk deploy --express
 
@@ -221,6 +241,7 @@ Resources continue stabilizing in the background.
 ```
 
 ### Example: Express mode with rollback enabled
+
 ```
 $ aws cloudformation update-stack \
     --stack-name my-dev-vpc \


### PR DESCRIPTION
## Description

Two feature updates to the `aws-cloudformation` skill:

### 1. Pre-deployment validation expanded to all stack operations

Pre-deployment validation now runs automatically on Create Stack and Update Stack operations (not just change sets), enabled by default with no opt-in required.

- 3 new warning checks during change set creation: service quota limits, AWS Config Recorder conflicts, ECR repository delete readiness
- `describe-events` scoping by `--operation-id` and `--stack-name` (in addition to `--change-set-name`)
- CDK: `cdk deploy` and `cdk validate` surface validation results in a unified report with construct-level tracing
- New `DisableValidation` / `--disable-validation` flag (not recommended)

### 2. New Express mode SOP

Express mode completes stack operations when resource configuration is applied, skipping stabilization checks. Designed for development iteration workflows.

- CLI: `--deployment-config '{"mode": "EXPRESS"}'` on create/update/delete-stack
- CDK: `cdk deploy --express`
- Rollback disabled by default; re-enable with `"disableRollback": false`
- Resource readiness guidance (background stabilization timelines)
- Unsupported features: custom resources, StackSets, SAM, `deploy` CLI command

### Files changed (both `skills/core-skills/` and `plugins/aws-core/` trees)

- `SKILL.md` — Express mode routing entry + decision guide + trimmed pre-deploy note
- `references/cloudformation-pre-deploy-validation.script.md` — reworked for default-on validation
- `references/deploy-with-express-mode.script.md` — new file

### Testing

- Validated pre-deployment validation on a real change set (eu-central-1)
- CLI examples match the published Express mode documentation
- Internal CRs: CR-285715530, CR-285715608