### PR TITLE
feat(dms-sc): add offline source support and improve action item work…

### DIFF
--- a/skills/specialized-skills/migration-and-modernization-skills/dms-schema-conversion/SKILL.md
+++ b/skills/specialized-skills/migration-and-modernization-skills/dms-schema-conversion/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dms-schema-conversion
 description: Handles the full DMS Schema Conversion lifecycle including creating migration projects, converting database schemas to a target engine, running compatibility assessments, navigating metadata trees, exporting converted DDL to S3, applying schema changes to a target database, and converting SQL statements between database engines.
-version: 1
+version: 2
 ---
 
 # DMS Schema Conversion
@@ -110,7 +110,7 @@ After each action completes, return to this menu by presenting the same selectio
      --migration-project-identifier <migration_project_identifier>
    ```
 
-5. **Export conversion assessment report:** On conversion success, call `export-metadata-model-assessment` with the same selection rules. Provide the customer with S3 links for both PDF and CSV reports (`PdfReport.S3ObjectKey` and `CsvReport.S3ObjectKey`).
+5. **Export conversion assessment report:** On conversion success, call `export-metadata-model-assessment` with selection rules using `rule-action: "explicit"` (this API requires explicit rules, not `include`). Provide the customer with S3 links for both PDF and CSV reports (`PdfReport.S3ObjectKey` and `CsvReport.S3ObjectKey`).
 
 6. **Show summary:** Download the Summary CSV from S3 using `aws s3 cp s3://<bucket>/<CsvReport.S3ObjectKey> ./Summary.csv`. Present its contents to the customer — show the number of objects per category, how many converted automatically, and how many have Action Items at each complexity level.
 

--- a/skills/specialized-skills/migration-and-modernization-skills/dms-schema-conversion/references/action-items.md
+++ b/skills/specialized-skills/migration-and-modernization-skills/dms-schema-conversion/references/action-items.md
@@ -80,7 +80,25 @@ When the customer asks to review or work through action items:
 
 When the customer asks to fix Action Items (e.g., "fix the action items", "help me resolve these"):
 
