### PR TITLE
feat(networking): add cloudfront skill

### DIFF
--- a/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/SKILL.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cloudfront
+description: >
+  Configures Amazon CloudFront content delivery across six workflows: when to use CloudFront and
+  how it fits with AWS WAF, Shield, CloudFront Functions, Lambda@Edge, Route 53, and origins
+  (creating a distribution, caching, and Flat Rate Pricing (FRP) versus pay-as-you-go pricing); managing
+  custom-domain TLS certificates (ACM in us-east-1); configuring multi-tenant distributions;
+  protecting origins with origin access control (OAC), VPC origins, and origin mutual TLS (mTLS);
+  securing content with signed URLs and cookies, geographic restrictions, viewer mutual TLS, and
+  edge token validation; and observing traffic with standard and real-time logs. Applicable when the
+  customer wants to put CloudFront in front of content, choose pricing, lock an origin, restrict who
+  can view content, or analyze logs. Not applicable for the Route 53 DNS side of a CloudFront custom
+  domain or failover between distributions (see the route53-cloudfront skill), or for pure-Route 53
+  DNS work (see the route53 skill).
+version: 1
+---
+
+# Amazon CloudFront
+
+## Overview
+
+Domain expertise for configuring Amazon CloudFront content delivery: deciding when to use
+CloudFront and how it fits the wider architecture, managing custom-domain certificates and
+multi-tenant distributions, protecting origins, securing content, and observing traffic.
+
+This skill is a router. Each customer task maps to a procedure file under `references/`. Read the
+matching reference in full before acting, then follow its constraints and steps. The reference
+files are self-contained: each carries its own decision tables, constraints, procedure, and
+troubleshooting.
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. CloudFront is a global service; its API calls
+and the AWS Certificate Manager (ACM) certificates it uses are made in `us-east-1` regardless of
+where the customer's application runs.
+
+## Which CloudFront task do you need?
+
+| Goal | Reference |
+| --- | --- |
+| Decide whether CloudFront is the right layer, see how it integrates, create a distribution, tune caching, or choose pricing | [when to use CloudFront](references/when-to-use-cloudfront.md) |
+| Serve a custom domain over HTTPS, manage ACM certificates, or run many domains with a certificate per tenant | [managing certificates with CloudFront](references/managing-certificates-with-cloudfront.md) |
+| Make CloudFront the only way to reach the origin (S3 OAC, VPC origins, origin mutual TLS, security groups) | [protecting your origins](references/protecting-your-origins.md) |
+| Limit who can view content by identity, location, client certificate, or auth token | [securing your content](references/securing-your-content.md) |
+| Get visibility into traffic with standard and real-time logs, and analyze them | [CloudFront observability](references/cloudfront-observability.md) |
+| Serve multiple domains through shared configuration with per-tenant customization (SaaS, platform) | [multi-tenant distributions](references/multi-tenant-distributions.md) |
+
+## Routing notes
+
+- **Choosing the layer and creating a distribution vs the rest.** Whether CloudFront is the right
+  entry layer, what it integrates with, creating a distribution, caching, and pricing live in the
+  when-to-use reference. The other references assume a distribution exists and configure one
+  aspect of it.
+- **Protecting origins vs securing content.** Locking the origin so it is reachable only through
+  CloudFront (OAC, VPC origins, origin mTLS) is the protecting-your-origins reference. Restricting
+  which viewers can see content (signed URLs and cookies, geographic restrictions, viewer mTLS,
+  edge token validation) is the securing-your-content reference. They are paired: a content control
+  only holds when the origin is also locked.
+- **Viewer mTLS vs origin mTLS.** Authenticating the client to CloudFront (viewer mTLS) is content
+  security. Authenticating CloudFront to the origin (origin mTLS) is origin protection. Different
+  controls, different references.
+- **Custom domain certificate vs Route 53 DNS cutover.** Requesting and validating the ACM
+  certificate and adding the alternate domain name is the managing-certificates reference here.
+  Pointing the domain's DNS at the distribution, including the zone apex alias and any failover, is
+  Route 53 work owned by the separate `route53-cloudfront` skill.
+
+## Cross-service work
+
+Pointing a custom domain's DNS at a CloudFront distribution, or failing over between distributions
+with Route 53 records, is cross-service work owned by the separate `route53-cloudfront` skill. Use
+this skill for the CloudFront-side configuration only.
+
+## Additional Resources
+
+- [Amazon CloudFront Developer Guide](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html)
+- [Security best practices for Amazon CloudFront (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/security-best-practices.html)
+- [Amazon CloudFront product page](https://aws.amazon.com/cloudfront/)
+- [Amazon CloudFront pricing](https://aws.amazon.com/cloudfront/pricing/)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/cloudfront-observability.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/cloudfront-observability.md
@@ -1,0 +1,225 @@
+# Observing CloudFront Traffic with Logs
+
+## Overview
+
+Domain expertise for getting visibility into CloudFront requests: choosing between standard logging
+and real-time logs, understanding their latency, completeness, and cost differences, reading the
+rich fields already present in the logs, and querying logs at rest with Amazon Athena.
+
+Standard logging (v2) delivers comprehensive access logs to Amazon CloudWatch Logs, Amazon Data
+Firehose, or Amazon S3 on a delay of minutes, with selectable fields and output formats. Real-time
+logs deliver sampled records to an Amazon Kinesis data stream within seconds, on a best-effort
+basis. The two coexist and serve different needs: completeness versus freshness.
+
+Does not cover creating the distribution (see when-to-use-cloudfront), origin or content security,
+or CloudWatch alarm authoring beyond pointing logs at a destination.
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise.
+
+## Table of Contents
+
+- Overview
+- Decision: standard logging vs real-time logs
+- Latency, completeness, and cost
+- Rich fields already in the logs
+- Querying at rest with Athena and Parquet
+- Procedure
+- Troubleshooting
+- Security Considerations
+- Additional Resources
+
+## Decision: standard logging vs real-time logs
+
+| Need | Choose |
+| --- | --- |
+| Complete record for billing reconciliation, audit, detailed after-the-fact analysis | Standard logging to S3, CloudWatch Logs, or Firehose |
+| Live dashboards, fast anomaly detection within seconds | Real-time logs to a Kinesis data stream |
+
+**Constraints:**
+
+- You MUST pick by whether the customer needs completeness (standard) or freshness (real-time)
+- You SHOULD note the two coexist, and standard logging also coexists with legacy standard
+  logging
+
+## Latency, completeness, and cost
+
+**Constraints:**
+
+- You MUST explain standard logs are comprehensive and arrive minutes later with no CloudFront
+  charge for log delivery (customer pays only for the destination — S3 storage, CloudWatch Logs
+  ingestion/storage, or Firehose delivery; CloudWatch Logs bills a per-event included byte allowance
+  with overage charged per byte — direct the customer to the current Amazon CloudWatch Logs pricing
+  page for the exact allowance and rates rather than quoting a fixed number, which can change);
+  real-time logs arrive within seconds, are sampled
+  at a rate you set, and are best-effort with a CloudFront per-line charge plus the Kinesis data
+  stream throughput cost (real-time logs go only to a Kinesis data stream)
+- You MUST set the expectation that real-time log counts will not match the AWS billing and usage
+  reports, because delivery is best-effort and sampled. Route exact accounting to standard logs
+- You MUST warn that 100% sampling on real-time logs generates significant charges; recommend
+  starting at a lower percentage for cost-sensitive workloads
+- You MUST surface the cost levers: real-time logs bill for CloudFront plus the destination, and
+  choosing Parquet output on standard logs incurs a CloudWatch vended-logs conversion charge
+- You SHOULD mention Amazon CloudWatch Internet Monitor provides internet weather data and connectivity
+  insights, helping customers correlate CloudFront performance with broader internet conditions
+
+## Rich fields already in the logs
+
+Customers often ask for data CloudFront already logs, then build extra tooling to derive it.
+
+**Constraints:**
+
+- You MUST surface the rich fields already present rather than send the customer to build tooling:
+  the edge result type and cache hit or miss, the origin response and origin errors, the time
+  taken, the viewer TLS protocol and cipher, and, for multi-tenant distributions, the distribution
+  tenant identifier the request belonged to (enabling per-tenant dashboards and alerting)
+- You MUST highlight field selection as configurable in both standard and real-time logs — customers
+  choose exactly which fields to include, reducing storage costs and simplifying analysis
+
+## Querying at rest with Athena and Parquet
+
+**Constraints:**
+
+- You SHOULD point the customer at Amazon Athena to query logs in S3 with SQL
+- You SHOULD enable Hive-compatible partitioning and the Parquet output format to cut the data
+  scanned per query, lowering cost and latency
+- You SHOULD reference the published integration patterns rather than have the customer build from
+  scratch
+
+## Procedure
+
+### Overview
+
+This procedure selects the logging mechanism, enables it with the chosen fields and destination,
+and points the customer at analysis.
+
+### Parameters
+
+- **distribution_id** (required): The distribution to log.
+- **mechanism** (required): `standard` or `real-time`.
+- **destination** (required): For standard, `s3` / `cloudwatch` / `firehose`; for real-time, the
+  Kinesis data stream.
+- **fields** (optional): The log fields to include.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask whether the customer needs completeness or freshness before choosing the mechanism
+- You MUST confirm the destination and any required permissions
+
+### Steps
+
+#### 1. Verify dependencies
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You MUST confirm the destination exists and has the required delivery permissions
+- You MUST enable encryption at rest on the log destination: SSE-S3 or SSE-KMS on an S3 bucket,
+  SSE-KMS on an Amazon Data Firehose delivery stream, KMS encryption on a Kinesis data stream used
+  for real-time logs, and a KMS key on every CloudWatch Logs log group receiving CloudFront logs
+  (CloudFront request logs routinely carry sensitive data such as signed URL query strings and
+  cookie values)
+- You SHOULD warn that signed URL query strings and cookie values can appear in the logs, and use
+  field selection to exclude sensitive fields when they are not needed for analysis
+- You MUST enable AWS CloudTrail to record CloudFront management API calls (such as
+  `cloudfront:CreateDistribution` and `cloudfront:UpdateDistribution`) for a compliance and forensic
+  audit trail, separate from the request access logs above
+
+#### 2a. Enable standard logging
+
+**Constraints:**
+
+- You MUST enable standard logging to the chosen destination, selecting fields and, for S3,
+  partitioning and (if wanted) the Parquet output format, noting the conversion charge
+
+#### 2b. Create a real-time log configuration
+
+**Constraints:**
+
+- You MUST create the real-time configuration with a sampling rate, the chosen fields, and the
+  Kinesis data stream, then attach it to the cache behaviors to cover:
+
+  ```
+  aws cloudfront create-realtime-log-config --name {name} \
+    --sampling-rate {rate} --fields {fields} \
+    --end-points '[{"StreamType":"Kinesis","KinesisStreamConfig":{...}}]'
+  ```
+
+#### 3. Point at analysis and surface the console link
+
+**Constraints:**
+
+- You SHOULD set up an Athena table over the S3 logs (Hive partitioning, Parquet) for ad hoc
+  queries, or a Kinesis consumer for real-time
+- You MUST present the distribution detail console link, filling `{distributionId}` from the input
+  `distribution_id` parameter:
+
+  ```
+  https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/{distributionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "distribution_id": "E1ABCDEF2GHIJK",
+  "mechanism": "standard",
+  "destination": "s3",
+  "fields": ["timestamp", "x-edge-result-type", "sc-status", "time-taken"]
+}
+```
+
+#### Example output
+
+```
+Enabled standard logging on E1ABCDEF2GHIJK to S3.
+Logs include edge result type, status, and time taken; query them with Athena.
+Consider enabling Hive partitioning and Parquet output to reduce query cost (note: Parquet incurs a vended-logs conversion charge).
+Verify in the console:
+https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E1ABCDEF2GHIJK
+```
+
+## Troubleshooting
+
+### Real-time log counts do not match the billing reports
+Real-time delivery is best-effort and sampled, so counts will differ. Use standard logs for exact
+accounting.
+
+### Standard logs are not arriving in the destination
+The destination is missing the required delivery permissions, or the S3 path conflicts with legacy
+logging. Set the vended-logs permissions and use a separate bucket or prefix from legacy logs.
+
+### Athena queries are slow or expensive
+The logs are not partitioned or not in Parquet, so queries scan everything. Enable Hive-compatible
+partitioning and the Parquet output format.
+
+### A field the customer wants seems missing
+It may already be a selectable field. Check the standard log fields reference for edge result type,
+origin errors, time taken, TLS protocol and cipher, and the tenant field.
+
+## Security Considerations
+
+- **Logs can carry sensitive data.** Signed URL query strings and cookie values appear in the logs.
+  Use field selection to exclude these fields when they are not needed for analysis.
+- **Encrypt the log destination.** Enable SSE-S3 or SSE-KMS on the S3 bucket, SSE-KMS on an Amazon
+  Data Firehose delivery stream, KMS encryption on a Kinesis data stream for real-time logs, and a
+  KMS key on the CloudWatch Logs log group.
+- **Lock down access to log destinations.** Scope read access to the log bucket, stream, or log
+  group to the operators and tools that need it, not a broad grant, since logs expose request
+  detail.
+- **High sampling exposes volume.** 100% real-time sampling captures every request (and any
+  sensitive fields) in addition to the cost; start at a lower rate unless full capture is required.
+- **Audit the management plane with CloudTrail.** Request access logs do not record who changed the
+  distribution. Enable AWS CloudTrail to track CloudFront API calls
+  (`cloudfront:CreateDistribution`, `cloudfront:UpdateDistribution`) for a compliance and forensic
+  audit trail.
+
+## Additional Resources
+
+- [Configure standard logging (v2) (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html)
+- [Use real-time access logs (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/real-time-logs.html)
+- [Standard log file fields reference (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logs-reference.html)
+- [Querying Amazon CloudFront logs (Amazon Athena User Guide)](https://docs.aws.amazon.com/athena/latest/ug/cloudfront-logs.html)
+- [Sending CloudFront standard logs to CloudWatch Logs for analysis (AWS Cloud Operations Blog)](https://aws.amazon.com/blogs/mt/sending-cloudfront-standard-logs-to-cloudwatch-logs-for-analysis/)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/managing-certificates-with-cloudfront.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/managing-certificates-with-cloudfront.md
@@ -1,0 +1,292 @@
+# Managing Certificates with CloudFront
+
+## Overview
+
+Domain expertise for serving content from a custom domain over HTTPS, covering a single standard
+distribution, a domain migrating from a third-party CDN, and a SaaS or platform provider running
+many domains off one shared configuration with a certificate per tenant. The certificate work is
+the part that trips customers up, and multi-tenant distributions are the scaling path where
+certificate management matters most.
+
+The ACM certificate CloudFront uses must be in `us-east-1` regardless of where the application
+runs. For a standard distribution, add the domain as an alternate domain name (CNAME), attach a
+`us-east-1` certificate that covers it, validate ownership, and wait for the certificate to reach
+Issued. For many domains, a multi-tenant distribution is a template that cannot serve traffic
+directly; each domain is a distribution tenant that inherits the template, and a connection group
+provides the CloudFront routing endpoint DNS points at.
+
+Does not cover the Route 53 DNS cutover (owned by the route53-cloudfront skill), creating the
+distribution itself (see when-to-use-cloudfront), or origin and content security (see
+protecting-your-origins and securing-your-content).
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. CloudFront and its ACM certificates operate in
+`us-east-1`.
+
+## Table of Contents
+
+- Overview
+- The certificate must be in us-east-1
+- Decision: validation method
+- Decision: standard distribution vs multi-tenant
+- The multi-tenant three-part model
+- Decision: shared vs per-tenant certificate
+- Test a tenant before the DNS cutover
+- Procedure
+- Troubleshooting
+- Security Considerations
+- Additional Resources
+
+## The certificate must be in us-east-1
+
+Customers request the certificate in their application's Region, try to attach it, and get an
+error.
+
+**Constraints:**
+
+- You MUST always request or locate the ACM certificate in `us-east-1`, regardless of where the
+  application runs
+- You MUST identify a certificate requested in the application Region as the cause when attachment
+  fails
+
+## Decision: validation method
+
+| Situation | Validation |
+| --- | --- |
+| New domain, no live traffic | DNS validation (CNAME records ACM provides) |
+| Domain migrating from another CDN, still serving traffic | Import or reuse an existing certificate (standard), or HTTP-based validation (file upload or HTTP redirect) for a distribution tenant, so the certificate issues without a premature DNS change |
+
+**Constraints:**
+
+- You MUST detect when a domain already serves live traffic and offer a validation method that does
+  not disrupt it
+- You MUST check whether the domain is already associated with another CloudFront resource before
+  adding it, because a domain can associate with only one CloudFront distribution or tenant at a
+  time (otherwise a `CNAMEAlreadyExists` error)
+
+## Decision: standard distribution vs multi-tenant
+
+| Situation | Use |
+| --- | --- |
+| One domain, or a few unrelated ones | Standard distribution with an alternate domain name and a certificate |
+| Many domains sharing configuration | Multi-tenant distribution with a distribution tenant per domain and per-tenant managed certificates |
+
+**Constraints:**
+
+- You MUST route a customer managing many similar domains to a multi-tenant distribution rather than
+  repeated standard distributions
+
+## The multi-tenant three-part model
+
+The multi-tenant distribution is a template that holds shared settings and cannot serve traffic
+directly. A distribution tenant is the front door for each domain and inherits the template. A
+connection group provides the CloudFront routing endpoint that DNS points at.
+
+**Constraints:**
+
+- You MUST explain this three-part model before the customer creates resources
+- You MUST point DNS at the connection group routing endpoint, never at the multi-tenant
+  distribution template
+- You SHOULD note that only a limited set of settings is customizable per tenant (examples that have
+  been overridable: AWS WAF web ACL, TLS certificate, geographic restrictions, and parameters such as
+  origin path and domain), and direct the customer to verify the current set against the CloudFront
+  Developer Guide rather than treating the list as exhaustive
+
+## Decision: shared vs per-tenant certificate
+
+| Tenant domains | Certificate |
+| --- | --- |
+| Subdomains the provider controls | Shared wildcard certificate inherited from the template |
+| Tenants bring their own domain names | Per-tenant managed certificate CloudFront requests on their behalf |
+
+**Constraints:**
+
+- You MUST match the certificate approach to the domain ownership model
+
+## HTTP validation options for tenant-level certificates
+
+For per-tenant managed certificates, CloudFront initiates the certificate request. The customer
+proves domain ownership through one of three options:
+
+| Option | How it works |
+| --- | --- |
+| Managed | Configure DNS to resolve the domain to CloudFront DNS (e.g., d123.cloudfront.net) or Anycast IP |
+| Self-hosted with redirect | Place an HTTP redirect for the well-known certification validation path to the ACM endpoint (provided by Tenant API) |
+| Self-hosted with direct token serving | Serve the token provided by CloudFront APIs from the well-known validation path |
+
+**Constraints:**
+
+- You MUST use self-hosted validation (redirect or token) when the domain still serves live traffic
+  from another provider, because managed validation requires DNS to already point at CloudFront
+- You MUST note that for HTTP-validated managed certificates, CloudFront associates the certificate
+  automatically once validated — no explicit customer action needed
+- You MUST note that for DNS validation and imported certificates, the customer must explicitly
+  associate the certificate with the tenant AND activate the tenant to serve traffic
+- You MUST remind customers that tenants must be explicitly activated after certificate association
+  (for DNS and import methods) or after HTTP validation completes (for managed certificates)
+
+## Test a tenant before the DNS cutover
+
+Customers cut a production domain straight over and discover a misconfiguration only after live
+traffic breaks.
+
+**Constraints:**
+
+- You MUST validate the tenant against the connection group's CloudFront routing endpoint before the
+  DNS cutover, so the tenant is confirmed serving correctly while the real domain still resolves to
+  its old target
+- You MUST move DNS only after the tenant validates
+
+## Procedure
+
+### Overview
+
+This procedure adds a custom domain over HTTPS, requesting the certificate in `us-east-1`,
+choosing the validation method and (for many domains) the multi-tenant path, testing the tenant,
+and surfacing the console link.
+
+### Parameters
+
+- **domain_name** (required): The custom domain (for example `www.example.com`).
+- **distribution_id** (required for standard): The distribution to add the domain to.
+- **multi_tenant** (required): Whether the customer is running many domains (`true`/`false`).
+- **has_live_traffic** (required): Whether the domain already serves traffic elsewhere.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask whether the customer is managing one domain or many upfront
+- You MUST ask whether the domain already has live traffic to pick the validation method
+
+### Steps
+
+#### 1. Verify dependencies
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You MUST check the domain is not already associated with another CloudFront resource
+
+#### 2. Request or locate the certificate in us-east-1
+
+**Constraints:**
+
+- You MUST request or import the certificate in `us-east-1` covering the domain:
+
+  ```
+  aws acm request-certificate --domain-name {domain_name} \
+    --validation-method DNS --region us-east-1
+  ```
+
+- You MUST choose HTTP-based validation or an imported certificate when the domain already serves
+  live traffic
+
+#### 3. Add the domain and attach the certificate
+
+**Constraints:**
+
+- For a standard distribution, you MUST add the domain as an alternate domain name (CNAME) and
+  attach the `us-east-1` certificate once it reaches `ISSUED`
+- You MUST set the distribution's minimum protocol version to a current strong security policy (a
+  TLS 1.2-or-higher `MinimumProtocolVersion`) rather than relying on the default, which may allow
+  older TLS versions, to ensure strong encryption in transit. Do not hardcode a policy string that
+  ages — select the newest TLS 1.2+ security policy CloudFront offers, confirming the current options
+  against the CloudFront Developer Guide "supported protocols and ciphers" page
+- You MUST enable standard logging on the distribution as part of this change if it is not already
+  enabled, so configuring the custom domain does not leave an audit-trail gap on a production
+  web-facing distribution (see the cloudfront-observability workflow for the logging configuration)
+- For many domains, you MUST create the multi-tenant distribution (template), let CloudFront create
+  the connection group, and create a distribution tenant per domain with the appropriate certificate
+
+#### 4. Test the tenant before cutover (multi-tenant)
+
+**Constraints:**
+
+- You MUST validate the tenant against the connection group's CloudFront routing endpoint before any
+  DNS change
+
+#### 5. Hand off DNS and surface the console link
+
+**Constraints:**
+
+- You MUST hand the DNS cutover to the route53-cloudfront workflow (alias or CNAME at the routing
+  endpoint), not perform it here
+- You MUST present the distribution detail console link, filling `{distributionId}` from the input
+  `distribution_id` parameter:
+
+  ```
+  https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/{distributionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "domain_name": "www.example.com",
+  "distribution_id": "E1ABCDEF2GHIJK",
+  "multi_tenant": false,
+  "has_live_traffic": false
+}
+```
+
+#### Example output
+
+```
+Requested an ACM certificate in us-east-1 covering www.example.com, validated by DNS.
+Added www.example.com as an alternate domain name on E1ABCDEF2GHIJK and attached the certificate.
+DNS cutover is a Route 53 step (route53-cloudfront skill).
+Verify in the console:
+https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E1ABCDEF2GHIJK
+```
+
+## Troubleshooting
+
+### CloudFront will not attach the ACM certificate
+The certificate is not in `us-east-1`. Request or import it in `us-east-1` and attach the new one.
+
+### CNAMEAlreadyExists when adding the domain
+The domain is associated with another CloudFront distribution or tenant. Move it before adding.
+
+### The certificate stays Pending validation
+DNS validation records are missing, or the domain serves traffic elsewhere and cannot be reached.
+Add the CNAME validation records, or use HTTP-based validation for a tenant.
+
+### The multi-tenant distribution does not serve traffic
+The template cannot serve traffic directly. Point DNS at the connection group routing endpoint, not
+the template, and create distribution tenants for each domain.
+
+### A tenant works on the routing endpoint but the custom domain fails
+DNS has not been cut over, or the certificate does not cover the tenant domain. Confirm the
+certificate covers the domain, then complete the Route 53 cutover.
+
+## Security Considerations
+
+- **Let ACM hold the private key.** Prefer ACM-issued or ACM-managed certificates so the private key
+  never leaves ACM. For an imported certificate, store its private key in AWS Secrets Manager rather
+  than on disk or in application config.
+- **Enforce a minimum TLS version.** Set the distribution's minimum protocol version to a current
+  strong TLS 1.2-or-higher security policy rather than relying on the default, which may allow older
+  TLS versions. Choose the newest TLS 1.2+ policy CloudFront offers (confirm current options in the
+  CloudFront Developer Guide) instead of hardcoding a policy string that ages.
+- **Watch for stale or expiring certificates.** An expired certificate breaks HTTPS for the domain.
+  Track expirations and renew ahead of time; ACM-managed certificates renew automatically while
+  imported ones do not. Set a CloudWatch alarm on the ACM `DaysToExpiry` metric (or enable the AWS
+  Config `acm-certificate-expiration-check` managed rule) to alert before a certificate expires,
+  especially for imported certificates that do not auto-renew.
+- **Keep DNS validation records in place.** ACM uses the DNS validation CNAME records to
+  automatically renew certificates. Removing them prevents renewal and will cause HTTPS to break
+  when the certificate expires.
+- **Audit certificate operations with CloudTrail.** Enable AWS CloudTrail to record the ACM and
+  CloudFront management API calls that change certificates and alternate domain names
+  (`acm:RequestCertificate`, `acm:ImportCertificate`, `cloudfront:UpdateDistribution`) for a
+  compliance and forensic audit trail.
+
+## Additional Resources
+
+- [Use custom URLs by adding alternate domain names (CNAMEs) (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html)
+- [Requirements for using SSL/TLS certificates with CloudFront (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html)
+- [Request certificates for your CloudFront distribution tenant (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/managed-cloudfront-certificates.html)
+- [Move an alternate domain name (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move.html)
+- [Understand how multi-tenant distributions work (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html)
+- [Create custom connection group (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-connection-group.html)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/multi-tenant-distributions.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/multi-tenant-distributions.md
@@ -1,0 +1,291 @@
+# Configure a Multi-Tenant Distribution
+
+## Overview
+
+Domain expertise for serving content for multiple domains through a single shared CloudFront
+configuration, using multi-tenant distributions. A multi-tenant distribution acts as a template
+defining shared settings (cache behaviors, origins, security). Distribution tenants inherit those
+settings, each serving as the front door for a specific domain. A connection group provides the
+CloudFront routing endpoint (DNS and Anycast routing) that tenants share.
+
+This is the scaling path for SaaS providers and platform teams managing many customer domains.
+Instead of creating a separate standard distribution for each domain (duplicating configuration
+and making updates error-prone at scale), customers define the configuration once and inherit it
+across all tenants.
+
+Does not cover the certificate management details for tenants (see
+managing-certificates-with-cloudfront), creating the initial distribution (see
+when-to-use-cloudfront), or origin security (see protecting-your-origins).
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise.
+
+## Table of Contents
+
+- Overview
+- The three-part model
+- Decision: standard distribution vs multi-tenant
+- Per-tenant customizations
+- Unsupported features
+- Connection groups and blast radius management
+- Tenant activation
+- Procedure
+- Troubleshooting
+- Security Considerations
+- Additional Resources
+
+## The three-part model
+
+| Component | Role |
+| --- | --- |
+| Multi-tenant distribution | Template defining shared settings. Cannot serve traffic directly |
+| Distribution tenant | Front door for each domain. Inherits the template configuration |
+| Connection group | Provides the CloudFront routing endpoint (DNS like d123.cloudfront.net and Anycast routing) used in DNS |
+
+**Constraints:**
+
+- You MUST explain this three-part model before the customer starts creating resources
+- You MUST make clear the multi-tenant distribution cannot serve traffic directly — only tenants do
+- You MUST point DNS at the connection group routing endpoint, never at the multi-tenant
+  distribution template
+
+## Decision: standard distribution vs multi-tenant
+
+| Situation | Use |
+| --- | --- |
+| One domain, or a few unrelated ones | Standard distribution |
+| Many domains sharing configuration (SaaS, platform) | Multi-tenant distribution |
+
+**Constraints:**
+
+- You MUST identify when a customer manages multiple domains with similar settings and guide them
+  toward a multi-tenant distribution instead of repeated standard distributions
+
+## Per-tenant customizations
+
+A limited set of settings can be overridden at the distribution tenant level; everything else is
+inherited from the multi-tenant distribution template. The set evolves as the service adds support,
+so verify the current list of per-tenant customizable settings against the CloudFront Developer Guide
+rather than treating the examples below as exhaustive. Examples that have been overridable per tenant:
+
+- AWS WAF web ACL
+- TLS certificate
+- Geographic restrictions
+- Parameters (such as origin path and domain)
+
+Everything else is fixed at the multi-tenant distribution level.
+
+**Constraints:**
+
+- You MUST clarify what is customizable per tenant versus what is fixed at the multi-tenant
+  distribution level
+- You MUST NOT lead customers to expect per-tenant cache behavior or origin configuration changes
+
+## Unsupported features
+
+Multi-tenant distributions do not support every standard-distribution feature, and the exact list
+evolves as the service adds support. Examples of features that have been unsupported or have required
+a standard distribution include origin access identity (OAI) — use OAC instead — AWS WAF Classic
+(use AWS WAF v2), Smooth streaming, continuous deployment, dedicated IP custom SSL, and the default
+testing domain.
+
+- You MUST verify the current support matrix in the CloudFront Developer Guide (multi-tenant /
+  distribution tenants) rather than relying on a fixed list, since unsupported features can become
+  supported as the service evolves; treat the items above as examples to check, not an authoritative
+  list
+
+**Constraints:**
+
+- You MUST surface unsupported features and their better alternatives before migration, so the
+  customer does not discover gaps after switching
+- You MUST recommend a standard distribution when the customer requires a feature that the current
+  CloudFront Developer Guide lists as unsupported on multi-tenant distributions (verify against the
+  guide rather than a fixed list)
+
+## Connection groups and blast radius management
+
+A default connection group is created automatically by CloudFront when the multi-tenant
+distribution is created. Customers may create additional connection groups to limit the blast
+radius — if one connection group has an issue, tenants on other connection groups are unaffected.
+
+**Constraints:**
+
+- You SHOULD suggest additional connection groups for large-scale deployments where blast radius
+  isolation matters
+- You MUST note that if no connection group is specified when creating a tenant, it uses the default
+
+## Tenant activation
+
+Tenants must be explicitly activated to serve traffic. This is a manual step.
+
+- For DNS and import certificate validation: activate after explicitly associating the issued
+  certificate with the tenant
+- For HTTP-validated managed certificates: activate after HTTP validation completes (certificate
+  association is automatic)
+
+**Constraints:**
+
+- You MUST always remind customers about the explicit activation step
+- You MUST explain there is no automated mechanism to activate the tenant — activation always
+  requires explicit customer action (for HTTP-validated managed certificates, certificate
+  association is automatic, but the tenant still must be activated)
+
+## Procedure
+
+### Overview
+
+This procedure creates a multi-tenant distribution, adds distribution tenants for each domain,
+and activates them.
+
+### Parameters
+
+- **domains** (required): List of domains to serve.
+- **shared_origin** (required): The origin all tenants share.
+- **certificate_approach** (required): `wildcard` or `per-tenant`.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask how many domains and whether they share configuration
+- You MUST ask whether the provider controls subdomains (wildcard) or tenants bring their own
+  domains (per-tenant certificates)
+
+### Steps
+
+#### 1. Verify dependencies
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+
+#### 2. Create the multi-tenant distribution
+
+**Constraints:**
+
+- You MUST create the multi-tenant distribution with the shared configuration (cache behaviors,
+  origins, security settings). Do not embed a static managed cache policy id; look up the current
+  `Managed-CachingOptimized` policy by name and use its id for `CachePolicyId` (managed policy ids
+  can change):
+
+  ```
+  # resolve the managed CachingOptimized cache policy id (do not hardcode a UUID):
+  aws cloudfront list-cache-policies --type managed \
+    --query "CachePolicyList.Items[?CachePolicy.CachePolicyConfig.Name=='Managed-CachingOptimized'].CachePolicy.Id | [0]" --output text
+  aws cloudfront create-distribution --distribution-config '{"CallerReference":"mt-2024-01","ConnectionMode":"tenant-only","Origins":{"Quantity":1,"Items":[{"Id":"shared-origin","DomainName":"origin.myapp.com","CustomOriginConfig":{"HTTPPort":80,"HTTPSPort":443,"OriginProtocolPolicy":"https-only"}}]},"DefaultCacheBehavior":{"TargetOriginId":"shared-origin","ViewerProtocolPolicy":"redirect-to-https","CachePolicyId":"{cache_policy_id}"},"Enabled":true}'
+  ```
+
+- You MUST set the shared template's viewer protocol policy to redirect-HTTP-to-HTTPS (or
+  HTTPS-only) and, for custom origins, the origin protocol policy to HTTPS-only, so every tenant
+  inherits encryption in transit end-to-end
+- You MUST note the default connection group is created automatically
+- You MUST attach a response headers policy with browser security headers (HSTS, CSP,
+  X-Frame-Options, X-Content-Type-Options) to the shared template so every tenant inherits the
+  security baseline; look up the managed `Managed-SecurityHeadersPolicy` id by name via
+  `aws cloudfront list-response-headers-policies --type managed` rather than hardcoding a UUID (see
+  securing-your-content for the lookup), since managed policy ids can change
+- You SHOULD attach an AWS WAF web ACL to the multi-tenant distribution for baseline Layer 7
+  protection, noting that because tenants serve multiple customer domains the attack surface is
+  larger, and that the web ACL can be customized per tenant
+- You SHOULD enable standard logging on the multi-tenant distribution for traffic visibility across
+  all tenants (the distribution tenant identifier field lets you break logs down per tenant)
+
+#### 3. Create distribution tenants
+
+**Constraints:**
+
+- You MUST create a distribution tenant for each domain, referencing the multi-tenant
+  distribution as the template:
+
+  ```
+  aws cloudfront create-distribution-tenant --distribution-id {distributionId} \
+    --name {tenant-name} --domains '[{"Domain":"tenant1.myapp.com"}]'
+  ```
+
+- You MUST associate the appropriate certificate (wildcard inherited or per-tenant managed)
+- You MUST activate each tenant after certificate association/validation by updating it with
+  `Enabled` set to true:
+
+  ```
+  aws cloudfront update-distribution-tenant --id {tenantId} --enabled --if-match {etag}
+  ```
+
+#### 4. Surface the console link
+
+**Constraints:**
+
+- You MUST present the distribution detail console link:
+
+  ```
+  https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/{distributionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "domains": ["tenant1.myapp.com", "tenant2.myapp.com"],
+  "shared_origin": "origin.myapp.com",
+  "certificate_approach": "wildcard"
+}
+```
+
+#### Example output
+
+```
+Created multi-tenant distribution E1ABCDEF2GHIJK with shared origin and cache behaviors.
+Default connection group created automatically.
+Created distribution tenants for tenant1.myapp.com and tenant2.myapp.com, inheriting
+the wildcard certificate *.myapp.com from the distribution.
+Tenants activated and ready to serve traffic.
+Verify in the console:
+https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E1ABCDEF2GHIJK
+```
+
+## Troubleshooting
+
+### The multi-tenant distribution does not serve traffic
+The template cannot serve traffic directly. Create distribution tenants for each domain and point
+DNS at the connection group routing endpoint.
+
+### A tenant is not serving traffic after certificate issuance
+The tenant has not been activated. Explicitly activate the tenant after associating the certificate.
+
+### A feature the customer needs is not available
+Verify the feature against the current CloudFront Developer Guide support matrix rather than a fixed
+list. As examples that have required a standard distribution or been unsupported on multi-tenant:
+OAI (use OAC), AWS WAF Classic (use AWS WAF v2), smooth streaming, continuous deployment, dedicated
+IP custom SSL, and the default testing domain.
+
+### Configuration changes don't apply to a specific tenant
+Only a limited set of settings is customizable per tenant (examples that have been overridable: AWS
+WAF web ACL, TLS certificate, geographic restrictions, and parameters — verify the current set
+against the CloudFront Developer Guide); all other settings are inherited from the multi-tenant
+distribution template.
+
+## Security Considerations
+
+- **Shared configuration is a shared blast radius.** A misconfiguration on the multi-tenant
+  template (origin, cache behavior, security setting) propagates to every tenant at once. Review
+  template changes against all tenants before applying.
+- **Isolate tenants with per-tenant AWS WAF web ACLs.** The web ACL is customizable per tenant; use it
+  to apply per-customer Layer 7 rules and rate limits rather than relying only on a single shared
+  ACL across all domains.
+- **Encryption in transit on the template.** Set the viewer protocol policy to
+  redirect-HTTP-to-HTTPS (or HTTPS-only) and the origin protocol policy to HTTPS-only on the shared
+  template so every inheriting tenant is encrypted end-to-end.
+- **Enable logging for cross-tenant audit.** Enable standard logging on the distribution; the
+  distribution tenant identifier field lets you attribute and audit requests per tenant.
+- **Least-privilege IAM for tenant management.** Scope tenant create/update/activate permissions to
+  the operators who manage them rather than granting broad `cloudfront:*`, since these operations
+  affect customer-facing domains.
+- **Audit the management plane with CloudTrail.** Enable AWS CloudTrail to track tenant creation,
+  activation, and template changes (`cloudfront:CreateDistribution`,
+  `cloudfront:CreateDistributionTenant`, `cloudfront:UpdateDistributionTenant`) for a compliance and
+  forensic audit trail.
+
+## Additional Resources
+
+- [Understand how multi-tenant distributions work (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/multi-tenant-distributions.html)
+- [Distribution tenant customizations (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-tenant-customizations.html)
+- [Migrate to a multi-tenant distribution (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/migrate-to-multi-tenant.html)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/protecting-your-origins.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/protecting-your-origins.md
@@ -1,0 +1,267 @@
+# Protecting Your Origins
+
+## Overview
+
+Domain expertise for making CloudFront the only way to reach an origin, so viewers cannot bypass
+the edge by hitting the origin directly. The right mechanism depends on the origin type, and the
+three combine to cover the full catalog:
+
+- Amazon S3 origin: origin access control (OAC) plus a scoped bucket policy and Block Public Access.
+- ALB, NLB, or EC2 in a private subnet: a VPC origin plus a security group that allows the
+  CloudFront managed prefix list or service-managed security group.
+- Public, on-premises, or other-cloud origin: origin mutual TLS (origin mTLS), where CloudFront
+  presents a client certificate the origin validates.
+
+Does not cover restricting which viewers can see content (see securing-your-content), creating the
+distribution (see when-to-use-cloudfront), or custom domains (see
+managing-certificates-with-cloudfront).
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise.
+
+## Table of Contents
+
+- Overview
+- Decision: which origin-locking mechanism
+- S3 origin: OAC, scoped bucket policy, Block Public Access
+- Private ALB, NLB, or EC2: VPC origins and security groups
+- Security groups as a lighter alternative to VPC origins
+- Public or hybrid origin: origin mutual TLS
+- Procedure
+- Troubleshooting
+- Security Considerations
+- Additional Resources
+
+## Decision: which origin-locking mechanism
+
+| Origin | Mechanism |
+| --- | --- |
+| Private Amazon S3 bucket | Origin access control (OAC) + scoped bucket policy + Block Public Access |
+| ALB, NLB, or EC2 in a private subnet | VPC origin + security group referencing the CloudFront managed prefix list or service-managed security group |
+| Public, on-premises, or other-cloud HTTP origin | Origin mutual TLS (CloudFront presents a client certificate) |
+
+**Constraints:**
+
+- You MUST pick the mechanism by origin type; they are not interchangeable
+- You MAY combine mechanisms, for example a VPC origin and origin mTLS, when an origin needs both
+
+## S3 origin: OAC, scoped bucket policy, Block Public Access
+
+**Constraints:**
+
+- You MUST default to origin access control (OAC), not origin access identity (OAI). OAI does not
+  cover all Regions, server-side encryption with AWS KMS, or write requests. Reserve OAI for
+  migrating an older setup
+- You MUST create the OAC set to always sign and attach it to the S3 origin
+- You MUST write the bucket policy together with the OAC, allowing `cloudfront.amazonaws.com` scoped
+  to the specific distribution with both `AWS:SourceArn` and `AWS:SourceAccount` conditions, not a
+  broad grant
+- You MUST keep S3 Block Public Access fully on
+- You SHOULD enable default encryption (SSE-S3 or SSE-KMS) on the S3 bucket. If using SSE-KMS, the
+  KMS key policy MUST grant `kms:Decrypt` (and `kms:GenerateDataKey*` for writes) to the
+  `cloudfront.amazonaws.com` service principal, scoped to the distribution ARN with both
+  `AWS:SourceArn` and `AWS:SourceAccount` conditions, so CloudFront can read the encrypted objects
+- You MUST confirm the origin is a standard S3 bucket, not a website endpoint, which OAC does not
+  support
+
+## Private ALB, NLB, or EC2: VPC origins and security groups
+
+**Constraints:**
+
+- You MUST recommend a VPC origin for an ALB, NLB, or EC2 origin in a private subnet rather than
+  moving it to a public subnet
+- You MUST update the security group on the origin resource to allow inbound traffic from the
+  CloudFront managed prefix list or the service-managed security group, not a broad CIDR. Missing
+  this rule causes silent failures
+- You MUST validate the resource type against the current VPC origins documentation before
+  proceeding, rather than relying on a fixed list — supported and unsupported origin types and
+  features evolve as the service changes. As examples to verify (not an authoritative list): some
+  load-balancer types such as Gateway Load Balancers, dual-stack NLBs, and NLBs with TLS listeners
+  have been unsupported, an NLB must have a security group attached, and VPC origins have not
+  supported gRPC or Lambda@Edge origin-facing triggers
+- You MUST allow time for the VPC origin to deploy (on the order of several minutes); confirm the
+  origin reaches a deployed state before relying on it
+
+## Public or hybrid origin: origin mutual TLS
+
+Origin mTLS lets CloudFront authenticate itself to the origin with a client certificate, so the
+origin accepts connections only from authorized CloudFront distributions. It replaces brittle IP
+allowlists and secret-header schemes for public, on-premises, and other-cloud origins.
+
+**Constraints:**
+
+- You MUST make clear the origin server, not CloudFront, validates the client certificate: the
+  origin must request client certificates and hold the issuing CA in its trust store before origin
+  mTLS is enabled
+- You MUST import the client certificate in ACM and enable origin mTLS per origin (different origins
+  can use different certificates)
+- You SHOULD use origin mTLS instead of IP allowlists or custom-header secrets for hybrid and
+  multi-cloud origins
+
+## Security groups as a lighter alternative to VPC origins
+
+For ALB and NLB origins that must remain in a public subnet (not using VPC origins), the customer
+restricts the security group to only allow inbound traffic from CloudFront IP ranges using the
+CloudFront managed prefix list. This is simpler but less secure than VPC origins because the origin
+still has a public IP.
+
+**Constraints:**
+
+- You SHOULD recommend VPC origins as the more secure default; security group restrictions are a
+  fallback when the origin must remain in a public subnet
+- You MUST use the CloudFront managed prefix list, not manually maintained CIDR ranges
+
+## Procedure
+
+### Overview
+
+This procedure selects the mechanism by origin type, applies it, and surfaces the console link to
+verify.
+
+### Parameters
+
+- **distribution_id** (required): The distribution with the origin.
+- **origin_type** (required): `s3`, `vpc-origin`, or `public-custom`.
+- **origin_ref** (required): The bucket name, the ALB/NLB/EC2 ARN, or the custom origin domain.
+- **account_id** (required for S3): For the bucket-policy source ARN.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask for the origin type and reference upfront
+- You MUST confirm an S3 origin is a standard bucket, not a website endpoint
+
+### Steps
+
+#### 1. Verify dependencies
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You MUST confirm the origin type and, for VPC origins, that the resource type is supported
+
+#### 2a. S3 origin: OAC and scoped bucket policy
+
+**Constraints:**
+
+- You MUST create the OAC set to always sign and attach it to the S3 origin:
+
+  ```
+  aws cloudfront create-origin-access-control --origin-access-control-config '{
+    "Name": "{origin_ref}-oac", "OriginAccessControlOriginType": "s3",
+    "SigningBehavior": "always", "SigningProtocol": "sigv4"
+  }'
+  ```
+
+- You MUST write the scoped bucket policy and keep Block Public Access on:
+
+  ```
+  {"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+    "Principal":{"Service":"cloudfront.amazonaws.com"},"Action":"s3:GetObject",
+    "Resource":"arn:aws:s3:::{origin_ref}/*",
+    "Condition":{"StringEquals":{"AWS:SourceArn":"arn:aws:cloudfront::{account_id}:distribution/{distribution_id}","AWS:SourceAccount":"{account_id}"}}}]}
+  ```
+
+  Include both `AWS:SourceArn` and `AWS:SourceAccount` for defense in depth, so the bucket admits
+  only the specific distribution in the expected account and a confused-deputy request from another
+  account cannot reach the origin.
+
+#### 2b. Private ALB/NLB/EC2: VPC origin and security group
+
+**Constraints:**
+
+- You MUST create the VPC origin from the resource ARN, add it as the distribution origin, and add
+  the security group inbound rule referencing the CloudFront managed prefix list or service-managed
+  security group
+
+#### 2c. Public or hybrid origin: origin mTLS
+
+**Constraints:**
+
+- You MUST import the client certificate in ACM, confirm the origin is configured to request and
+  validate client certificates, then enable origin mTLS on the origin
+
+#### 3. Confirm and surface the console link
+
+**Constraints:**
+
+- You MUST wait for the distribution to reach `Deployed`, then confirm content loads through
+  CloudFront and the origin rejects direct access
+- You MUST present the distribution detail console link, filling `{distributionId}` from the input
+  `distribution_id` parameter:
+
+  ```
+  https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/{distributionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "distribution_id": "E1ABCDEF2GHIJK",
+  "origin_type": "vpc-origin",
+  "origin_ref": "arn:aws:elasticloadbalancing:us-east-1:111122223333:loadbalancer/app/my-alb/abc",
+  "account_id": "111122223333"
+}
+```
+
+#### Example output
+
+```
+Created a VPC origin for the private ALB and added it to E1ABCDEF2GHIJK.
+Added an inbound rule on the ALB security group referencing the CloudFront managed prefix list.
+Verify in the console:
+https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E1ABCDEF2GHIJK
+```
+
+## Troubleshooting
+
+### VPC origin requests fail silently with no error in the logs
+The origin security group is missing the inbound rule for the CloudFront managed prefix list or
+service-managed security group. Add it.
+
+### Cannot point a VPC origin at a Gateway Load Balancer
+Some load-balancer types (for example Gateway Load Balancers, dual-stack NLBs, and NLBs with TLS
+listeners) have not been supported as VPC origins; confirm against the current VPC origins
+documentation. Use a supported ALB, NLB, or EC2 origin.
+
+### CloudFront returns access denied reaching the S3 bucket
+The scoped bucket policy is missing or does not allow `cloudfront.amazonaws.com` for this
+distribution. Write the scoped policy.
+
+### OAC does not work on the S3 origin
+The origin is a website endpoint. Use a standard S3 bucket origin.
+
+### The origin rejects CloudFront with origin mTLS enabled
+The origin server is not configured with the issuing CA in its trust store, or is not requesting
+client certificates. Configure the origin to validate the client certificate; CloudFront only
+presents it.
+
+## Security Considerations
+
+- **Scope the bucket policy, never broaden it.** Allow `cloudfront.amazonaws.com` scoped to the
+  specific distribution with both `AWS:SourceArn` and `AWS:SourceAccount` conditions rather than a
+  broad grant, and keep S3 Block Public Access fully on.
+- **Scope the KMS key policy for SSE-KMS origins.** Grant `kms:Decrypt` (and `kms:GenerateDataKey*`
+  for writes) only to `cloudfront.amazonaws.com`, scoped to the distribution ARN with both
+  `AWS:SourceArn` and `AWS:SourceAccount` conditions, not a broad key grant.
+- **Prune stale security group rules.** Use the CloudFront managed prefix list or service-managed
+  security group; remove manually maintained CIDR rules, which drift and leave the origin reachable
+  from unintended ranges.
+- **Rotate origin mTLS certificates.** The origin validates the client certificate CloudFront
+  presents; track its expiry and rotate ahead of time so origin connections do not break or fall
+  back to weaker controls.
+- **Audit origin protection changes with CloudTrail.** Enable AWS CloudTrail to record the
+  CloudFront, S3, and EC2 management API calls that change origin locking
+  (`cloudfront:UpdateDistribution`, `s3:PutBucketPolicy`, `ec2:AuthorizeSecurityGroupIngress`) so
+  changes are tracked for a compliance and forensic audit trail.
+
+## Additional Resources
+
+- [Restrict access to an Amazon S3 origin (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html)
+- [Amazon CloudFront introduces origin access control (OAC) (AWS Networking and Content Delivery Blog)](https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-cloudfront-introduces-origin-access-control-oac/)
+- [Restrict access with VPC origins (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-vpc-origins.html)
+- [Introducing CloudFront VPC origins (AWS Networking and Content Delivery Blog)](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-cloudfront-virtual-private-cloud-vpc-origins-shield-your-web-applications-from-public-internet/)
+- [Origin mutual TLS with CloudFront (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-mtls-authentication.html)
+- [Amazon CloudFront now supports mTLS authentication to origins (AWS Networking and Content Delivery Blog)](https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-cloudfront-now-supports-mtls-authentication-to-origins/)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/securing-your-content.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/securing-your-content.md
@@ -1,0 +1,305 @@
+# Securing Your Content
+
+## Overview
+
+Domain expertise for limiting who can view content served through CloudFront, using four controls
+that answer different questions:
+
+- Identity: signed URLs or signed cookies, backed by a trusted key group.
+- Location: built-in geographic restrictions, by country, across the whole distribution.
+- Client certificate: viewer mutual TLS (viewer mTLS), where the client presents a certificate
+  CloudFront validates against a trust store.
+- Authorization token: a CloudFront function on the viewer-request event that validates an OAuth
+  bearer token or JSON Web Token (JWT) at the edge.
+
+All four only hold if the origin cannot be reached directly. Pair every content control with origin
+locking (see protecting-your-origins).
+
+Does not cover locking the origin (see protecting-your-origins), custom domains (see
+managing-certificates-with-cloudfront), or creating the distribution (see when-to-use-cloudfront).
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise.
+
+## Table of Contents
+
+- Overview
+- Decision: which content control
+- Identity: signed URLs vs signed cookies
+- Location: geographic restrictions
+- Client certificate: viewer mutual TLS
+- Authorization token: validate at the edge with CloudFront Functions
+- Pair every control with origin locking
+- Procedure
+- Troubleshooting
+- Security Considerations
+- Additional Resources
+
+## Decision: which content control
+
+| Question | Control |
+| --- | --- |
+| Is this viewer authorized (paying, licensed)? | Signed URLs or signed cookies |
+| Is this viewer in an allowed country? | Geographic restrictions |
+| Does this client hold a valid certificate? | Viewer mutual TLS |
+| Does this request carry a valid auth token? | CloudFront function on viewer-request |
+
+**Constraints:**
+
+- You MUST ask whether the customer is gating on identity, location, client certificate, or token,
+  and route to the matching control rather than letting one stand in for another
+- You MAY combine controls; they are independent
+
+## Identity: signed URLs vs signed cookies
+
+| Choice | Use when |
+| --- | --- |
+| Signed URLs | A single file, or a client without cookie support. Signature, policy, and expiration go in query-string parameters |
+| Signed cookies | Many files, or no change to the URL is acceptable. Same data goes in cookies; the URL is unchanged |
+
+**Constraints:**
+
+- You MUST set up trusted key groups on the distribution and have the application issue the signed
+  URL or cookies. The legacy CloudFront key pairs approach is deprecated and MUST NOT be used for
+  new implementations
+- You MUST store the private signing key in AWS Secrets Manager (or AWS Systems Manager Parameter
+  Store SecureString), not on disk or in application config, so the key is not exposed
+- You MUST match the choice to one file versus many, and to whether any URL change is acceptable
+
+## Location: geographic restrictions
+
+**Constraints:**
+
+- You MUST explain geographic restrictions apply to the whole distribution at the country level, not
+  per path
+- You SHOULD route per-path or finer-than-country needs to separate distributions or a third-party
+  geolocation approach
+
+## Client certificate: viewer mutual TLS
+
+**Constraints:**
+
+- You MUST create the trust store from a PEM CA bundle in S3, then enable viewer mutual
+  authentication on the distribution
+- You MUST select required mode to reject any client without a valid certificate (optional lets
+  unauthenticated clients through; passthrough forwards the raw certificate to the origin)
+- You MUST disable HTTP/3 and confirm every cache behavior uses HTTPS-only or
+  redirect-HTTP-to-HTTPS before enabling mTLS
+- You SHOULD note the trust store reads the CA bundle from S3 only at creation time, so rotation
+  needs a manual trust store update
+
+## Authorization token: validate at the edge with CloudFront Functions
+
+**Constraints:**
+
+- You SHOULD validate an OAuth bearer token or JWT in a CloudFront function on the viewer-request
+  event when the logic is lightweight and viewer-facing
+- You MUST route token checks that need network access or origin-facing events to Lambda@Edge
+- You MUST publish the function to the LIVE stage before associating it with the distribution
+
+## Pair every control with origin locking
+
+A content control only holds if access is forced through CloudFront. While the origin URL is
+directly reachable, viewers bypass the control entirely.
+
+**Constraints:**
+
+- You MUST pair every content control with an origin-locking mechanism: origin access control for an
+  S3 origin, or VPC origins or origin mTLS for a custom origin (see protecting-your-origins)
+- You MUST NOT present a content control as complete while the origin is still directly reachable
+
+## Procedure
+
+### Overview
+
+This procedure selects the content control by question, applies it, pairs it with origin locking,
+and surfaces the console link.
+
+### Parameters
+
+- **distribution_id** (required): The distribution to secure.
+- **control** (required): `signed`, `geo`, `viewer-mtls`, or `token`.
+- **gate_detail** (required): The key group, country list, trust store source, or token type.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask what the customer is gating on upfront
+- You MUST confirm the origin-locking plan before calling the setup complete
+
+### Steps
+
+#### 1. Verify dependencies
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You MUST confirm the origin is locked or plan to lock it (see protecting-your-origins)
+
+#### 2. Apply the chosen control
+
+**Constraints:**
+
+- For identity, you MUST configure a trusted key group and have the application issue signed URLs or
+  cookies. Create the key group, then reference it from the cache behavior's `TrustedKeyGroups`:
+
+  ```
+  aws cloudfront create-key-group --key-group-config \
+    '{"Name":"paid-users","Items":["{publicKeyId}"]}'
+  ```
+
+- For location, you MUST set the geographic restriction allowlist or denylist on the distribution by
+  updating its config (the `Restrictions.GeoRestriction` block). Fetch the current config and ETag,
+  set the `Restrictions.GeoRestriction` block, then pass the full modified config back as an inline
+  JSON string (use an inline JSON string, not a `file://` reference, for portability across
+  execution environments):
+
+  ```
+  aws cloudfront get-distribution-config --id {distribution_id}
+  # set Restrictions.GeoRestriction in the returned DistributionConfig, then put it back.
+  # RestrictionType is an AWS API enum; its only allowed values are "whitelist" (allowlist),
+  # "blacklist" (denylist), and "none" — use the API's exact token here for the allowlist case:
+  aws cloudfront update-distribution --id {distribution_id} --if-match {etag} \
+    --distribution-config '{"CallerReference":"...","Restrictions":{"GeoRestriction":{"RestrictionType":"whitelist","Quantity":1,"Items":["US"]}}, ...rest of the unchanged config...}'
+  ```
+
+- For client certificate, you MUST create the trust store, disable HTTP/3, set all behaviors to
+  HTTPS, and enable viewer mutual authentication in required mode. Create the trust store from the
+  PEM CA bundle in S3:
+
+  ```
+  aws cloudfront create-trust-store --name {name} \
+    --s3-bucket {bucket} --s3-object-key {ca-bundle.pem}
+  ```
+
+- For token, you MUST write a CloudFront function on viewer-request that validates the token, then
+  publish and associate it.
+- ⚠️ You MUST implement real signature verification before publishing. A function that only checks
+  token presence and length does not verify authenticity — any arbitrary string passes, which is a
+  false sense of security. The validation logic below is described as steps, not as runnable code, so
+  it is not deployed as-is: the function MUST (a) read the bearer token from the `authorization`
+  header, (b) reject a missing or over-length token with a 401, and (c) **verify the token's
+  signature** (for example, validate the JWT signature with `crypto.subtle` in a CloudFront Functions
+  runtime that supports it) before returning `event.request`. Author the function code to do all three.
+- Create the function with your authored, signature-verifying code (replace `{function_code}` with
+  it), and set `Runtime` to the current CloudFront Functions runtime that supports your code — do not
+  hardcode a runtime string that ages; check the available runtimes in the CloudFront Developer Guide
+  (CloudFront Functions) and select the latest supported one for `{runtime}`:
+
+  ```
+  aws cloudfront create-function --name {name} \
+    --function-config '{"Comment":"token-check","Runtime":"{runtime}"}' \
+    --function-code '{function_code}'
+  ```
+
+- Only after the function performs signature verification, publish and associate it:
+
+  ```
+  aws cloudfront publish-function --name {name} --if-match {etag}
+  ```
+
+- You MUST also attach a response headers policy that adds browser security headers (HSTS,
+  Content-Security-Policy, X-Frame-Options, X-Content-Type-Options) to complement these access
+  controls, since they defend against different browser-based attacks (clickjacking, MIME sniffing,
+  protocol downgrade). The AWS managed `SecurityHeadersPolicy` is a starting point. Look up its
+  current id by name (do not hardcode a UUID — managed policy ids can change), fetch the current
+  config and ETag, set the behavior's `ResponseHeadersPolicyId`, then pass the full modified config
+  back as an inline JSON string (use an inline JSON string, not a `file://` reference, for
+  portability across execution environments):
+
+  ```
+  # resolve the managed SecurityHeadersPolicy id by name (do not hardcode a UUID):
+  aws cloudfront list-response-headers-policies --type managed \
+    --query "ResponseHeadersPolicyList.Items[?ResponseHeadersPolicy.ResponseHeadersPolicyConfig.Name=='Managed-SecurityHeadersPolicy'].ResponseHeadersPolicy.Id | [0]" --output text
+  aws cloudfront get-distribution-config --id {distribution_id}
+  # set DefaultCacheBehavior.ResponseHeadersPolicyId to the resolved managed SecurityHeadersPolicy id
+  # in the returned DistributionConfig, then put it back:
+  aws cloudfront update-distribution --id {distribution_id} --if-match {etag} \
+    --distribution-config '{"CallerReference":"...","DefaultCacheBehavior":{"ResponseHeadersPolicyId":"{security_headers_policy_id}", ...}, ...rest of the unchanged config...}'
+  ```
+
+#### 3. Confirm origin locking and surface the console link
+
+**Constraints:**
+
+- You MUST confirm the origin cannot be reached directly before calling the control complete
+- You MUST present the distribution detail console link, filling `{distributionId}` from the input
+  `distribution_id` parameter:
+
+  ```
+  https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/{distributionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "distribution_id": "E1ABCDEF2GHIJK",
+  "control": "signed",
+  "gate_detail": "trusted-key-group: paid-users"
+}
+```
+
+#### Example output
+
+```
+Configured trusted key group paid-users on E1ABCDEF2GHIJK for signed URLs.
+Origin locked with origin access control so the signing cannot be bypassed.
+Verify in the console:
+https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E1ABCDEF2GHIJK
+```
+
+## Troubleshooting
+
+### Viewers still download files directly despite signed URLs
+The origin is directly reachable, so signing is bypassed. Lock the origin (see
+protecting-your-origins).
+
+### Geographic restrictions do not apply to only part of the content
+Geographic restrictions apply to the whole distribution at the country level. Use separate
+distributions or a third-party geolocation approach for finer control.
+
+### Enabling viewer mTLS returns a configuration error
+HTTP/3 is enabled or a cache behavior allows HTTP. Disable HTTP/3 and set every behavior to HTTPS,
+then enable mTLS.
+
+### Clients without a certificate are still allowed through
+The validation mode is optional or passthrough. Use required mode to reject clients without a valid
+certificate.
+
+### A token-validation function association fails
+The function was not published to the LIVE stage. Publish it, then associate it.
+
+## Security Considerations
+
+- **Origin locking is mandatory.** Every content control here is bypassed while the origin is
+  directly reachable. Pair each control with origin access control, VPC origins, or origin mTLS
+  (see protecting-your-origins) before calling it complete.
+- **Rotate signing keys.** Signed URLs and cookies stay valid until they expire. Rotate the keys in
+  the trusted key group on a schedule and on suspected compromise, and keep expirations short.
+- **Rotate the viewer mTLS trust store.** The trust store reads the CA bundle from S3 only at
+  creation time, so rotating or revoking a CA requires a manual trust store update; stale CAs keep
+  granting access.
+- **Avoid permissive geographic restrictions.** Country-level allowlists or denylists apply to the whole
+  distribution. Overly broad lists weaken the control; confirm the list matches the actual policy.
+- **Add browser security headers.** Attach a response headers policy (HSTS, CSP, X-Frame-Options,
+  X-Content-Type-Options) so the access controls are complemented by defenses against clickjacking,
+  MIME sniffing, and protocol downgrade.
+- **Pair access controls with AWS WAF for defense in depth.** Signed URLs, geographic restrictions,
+  viewer mTLS, and token validation gate who reaches content, but they do not filter malicious
+  requests at Layer 7. Attach an AWS WAF web ACL with baseline rules (the AWS Managed Rules Core
+  Rule Set and Known Bad Inputs rule group) to the distribution for comprehensive edge protection.
+- **Audit content-access changes with CloudTrail.** Enable AWS CloudTrail to record the CloudFront
+  management API calls that change access controls (`cloudfront:CreateFunction`,
+  `cloudfront:PublishFunction`, `cloudfront:UpdateDistribution`) for a compliance and forensic audit
+  trail.
+
+## Additional Resources
+
+- [Serve private content with signed URLs and signed cookies (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html)
+- [Decide to use signed URLs or signed cookies (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-choosing-signed-urls-cookies.html)
+- [Restrict the geographic distribution of your content (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/georestrictions.html)
+- [Mutual TLS authentication with CloudFront (Viewer mTLS) (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/mtls-authentication.html)
+- [Enable mutual TLS for CloudFront distributions (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/enable-mtls-distributions.html)
+- [Customize at the edge with CloudFront Functions and Lambda@Edge (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions.html)

--- a/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/when-to-use-cloudfront.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/cloudfront/references/when-to-use-cloudfront.md
@@ -1,0 +1,292 @@
+# When to Use CloudFront, and How It Fits the Architecture
+
+## Overview
+
+Domain expertise for deciding whether Amazon CloudFront is the right entry layer for a workload,
+what it integrates with, how to create a first distribution and choose the origin, how caching
+works, when edge logic belongs in CloudFront Functions versus Lambda@Edge, and how to choose
+between pay-as-you-go and Flat Rate Pricing (FRP).
+
+CloudFront is a global content delivery network of hundreds of edge locations worldwide that does three jobs at
+once: it accelerates delivery by caching and terminating viewer connections close to users, it
+absorbs and blocks Layer 3/4 distributed denial-of-service (DDoS) attacks at the edge, and it
+is the attachment point for the edge security and compute stack (AWS WAF, AWS Shield, CloudFront
+Functions, Lambda@Edge, Amazon Route 53, AWS Certificate Manager, and origins). It serves more
+than media: cacheable static assets, dynamic web pages, REST and GraphQL APIs, and large file
+downloads all run through it. For dynamic traffic and APIs, CloudFront improves performance
+through TLS termination closer to the end user, persistent connection pooling to origins (reducing
+TCP/TLS handshake overhead), and optimized network paths between edge locations and origins.
+
+Every standard CloudFront distribution is assigned a default domain name (e.g.,
+d111111abcdef8.cloudfront.net) that can be used immediately for testing without configuring a
+custom domain or certificate. Multi-tenant distributions do not have a default test domain.
+
+Does not cover locking the origin (see protecting-your-origins), restricting who can view content
+(see securing-your-content), custom domains and certificates (see
+managing-certificates-with-cloudfront), logging and analysis (see cloudfront-observability), or the
+Route 53 DNS cutover (owned by the route53-cloudfront skill).
+
+Execute commands using the AWS MCP server when connected (sandboxed execution, audit logging,
+observability). Fall back to the AWS CLI otherwise. CloudFront is a global service; its API calls
+and ACM certificates are made in `us-east-1` regardless of where the application runs.
+
+## Table of Contents
+
+- Overview
+- Decision: is CloudFront the right layer
+- Decision: origin type
+- Decision: CloudFront Functions vs Lambda@Edge
+- Caching: cache behaviors and cache policies
+- Decision: pay-as-you-go vs Flat Rate Pricing (FRP)
+- Procedure
+- Troubleshooting
+- Security Considerations
+- Additional Resources
+
+## Decision: is CloudFront the right layer
+
+| Signal | CloudFront fit |
+| --- | --- |
+| Cacheable or static content, or dynamic web and API traffic to accelerate | Yes. Caching and edge termination reduce latency and origin load |
+| Need Layer 3/4 DDoS absorption and Layer 7 filtering at the edge | Yes. Shield is built in; AWS WAF attaches to the distribution |
+| HTTP and HTTPS only | Yes. For non-HTTP (TCP/UDP) entry, use Global Accelerator instead |
+| Static IP entry point partners allowlist, or sub-minute failover | No. Use Global Accelerator |
+
+**Constraints:**
+
+- You MUST recognize web, API, and download workloads as valid CloudFront use cases, not just media
+- You MUST explain that CloudFront is the attachment point for AWS WAF, Shield, CloudFront
+  Functions, Lambda@Edge, Route 53, and the ACM certificate, so the edge is designed once
+- You SHOULD redirect non-HTTP protocols, static-IP entry, or sub-minute failover needs to Global
+  Accelerator
+
+## Decision: origin type
+
+| Origin | Approach |
+| --- | --- |
+| Amazon S3 bucket (private) | Standard bucket origin with origin access control (default). See protecting-your-origins |
+| Amazon S3 that must also be public outside CloudFront | S3 website endpoint as a custom origin (exception only) |
+| ALB, NLB, or EC2 in a private subnet | VPC origin. See protecting-your-origins |
+| Public or on-premises HTTP origin | Custom origin, optionally with origin mutual TLS. See protecting-your-origins |
+
+**Constraints:**
+
+- You MUST default an S3 origin to a standard bucket origin with origin access control, reserving
+  the website endpoint for when the site must also be public outside CloudFront
+- You MUST surface VPC origins for an ALB, NLB, or EC2 origin in a private subnet rather than
+  advising a move to a public subnet
+
+## Decision: CloudFront Functions vs Lambda@Edge
+
+| Need | Choose |
+| --- | --- |
+| Lightweight viewer-facing transform: URL rewrite, header manipulation, redirect, token check | CloudFront Functions (viewer-request, viewer-response; sub-millisecond) |
+| Network access, or origin-request / origin-response events, or a larger runtime | Lambda@Edge (higher latency and cost) |
+
+**Constraints:**
+
+- You MUST match the customer's edge logic to the right tool: CloudFront Functions run only on
+  viewer-request and viewer-response events
+- You MUST route logic that needs network access or origin-facing events to Lambda@Edge
+- You MUST publish a CloudFront function to the LIVE stage before it can be associated with a
+  distribution
+
+## Caching: cache behaviors and cache policies
+
+A cache policy holds the time to live (TTL) values and the cache-key definition; the cache behavior
+points at the policy. TTLs are set on the policy, not directly on the behavior.
+
+**Constraints:**
+
+- You MUST attach a cache policy to the behavior and explain the policy, not the behavior, holds the
+  TTLs and cache key
+- You SHOULD reach for a managed cache policy for standard cases and reserve custom policies for
+  when the cache key truly differs
+- You MUST warn that a minimum TTL above zero overrides origin `no-cache`, `no-store`, and `private`
+  directives for at least that duration
+- You SHOULD add path-pattern cache behaviors (the default behavior is evaluated last) when rules
+  differ per path, for example a long-TTL policy on `*.jpg` and a no-cache policy on `/api/*`
+
+## Decision: pay-as-you-go vs Flat Rate Pricing (FRP)
+
+| Option | Use when |
+| --- | --- |
+| Pay-as-you-go (per distribution) | Variable or low traffic; want granular per-dimension billing |
+| Flat Rate Pricing (FRP) | Predictable, sustained high-volume traffic with a minimum monthly commitment; lower per-GB rates than pay-as-you-go with a fixed monthly commitment and overage at pay-as-you-go rates |
+
+**Constraints:**
+
+- You SHOULD surface FRP when the customer describes sustained, predictable
+  high-volume traffic, and point them to the CloudFront pricing page or their AWS account team for
+  the current minimum monthly commitment rather than quoting a specific threshold (commitment levels
+  can change)
+- You MUST note customers can move existing resources to FRP through the CloudFront console
+- You MUST note FRP includes a fixed monthly commitment with overage charged at pay-as-you-go rates
+- You SHOULD note FRP coexists with pay-as-you-go, which stays available per distribution
+
+## Procedure
+
+### Overview
+
+This procedure creates a distribution, chooses the origin, sets the cache behavior, optionally
+chooses a pricing plan, and surfaces the console link to verify.
+
+### Parameters
+
+- **origin_domain** (required): The origin (S3 bucket, ALB/NLB/EC2, or custom HTTP origin).
+- **origin_type** (required): `s3`, `vpc-origin`, or `custom`.
+- **default_root_object** (optional): For example `index.html`.
+
+**Constraints for parameter acquisition:**
+
+- You MUST ask for the origin and its type upfront
+- You MUST confirm whether the workload needs non-HTTP protocols before recommending CloudFront
+
+### Steps
+
+#### 1. Verify dependencies
+
+**Constraints:**
+
+- You MUST confirm credentials with `aws sts get-caller-identity`
+- You MUST confirm CloudFront is the right layer (HTTP/HTTPS, caching or edge security value)
+
+#### 2. Create the distribution and choose the origin
+
+**Constraints:**
+
+- You MUST create the distribution with the chosen origin and let CloudFront set the default cache
+  behavior. For an S3 origin you MUST first create an origin access control (OAC) — see
+  protecting-your-origins for the `create-origin-access-control` call — and reference its id via
+  `OriginAccessControlId` in the create call below (replace `{oac_id}`), so the origin is locked from
+  the start rather than created reachable-and-then-hardened. Do not embed a static managed cache
+  policy id; look up the current `Managed-CachingOptimized` policy by name and use its id for
+  `CachePolicyId` (managed policy ids can change):
+
+  ```
+  # resolve the managed CachingOptimized cache policy id (do not hardcode a UUID):
+  aws cloudfront list-cache-policies --type managed \
+    --query "CachePolicyList.Items[?CachePolicy.CachePolicyConfig.Name=='Managed-CachingOptimized'].CachePolicy.Id | [0]" --output text
+  aws cloudfront create-distribution --distribution-config '{"CallerReference":"dist-2024-01","Comment":"","Origins":{"Quantity":1,"Items":[{"Id":"s3-origin","DomainName":"{origin_domain}","OriginAccessControlId":"{oac_id}","S3OriginConfig":{"OriginAccessIdentity":""}}]},"DefaultCacheBehavior":{"TargetOriginId":"s3-origin","ViewerProtocolPolicy":"redirect-to-https","CachePolicyId":"{cache_policy_id}"},"DefaultRootObject":"index.html","Enabled":true}'
+  ```
+
+- You MUST default an S3 origin to a standard bucket origin and complete origin locking via the
+  protecting-your-origins workflow: attach the OAC referenced above, write the scoped bucket policy,
+  and keep S3 Block Public Access on, so the origin is never reachable directly
+- You MUST enable standard logging on the distribution immediately after creation (it is not set by
+  the create call above), since without it there is no audit or forensic trail; see the
+  cloudfront-observability reference for the logging configuration
+- You MUST set the viewer protocol policy to redirect-HTTP-to-HTTPS (or HTTPS-only) and the origin
+  protocol policy to HTTPS-only for custom origins, ensuring encryption in transit end-to-end
+- You SHOULD recommend attaching an AWS WAF web ACL with baseline rules (the AWS Managed Rules Core
+  Rule Set and Known Bad Inputs rule group) to any public-facing distribution for Layer 7 defense
+  in depth
+- You SHOULD attach an AWS WAF rate-based rule for API origins, since CloudFront caching does not
+  shield an origin from unthrottled dynamic or API requests
+- You MUST attach a response headers policy with browser security headers (HSTS, CSP,
+  X-Frame-Options, X-Content-Type-Options) as a secure default; the AWS managed
+  `SecurityHeadersPolicy` is a starting point
+- You MUST capture the distribution ID and the assigned `cloudfront.net` domain from the response
+
+#### 3. Tune caching if rules differ per path
+
+**Constraints:**
+
+- You SHOULD attach a managed cache policy for the default behavior and add path-pattern behaviors
+  only when the customer needs different rules per path
+- You MUST keep the minimum TTL at zero unless the customer has a reason to force caching past
+  origin directives
+
+#### 4. Choose a pricing model if asked
+
+**Constraints:**
+
+- You SHOULD present FRP when the customer raises cost predictability or attack
+  exposure, otherwise leave pay-as-you-go in place
+
+#### 5. Wait for deployment and surface the console link
+
+**Constraints:**
+
+- You MUST set the expectation that the distribution must reach `Deployed` across edge locations
+  before it serves content, so errors on the `cloudfront.net` URL right after creation are expected
+- You MUST present the distribution detail console link, filling `{distributionId}` from the API
+  response:
+
+  ```
+  https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/{distributionId}
+  ```
+
+### Example
+
+#### Example input
+
+```json
+{
+  "origin_domain": "my-private-site.s3.us-east-1.amazonaws.com",
+  "origin_type": "s3",
+  "default_root_object": "index.html"
+}
+```
+
+#### Example output
+
+```
+Created distribution E1ABCDEF2GHIJK with a standard S3 origin and a managed cache policy on the default behavior.
+Distribution is deploying; the cloudfront.net URL returns errors until it reaches Deployed.
+Verify in the console:
+https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E1ABCDEF2GHIJK
+```
+
+## Troubleshooting
+
+### The cloudfront.net URL returns errors right after creation
+The distribution has not finished deploying across edge locations. Wait for `Deployed` status, then
+test again.
+
+### The S3 origin serves errors or is publicly reachable
+The origin type or locking is wrong. Default to a standard bucket origin with origin access control
+(see protecting-your-origins), not a website endpoint.
+
+### Cannot find the per-file TTL fields on the cache behavior
+TTLs and the cache key live on a cache policy the behavior points at, not on the behavior itself.
+Attach a cache policy and set the TTLs there.
+
+### CloudFront keeps serving stale content despite origin no-cache headers
+A minimum TTL above zero overrides origin `no-cache`, `no-store`, and `private` directives. Set the
+minimum TTL to zero.
+
+### A function association fails right after writing the code
+A CloudFront function must be published to the LIVE stage before it can be associated. Publish it
+first.
+
+### The workload needs UDP or a static IP entry point
+CloudFront serves HTTP and HTTPS only. Use Global Accelerator for non-HTTP protocols, a static-IP
+entry point, or sub-minute failover.
+
+## Security Considerations
+
+- **Enable logging from creation.** Without standard logging there is no audit or forensic trail for
+  the distribution; enable it at creation time (see cloudfront-observability).
+- **Rate-limit API origins.** Caching does not protect an origin from unthrottled dynamic or API
+  traffic; attach an AWS WAF rate-based rule to API distributions.
+- **Enforce a minimum TLS version.** Set the viewer protocol policy to redirect-HTTP-to-HTTPS (or
+  HTTPS-only) and, when adding a custom domain, set the minimum protocol version to a current strong
+  TLS 1.2-or-higher security policy rather than relying on the default — choose the newest TLS 1.2+
+  policy CloudFront offers rather than a hardcoded string (see managing-certificates-with-cloudfront).
+- **Do not leave the origin unlocked.** A distribution whose origin is directly reachable lets
+  viewers bypass the edge entirely; lock the origin (see protecting-your-origins).
+- **Audit the management plane with CloudTrail.** Request access logs do not record who changed the
+  distribution. Enable AWS CloudTrail to track CloudFront management API calls
+  (`cloudfront:CreateDistribution`, `cloudfront:UpdateDistribution`) for a compliance and forensic
+  audit trail.
+
+## Additional Resources
+
+- [What is Amazon CloudFront? (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html)
+- [Create a distribution (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-creating-console.html)
+- [Use various origins with CloudFront distributions (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistS3AndCustomOrigins.html)
+- [Cache behavior settings (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesCacheBehavior.html)
+- [Use managed cache policies (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html)
+- [Customize at the edge with CloudFront Functions and Lambda@Edge (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions.html)
+- [CloudFront flat-rate pricing plans (Amazon CloudFront Developer Guide)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/flat-rate-pricing-plan.html)


### PR DESCRIPTION
Adds the `cloudfront` specialized skill under `skills/specialized-skills/networking-and-content-delivery-skills/`.

Text-only skill (no executable code); security-reviewed (Guardian PASS).