-1. **Export target as SQL script:**
+### Step 1 — Verify existing conversion
+
+Before proposing any fixes, confirm the object has already been converted by checking for existing TARGET DDL. Use the object's `Occurrence` path from the Detailed CSV to build `explicit` selection rules targeting that specific object: [Selection rules in DMS Schema Conversion](https://docs.aws.amazon.com/dms/latest/userguide/sc-selection-rules.html)
+
+If `TargetMetadataModels` is populated in the response, the object has been converted. Extract `TargetMetadataModels[0].SelectionRules` and verify target DDL:
+
+```
+aws dms describe-metadata-model \
+  --migration-project-identifier <migration_project_identifier> \
+  --origin TARGET \
+  --selection-rules '<target_selection_rules_from_above>'
+```
+
+- **If TARGET DDL exists** (i.e., `Definition` is non-empty) → the object was already converted by the DMS Schema Conversion engine. Proceed to Step 2 to apply targeted fixes to the action-item-affected code only. Do NOT trigger a full reconversion.
+- **If TARGET DDL does not exist** (i.e., `TargetMetadataModels` is empty or `Definition` is empty) → inform the customer that this object has not been converted yet and ask whether they want to convert it first (via [Convert Database](../SKILL.md#convert-database)) before fixing action items.
+
+### Step 2 — Export and prepare
+
+1. **Export target as SQL script:** Use `--origin TARGET` with selection rules containing the **target** server name (from `TargetMetadataModels[0].SelectionRules` in Step 1):
 
    ```
    aws dms start-metadata-model-export-as-script \
@@ -88,6 +106,8 @@ When the customer asks to fix Action Items (e.g., "fix the action items", "help 
      --origin TARGET \
      --selection-rules '<json>'
    ```
+
+   > **Important:** The `server-name` must be the target data provider server name (e.g., `"virtual"` for virtual targets), NOT the source server name. The schema name also uses the target naming convention (e.g., `bobsusedbookstore_dbo` instead of `dbo`).
 
    Wait via `aws dms wait metadata-model-exported-as-script --migration-project-identifier <migration_project_identifier>`. Download the exported SQL file from S3 and restrict permissions:
 
@@ -100,22 +120,46 @@ When the customer asks to fix Action Items (e.g., "fix the action items", "help 
 
 3. **Load the Detailed CSV** to get the list of affected objects grouped by occurrence path.
 
-4. **For each affected object:**
-   a. Locate the object's DDL in the SQL file — find the line where the object's `CREATE` statement begins (match by object name from the `Occurrence` column).
-   b. Analyze the action item description and the current DDL at that location.
-   c. Propose the corrected SQL to the customer — explain the issue in plain language and show the before/after.
-   d. On customer confirmation, replace the relevant portion of the DDL in the working copy.
-   e. Move to the next object.
+### Step 3 — Targeted fixes (preserve rule-based conversion)
 
-5. **After all fixes:** The customer has a corrected SQL script they can apply to the target database manually or review further.
+For each affected object:
+
+1. **Locate the action-item scope:** Use the `Line` and `Position` columns from the Detailed CSV to identify the exact lines/section of code covered by the action item.
+
+2. **Fix only the action-item-affected code.** Rewrite ONLY the specific lines or code block identified by the action item. The surrounding DDL produced by the DMS Schema Conversion rule-based engine MUST remain untouched.
+
+3. **Mark generated code:** Wrap any agent-generated SQL with a comment indicating it requires verification:
+
+   ```sql
+   -- [GenAI-generated] Begin. Requires verification.
+   <generated SQL>
+   -- [GenAI-generated] End.
+   ```
+
+4. **Present the fix:** Show the customer:
+   - The original action-item-affected code (before)
+   - The proposed replacement (after)
+   - A plain-language explanation of what was changed and why
+
+5. **On customer confirmation**, apply the replacement to the working copy.
+
+6. **Move to the next action item.**
+
+### Step 4 — Completion
+
+After all fixes, the customer has a corrected SQL script they can apply to the target database manually or review further.
 
 **Constraints:**
 
+- You MUST verify that TARGET DDL exists (Step 1) before proposing fixes — do NOT assume conversion has run.
+- You MUST fix only the code covered by the action item — do NOT reconvert or rewrite the entire object. Full-object reconversion MUST only happen if the customer explicitly requests it (e.g., "reconvert the whole object", "redo the entire procedure").
+- You MUST mark all agent-generated SQL with `-- [GenAI-generated]` comments so the customer can identify what needs verification.
 - You MUST process objects one at a time and get customer confirmation before modifying each.
 - You MUST show the original and proposed DDL so the customer has full context.
 - You MUST explain the action item in plain language — do not just repeat the CSV description verbatim.
 - You MUST only modify the specific lines for the affected object — do not alter other objects in the file.
 - For `Info`-level items, inform the customer these are informational and may not require changes — ask if they want to review or skip them.
+- If the customer explicitly asks to reconvert an entire object, use `start-metadata-model-conversion` with selection rules scoped to that object and inform them that the full rule-based conversion output will be replaced.
 
 ---
 

--- a/skills/specialized-skills/migration-and-modernization-skills/dms-schema-conversion/references/setup-wizard.md
+++ b/skills/specialized-skills/migration-and-modernization-skills/dms-schema-conversion/references/setup-wizard.md
@@ -6,6 +6,7 @@
 - [Phase 1 — Project Name](#phase-1--project-name)
 - [Phase 2 — Target Type Selection](#phase-2--target-type-selection)
 - [Phase 3 — Source Database](#phase-3--source-database)
+  - [3d — Offline source configuration](#3d--offline-source-configuration)
 - [Phase 4 — Network Investigation & Connectivity](#phase-4--network-investigation--connectivity)
 - [Phase 5 — Create DMS Subnet Group](#phase-5--create-dms-subnet-group)
 - [Phase 6 — Database Credentials](#phase-6--database-credentials)
@@ -48,9 +49,10 @@ Ask:
 | DMS Subnet Group | `<project_name>-subnet-group` |
 | Source Data Provider | `<project_name>-source` |
 | Target Data Provider | `<project_name>-target` |
-| S3 Bucket | `<project_name>-sc-bucket-<aws_account_id>-<aws_region>` |
+| S3 Bucket (migration artifacts) | `<project_name>-sc-bucket-<aws_account_id>-<aws_region>` |
 | Secrets IAM Role | `<project_name>-sc-secrets-role` |
-| S3 IAM Role | `<project_name>-sc-s3-role` |
+| S3 IAM Role (migration artifacts) | `<project_name>-sc-s3-role` |
+| S3 Access Role (offline source, if applicable) | `<project_name>-sc-s3-access-role` |
 
 **Constraints:**
 
@@ -69,6 +71,7 @@ Ask:
   aws s3api head-bucket --bucket <project_name>-sc-bucket-<aws_account_id>-<aws_region>
   aws iam get-role --role-name <project_name>-sc-secrets-role
   aws iam get-role --role-name <project_name>-sc-s3-role
+  aws iam get-role --role-name <project_name>-sc-s3-access-role
   aws iam get-role --role-name dms-vpc-role
   aws iam get-role --role-name dms-cloudwatch-logs-role
   ```
@@ -86,6 +89,7 @@ Ask:
   | S3 Bucket `<project_name>-sc-bucket-<aws_account_id>-<aws_region>` | EXISTS / will be created |
   | Secrets IAM Role `<project_name>-sc-secrets-role` | EXISTS / will be created |
   | S3 IAM Role `<project_name>-sc-s3-role` | EXISTS / will be created |
+  | S3 Access Role `<project_name>-sc-s3-access-role` (offline source) | EXISTS / will be created if needed |
   | DMS VPC Role `dms-vpc-role` | EXISTS / will be created |
   | DMS CloudWatch Role `dms-cloudwatch-logs-role` | EXISTS / will be created |
 
@@ -130,7 +134,22 @@ Explain:
 
 Ask for source engine. Supported source engines: `sqlserver`, `oracle`, `mysql`, `postgresql`, `db2-luw`, `db2-zos`, `sybase`. See [DMS SC supported source databases](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Introduction.Sources.html#CHAP_Introduction.Sources.SchemaConversion) for the full list. The customer may provide the engine name in any format — map it to the correct API identifier automatically.
 
-### 3b — Source connection
+### 3b — Source mode (online / offline)
+
+**If source engine is `sqlserver`**, ask:
+> "Would you like to connect directly to the source database (online mode), or use exported DDL scripts from S3 (offline mode)?
+> - **Online** — DMS connects to your database to read metadata directly.
+> - **Offline** — DMS reads metadata from DDL scripts you've uploaded to S3. No database connectivity required."
+
+Store as `source_mode` (`online` or `offline`).
+
+**If offline:** Proceed to [Phase 3d — Offline Source Configuration](#3d--offline-source-configuration).
+
+**If source engine is NOT `sqlserver`**, set `source_mode = online` (offline is available only for SQL Server).
+
+### 3c — Source connection (online mode only)
+
+**Skip this step if `source_mode = offline`.**
 
 Ask for hostname, port, and database name in a single prompt. If the source is an RDS instance, offer to look up the connection details automatically:
 > "Is your source database an RDS instance? If yes, provide the RDS instance ARN or identifier and I'll retrieve the connection details automatically. Otherwise, please provide the hostname, port, and database name."
@@ -140,6 +159,90 @@ Ask for hostname, port, and database name in a single prompt. If the source is a
 
 Store as `source_hostname`, `source_port`, `source_database_name`.
 
+### 3d — Offline source configuration
+
+**Skip this step if `source_mode = online`.**
+
+#### Step 1 — DDL Scripts (Offline Source)
+
+Ask:
+> "What is the current state of your DDL scripts?
+> 1. Already exported and uploaded to S3
+> 2. Already exported but not yet uploaded to S3
+> 3. Not yet exported — I'd like help"
+
+**Option 1 (exported + uploaded):** Proceed to Step 2.
+
+**Option 2 (exported, not uploaded):** Ask for the local path and target S3 bucket. Upload using:
+```
+aws s3 sync <local_path>/ s3://<bucket>/<database_name>/ --sse AES256
+```
+Verify upload: `aws s3 ls s3://<bucket>/<database_name>/ --recursive | head -10`. Proceed to Step 2.
+
+**Option 3 (not exported):** Ask:
+> "Would you like me to extract the DDL scripts from your database via CLI, or would you prefer to do it yourself?"
+
+- **Agent extracts (with customer permission):** Read [Export SQL Server database objects](https://docs.aws.amazon.com/dms/latest/userguide/export-sql-server-database-objects.html) for the CLI extraction approach. Then:
+  1. Ask for database connection details (hostname, port, database name). For credentials, ask if they are stored in AWS Secrets Manager (provide the secret ARN) or provide directly — credentials will not be logged or persisted.
+  2. Verify the customer's environment has the required tools (PowerShell, `SqlServer` PowerShell module — provides SQL Server Management Objects for scripting database objects). If not, guide installation: `Install-Module SqlServer`.
+  3. Generate the PowerShell SMO export script configured for the customer's database, following the settings and approach from the user guide.
+  4. Ask the customer for permission to execute the script on their machine. If granted, run it via CLI. If not, provide the script for the customer to run manually.
+  5. After extraction completes, upload results to S3 with `aws s3 sync <output_dir>/ s3://<bucket>/<database_name>/ --sse AES256`.
+  6. Proceed to Step 2.
+
+- **Customer extracts:** Provide the link: [Export SQL Server database objects](https://docs.aws.amazon.com/dms/latest/userguide/export-sql-server-database-objects.html). Inform the customer about the DDL structure requirements (below) and wait for them to complete. Then ask whether scripts are uploaded to S3 (→ Option 1) or need uploading (→ Option 2).
+
+**DDL structure requirements** (inform customer if they export themselves):
+- One SQL file per database object
+- Each file contains exactly one `CREATE` statement
+- `USE [DatabaseName];` at the top of each file
+- All objects for one database under a single S3 prefix
+- No DML or DROP statements
+
+#### Step 2 — S3 Configuration (Offline Source)
+
+1. **S3 path:** Ask:
+   > "Please provide the S3 path to your DDL scripts (e.g., `s3://my-bucket/MyDatabase/`)."
+
+   Store as `ddl_s3_path`.
+
+2. **Verify S3 content:** List objects to confirm scripts are present:
+   ```
+   aws s3 ls <ddl_s3_path> --recursive | head -10
+   ```
+   If empty or path not found, inform the customer and ask to correct.
+
+3. **S3 access role:** Ask:
+   > "Do you have an IAM role that grants DMS read access to this S3 bucket? If yes, provide the ARN. If no, I'll create one."
+
+   - **If provided:** Validate with `aws iam get-role`. Store as `offline_s3_access_role_arn`.
+   - **If not provided:** Create the role in [Phase 9e](#9e--s3-access-role-for-offline-source).
+
+4. **KMS encryption (optional):** Ask:
+   > "Are the S3 objects encrypted with a customer-managed KMS key? (yes / no)"
+
+   - **If yes:** Ask for the KMS key ARN. Store as `s3_kms_key_arn`.
+   - **If no:** No additional configuration needed.
+
+#### Step 3 — Prepare Source Data Provider Settings (Offline Source)
+
+Store the following for use in Phase 7a:
+
+```
+source_engine = "sqlserver"
+source_mode = "offline"
+source_settings = {
+  "MicrosoftSqlServerSettings": {
+    "ServerName": "offline",
+    "Port": 1433,
+    "DatabaseName": "offline",
+    "SslMode": "none",
+    "S3Path": "<ddl_s3_path>",
+    "S3AccessRoleArn": "<offline_s3_access_role_arn>"
+  }
+}
+```
+
 ---
 
 ## Phase 4 — Network Investigation & Connectivity
@@ -148,9 +251,11 @@ Store as `source_hostname`, `source_port`, `source_database_name`.
 
 ### 4a — Derive or ask for VPC
 
+**Skip Phase 4 entirely (4a, 4b, 4c) if `source_mode = offline` AND `use_virtual_target = true`.** No network configuration is needed — the instance profile will be created without subnet group or security groups.
+
 - **If live target:** Use `target_vpc_id` from Phase 2. Ask if the customer also wants to reuse the target subnets and security groups. If yes, skip to 4c.
   > **Note:** Reusing the same security group is less secure than creating a dedicated SG with minimal permissions.
-- **If virtual target:** Use the VPC where the source database resides. If the source is an RDS instance, derive the VPC from the RDS metadata. Otherwise, ask the customer which VPC the source database is in.
+- **If virtual target AND `source_mode = online`:** Use the VPC where the source database resides. If the source is an RDS instance, derive the VPC from the RDS metadata. Otherwise, ask the customer which VPC the source database is in.
 
 ### 4b — Collect subnets and security groups manually
 
@@ -161,6 +266,8 @@ Store as `source_hostname`, `source_port`, `source_database_name`.
 - After collecting security group IDs, run `aws ec2 describe-security-groups --group-ids <ids>` and check for rules referencing `0.0.0.0/0` or `::/0`. If found, warn the customer and recommend scoping rules to the specific database port and source CIDR or security group reference.
 
 ### 4c — Connectivity confirmation
+
+**Skip this step if `source_mode = offline`** — no source database connectivity is needed.
 
 Ask:
 > "Does your source database require special network setup to be reachable from this VPC? (VPN, Direct Connect, VPC peering, firewall rules) (yes / no)"
@@ -173,6 +280,8 @@ Store final `vpc_id`, `subnet_ids`, `security_group_ids`.
 ---
 
 ## Phase 5 — Create DMS Subnet Group
+
+**Skip this phase if `source_mode = offline` AND `use_virtual_target = true`.**
 
 **Goal:** Create the subnet group for the DMS instance profile.
 
@@ -233,18 +342,21 @@ Store as `target_secret_arn`.
 
 ### 7a — Source data provider
 
-Use the connection values collected in Phase 3. See [create-data-provider CLI reference](https://docs.aws.amazon.com/cli/latest/reference/dms/create-data-provider.html) for the full list of engine-specific settings structures.
+Use the settings prepared in Phase 3c (online) or Phase 3d (offline). See [create-data-provider CLI reference](https://docs.aws.amazon.com/cli/latest/reference/dms/create-data-provider.html) for engine-specific settings structures.
 
 ```
 aws dms create-data-provider \
   --data-provider-name <project_name>-source \
   --engine <source_engine> \
-  --settings '{...}'
+  [--virtual] \
+  --settings '<source_settings>'
 ```
+
+Pass `--virtual` only if `source_mode = offline`.
 
 Store `source_data_provider_arn`. Do NOT include credentials in settings.
 
-**SSL/TLS:** Ask the customer which SSL mode to use for the database connection (e.g., `none`, `require`, `verify-ca`, `verify-full`). Recommend `require` or higher for encryption in transit. Set the `SslMode` field in the data provider settings accordingly.
+**SSL/TLS:** For offline mode, SslMode is already set to `"none"` in the prepared settings — do NOT ask the customer. For online mode, ask the customer which SSL mode to use for the database connection (e.g., `none`, `require`, `verify-ca`, `verify-full`). Recommend `require` or higher for encryption in transit. Set the `SslMode` field in the data provider settings accordingly.
 
 ### 7b — Target data provider
 
@@ -322,7 +434,7 @@ Ask if an existing role is available. If yes, validate with `aws iam get-role`. 
    ```
    aws iam create-role \
      --role-name <project_name>-sc-secrets-role \
-     --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":["dms.amazonaws.com","dms.<aws_region>.amazonaws.com"]},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"aws:SourceAccount":"<aws_account_id>"},"ArnLike":{"aws:SourceArn":"arn:aws:dms:<aws_region>:<aws_account_id>:*"}}}]}'
+     --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"dms.amazonaws.com"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"aws:SourceAccount":"<aws_account_id>"},"ArnLike":{"aws:SourceArn":"arn:aws:dms:<aws_region>:<aws_account_id>:*"}}}]}'
    ```
 
 2. Attach a policy granting access to the secret ARNs used by the migration project. See [IAM policies for DMS](https://docs.aws.amazon.com/dms/latest/userguide/set-up.html#set-up-iam-policies) for the required permissions (Secrets Manager and KMS actions). Scope the resource to `<source_secret_arn>` and `<target_secret_arn>`.
@@ -338,7 +450,7 @@ Ask if an existing role is available. If yes, validate. If no, create:
    ```
    aws iam create-role \
      --role-name <project_name>-sc-s3-role \
-     --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":["dms.amazonaws.com","dms.<aws_region>.amazonaws.com"]},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"aws:SourceAccount":"<aws_account_id>"},"ArnLike":{"aws:SourceArn":"arn:aws:dms:<aws_region>:<aws_account_id>:*"}}}]}'
+     --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"dms.amazonaws.com"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"aws:SourceAccount":"<aws_account_id>"},"ArnLike":{"aws:SourceArn":"arn:aws:dms:<aws_region>:<aws_account_id>:*"}}}]}'
    ```
 
 2. Attach a policy granting S3 access to the migration bucket. See [IAM policies for DMS](https://docs.aws.amazon.com/dms/latest/userguide/set-up.html#set-up-iam-policies) for the required permissions. Scope the resource to `arn:aws:s3:::<bucket_name>` and `arn:aws:s3:::<bucket_name>/*`.
@@ -401,12 +513,50 @@ If the role already exists (found in Phase 1 lookup or via the check above), ski
      --policy-arn arn:aws:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole
    ```
 
+### 9e — S3 Access Role for Offline Source
+
+**Skip this step if `source_mode = online` or the customer already provided `offline_s3_access_role_arn` in Phase 3d.**
+
+Create an IAM role allowing DMS to read DDL scripts from the customer's S3 bucket (the bucket from `ddl_s3_path`, NOT the migration artifacts bucket from Phase 8):
+
+1. Create the role with trust policy:
+   ```
+   aws iam create-role \
+     --role-name <project_name>-sc-s3-access-role \
+     --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"dms.amazonaws.com"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"aws:SourceAccount":"<aws_account_id>"},"ArnLike":{"aws:SourceArn":"arn:aws:dms:<aws_region>:<aws_account_id>:*"}}}]}'
+   ```
+
+2. Attach S3 read policy scoped to the DDL scripts bucket (extract bucket name from `ddl_s3_path`):
+   ```
+   aws iam put-role-policy \
+     --role-name <project_name>-sc-s3-access-role \
+     --policy-name S3ReadAccess \
+     --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:ListBucket","Resource":"arn:aws:s3:::<ddl_bucket_name>"},{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::<ddl_bucket_name>/*"}]}'
+   ```
+
+3. **If `s3_kms_key_arn` is set**, add KMS decrypt:
+   ```
+   aws iam put-role-policy \
+     --role-name <project_name>-sc-s3-access-role \
+     --policy-name KmsDecrypt \
+     --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"kms:Decrypt","Resource":"<s3_kms_key_arn>","Condition":{"StringEquals":{"kms:ViaService":"s3.<aws_region>.amazonaws.com"}}}]}'
+   ```
+
+Store `offline_s3_access_role_arn`.
+
 ---
 
 ## Phase 10 — Create Instance Profile
 
 **Goal:** Create the DMS instance profile that ties together the subnet group and security groups.
 
+**If `source_mode = offline` AND `use_virtual_target = true`:**
+```
+aws dms create-instance-profile \
+  --instance-profile-name <project_name>-instance-profile
+```
+
+**Otherwise:**
 ```
 aws dms create-instance-profile \
   --instance-profile-name <project_name>-instance-profile \

--- a/skills/specialized-skills/migration-and-modernization-skills/dms-schema-conversion/references/troubleshooting.md
+++ b/skills/specialized-skills/migration-and-modernization-skills/dms-schema-conversion/references/troubleshooting.md
@@ -6,6 +6,7 @@
 - [Async Exceptions](#async-exceptions)
 - [Outdated AWS CLI Version](#outdated-aws-cli-version)
 - [Verify Connectivity](#verify-connectivity)
+- [DDL Processing Statistics (Offline Source)](#ddl-processing-statistics-offline-source)
 
 ---
 
@@ -331,3 +332,16 @@ If a DMS command fails with `Invalid choice` or `argument operation: Invalid cho
 ## Verify Connectivity
 
 If the error indicates a network or connectivity issue, read [DMS SC network configuration](https://docs.aws.amazon.com/dms/latest/userguide/instance-profiles-network.html) and guide the customer through setting up the correct network configuration.
+
+---
+
+## DDL Processing Statistics (Offline Source)
+
+For offline source projects, DMS produces processing statistics in the project's S3 bucket after import, conversion, or assessment operations. **Check these statistics proactively** when results contain fewer objects than expected or when an operation completes without errors but the metadata tree appears incomplete.
+
+Retrieve the statistics:
+```
+aws s3 cp s3://<project-bucket>/<migration-project-folder>/ddl-statistics/ds.csv ./ds.csv
+```
+
+Review the output for entries indicating processing failures. Common causes: malformed DDL, unsupported statements (DML/DROP), encoding issues, or non-compliant file structure. Refer to Phase 3d of the setup wizard for DDL structure requirements.


### PR DESCRIPTION
## Description

  Update the DMS Schema Conversion skill (v1 → v2) with three improvements:

  - **Offline source support:** Add full setup wizard flow for SQL Server offline mode (DDL scripts from S3), including S3
  access role creation, DDL extraction guidance, and conditional phase skipping when no network connectivity is needed.
  - **Action item workflow hardening:** Require verification of existing TARGET DDL before proposing fixes, scope edits to
  action-item-affected code only (preserving rule-based engine output), and mandate `[GenAI-generated]` markers on
  agent-produced SQL.
  - **Fixes:** Use `rule-action: "explicit"` for assessment export API, simplify IAM trust policies by removing redundant
  regional service principal, and add DDL processing statistics troubleshooting section.

  ## Type of Change

  - [ ] New plugin
  - [ ] New skill
  - [x] Bug fix
  - [x] Documentation update
  - [ ] CI/CD change
  - [ ] Other

  ## Checklist

  - [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
  - [x] My changes pass `python3 tools/validate.py`
  - [x] I have updated relevant documentation

  *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under
  the terms of your choice.*