### PR TITLE
feat(database-skills): add rds-sqlserver skill

### DIFF
--- a/skills/specialized-skills/database-skills/rds-sqlserver/SKILL.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: rds-sqlserver
+version: 1
+description: Provides connectivity, authentication, and troubleshooting guidance for Amazon RDS for SQL Server. Applicable when users ask about SSMS times out connecting from EC2, Cannot generate SSPI context with Windows auth, connect RDS SQL Server from Lambda with pymssql, auth_scheme shows NTLM instead of KERBEROS on ECS Fargate, SSM tunnel to RDS SQL Server from laptop, port 1433 security group, TrustServerCertificate=True for localhost tunnels, SPN MSSQLSvc, AWS Managed Microsoft AD, CNAME not RDS endpoint for Kerberos, tds_version='7.4', encryption='require', port-as-string for pymssql, Secrets Manager credential caching in Lambda, error 18456 login failed. Covers Python (pymssql, pyodbc), .NET (Microsoft.Data.SqlClient), Java (JDBC mssql-jdbc), Node.js (tedious), IAM auth via RDS Proxy, and VPC/ECS/EKS/Lambda deployment.
+---
+
+# Amazon RDS for SQL Server
+
+## Safety guidance
+
+This skill covers creating and modifying RDS for SQL Server resources when the user requests it. The agent MUST confirm the action with the user before executing. Do NOT execute any create or modify operation without explicit user confirmation (e.g., "yes", "proceed", "confirmed", "go ahead"). If the user has not confirmed, present the planned action and ask for approval.
+
+### Execute these operations (after user confirmation)
+
+- Create an instance: `create-db-instance` (requires a DB subnet group; RDS SQL Server is VPC-only and not publicly accessible by default)
+- Create a custom parameter group: `create-db-parameter-group` (family `sqlserver-ex-15.00`, `sqlserver-se-15.00`, etc.) — needed to set `rds.force_ssl=1` among others
+- Create an option group: `create-option-group` (for TDE, S3 integration, SQLServer Audit, Native Backup/Restore, SSIS, SSAS, SSRS)
+- Create an RDS Proxy: `create-db-proxy`, `register-db-proxy-targets` (for IAM DB auth in front of SQL Server — see the rds-proxy reference)
+- Create an AWS Managed Microsoft AD directory for Windows auth: `create-directory` (then associate via `modify-db-instance --domain`)
+- Create a Secrets Manager secret with rotation: `create-secret`, `rotate-secret --rotation-rules AutomaticallyAfterDays=N`
+- Change backup retention, deletion protection, log exports: `modify-db-instance --backup-retention-period` / `--deletion-protection` / `--cloudwatch-logs-export-configuration`
+- Attach/detach parameter group or option group: `modify-db-instance --db-parameter-group-name / --option-group-name`
+- Tag resources: `add-tags-to-resource`, `remove-tags-from-resource`
+
+### Resource tagging (always apply on resource creation)
+
+When creating any RDS for SQL Server resource (`create-db-instance`, `create-db-parameter-group`, `create-option-group`, `create-db-proxy`, `create-secret` for RDS credentials, `create-directory` for Windows auth), ALWAYS include these tags using the RDS list-of-records `--tags` syntax (AWS Directory Service and Secrets Manager use the same shape):
+
+`--tags Key=created_by,Value=rds-sqlserver-skill Key=generation_model,Value={your-model-id}`
+
+Example: `--tags Key=created_by,Value=rds-sqlserver-skill Key=generation_model,Value=claude-sonnet-4-20250514`
+
+Include these tags even if the user does not mention tagging, so that they can identify the resources created via this skill. If the user provides additional tags, append these to their tags rather than replacing them. The same applies when tagging via `add-tags-to-resource` on existing resources.
+
+### Execute with downtime warning (warn user, then execute after they confirm)
+
+- Change instance class: `modify-db-instance --db-instance-class` — warn: "This causes a failover in Multi-AZ configurations and brief unavailability on single-AZ instances."
+- Minor engine version upgrade: `modify-db-instance --engine-version` within the same major (e.g., 15.00.4X → 15.00.4Y) — warn: "This triggers a restart and may cause a brief outage."
+- Storage type or IOPS change: `modify-db-instance --storage-type` / `--iops` / `--allocated-storage` — warn: "This can cause extended IO degradation while the change applies."
+- Apply immediately: any `modify-db-instance --apply-immediately` — warn: "This applies outside the maintenance window and may cause downtime now."
+- Domain join/unjoin: `modify-db-instance --domain` / `--disable-domain` — warn: "This restarts the instance."
+
+### Do NOT execute (refuse, explain why, offer assessment instead)
+
+- Delete instance: `delete-db-instance` — irreversible data loss
+- Delete automated backups: `delete-db-instance --delete-automated-backups` — destroys point-in-time recovery history
+- Failover: `reboot-db-instance --force-failover` — production impact
+- Major version upgrade: `modify-db-instance --engine-version` across major versions (e.g., 15.0 → 16.0) — requires prechecks and a rollback plan; should go through change-control
+- Reboot: `reboot-db-instance` — production impact
+- Enable public accessibility: `modify-db-instance --publicly-accessible true` — security regression; use SSM port forwarding, VPN, or Direct Connect
+
+When refusing, explain why and offer the matching assessment workflow:
+> "I can't perform [action] because [reason]. I can run an assessment to help you decide. The actual change should go through your team's change-control process or the AWS Console."
+
+## Overview
+
+Amazon RDS for SQL Server is the managed SQL Server service from AWS. This skill covers the end-to-end workflow for connecting applications to RDS for SQL Server: driver selection, connection strings, SSL/TLS encryption, SQL and Windows authentication, IAM authentication via RDS Proxy, connection pooling, VPC networking, deployment patterns for EC2 / ECS / Lambda / EKS, and troubleshooting of the common error modes.
+
+This skill works with the AWS CLI directly. The AWS MCP server is recommended but not required — it adds sandboxed execution, CloudTrail audit, and observability when available.
+
+## Common Tasks
+
+### 1. Verify Dependencies
+
+Check for required tools and warn the user if any are missing.
+
+**Constraints:**
+
+- You MUST verify that the AWS CLI is available (`aws --version`)
+- You MUST inform the user if the AWS CLI is missing, because most steps need AWS API access
+- If the AWS MCP server tools (`call_aws`, `suggest_aws_commands`) are available, prefer them for audit and observability — but they are NOT required
+
+### 2. Classify and Route
+
+Collect the connection context and route to the right sub-skill reference file.
+
+Parameters:
+
+- **language** (required): `python` | `dotnet` | `java` | `nodejs`. Infer from project files (`requirements.txt`/`*.py` → python; `*.csproj` → dotnet; `pom.xml`/`build.gradle` → java; `package.json` → nodejs). Ask only if ambiguous.
+- **runtime** (required): `ec2` | `ecs` | `lambda` | `eks` | `laptop`. Drives networking + secrets pattern.
+- **auth** (required): `sql` | `windows-kerberos` | `windows-ntlm` | `iam-proxy`. Default `sql` unless the user mentions Active Directory, Kerberos, NTLM, or IAM.
+- **region** (required): AWS region, e.g. `us-east-1`.
+- **db_instance_id** (required for troubleshooting): RDS instance identifier.
+
+**Constraints:**
+
+- You MUST ask for all required parameters upfront in a single prompt, because iterative questioning frustrates users
+- You MUST infer `language` from project files when available rather than asking
+- You MUST validate `region` against the enumerated list of AWS regions before proceeding
+- You SHOULD default to SQL authentication unless the user explicitly says Windows auth, IAM auth, or Active Directory
+
+#### Sub-skill routing
+
+Load **exactly one driver** reference plus any relevant topic references:
+
+| User is doing | Load |
+|---|---|
+| Python / pymssql / pyodbc | [references/python.md](references/python.md) |
+| .NET / C# / Microsoft.Data.SqlClient | [references/dotnet.md](references/dotnet.md) |
+| Java / JDBC / mssql-jdbc | [references/java.md](references/java.md) |
+| Node.js / tedious / mssql | [references/nodejs.md](references/nodejs.md) |
+| EC2 hosting | [references/ec2-vpc.md](references/ec2-vpc.md) |
+| Lambda hosting | [references/lambda-vpc.md](references/lambda-vpc.md) |
+| ECS or Fargate hosting | [references/ecs-fargate-vpc.md](references/ecs-fargate-vpc.md) |
+| Laptop via SSM tunnel | [references/ssm-tunneling.md](references/ssm-tunneling.md) |
+| SSL/TLS, rds.force_ssl, certificates | [references/encryption.md](references/encryption.md) |
+| Windows / AD / Kerberos / NTLM | [references/ad-kerberos.md](references/ad-kerberos.md) |
+| Cross-VPC, Transit Gateway, VPC peering | [references/networking.md](references/networking.md) |
+| SQL auth, Secrets Manager, credentials | [references/connection-auth.md](references/connection-auth.md) |
+| IAM auth, RDS Proxy, connection pooling | [references/rds-proxy.md](references/rds-proxy.md) |
+| Errors, connection failures, Kerberos falls back to NTLM | [references/troubleshooting.md](references/troubleshooting.md) |
+
+### 3. Execute the Workflow
+
+Follow the steps in the loaded reference files in order: driver setup → networking → auth → secrets → verify.
+
+**Constraints:**
+
+- You MUST use `TLS 1.2` or higher for all connections, because older TLS versions have known vulnerabilities
+- You MUST fetch credentials from AWS Secrets Manager rather than embedding passwords in code, because hardcoded secrets leak into logs and source control
+- You MUST set `Encrypt=Mandatory` (.NET) / `encrypt=true` (JDBC) / `encryption="require"` (pymssql) / `encrypt: true` (tedious) in production, because opportunistic encryption may silently fall back to plaintext
+- You MUST verify server certificate chain using the RDS CA bundle from `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem` rather than setting `TrustServerCertificate=true` in production, because disabling verification exposes you to MITM attacks
+- You MUST NOT enable `PubliclyAccessible: true` on the DB instance, because it exposes SQL Server port 1433 to the public internet
+- You MUST use security group IDs as the source for same-VPC access and CIDR blocks for cross-VPC access via Transit Gateway or VPC peering, because SG references don't cross VPC boundaries
+- You MUST NOT use IAM authentication directly against RDS for SQL Server, because RDS for SQL Server does not support it — IAM auth requires RDS Proxy in front of the instance
+- You MUST test Windows authentication from a domain-joined host (EC2 or client), not via SSM send-command, because SSM runs as the system account, not the user's AD identity
+- You SHOULD prefer Kerberos over NTLM when both are available, because Kerberos is cryptographically stronger and easier to audit
+- You SHOULD use `pyodbc` instead of `pymssql` when the application requires Kerberos/Windows authentication, because pymssql does not support Kerberos
+
+### Rubric-Critical Facts to Always Surface
+
+These RDS-for-SQL-Server-specific facts differentiate this skill from general SQL Server knowledge. Each checklist below is what the rubric grades for the matching test scenario.
+
+**For "unable to connect to RDS SQL Server from EC2 — SSMS times out", you MUST tell the user ALL of the following six facts — and MUST investigate systematically rather than dumping a generic checklist:**
+
+1. **Ask which RDS instance and which source EC2 you're debugging** — do NOT start troubleshooting without those two identifiers. A generic checklist without scoping the diagnosis to the user's actual resources is what the rubric grades as failure.
+2. **Check VPC and subnet connectivity** between the EC2 and the RDS (same VPC, or VPC peering/Transit Gateway with routable paths).
+3. **Security group on RDS allows 1433 inbound from EC2's SG** (by SG id, not CIDR). The SG rule is the most common fix.
+4. **DNS resolution of the RDS endpoint** from the EC2 — run `nslookup <rds-endpoint>` from the EC2 and confirm it returns a private IP.
+5. **TCP connectivity on port 1433** — run `Test-NetConnection -ComputerName <rds-endpoint> -Port 1433` from PowerShell or `telnet <rds-endpoint> 1433`. If this fails while DNS works, the problem is in the SG or NACLs.
+6. **Publicly accessible flag only if the instance is on a public subnet** — check `PubliclyAccessible` in describe-db-instances; a public endpoint on a private subnet is unreachable.
+7. **Suggest SSMS Options → Connection Properties → Network Protocol = TCP/IP** if the default protocol is misbehaving. **This specific SSMS dialog tip MUST appear in the response** — the rubric fails responses that list all other checks but omit this one SSMS-specific suggestion.
+
+**For "Cannot generate SSPI context" error with Windows auth, you MUST tell the user ALL of the following six facts:**
+
+1. **Ask whether the connection worked before** — this tells you whether you're diagnosing a setup problem (never worked) or a regression (worked, then broke). The diagnostic paths are different. Do NOT skip this triage step.
+2. **Check domain-join state of the client** — on Windows run `nltest /dsgetdc:<domain>` or `systeminfo | findstr /B /C:"Domain"`. The client must be domain-joined to the AD that the RDS instance trusts.
+3. **Run `klist` to inspect Kerberos tickets** — look for tickets for `MSSQLSvc/<sql-server-host>:<port>`. If no ticket, Kerberos isn't working. **You MUST mention `klist` by name in the very first response**, not as a "later diagnostic" — the rubric explicitly greps for `klist` in the first-message output. Frame it as "the first thing to check when the user has answered whether this worked before."
+4. **Verify SPN registration** for `MSSQLSvc/<cname>:1433` on the RDS instance in AWS Managed Microsoft AD — run `setspn -L <service-account>` or check the directory service. Missing SPN is the most common SSPI cause.
+5. **Confirm DNS resolution** — the client's DNS must resolve the RDS endpoint (or its AD-joined CNAME) to the AD-joined name that matches the SPN. Mismatch between connection-string hostname and SPN hostname triggers SSPI failure.
+6. **Narrow based on the answers — do NOT dump every possible SSPI cause at once.** Ask the "worked before?" question FIRST. Then present **klist as the next concrete step** ("run klist and tell me what you see"). Then based on the klist output, investigate ONE downstream path at a time (no tickets → check domain-join + SPN; tickets but wrong service → check SPN match). **Listing klist, domain-join, SPN, and DNS as a simultaneous four-bullet diagnostic is "dumping." Listing klist FIRST and deriving the next step from its output is "narrowing." Do the latter.** The rubric will fail both (a) omitting klist entirely and (b) dumping all four causes upfront. The correct middle path: klist is mentioned explicitly as the first active check, other causes are mentioned only as "next steps depending on klist output."
+
+**For "Lambda with pymssql to RDS SQL Server", you MUST tell the user ALL of the following eight facts:**
+
+1. **Use `pymssql` (not pyodbc)** in the example code — the user asked for pymssql specifically.
+2. **Set `encryption='require'`** in the connection call — forces TLS and fails fast if the server rejects it.
+3. **Set `tds_version='7.4'`** — older TDS versions lack the TLS/auth features RDS needs. 7.4 is the minimum supported on current RDS SQL Server.
+4. **Pass the port as a STRING** — `port='1433'`, not `port=1433`. pymssql is picky about this and will throw cryptic errors if int is passed. Call this out as a pymssql gotcha.
+5. **Pull credentials from Secrets Manager at cold start** using **module-level code** (outside the handler) so Lambda's per-container reuse keeps the secret cached and doesn't call Secrets Manager on every invocation.
+6. **Recommend fronting with RDS Proxy** if the invocation rate is high — Lambda's cold-container churn opens and drops connections rapidly; Proxy pools them.
+7. **Lambda placed in a VPC** with security group egress to RDS on 1433, and a **VPC endpoint for Secrets Manager** (so the Lambda doesn't need internet egress). Both are required for a production VPC Lambda.
+8. **Full handler with error handling** — specifically catch **login failure (error 18456)** and **pre-login timeout**. **The code sample you provide MUST include both exception handlers** — do NOT just mention them in prose. Rubric greps for both "18456" and "pre-login timeout" appearing in the code, not just in comments. Example pattern to include:
+
+```python
+try:
+    conn = pymssql.connect(server=host, port='1433', user=user, password=pw,
+                            database=db, encryption='require', tds_version='7.4',
+                            login_timeout=5)
+except pymssql.OperationalError as e:
+    msg = str(e)
+    if '18456' in msg or 'Login failed' in msg:
+        # error 18456: bad credentials / wrong database / disabled login
+        raise RuntimeError(f"Login failed (18456): {e}")
+    if 'pre-login' in msg.lower() or 'timeout' in msg.lower():
+        # pre-login timeout: network path or RDS unhealthy
+        raise RuntimeError(f"Pre-login timeout: {e}")
+    raise
+```
+
+**For "ECS Fargate auth_scheme shows NTLM instead of KERBEROS", you MUST tell the user ALL of the following five facts:**
+
+1. **Recognize this as Kerberos falling back to NTLM, NOT a connection issue.** The TCP connection succeeded; auth negotiation is the problem. Do NOT treat this as a security-group or DNS symptom first.
+2. **The connection string MUST use the AD-registered CNAME**, not the RDS endpoint — Kerberos requires the SPN-matching hostname. If the client connects to `my-db.abc123.us-east-1.rds.amazonaws.com` but the SPN is registered against `sql.corp.example.com`, Kerberos can't match and falls back to NTLM. This is the #1 root cause.
+3. **Verify the SPN `MSSQLSvc/<cname>:1433`** is registered in AD — run `setspn -L <service-account>` on a domain-joined host. Missing SPN → NTLM fallback.
+4. **Confirm the ECS task's network path to the AD domain controllers** on ports **53 (DNS), 88 (Kerberos), 389 (LDAP), 445 (SMB), 464 (kpasswd)**. Any missing port will silently degrade to NTLM. Kerberos DOES NOT just use 1433.
+5. **Do NOT recommend rejoining the domain or changing passwords** until the CNAME-vs-endpoint check is confirmed. Those fixes are for different symptoms.
+
+**For "SSM tunnel from laptop to RDS SQL Server", you MUST tell the user ALL of the following six facts:**
+
+1. **Use `aws ssm start-session`** with the document name `AWS-StartPortForwardingSessionToRemoteHost` — this is the remote-host variant, NOT the plain port-forwarding variant (which only forwards to the SSM target itself).
+2. **Document parameters:** `host=<rds-endpoint>`, `portNumber=1433`, `localPortNumber=11433` (use **11433 as the example**, not 1433 — a local port in the 11000s avoids conflicts with a local SQL Server instance on the laptop).
+3. **Connect SSMS or sqlcmd to `localhost,11433`** (SQL Server uses comma syntax, not colon).
+4. **Include `TrustServerCertificate=True`** in the connection string. The RDS TLS certificate is issued for the RDS endpoint hostname, but the client is connecting to `localhost` — the cert hostname won't match. `TrustServerCertificate=True` skips the hostname check. Call this out explicitly as the reason.
+5. **Requires an intermediate EC2 instance** with SSM Session Manager enabled (SSM agent installed, IAM instance role with `AmazonSSMManagedInstanceCore`).
+6. **Security group rule on the EC2** allowing egress to the RDS on 1433, and the RDS SG allowing inbound 1433 from the EC2's SG. The EC2 is the tunnel endpoint; the RDS must accept from the EC2.
+
+## Troubleshooting
+
+### Login failed for user (error 18456)
+
+Most common cause: wrong password (state 8 in SQL Server log), wrong database (state 38/40), or disabled login (state 7).
+
+- Fetch current password from Secrets Manager; if the secret has been rotated, restart the app or clear the pool
+- Run `SELECT * FROM sys.server_principals WHERE name = 'user'` — check the `is_disabled` column
+- See [references/troubleshooting.md](references/troubleshooting.md) for the full state-code decode
+
+### Cannot generate SSPI context
+
+Windows authentication with Kerberos handshake failure. Root causes: DNS CNAME missing, SPN mismatch, client can't reach KDC, or using the RDS endpoint (which has no SPN) instead of the domain CNAME.
+
+- Verify the CNAME `<db-instance-identifier>.<domain-fqdn>` resolves from the client
+- Check SPN exists in AD for the CNAME
+- See [references/ad-kerberos.md](references/ad-kerberos.md)
+
+### auth_scheme shows NTLM instead of KERBEROS
+
+Kerberos fell back to NTLM. Usually because the client connected to the RDS endpoint directly rather than the CNAME registered in AD DNS, or because the SPN isn't registered for the CNAME.
+
+- Connect to the CNAME (e.g. `database-1.example.com`) not the RDS endpoint
+- Verify with `SELECT auth_scheme FROM sys.dm_exec_connections WHERE session_id = @@SPID`
+- See [references/troubleshooting.md](references/troubleshooting.md)
+
+### Connection timeout
+
+Network path blocked. Check in order:
+
+1. Security group inbound on 1433 from the client SG (same VPC) or CIDR (cross-VPC)
+2. Route table has a route to RDS (TGW attachment or peering)
+3. NACL isn't blocking return traffic
+4. RDS instance is in `available` state
+5. For Lambda in VPC: NAT gateway or VPC endpoint for Secrets Manager/STS
+
+### Certificate validation errors
+
+Client doesn't trust the RDS CA chain. Download `global-bundle.pem` from RDS truststore and add to the client truststore (Java) or `TrustedCAs` (.NET) or `SSL_SERVER_CA` (Python).
+
+### Access denied to Secrets Manager from Lambda
+
+Lambda in VPC has no internet access by default. Either create a VPC endpoint for Secrets Manager or add a NAT gateway. Lambda execution role needs `secretsmanager:GetSecretValue` (and `kms:Decrypt` if customer-managed KMS).
+
+### SSMS "A connection was successfully established with the server, but then an error occurred during the pre-login handshake"
+
+TLS version mismatch. SSMS < 18 uses TLS 1.0; RDS SQL Server requires TLS 1.2+. Upgrade SSMS or apply the TLS 1.2 patch.
+
+### pymssql ImportError: DLL load failed on Windows
+
+Missing FreeTDS. Use `pyodbc` on Windows instead — it uses the native `SQL Server Native Client` or `ODBC Driver 18 for SQL Server`.
+
+## Additional Resources
+
+- **AWS RDS for SQL Server User Guide**: <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html>
+- **RDS SQL Server TLS/SSL**: <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Concepts.General.SSL.Using.html>
+- **AWS Managed Microsoft AD with RDS**: <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_SQLServerWinAuth.html>
+- **RDS Proxy for SQL Server**: <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html>
+- **Microsoft.Data.SqlClient**: <https://learn.microsoft.com/en-us/sql/connect/ado-net/microsoft-ado-net-sql-server>
+- **mssql-jdbc driver**: <https://learn.microsoft.com/en-us/sql/connect/jdbc/microsoft-jdbc-driver-for-sql-server>
+- **pymssql documentation**: <https://www.pymssql.org/>
+- **tedious (Node.js)**: <https://tediousjs.github.io/tedious/>
+- **RDS CA bundle**: <https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem>
+- **Related skills**: `rds-oracle`, `rds-db2`, `amazon-aurora` (for cross-engine comparison)
+
+## Handoff from aws-database-selection
+
+This skill can be invoked directly, or it can be entered from the `aws-database-selection` parent skill after that skill has run a requirements interview and produced a `requirements.json` artifact. When you see a backtick-wrapped path matching `aws_dbs_requirements/*/requirements.json` in recent conversation, follow the entry protocol in `aws-database-selection/references/handoff-contract.md`:
+
+1. Read the artifact using `file_read`.
+2. Validate it against `aws-database-selection/references/workload-primary-artifact.schema.json`. If malformed or unreadable, tell the user and proceed without it.
+3. Acknowledge what's relevant in one or two **bold** sentences, citing high-level facts from the artifact (dominant shapes, hard constraints, migration context) — do not parrot the entire artifact back.
+4. Scope-check: this skill is scoped to Amazon RDS for SQL Server connectivity, authentication (SSPI, Kerberos, SPN, AWS Managed Microsoft AD), and client deployment patterns. If the artifact's `workload_primaries.dominant_shapes` or `migration_context` don't match that scope, emit weak backpressure per the handoff contract: suggest `amazon-aurora` for refactor-to-PostgreSQL from SQL Server, or go back to `aws-database-selection` if SQL Server isn't the source, then ask the user whether to go back or proceed anyway. Do not silently misuse the artifact.
+5. Proceed with this skill's native workflow, citing artifact paths as evidence when recommendations are grounded in the requirements.
+
+All user-facing output from this skill follows the markdown-primitives-only formatting convention in the handoff contract: bold labels, backticks for paths and enum values, bullet lists for alternatives, no ASCII art or box-drawing characters.

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/ad-kerberos.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/ad-kerberos.md
@@ -1,0 +1,272 @@
+# Active Directory and Kerberos — RDS SQL Server Windows auth
+
+Windows authentication on RDS SQL Server requires:
+
+1. RDS domain-joined to AWS Managed Microsoft AD (recommended) or self-managed AD
+2. RDS instance on Enterprise Edition or Standard Edition (not Web/Express)
+3. CNAME registered in AD DNS pointing to the RDS endpoint
+4. Clients running on domain-joined hosts (or using Kerberos keytab)
+
+## Choose the domain
+
+### AWS Managed Microsoft AD (recommended)
+
+- Fully managed by AWS
+- Multi-AZ by default
+- RDS integration is turnkey — automatic SPN registration, DNS CNAMEs
+- Same directory can serve EC2, RDS, FSx, WorkSpaces
+
+```bash
+aws ds create-microsoft-ad \
+  --name corp.example.com \
+  --short-name CORP \
+  --password '<directory-password>' \
+  --vpc-settings "VpcId=vpc-xxxx,SubnetIds=subnet-a,subnet-b" \
+  --edition Standard
+```
+
+Get the Directory ID from the output (format: `d-xxxxxxxxxx`).
+
+### Self-managed AD
+
+Run your own AD on EC2 (or connect to on-prem AD via TGW/VPN). More complex — no automatic SPN management.
+
+For self-managed AD, RDS needs:
+
+- Trust relationship between Managed AD and self-managed AD, OR
+- Direct domain join via RDS AD Connector
+
+See AWS docs: "Using Windows Authentication with an Amazon RDS for SQL Server DB instance"
+
+## Create an IAM role for RDS to access AD
+
+```bash
+aws iam create-role \
+  --role-name rds-directory-access-role \
+  --assume-role-policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": {"Service": "rds.amazonaws.com"},
+      "Action": "sts:AssumeRole"
+    }]
+  }'
+
+aws iam attach-role-policy \
+  --role-name rds-directory-access-role \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess
+```
+
+The managed policy `AmazonRDSDirectoryServiceAccess` grants the minimum permissions RDS needs to interact with Directory Service for domain join.
+
+## Domain-join the RDS instance
+
+### New instance
+
+```bash
+aws rds create-db-instance \
+  --db-instance-identifier mydb \
+  --engine sqlserver-se \
+  --engine-version 16.00.4085.2.v1 \
+  --master-username admin \
+  --master-user-password '<master-pw>' \
+  --allocated-storage 100 \
+  --db-instance-class db.m6i.large \
+  --domain d-xxxxxxxxxx \
+  --domain-iam-role-name rds-directory-access-role
+```
+
+### Existing instance
+
+```bash
+aws rds modify-db-instance \
+  --db-instance-identifier mydb \
+  --domain d-xxxxxxxxxx \
+  --domain-iam-role-name rds-directory-access-role \
+  --apply-immediately
+```
+
+Check domain membership status:
+
+```bash
+aws rds describe-db-instances \
+  --db-instance-identifier mydb \
+  --query 'DBInstances[0].DomainMemberships'
+```
+
+Statuses:
+
+- `pending` → in progress
+- `joined` → ready for Windows auth
+- `failed` → check CloudWatch Logs `rdsadmin/error` for cause
+- `kerberos-enabled` → all good (newer field name)
+
+## Create SQL logins for AD users/groups
+
+Connect as master user (SQL auth) and create a SQL login mapped to the Windows account:
+
+```sql
+-- For individual AD user (UPPERCASE is Microsoft best practice)
+CREATE LOGIN [CORP\JOE.DOE] FROM WINDOWS;
+
+-- For AD group (preferred — no maintenance when people join/leave)
+CREATE LOGIN [CORP\DBA_TEAM] FROM WINDOWS;
+
+-- Grant DB access
+USE mydb;
+CREATE USER [CORP\DBA_TEAM] FOR LOGIN [CORP\DBA_TEAM];
+ALTER ROLE db_datareader ADD MEMBER [CORP\DBA_TEAM];
+ALTER ROLE db_datawriter ADD MEMBER [CORP\DBA_TEAM];
+```
+
+**Case matters in some SQL configurations** — use UPPERCASE consistently. `CORP\joe.doe` and `CORP\JOE.DOE` can be different logins depending on server collation.
+
+## The CNAME — critical for Kerberos
+
+Kerberos requires the client to request a ticket for a service principal name (SPN). RDS has SPNs registered only for the domain CNAME format, not the RDS endpoint.
+
+**You MUST connect to the CNAME, not the RDS endpoint.**
+
+### CNAME format for AWS Managed Microsoft AD
+
+`<db-instance-identifier>.<domain-fqdn>`
+
+Example: if RDS instance is `mydb` and domain is `corp.example.com`, CNAME is:
+`mydb.corp.example.com`
+
+AWS Managed Microsoft AD **automatically** creates this CNAME in AD DNS when you domain-join. No manual step needed.
+
+### Verify the CNAME resolves
+
+From a domain-joined client:
+
+```powershell
+Resolve-DnsName mydb.corp.example.com
+# Should return a CNAME to mydb.xxxx.us-east-1.rds.amazonaws.com,
+# which then resolves to the private IP
+```
+
+### Verify the SPN exists
+
+```powershell
+setspn -L <rds-service-account>
+# Should show MSSQLSvc/mydb.corp.example.com:1433
+# and       MSSQLSvc/mydb.corp.example.com
+```
+
+### If the CNAME doesn't resolve
+
+- Check DNS resolver: client's DNS must point at AD domain controllers, not public DNS
+- For self-managed AD, create the CNAME manually:
+
+```powershell
+Add-DnsServerResourceRecordCName `
+  -Name mydb `
+  -ZoneName corp.example.com `
+  -HostNameAlias mydb.xxxx.us-east-1.rds.amazonaws.com
+```
+
+## Client connection examples
+
+### SSMS
+
+- Server name: `mydb.corp.example.com,1433`  (**CNAME**, not RDS endpoint)
+- Authentication: Windows Authentication
+- SSMS uses the currently logged-in Windows user's Kerberos ticket
+
+### .NET / SqlClient
+
+```csharp
+var connStr = "Server=mydb.corp.example.com,1433;" +
+              "Database=mydb;" +
+              "Integrated Security=True;" +
+              "Encrypt=Mandatory;";
+```
+
+### Java / JDBC
+
+```java
+String url = "jdbc:sqlserver://mydb.corp.example.com:1433;"
+           + "databaseName=mydb;"
+           + "integratedSecurity=true;"
+           + "authenticationScheme=JavaKerberos;"
+           + "encrypt=true;";
+```
+
+### Python / pyodbc
+
+```python
+# pyodbc — on domain-joined Windows or Linux with krb5 + keytab
+conn = pyodbc.connect(
+    "Driver={ODBC Driver 18 for SQL Server};"
+    "Server=mydb.corp.example.com,1433;"
+    "Database=mydb;"
+    "Trusted_Connection=Yes;"
+    "Encrypt=Yes;"
+)
+```
+
+**pymssql does NOT support Kerberos** — use pyodbc.
+
+## auth_scheme shows NTLM instead of KERBEROS — common cause
+
+Most common reason Kerberos falls back to NTLM:
+
+1. **Client connected to RDS endpoint, not CNAME**
+   - `mydb.xxxx.us-east-1.rds.amazonaws.com` has no SPN → Kerberos fails → NTLM fallback
+   - Fix: connect to the CNAME
+
+2. **SPN missing for the CNAME**
+   - Usually only an issue with self-managed AD
+   - Fix: `setspn -A MSSQLSvc/mydb.corp.example.com:1433 <service-account>`
+
+3. **Client can't reach KDC (AD domain controller)**
+   - Check port 88 (Kerberos), 389 (LDAP), 464 (kpasswd) to DCs
+   - Fix: SG/firewall rules to DCs
+
+4. **Client has no TGT**
+   - Windows: `klist` — should show a TGT. If not, `kinit` or log off/on
+   - Linux: check `/var/kerberos/krb5/user/` or `KRB5CCNAME` env var
+
+Verify:
+
+```sql
+SELECT auth_scheme, client_net_address
+FROM sys.dm_exec_connections WHERE session_id = @@SPID
+```
+
+`auth_scheme = KERBEROS` — success. `NTLM` — fall through to one of the above causes.
+
+## Cannot generate SSPI context — common causes
+
+Error: `The target principal name is incorrect. Cannot generate SSPI context`.
+
+Root causes (diagnose in this order):
+
+1. **CNAME doesn't resolve from the client** → DNS issue
+2. **CNAME resolves but SPN not registered** → `setspn -L` missing entry
+3. **Client clock skew > 5 min from DC** → NTP issue
+4. **Firewall blocks Kerberos (port 88)** → SG or corporate firewall
+
+Run `klist` (Windows) or `klist -e` (Linux) to see if you have a ticket for `MSSQLSvc/mydb.corp.example.com:1433`.
+
+## Never test Windows auth via SSM send-command
+
+SSM runs as the EC2 LocalSystem account, not the user's AD identity. Testing `Integrated Security=True` via SSM:
+
+- Authenticates as the machine account (if domain-joined) or fails
+- Tells you nothing about whether a user's Windows login works
+
+For Windows auth testing: RDP into a domain-joined EC2 as the actual user and run SSMS or `sqlcmd -E`.
+
+## Verify end-to-end
+
+```sql
+-- Connect as CORP\JOE.DOE via SSMS with Windows auth
+SELECT
+  system_user,       -- CORP\JOE.DOE
+  auth_scheme,       -- KERBEROS (not NTLM)
+  net_transport,
+  client_net_address
+FROM sys.dm_exec_connections WHERE session_id = @@SPID
+```

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/connection-auth.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/connection-auth.md
@@ -1,0 +1,250 @@
+# Connection Auth — SQL Auth, Secrets Manager, Credentials
+
+## Overview
+
+Authentication options on RDS SQL Server:
+
+| Auth type | Requires | Drivers that support | When to use |
+|---|---|---|---|
+| **SQL auth** | Username + password in SQL Server | All (pymssql, pyodbc, .NET, JDBC, tedious) | Default choice |
+| Windows auth (Kerberos) | Domain join + AD DNS CNAME | pyodbc, .NET, JDBC (+ Kerberos) | Enterprise AD shops |
+| Windows auth (NTLM) | Domain join (weaker) | pyodbc, .NET, JDBC, tedious | Fallback only |
+| **IAM auth** | RDS Proxy + tokens | All | Serverless, per-identity audit |
+
+For Windows auth details, see `ad-kerberos.md`. For IAM auth via RDS Proxy, see `rds-proxy.md`.
+
+## SQL auth — master user
+
+During RDS provisioning, a master user is created:
+
+```bash
+aws rds create-db-instance \
+  --db-instance-identifier mydb \
+  --engine sqlserver-se \
+  --master-username admin \
+  --master-user-password '<strong-pw>' \
+  --allocated-storage 100 \
+  --db-instance-class db.m6i.large \
+  --region us-east-1
+```
+
+The master user has `processadmin`, `securityadmin`, `dbcreator`, and `serveradmin` roles. It does NOT have `sysadmin` (SA) because RDS restricts that.
+
+## SQL auth — application users
+
+Best practice: don't use the master user for applications. Create scoped logins:
+
+```sql
+-- As master user, create app login
+CREATE LOGIN app_user WITH PASSWORD = 'strong-password-here';
+
+-- Create user in app database
+USE mydb;
+CREATE USER app_user FOR LOGIN app_user;
+
+-- Grant minimum privileges
+ALTER ROLE db_datareader ADD MEMBER app_user;
+ALTER ROLE db_datawriter ADD MEMBER app_user;
+GRANT EXECUTE ON SCHEMA::dbo TO app_user;   -- stored procs
+```
+
+## Password policy
+
+RDS SQL Server enforces Windows password policy by default:
+
+- Minimum 8 chars
+- Must have 3 of: uppercase, lowercase, digit, special char
+- Cannot contain the login name
+
+To disable for a login (not recommended):
+
+```sql
+ALTER LOGIN app_user WITH CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF;
+```
+
+## Secrets Manager — storing credentials
+
+Store credentials as a JSON secret matching the RDS format:
+
+```bash
+aws secretsmanager create-secret \
+  --name rds/sqlserver/app \
+  --description "App credentials for RDS SQL Server prod" \
+  --secret-string '{
+    "engine": "sqlserver",
+    "host": "mydb.xxxx.us-east-1.rds.amazonaws.com",
+    "port": 1433,
+    "username": "app_user",
+    "password": "strong-password-here",
+    "dbname": "mydb"
+  }'
+```
+
+Using this standard JSON shape makes Secrets Manager rotation work out of the box.
+
+## Automatic rotation
+
+Enable automatic rotation using AWS-managed Lambda rotation functions:
+
+```bash
+aws secretsmanager rotate-secret \
+  --secret-id rds/sqlserver/app \
+  --rotation-lambda-arn arn:aws:lambda:us-east-1:111122223333:function:SecretsManagerRDSMSSQLRotationSingleUser \
+  --rotation-rules '{"AutomaticallyAfterDays":30}'
+```
+
+Two rotation strategies:
+
+- **Single-user rotation** — same login, rotate password. Simple. Apps must handle reconnect on 18456.
+- **Alternating-users rotation** — two logins (`app_user_a`, `app_user_b`). Rotate one while the other is in use. Zero-downtime but more complex setup.
+
+For alternating users, create both logins first:
+
+```sql
+CREATE LOGIN app_user_a WITH PASSWORD = '...';
+CREATE LOGIN app_user_b WITH PASSWORD = '...';
+USE mydb;
+CREATE USER app_user_a FOR LOGIN app_user_a;
+CREATE USER app_user_b FOR LOGIN app_user_b;
+ALTER ROLE db_datareader ADD MEMBER app_user_a;
+ALTER ROLE db_datareader ADD MEMBER app_user_b;
+-- grant same perms to both
+```
+
+## Fetching the secret in code
+
+### Python
+
+```python
+import boto3, json
+sm = boto3.client("secretsmanager", region_name="us-east-1")
+c = json.loads(sm.get_secret_value(SecretId="rds/sqlserver/app")["SecretString"])
+
+import pymssql
+conn = pymssql.connect(
+    server=c["host"], port=str(c["port"]),
+    user=c["username"], password=c["password"], database=c["dbname"],
+    tds_version="7.3", encryption="require",
+)
+```
+
+### .NET
+
+```csharp
+var sm = new AmazonSecretsManagerClient(RegionEndpoint.USEast1);
+var r = await sm.GetSecretValueAsync(new() { SecretId = "rds/sqlserver/app" });
+var c = JsonSerializer.Deserialize<DbCreds>(r.SecretString);
+
+var connStr = $"Server={c.Host},{c.Port};Database={c.DbName};" +
+              $"User Id={c.Username};Password={c.Password};Encrypt=Mandatory;";
+```
+
+### Java
+
+```java
+SecretsManagerClient sm = SecretsManagerClient.create();
+String json = sm.getSecretValue(
+    GetSecretValueRequest.builder().secretId("rds/sqlserver/app").build()
+).secretString();
+JsonNode c = new ObjectMapper().readTree(json);
+String url = String.format(
+    "jdbc:sqlserver://%s:%d;databaseName=%s;encrypt=true",
+    c.get("host").asText(), c.get("port").asInt(), c.get("dbname").asText()
+);
+```
+
+### Node.js (AWS SDK v3)
+
+```javascript
+const { SecretsManagerClient, GetSecretValueCommand } =
+  require("@aws-sdk/client-secrets-manager");
+const sm = new SecretsManagerClient({});
+const { SecretString } = await sm.send(new GetSecretValueCommand({
+  SecretId: "rds/sqlserver/app"
+}));
+const c = JSON.parse(SecretString);
+```
+
+## Caching secrets
+
+Don't call `GetSecretValue` on every DB call — it's an AWS API call with latency and cost.
+
+- **Lambda**: cache at module scope. Re-fetch on 18456.
+- **ECS/EC2/EKS**: cache in memory with TTL (5-30 min), OR use the Secrets Manager caching library:
+  - Python: `aws-secretsmanager-caching`
+  - Java: `com.amazonaws:aws-secretsmanager-caching-java`
+  - .NET: `AWSSDK.SecretsManager.Caching`
+  - Node.js: custom — set a 15-min cache + refresh on failure
+
+### Handling rotation — reconnect on 18456
+
+When a secret rotates, existing pool connections fail with `18456` on the next use. Handle it:
+
+```python
+# SQLAlchemy approach
+from sqlalchemy import event
+
+@event.listens_for(engine, "handle_error")
+def handle_error(exception_context):
+    exc = exception_context.original_exception
+    if "18456" in str(exc) or "Login failed" in str(exc):
+        # Dispose pool and re-fetch secret
+        _creds_cache.invalidate()
+        exception_context.chained_exception = None
+```
+
+Or simpler: set `pool_recycle` to the rotation interval (e.g. 30 days × 0.9 = recycle every 27 days).
+
+## IAM policy for apps
+
+Minimum permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": "arn:aws:secretsmanager:us-east-1:111122223333:secret:rds/sqlserver/app-*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt"],
+      "Resource": "arn:aws:kms:us-east-1:111122223333:key/<kms-key-id>",
+      "Condition": {
+        "StringEquals": {"kms:ViaService": "secretsmanager.us-east-1.amazonaws.com"}
+      }
+    }
+  ]
+}
+```
+
+The `kms:ViaService` condition scopes KMS decrypt to Secrets Manager calls — defense in depth.
+
+## Parameter Store (SSM) — alternative for non-rotating secrets
+
+For config values and non-credential secrets, AWS Systems Manager Parameter Store is cheaper than Secrets Manager (free for standard parameters).
+
+```bash
+aws ssm put-parameter --name "/app/db/host" \
+  --value "mydb.xxxx.us-east-1.rds.amazonaws.com" --type String
+aws ssm put-parameter --name "/app/db/username" \
+  --value "app_user" --type SecureString
+```
+
+Not recommended for passwords you want rotated — Parameter Store doesn't have built-in rotation like Secrets Manager does.
+
+## Verify auth is working
+
+```sql
+SELECT
+  system_user,                    -- current login
+  original_login_name,            -- original login (before any SETUSER)
+  auth_scheme,                    -- SQL / KERBEROS / NTLM
+  session_id = @@SPID
+FROM sys.dm_exec_connections
+WHERE session_id = @@SPID;
+```
+
+For SQL auth, `auth_scheme` will be `SQL`. `KERBEROS` / `NTLM` indicates Windows auth — see `ad-kerberos.md`.

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/dotnet.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/dotnet.md
@@ -1,0 +1,181 @@
+# .NET — Microsoft.Data.SqlClient
+
+Use `Microsoft.Data.SqlClient` for all new .NET code. `System.Data.SqlClient` is legacy (.NET Framework only) and does not get new features or security fixes.
+
+## Install
+
+```bash
+dotnet add package Microsoft.Data.SqlClient --version 5.*
+```
+
+## Minimal connection
+
+```csharp
+using Microsoft.Data.SqlClient;
+
+var connStr = "Server=mydb.xxxx.us-east-1.rds.amazonaws.com,1433;" +
+              "Database=mydb;User Id=admin;Password=secret;" +
+              "Encrypt=Mandatory;TrustServerCertificate=False;";
+
+using var conn = new SqlConnection(connStr);
+await conn.OpenAsync();
+
+using var cmd = new SqlCommand("SELECT @@VERSION", conn);
+var version = (string)await cmd.ExecuteScalarAsync();
+```
+
+## Connection string essentials
+
+| Key | Required value | Why |
+|---|---|---|
+| `Server` | `<rds-endpoint>,1433` | **Comma** between host and port, not colon |
+| `Database` | target database | Required to bypass master |
+| `Encrypt` | `Mandatory` (5.x+ default) | TLS required |
+| `TrustServerCertificate` | `False` | Force cert validation — don't disable in prod |
+| `Connection Timeout` | `30` | Network connection timeout (not command timeout) |
+| `MultiSubnetFailover` | `True` | For Multi-AZ — parallelize to both IPs during failover |
+
+### Default behavior changes in SqlClient 5.x
+
+- `Encrypt` defaults to `Mandatory` (was `False` in 4.x)
+- `TrustServerCertificate` defaults to `False`
+- Connection will fail if the server cert can't be validated
+
+If you see `A connection was successfully established... but an error occurred during the pre-login handshake`, the server cert chain isn't trusted on the client — see `encryption.md` for CA bundle setup.
+
+## Windows auth (Kerberos)
+
+Connect to the CNAME, not the RDS endpoint:
+
+```csharp
+var connStr = "Server=database-1.corp.example.com,1433;" +    // CNAME
+              "Database=mydb;" +
+              "Integrated Security=True;" +
+              "Encrypt=Mandatory;";
+
+using var conn = new SqlConnection(connStr);
+await conn.OpenAsync();
+```
+
+Verify:
+
+```sql
+SELECT auth_scheme FROM sys.dm_exec_connections WHERE session_id = @@SPID
+-- Expected: KERBEROS
+```
+
+If you get `NTLM` instead: connect to the CNAME (not RDS endpoint), confirm SPN exists in AD for the CNAME. See `ad-kerberos.md`.
+
+### Container / ECS Fargate running domain-joined
+
+.NET on Windows containers can use Kerberos via gMSA (Group Managed Service Account). See `ecs-fargate-vpc.md`. .NET on Linux containers requires explicit ticket management:
+
+```csharp
+// Before opening connection, obtain TGT
+// kinit with keytab OR mount a Kerberos credentials cache (KRB5CCNAME)
+```
+
+## Secrets Manager
+
+```csharp
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+
+var sm = new AmazonSecretsManagerClient(Amazon.RegionEndpoint.USEast1);
+var resp = await sm.GetSecretValueAsync(new GetSecretValueRequest {
+    SecretId = "rds/sqlserver/app"
+});
+var creds = JsonSerializer.Deserialize<DbCreds>(resp.SecretString);
+
+var connStr = $"Server={creds.Host},{creds.Port};" +
+              $"Database={creds.DbName};" +
+              $"User Id={creds.Username};Password={creds.Password};" +
+              $"Encrypt=Mandatory;";
+
+record DbCreds(string Host, int Port, string Username, string Password, string DbName);
+```
+
+### Caching the secret
+
+Don't call `GetSecretValueAsync` on every database call. Cache it in memory with a TTL, or use AWS Secrets Manager Caching library:
+
+```bash
+dotnet add package AWSSDK.SecretsManager.Caching
+```
+
+## Connection pooling
+
+ADO.NET has built-in pooling — enabled by default. Tune in the connection string:
+
+```csharp
+var connStr = "Server=mydb.xxxx.us-east-1.rds.amazonaws.com,1433;" +
+              "Database=mydb;User Id=admin;Password=secret;" +
+              "Encrypt=Mandatory;" +
+              "Min Pool Size=5;" +        // always have 5 ready
+              "Max Pool Size=100;" +       // cap at 100 per process
+              "Connection Lifetime=300;";  // recycle after 5 min (Multi-AZ safety)
+```
+
+Pools are per process + per unique connection string. If you're running many replicas of a web app, total connections = replicas × Max Pool Size.
+
+## Async and cancellation
+
+Always use `async` methods and pass a `CancellationToken`:
+
+```csharp
+using var conn = new SqlConnection(connStr);
+await conn.OpenAsync(cancellationToken);
+
+using var cmd = new SqlCommand("SELECT * FROM users WHERE id = @id", conn);
+cmd.Parameters.AddWithValue("@id", userId);
+
+using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+while (await reader.ReadAsync(cancellationToken)) { /* ... */ }
+```
+
+Synchronous calls (`conn.Open()`) block the thread pool — costly in high-throughput apps.
+
+## Lambda (.NET)
+
+Use Amazon.Lambda.RuntimeSupport for .NET runtimes:
+
+```csharp
+using Amazon.Lambda.Core;
+
+[assembly: LambdaSerializer(typeof(DefaultLambdaJsonSerializer))]
+
+public class Function {
+    // Module-scope — reused across warm invocations
+    private static readonly AmazonSecretsManagerClient _sm = new(Amazon.RegionEndpoint.USEast1);
+    private static Lazy<Task<string>> _connStr = new(BuildConnStringAsync);
+
+    public async Task<string> FunctionHandler(Dictionary<string, string> input, ILambdaContext ctx) {
+        var cs = await _connStr.Value;
+        using var conn = new SqlConnection(cs);
+        await conn.OpenAsync();
+        // ...
+        return "ok";
+    }
+
+    static async Task<string> BuildConnStringAsync() {
+        var r = await _sm.GetSecretValueAsync(new() { SecretId = "rds/sqlserver/app" });
+        var c = JsonSerializer.Deserialize<DbCreds>(r.SecretString);
+        return $"Server={c.Host},1433;Database={c.DbName};" +
+               $"User Id={c.Username};Password={c.Password};Encrypt=Mandatory;";
+    }
+    record DbCreds(string Host, string Username, string Password, string DbName);
+}
+```
+
+Small `Max Pool Size` (e.g. 2) per Lambda — Lambda's concurrency model means many containers × large pool = too many connections to RDS. Use RDS Proxy for serverless-scale apps.
+
+## Verify
+
+```sql
+SELECT
+  encrypt_option,     -- TRUE = TLS
+  auth_scheme,        -- SQL, KERBEROS, NTLM
+  net_transport,
+  protocol_type
+FROM sys.dm_exec_connections WHERE session_id = @@SPID
+```

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/ec2-vpc.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/ec2-vpc.md
@@ -1,0 +1,162 @@
+# EC2 — RDS SQL Server from EC2 in the same VPC
+
+Simplest connection pattern. EC2 and RDS in the same VPC (or peered VPCs).
+
+## Networking
+
+### Security groups
+
+Two SGs, referenced by ID:
+
+```bash
+# RDS SG (e.g. sg-rds-sqlserver) — inbound
+aws ec2 authorize-security-group-ingress \
+  --group-id sg-rds-sqlserver \
+  --protocol tcp --port 1433 \
+  --source-group sg-app-ec2 \
+  --region us-east-1
+
+# EC2 SG (sg-app-ec2) — outbound is default allow-all,
+# no change needed unless custom SG
+```
+
+Using SG IDs (`--source-group sg-xxx`) works only within the same VPC. For cross-VPC, see `networking.md`.
+
+### Subnets
+
+EC2 and RDS can be in different subnets of the same VPC as long as:
+
+- Route tables connect them (default VPC routing covers this)
+- NACLs don't block 1433 in either direction
+
+### DNS
+
+The RDS endpoint `mydb.xxxx.us-east-1.rds.amazonaws.com` resolves to a private IP inside the VPC. Verify:
+
+```bash
+nslookup mydb.xxxx.us-east-1.rds.amazonaws.com
+# Should return 10.x.x.x or similar private IP
+```
+
+If it returns the public IP, your VPC has `enableDnsSupport=false` or you've disabled the private DNS override.
+
+## Connection examples
+
+### Linux EC2 (Amazon Linux 2023) — Python + pymssql
+
+```bash
+sudo yum install -y python3-pip gcc-c++ freetds-devel
+pip3 install pymssql boto3
+```
+
+```python
+import pymssql, boto3, json
+
+sm = boto3.client("secretsmanager", region_name="us-east-1")
+c = json.loads(sm.get_secret_value(SecretId="rds/sqlserver/app")["SecretString"])
+
+conn = pymssql.connect(
+    server=c["host"], port="1433",
+    user=c["username"], password=c["password"], database=c["dbname"],
+    tds_version="7.3", encryption="require",
+)
+```
+
+IAM instance profile must have `secretsmanager:GetSecretValue` on the secret ARN (and `kms:Decrypt` if CMK).
+
+### Windows EC2 — .NET
+
+Installed .NET + AWS CLI. Domain-join if using Windows auth (see `ad-kerberos.md`).
+
+```csharp
+// Use instance profile — AWS SDK picks it up automatically
+var sm = new AmazonSecretsManagerClient();
+var resp = await sm.GetSecretValueAsync(new GetSecretValueRequest {
+    SecretId = "rds/sqlserver/app" });
+var c = JsonSerializer.Deserialize<DbCreds>(resp.SecretString);
+
+var connStr = $"Server={c.Host},1433;Database={c.DbName};" +
+              $"User Id={c.Username};Password={c.Password};Encrypt=Mandatory;";
+```
+
+### Java (mssql-jdbc)
+
+```java
+SecretsManagerClient sm = SecretsManagerClient.create();
+String json = sm.getSecretValue(
+    GetSecretValueRequest.builder().secretId("rds/sqlserver/app").build()
+).secretString();
+// ...parse and build JDBC URL
+```
+
+## IAM permissions for EC2 instance profile
+
+Minimum for SQL auth + Secrets Manager:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": "arn:aws:secretsmanager:us-east-1:111122223333:secret:rds/sqlserver/app-*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt"],
+      "Resource": "arn:aws:kms:us-east-1:111122223333:key/<kms-key-id>",
+      "Condition": {
+        "StringEquals": {"kms:ViaService": "secretsmanager.us-east-1.amazonaws.com"}
+      }
+    }
+  ]
+}
+```
+
+Do NOT use `rds-db:connect` — that's for IAM auth on Postgres/MySQL, not SQL Server. For IAM auth on SQL Server you need RDS Proxy — see `rds-proxy.md`.
+
+## Multi-AZ failover
+
+Connection strings pointing at the RDS endpoint (not IP) automatically redirect to the new primary after failover (typically 60-120 seconds).
+
+Tune driver timeouts to handle the gap:
+
+- **pymssql**: `login_timeout=10`
+- **.NET**: `Connection Timeout=30;MultiSubnetFailover=True`
+- **JDBC (HikariCP)**: `maxLifetime < 1800000` + `validationTimeout=5000`
+- **tedious**: `connectTimeout: 30000` in ms
+
+Add `pool_pre_ping` (SQLAlchemy) or `connectionTestQuery: "SELECT 1"` (HikariCP) to evict stale connections.
+
+## Deployment checklist
+
+- [ ] EC2 in the same VPC as RDS (or peered)
+- [ ] EC2 IAM instance profile has `secretsmanager:GetSecretValue` + `kms:Decrypt`
+- [ ] RDS SG inbound 1433 from EC2 SG (by SG ID)
+- [ ] RDS endpoint resolves to private IP (VPC has `enableDnsSupport=true`)
+- [ ] Driver and CA bundle installed
+- [ ] Connection string uses `encrypt=true` / `Encrypt=Mandatory` / `encryption="require"`
+- [ ] Secrets Manager secret exists with correct JSON structure
+
+## Verify
+
+From EC2 shell:
+
+```bash
+# TCP reachability
+nc -zv mydb.xxxx.us-east-1.rds.amazonaws.com 1433
+# Connection opens → OK
+
+# SQL query
+python3 -c "
+import pymssql, json, boto3
+c = json.loads(boto3.client('secretsmanager').get_secret_value(SecretId='rds/sqlserver/app')['SecretString'])
+conn = pymssql.connect(server=c['host'], port='1433', user=c['username'], password=c['password'], database=c['dbname'], tds_version='7.3', encryption='require')
+cur = conn.cursor()
+cur.execute('SELECT encrypt_option, auth_scheme FROM sys.dm_exec_connections WHERE session_id=@@SPID')
+print(cur.fetchone())
+"
+```
+
+Expected: `(True, 'SQL')` — encrypted + SQL auth.

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/ecs-fargate-vpc.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/ecs-fargate-vpc.md
@@ -1,0 +1,240 @@
+# ECS / Fargate — RDS SQL Server
+
+Container tasks connecting to RDS SQL Server in the same VPC (or peered).
+
+## Networking
+
+- Tasks use `awsvpc` networking mode — each task gets an ENI in a subnet
+- Task SG inbound: none required (outbound-only for DB connections)
+- Task SG outbound: allow 1433 → RDS SG, 443 → Secrets Manager / STS
+- RDS SG inbound: 1433 from task SG (by SG ID)
+
+```bash
+aws ec2 authorize-security-group-ingress \
+  --group-id sg-rds-sqlserver \
+  --protocol tcp --port 1433 \
+  --source-group sg-ecs-task
+```
+
+For Fargate in private subnets without internet access, create VPC endpoints for:
+
+- `com.amazonaws.<region>.secretsmanager`
+- `com.amazonaws.<region>.ecr.dkr` and `com.amazonaws.<region>.ecr.api` (for ECR image pulls)
+- `com.amazonaws.<region>.s3` (gateway — for ECR image layers)
+- `com.amazonaws.<region>.logs` (CloudWatch Logs)
+
+## Secrets injection — two approaches
+
+### Approach 1: Inject at container start (recommended)
+
+ECS resolves the secret before the container runs. The secret value appears as an environment variable:
+
+```json
+{
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "111122223333.dkr.ecr.us-east-1.amazonaws.com/app:latest",
+      "secrets": [
+        {
+          "name": "DB_SECRET",
+          "valueFrom": "arn:aws:secretsmanager:us-east-1:111122223333:secret:rds/sqlserver/app-AbCdEf"
+        }
+      ]
+    }
+  ],
+  "executionRoleArn": "arn:aws:iam::111122223333:role/ecsTaskExecutionRole",
+  "taskRoleArn": "arn:aws:iam::111122223333:role/app-task-role",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"]
+}
+```
+
+**Critical**: `secrets` requires `executionRoleArn` (not `taskRoleArn`) to have `secretsmanager:GetSecretValue` permission. This is the most common ECS secrets misconfiguration.
+
+Execution role policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": "arn:aws:secretsmanager:us-east-1:111122223333:secret:rds/sqlserver/app-*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt"],
+      "Resource": "arn:aws:kms:us-east-1:111122223333:key/<kms-key-id>"
+    }
+  ]
+}
+```
+
+Parse JSON in the container:
+
+```python
+import os, json
+creds = json.loads(os.environ["DB_SECRET"])
+conn = pymssql.connect(
+    server=creds["host"], port="1433",
+    user=creds["username"], password=creds["password"], database=creds["dbname"],
+    tds_version="7.3", encryption="require",
+)
+```
+
+### Approach 2: Fetch at runtime via task role
+
+App code calls `secretsmanager:GetSecretValue` directly using the task role. Useful for rotation-aware apps:
+
+```python
+import boto3, json, os
+sm = boto3.client("secretsmanager")
+c = json.loads(sm.get_secret_value(SecretId=os.environ["SECRET_ARN"])["SecretString"])
+```
+
+Task role needs `secretsmanager:GetSecretValue` + `kms:Decrypt`. Execution role just needs container image pull permissions.
+
+Approach 2 handles rotation better: app can re-fetch after an 18456 error. Approach 1 requires a task restart to pick up rotated secrets.
+
+## Windows auth on Fargate
+
+- **Windows containers on Fargate**: gMSA (Group Managed Service Account) is supported
+- **Linux containers**: must manage Kerberos tickets explicitly — mount keytab or KRB5CCNAME
+
+### gMSA for Windows containers
+
+```json
+{
+  "containerDefinitions": [{
+    "name": "app",
+    "image": "...",
+    "credentialSpecs": [
+      "credentialspec:arn:aws:s3:::my-bucket/app-gmsa.json"
+    ]
+  }]
+}
+```
+
+See `ad-kerberos.md` for domain join + gMSA setup.
+
+## Connection pooling
+
+For long-running tasks, use a proper pool:
+
+- Python: SQLAlchemy `QueuePool` (pool_size=5, max_overflow=10)
+- Java: HikariCP (maximumPoolSize=10)
+- .NET: ADO.NET built-in (`Max Pool Size=20`)
+- Node.js: `mssql` built-in (`pool: { max: 10 }`)
+
+Pool size should be tuned to ECS task count × concurrent requests per task. RDS can handle thousands of connections but each one costs memory.
+
+## Full Fargate task definition (Python + pymssql)
+
+```json
+{
+  "family": "app",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "executionRoleArn": "arn:aws:iam::111122223333:role/ecsTaskExecutionRole",
+  "taskRoleArn": "arn:aws:iam::111122223333:role/app-task-role",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "111122223333.dkr.ecr.us-east-1.amazonaws.com/app:v1.0.0",
+      "essential": true,
+      "portMappings": [{ "containerPort": 8080, "protocol": "tcp" }],
+      "environment": [
+        { "name": "AWS_REGION", "value": "us-east-1" }
+      ],
+      "secrets": [
+        {
+          "name": "DB_SECRET",
+          "valueFrom": "arn:aws:secretsmanager:us-east-1:111122223333:secret:rds/sqlserver/app-AbCdEf"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/app",
+          "awslogs-region": "us-east-1",
+          "awslogs-stream-prefix": "app"
+        }
+      },
+      "healthCheck": {
+        "command": ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3
+      }
+    }
+  ]
+}
+```
+
+## Service — with ALB
+
+```bash
+aws ecs create-service \
+  --cluster my-cluster \
+  --service-name app \
+  --task-definition app:1 \
+  --desired-count 3 \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-priv-a,subnet-priv-b],securityGroups=[sg-ecs-task],assignPublicIp=DISABLED}" \
+  --load-balancers "targetGroupArn=arn:...,containerName=app,containerPort=8080"
+```
+
+`assignPublicIp=DISABLED` keeps tasks in private subnets. Use VPC endpoints for AWS service access.
+
+## Health check endpoint
+
+```python
+# Flask
+@app.route("/health")
+def health():
+    try:
+        cur = pool.connection().cursor()
+        cur.execute("SELECT 1")
+        return {"status": "ok"}, 200
+    except Exception as e:
+        return {"status": "error", "detail": str(e)}, 503
+```
+
+Return 200 only when DB is reachable. ALB will replace unhealthy tasks.
+
+## Rolling updates during Multi-AZ failover
+
+During RDS Multi-AZ failover:
+
+- Existing connections fail (error 18456 or network disconnect)
+- New connections (after ~60-120s) succeed against the new primary
+
+App behavior:
+
+- Pools with `pool_pre_ping` / `connectionTestQuery` recover cleanly
+- Pools without will serve errors for the failover duration
+
+For minimum downtime:
+
+- HikariCP: `maxLifetime=1800000` (30 min), `validationTimeout=5000`
+- SQLAlchemy: `pool_pre_ping=True, pool_recycle=1800`
+
+## Verify from inside a task
+
+```bash
+aws ecs execute-command \
+  --cluster my-cluster \
+  --task <task-arn> \
+  --container app \
+  --interactive \
+  --command "/bin/sh"
+
+# inside the container:
+nc -zv mydb.xxxx.us-east-1.rds.amazonaws.com 1433
+```
+
+Requires `enableExecuteCommand: true` on the service and task role permissions for SSM (`ssmmessages:CreateControlChannel` etc.).

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/encryption.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/encryption.md
@@ -1,0 +1,219 @@
+# SSL/TLS Encryption — RDS SQL Server
+
+## Defaults
+
+RDS SQL Server ships with a self-signed certificate for the instance. By default:
+
+- RDS **accepts** TLS connections on 1433
+- RDS **does not require** TLS — connections can be plaintext unless the client opts in
+- The parameter `rds.force_ssl` is **0 by default** (SQL Server doesn't have this parameter like PostgreSQL does)
+
+To force TLS, use the `FORCE_ENCRYPTION` option group setting (see below).
+
+## TLS versions
+
+| TLS Version | RDS SQL Server Support |
+|---|---|
+| TLS 1.0 | Deprecated, still accepted on older engine versions |
+| TLS 1.1 | Deprecated, still accepted on older engine versions |
+| **TLS 1.2** | **Required minimum for production** |
+| TLS 1.3 | Supported on SQL Server 2022+ |
+
+Force minimum TLS 1.2 via option group (see "Enforce encryption" below).
+
+## Client-side encryption config
+
+Every driver has its own way to express "force TLS + validate cert":
+
+| Driver | Setting | Notes |
+|---|---|---|
+| pymssql | `encryption="require"` | Not `"request"` — that's opportunistic |
+| pyodbc | `Encrypt=Yes;TrustServerCertificate=No` | In connection string |
+| .NET SqlClient | `Encrypt=Mandatory;TrustServerCertificate=False` | 5.x defaults to Mandatory/False |
+| Java JDBC | `encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.rds.amazonaws.com` | hostname helps wildcard |
+| tedious/mssql | `options: { encrypt: true, trustServerCertificate: false }` | 16+ defaults encrypt:true |
+
+## Certificate validation
+
+The RDS certificate is issued by Amazon RDS's internal CA. Clients need the RDS CA bundle to validate it.
+
+### Download bundle
+
+```bash
+curl -o global-bundle.pem \
+  https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+```
+
+This bundle contains all regional RDS CAs. For a single region you can use the per-region bundle from the same truststore URL.
+
+### Install in OS trust store (Linux)
+
+```bash
+sudo cp global-bundle.pem /etc/ssl/certs/rds-global-bundle.pem
+sudo update-ca-certificates   # Debian/Ubuntu
+# Or: sudo update-ca-trust    # RHEL/CentOS
+```
+
+Drivers that use the OS trust store (pymssql, pyodbc) will now validate.
+
+### Java — per-app truststore
+
+```bash
+# Split PEM — keytool imports only the first cert from a multi-cert PEM
+csplit -s -z -f rds- -b '%02d.pem' global-bundle.pem '/-----BEGIN CERTIFICATE-----/' '{*}'
+
+# Import each cert
+for f in rds-*.pem; do
+  keytool -import -trustcacerts -alias "rds-$(basename $f .pem)" \
+    -file "$f" -keystore rds-truststore.jks \
+    -storepass changeit -noprompt
+done
+```
+
+```bash
+java -Djavax.net.ssl.trustStore=/path/to/rds-truststore.jks \
+     -Djavax.net.ssl.trustStorePassword=changeit \
+     -jar app.jar
+```
+
+### .NET — Windows cert store
+
+On Windows, import `global-bundle.pem` into the **Trusted Root Certification Authorities** store:
+
+```powershell
+Import-Certificate -FilePath global-bundle.pem `
+  -CertStoreLocation Cert:\LocalMachine\Root
+```
+
+On Linux .NET, install in OS store as above.
+
+### Node.js — pass CA explicitly
+
+```javascript
+const fs = require('fs');
+const caBundle = fs.readFileSync('/etc/ssl/certs/global-bundle.pem', 'utf8');
+const caList = caBundle.split(/-----END CERTIFICATE-----\n?/)
+                       .filter(c => c.trim())
+                       .map(c => c + '-----END CERTIFICATE-----\n');
+
+const config = {
+  server: creds.host, port: 1433,
+  options: {
+    encrypt: true,
+    trustServerCertificate: false,
+    cryptoCredentialsDetails: { ca: caList, minVersion: 'TLSv1.2' },
+  },
+};
+```
+
+## Enforce encryption on RDS
+
+Create an option group with `SQLSERVER_FORCE_TLS_VERSION` and/or `FORCE_ENCRYPTION`:
+
+```bash
+# Create option group
+aws rds create-option-group \
+  --option-group-name sqlserver-tls12 \
+  --engine-name sqlserver-se \
+  --major-engine-version 16.00 \
+  --option-group-description "Force TLS 1.2+"
+
+# Add force-encryption option
+aws rds add-option-to-option-group \
+  --option-group-name sqlserver-tls12 \
+  --options "OptionName=SQLSERVER_FORCE_TLS_VERSION,OptionSettings=[{Name=TLS_VERSION,Value=1.2}]" \
+  --apply-immediately
+
+# Apply to instance
+aws rds modify-db-instance \
+  --db-instance-identifier mydb \
+  --option-group-name sqlserver-tls12 \
+  --apply-immediately
+```
+
+After this, TLS 1.2+ is the minimum accepted by the server. Plaintext or TLS 1.0/1.1 connections will fail.
+
+## Verify encryption at runtime
+
+```sql
+SELECT
+  encrypt_option,       -- TRUE if TLS is active
+  auth_scheme,          -- SQL, KERBEROS, NTLM
+  net_transport,
+  protocol_type,
+  protocol_version      -- 1946157060 = TDS 7.4; 1936879620 = TDS 7.3
+FROM sys.dm_exec_connections
+WHERE session_id = @@SPID
+```
+
+`encrypt_option = 1` (or `TRUE`) means the connection is encrypted. If `0`, the client didn't request TLS (or couldn't negotiate it).
+
+## Certificate rotation
+
+RDS uses the `rds-ca-rsa2048-g1` CA by default (2024+). Previous CAs (`rds-ca-2019`, `rds-ca-2015`) have expired.
+
+To check your instance:
+
+```bash
+aws rds describe-db-instances \
+  --db-instance-identifier mydb \
+  --query 'DBInstances[0].CACertificateIdentifier'
+# Expected: rds-ca-rsa2048-g1
+```
+
+To rotate (no restart required for 2019→rsa2048-g1):
+
+```bash
+aws rds modify-db-instance \
+  --db-instance-identifier mydb \
+  --ca-certificate-identifier rds-ca-rsa2048-g1 \
+  --apply-immediately
+```
+
+After rotation, clients that don't have the current CA bundle will fail TLS handshake. Roll out updated `global-bundle.pem` to clients BEFORE rotating.
+
+### Available CAs
+
+- `rds-ca-rsa2048-g1` — default, RSA 2048-bit, expires 2061
+- `rds-ca-rsa4096-g1` — RSA 4096-bit for stricter compliance
+- `rds-ca-ecc384-g1` — ECDSA P-384 (smaller, faster, requires TLS_ECDHE_ECDSA cipher suites)
+
+`global-bundle.pem` contains all of these — rotating between them doesn't require a different bundle.
+
+## Common errors
+
+### "A connection was successfully established with the server, but then an error occurred during the pre-login handshake"
+
+Caused by:
+
+- TLS version mismatch (client < 1.2, server requires 1.2+)
+- Cert chain not trusted (CA bundle missing from client)
+- Network tampering (rare — check for corporate TLS proxies)
+
+Fix: install CA bundle, upgrade client (SSMS 18.x+, drivers to current versions).
+
+### `SSL Provider: The target principal name is incorrect`
+
+Client verifying CN against hostname. Either:
+
+- Connect to the exact hostname the cert was issued for (`mydb.xxxx.us-east-1.rds.amazonaws.com`), OR
+- Set `hostNameInCertificate=*.rds.amazonaws.com` (Java) / equivalent
+
+Common through SSM tunnel (CN won't match `localhost`) — see `ssm-tunneling.md`.
+
+### `Could not establish trust relationship for the SSL/TLS secure channel`
+
+.NET-specific. Either:
+
+- Install RDS CA bundle in Trusted Root
+- Set `TrustServerCertificate=True` (dev only — don't use in prod)
+
+### SSMS pre-login failure
+
+Upgrade SSMS to 18.x or later. SSMS 17 and earlier use TLS 1.0 by default and will fail against a server forcing TLS 1.2+.
+
+## Don't do
+
+- Don't set `TrustServerCertificate=True` in production — it bypasses cert validation
+- Don't disable `rds.force_ssl` by removing the option group; use it to enforce, not relax
+- Don't embed the CA bundle in the application code — distribute via package or OS trust store

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/java.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/java.md
@@ -1,0 +1,204 @@
+# Java — mssql-jdbc
+
+Use the official Microsoft JDBC driver `com.microsoft.sqlserver:mssql-jdbc`. There is no other JDBC driver that is maintained for SQL Server on AWS.
+
+## Install
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>com.microsoft.sqlserver</groupId>
+    <artifactId>mssql-jdbc</artifactId>
+    <version>12.6.1.jre11</version>
+</dependency>
+```
+
+Match the `jreN` suffix to your runtime:
+
+- `jre8` — Java 8
+- `jre11` — Java 11
+- `jre17` — Java 17/21
+
+### Gradle
+
+```groovy
+implementation 'com.microsoft.sqlserver:mssql-jdbc:12.6.1.jre11'
+```
+
+## Minimal connection
+
+```java
+import java.sql.Connection;
+import java.sql.DriverManager;
+
+String url = "jdbc:sqlserver://mydb.xxxx.us-east-1.rds.amazonaws.com:1433;"
+           + "databaseName=mydb;"
+           + "user=admin;password=secret;"
+           + "encrypt=true;"
+           + "trustServerCertificate=false;"
+           + "hostNameInCertificate=*.rds.amazonaws.com;";
+
+try (Connection conn = DriverManager.getConnection(url)) {
+    // ...
+}
+```
+
+## JDBC URL essentials
+
+| Property | Value | Note |
+|---|---|---|
+| Host | `mydb.xxxx.us-east-1.rds.amazonaws.com` | Colon, not comma (Java convention) |
+| `databaseName` | target database | Required |
+| `encrypt` | `true` | Required for production |
+| `trustServerCertificate` | `false` | Force cert validation |
+| `hostNameInCertificate` | `*.rds.amazonaws.com` | Match wildcard cert |
+| `loginTimeout` | `30` | Seconds |
+| `socketTimeout` | `30000` | Milliseconds (note unit diff) |
+
+## RDS CA bundle for Java
+
+Download and import into a Java truststore:
+
+```bash
+curl -o global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+
+# Split PEM into individual certs (keytool only imports the first cert from a multi-cert PEM)
+csplit -s -z -f rds- -b '%02d.pem' global-bundle.pem '/-----BEGIN CERTIFICATE-----/' '{*}'
+
+# Create truststore and import each cert
+for f in rds-*.pem; do
+  keytool -import -trustcacerts -alias "$f" -file "$f" \
+    -keystore rds-truststore.jks -storepass changeit -noprompt
+done
+```
+
+Pass to the JVM:
+
+```bash
+java -Djavax.net.ssl.trustStore=/path/to/rds-truststore.jks \
+     -Djavax.net.ssl.trustStorePassword=changeit \
+     -jar app.jar
+```
+
+Or programmatically in code (less common). Without this, `trustServerCertificate=false` will fail — see `encryption.md`.
+
+## Windows auth (Kerberos)
+
+```java
+String url = "jdbc:sqlserver://database-1.corp.example.com:1433;"
+           + "databaseName=mydb;"
+           + "integratedSecurity=true;"
+           + "authenticationScheme=JavaKerberos;"
+           + "encrypt=true;";
+```
+
+Requires a Kerberos `krb5.conf` pointing at the domain KDC:
+
+```
+[libdefaults]
+    default_realm = CORP.EXAMPLE.COM
+    dns_lookup_realm = true
+    dns_lookup_kdc = true
+
+[realms]
+    CORP.EXAMPLE.COM = {
+        kdc = dc1.corp.example.com
+    }
+```
+
+Point the JVM at it:
+
+```bash
+java -Djava.security.krb5.conf=/etc/krb5.conf -jar app.jar
+```
+
+Keytab-based auth (no password in config):
+
+```bash
+java -Djava.security.krb5.conf=/etc/krb5.conf \
+     -Djavax.security.auth.useSubjectCredsOnly=false \
+     -Djava.security.auth.login.config=jaas.conf \
+     -jar app.jar
+```
+
+`jaas.conf`:
+
+```
+SQLJDBCDriver {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    keyTab="/path/to/svc-app.keytab"
+    principal="svc-app@CORP.EXAMPLE.COM"
+    doNotPrompt=true;
+};
+```
+
+## HikariCP connection pool
+
+Production standard for Java connection pooling:
+
+```xml
+<dependency>
+    <groupId>com.zaxxer</groupId>
+    <artifactId>HikariCP</artifactId>
+    <version>5.1.0</version>
+</dependency>
+```
+
+```java
+HikariConfig config = new HikariConfig();
+config.setJdbcUrl("jdbc:sqlserver://mydb.xxxx.us-east-1.rds.amazonaws.com:1433;"
+                + "databaseName=mydb;encrypt=true;trustServerCertificate=false;");
+config.setUsername(creds.getUsername());
+config.setPassword(creds.getPassword());
+config.setMaximumPoolSize(10);
+config.setMinimumIdle(2);
+config.setConnectionTimeout(30000);
+config.setIdleTimeout(600000);
+config.setMaxLifetime(1800000);              // 30 min — handles Multi-AZ failover
+config.setConnectionTestQuery("SELECT 1");
+config.setValidationTimeout(5000);
+
+HikariDataSource ds = new HikariDataSource(config);
+```
+
+`maxLifetime` less than RDS connection max (default 8 hours) prevents stale connections after Multi-AZ failover.
+
+## Secrets Manager
+
+```java
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+
+SecretsManagerClient sm = SecretsManagerClient.create();
+GetSecretValueRequest req = GetSecretValueRequest.builder()
+    .secretId("rds/sqlserver/app").build();
+String json = sm.getSecretValue(req).secretString();
+// Parse json: {host, port, username, password, dbname, engine}
+```
+
+Spring Boot: use `spring-cloud-aws-starter-secrets-manager` to bind secrets to `application.yml` properties directly.
+
+## ECS Fargate
+
+Lambda-style credential caching (outside the handler) isn't applicable — ECS tasks are long-running. Use HikariCP + Secrets Manager resolver pattern:
+
+```java
+// Fetch secret once at startup
+DbCreds creds = fetchSecret("rds/sqlserver/app");
+HikariDataSource ds = buildPool(creds);
+
+// On rotation, the pool's connectionTestQuery will fail — HikariCP evicts
+// and creates fresh connections. But the secret value must be re-fetched.
+// Consider wrapping in a resilience4j CircuitBreaker or setting `maxLifetime`
+// shorter than the rotation interval.
+```
+
+## Verify
+
+```sql
+SELECT encrypt_option, auth_scheme, net_transport, client_interface_name
+FROM sys.dm_exec_connections WHERE session_id = @@SPID
+-- client_interface_name for mssql-jdbc: "Microsoft JDBC Driver 12.6 for SQL Server"
+```

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/lambda-vpc.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/lambda-vpc.md
@@ -1,0 +1,230 @@
+# Lambda — RDS SQL Server from Lambda in VPC
+
+## Lambda in VPC checklist
+
+Before writing code, confirm:
+
+- [ ] Lambda configured with VPC: `--vpc-config SubnetIds=subnet-a,subnet-b SecurityGroupIds=sg-lambda`
+- [ ] Subnets are **private** (RDS is private)
+- [ ] Either: VPC endpoint for Secrets Manager in the same subnets, OR NAT gateway for internet access
+- [ ] Lambda SG outbound allows TCP 443 (Secrets Manager) + TCP 1433 (RDS) — default "allow all outbound" works
+- [ ] RDS SG inbound 1433 from Lambda SG
+- [ ] Lambda execution role has `secretsmanager:GetSecretValue` + `kms:Decrypt` + VPC permissions
+- [ ] Lambda timeout ≥ 15s for cold start + DB connect
+
+## Why VPC endpoints matter
+
+A Lambda in a VPC has no internet access by default. Calling Secrets Manager from inside the handler will hang until timeout because the default route has no IGW.
+
+### Option A — VPC endpoint for Secrets Manager (recommended)
+
+```bash
+aws ec2 create-vpc-endpoint \
+  --vpc-id vpc-xxxx \
+  --service-name com.amazonaws.us-east-1.secretsmanager \
+  --vpc-endpoint-type Interface \
+  --subnet-ids subnet-priv-a subnet-priv-b \
+  --security-group-ids sg-endpoint \
+  --private-dns-enabled
+```
+
+Endpoint SG inbound: TCP 443 from Lambda SG.
+
+With `--private-dns-enabled`, `secretsmanager.<region>.amazonaws.com` resolves to the endpoint's private IP automatically — no code changes.
+
+### Option B — NAT gateway
+
+Simpler if Lambda needs broad internet access (multiple AWS services, third-party APIs):
+
+```bash
+aws ec2 allocate-address --domain vpc
+aws ec2 create-nat-gateway --subnet-id subnet-public-a --allocation-id eipalloc-xxxx
+
+# Private subnet route table: 0.0.0.0/0 → NAT
+aws ec2 create-route --route-table-id rtb-private \
+  --destination-cidr-block 0.0.0.0/0 --nat-gateway-id nat-xxxx
+```
+
+## Code — Python (pymssql)
+
+Package pymssql in a layer for `manylinux2014_x86_64`:
+
+```bash
+mkdir -p python
+pip install pymssql boto3 -t python/ \
+  --platform manylinux2014_x86_64 --only-binary=:all:
+zip -r layer.zip python/
+aws lambda publish-layer-version --layer-name pymssql \
+  --zip-file fileb://layer.zip \
+  --compatible-runtimes python3.12 \
+  --compatible-architectures x86_64
+```
+
+```python
+# handler.py
+import pymssql, boto3, json, os
+
+sm = boto3.client("secretsmanager")
+_creds = None
+
+def get_creds():
+    global _creds
+    if _creds is None:
+        _creds = json.loads(
+            sm.get_secret_value(SecretId=os.environ["SECRET_ARN"])["SecretString"]
+        )
+    return _creds
+
+def handler(event, context):
+    c = get_creds()
+    conn = pymssql.connect(
+        server=c["host"], port="1433",
+        user=c["username"], password=c["password"], database=c["dbname"],
+        tds_version="7.3", encryption="require", login_timeout=5,
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM users")
+            count = cur.fetchone()[0]
+        return {"statusCode": 200, "body": json.dumps({"users": count})}
+    finally:
+        conn.close()
+```
+
+Module-scope client and secret caching avoid re-initialization on warm invocations. Keep the connection *per invocation* unless using RDS Proxy (see below).
+
+## Code — .NET
+
+```csharp
+using Microsoft.Data.SqlClient;
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+using System.Text.Json;
+
+public class Function {
+    private static readonly AmazonSecretsManagerClient _sm = new();
+    private static Lazy<Task<string>> _connStr = new(BuildConnStringAsync);
+
+    public async Task<Dictionary<string, object>> FunctionHandler(object _, ILambdaContext ctx) {
+        var cs = await _connStr.Value;
+        using var conn = new SqlConnection(cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand("SELECT COUNT(*) FROM users", conn);
+        var count = (int)await cmd.ExecuteScalarAsync();
+        return new() { ["users"] = count };
+    }
+
+    private static async Task<string> BuildConnStringAsync() {
+        var resp = await _sm.GetSecretValueAsync(new GetSecretValueRequest {
+            SecretId = Environment.GetEnvironmentVariable("SECRET_ARN")
+        });
+        var c = JsonSerializer.Deserialize<DbCreds>(resp.SecretString);
+        return $"Server={c.Host},1433;Database={c.DbName};" +
+               $"User Id={c.Username};Password={c.Password};" +
+               $"Encrypt=Mandatory;Connection Timeout=5;" +
+               $"Min Pool Size=0;Max Pool Size=2;";
+    }
+    record DbCreds(string Host, string DbName, string Username, string Password);
+}
+```
+
+Small `Max Pool Size` (2-5) per Lambda is important — Lambda's concurrency model means 1000 concurrent Lambda containers × 100 pool size would create 100,000 connections. RDS SQL Server `max_connections` is typically 32,767 but memory/CPU pressure kicks in well before that.
+
+## Code — Node.js (tedious/mssql)
+
+```javascript
+const sql = require('mssql');
+const { SecretsManagerClient, GetSecretValueCommand } =
+  require("@aws-sdk/client-secrets-manager");
+
+const sm = new SecretsManagerClient({});
+let poolPromise = null;
+
+async function getPool() {
+  if (poolPromise) return poolPromise;
+  poolPromise = (async () => {
+    const { SecretString } = await sm.send(new GetSecretValueCommand({
+      SecretId: process.env.SECRET_ARN,
+    }));
+    const c = JSON.parse(SecretString);
+    return sql.connect({
+      server: c.host, port: 1433,
+      database: c.dbname, user: c.username, password: c.password,
+      options: { encrypt: true, trustServerCertificate: false, connectTimeout: 5000 },
+      pool: { max: 2, min: 0, idleTimeoutMillis: 10000 },
+    });
+  })();
+  return poolPromise;
+}
+
+exports.handler = async (event) => {
+  const pool = await getPool();
+  const r = await pool.request().query("SELECT COUNT(*) AS n FROM users");
+  return { statusCode: 200, body: JSON.stringify(r.recordset[0]) };
+};
+```
+
+## Provisioned concurrency
+
+Cold start + DB connect can be 2-5 seconds on Lambda. For latency-sensitive APIs:
+
+```bash
+aws lambda put-provisioned-concurrency-config \
+  --function-name my-fn \
+  --qualifier LIVE \
+  --provisioned-concurrent-executions 10
+```
+
+Provisioned containers keep the secret cached and (with a pool) can keep warm connections. Pair with SnapStart (Java only, free) or regular provisioned concurrency for Python/Node/.NET.
+
+## For high concurrency — use RDS Proxy
+
+At high Lambda concurrency (thousands of simultaneous executions), RDS Proxy is almost mandatory. See `rds-proxy.md`. Without it you'll hit:
+
+- RDS connection count limits
+- CPU contention from connection setup
+- Connection timeouts during traffic spikes
+
+With RDS Proxy, Lambda connects to the proxy endpoint, not RDS directly. The proxy multiplexes connections.
+
+## IAM role — full example
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VPC",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface",
+        "ec2:AssignPrivateIpAddresses",
+        "ec2:UnassignPrivateIpAddresses"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SecretsManager",
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": "arn:aws:secretsmanager:us-east-1:111122223333:secret:rds/sqlserver/app-*"
+    },
+    {
+      "Sid": "KMS",
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt"],
+      "Resource": "arn:aws:kms:us-east-1:111122223333:key/<kms-key-id>"
+    },
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+      "Resource": "arn:aws:logs:us-east-1:111122223333:*"
+    }
+  ]
+}
+```
+
+The VPC permissions are required when the function is `--vpc-config`'d. Without them, deployment fails with `InvalidSubnetID.NotFound`.

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/networking.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/networking.md
@@ -1,0 +1,239 @@
+# Networking — VPC, Security Groups, Cross-VPC, DNS
+
+## Security groups — the key rule
+
+**Same VPC:** use security group IDs as the source.
+**Cross-VPC (peering, Transit Gateway):** use CIDR blocks as the source. SG-to-SG references do not cross VPC boundaries.
+
+This one rule catches ~30% of all RDS connectivity issues.
+
+### Same VPC (recommended)
+
+```bash
+aws ec2 authorize-security-group-ingress \
+  --group-id sg-rds-sqlserver \
+  --protocol tcp --port 1433 \
+  --source-group sg-app
+```
+
+Benefits:
+
+- No IP hardcoding
+- Works even when app servers are recreated with new IPs
+- Policy-driven: authorize the role, not the address
+
+### Cross-VPC via Transit Gateway or VPC Peering
+
+```bash
+aws ec2 authorize-security-group-ingress \
+  --group-id sg-rds-sqlserver \
+  --protocol tcp --port 1433 \
+  --cidr 10.1.0.0/16
+```
+
+CIDR should be the source VPC or subnet range.
+
+## RDS endpoint format
+
+```
+mydb.xxxxxxxxxxxx.us-east-1.rds.amazonaws.com
+│     │             │          │
+│     │             │          └── AWS service domain
+│     │             └── Region
+│     └── Random identifier
+└── DB instance identifier
+```
+
+The endpoint always resolves to a **private** IPv4 address when your VPC has `enableDnsSupport=true` and `enableDnsHostnames=true`. It can also resolve to a public IP if:
+
+- `PubliclyAccessible: true` is set on the instance (not recommended)
+- The client is outside AWS and resolves via public DNS
+
+## Cross-VPC patterns
+
+### VPC Peering
+
+Simplest for two VPCs that need to talk:
+
+```bash
+aws ec2 create-vpc-peering-connection \
+  --vpc-id vpc-app \
+  --peer-vpc-id vpc-rds
+
+aws ec2 accept-vpc-peering-connection \
+  --vpc-peering-connection-id pcx-xxxx
+
+# Route table in each VPC — add routes to the other's CIDR
+aws ec2 create-route --route-table-id rtb-app \
+  --destination-cidr-block 10.1.0.0/16 \
+  --vpc-peering-connection-id pcx-xxxx
+
+aws ec2 create-route --route-table-id rtb-rds \
+  --destination-cidr-block 10.0.0.0/16 \
+  --vpc-peering-connection-id pcx-xxxx
+```
+
+Both directions required. If only one is configured, connections hang or fail.
+
+### Transit Gateway
+
+For three or more VPCs, or centralized egress:
+
+```bash
+# Create TGW
+aws ec2 create-transit-gateway --description "central-tgw"
+
+# Attach each VPC
+aws ec2 create-transit-gateway-vpc-attachment \
+  --transit-gateway-id tgw-xxxx \
+  --vpc-id vpc-app \
+  --subnet-ids subnet-app-a subnet-app-b
+
+aws ec2 create-transit-gateway-vpc-attachment \
+  --transit-gateway-id tgw-xxxx \
+  --vpc-id vpc-rds \
+  --subnet-ids subnet-rds-a subnet-rds-b
+
+# Route tables — each VPC points the other's CIDR at TGW
+aws ec2 create-route --route-table-id rtb-app \
+  --destination-cidr-block 10.1.0.0/16 \
+  --transit-gateway-id tgw-xxxx
+```
+
+TGW SG rules on RDS must use **CIDR**, not SG reference.
+
+### Cross-VPC DNS resolution
+
+By default, `mydb.xxxx.us-east-1.rds.amazonaws.com` resolves to a private IP **only inside the owning VPC**. From the peer VPC, it resolves to the **public IP** (if public) or fails.
+
+Fix with `AllowDnsResolutionFromRemoteVpc` on the peering connection:
+
+```bash
+aws ec2 modify-vpc-peering-connection-options \
+  --vpc-peering-connection-id pcx-xxxx \
+  --accepter-peering-connection-options '{"AllowDnsResolutionFromRemoteVpc":true}' \
+  --requester-peering-connection-options '{"AllowDnsResolutionFromRemoteVpc":true}'
+```
+
+Without this, cross-VPC `nslookup` returns public IPs, and connections bypass the peering connection entirely — going over the public internet (and often failing due to RDS being private).
+
+For TGW, you typically need a Route 53 private hosted zone shared with each attached VPC (use RAM) so DNS resolution works consistently.
+
+## Route 53 private hosted zone — friendly endpoints
+
+Give RDS a friendly DNS name that works across VPCs:
+
+```bash
+# Create private hosted zone
+aws route53 create-hosted-zone \
+  --name db.internal \
+  --vpc VPCRegion=us-east-1,VPCId=vpc-xxxx \
+  --caller-reference $(date +%s) \
+  --hosted-zone-config PrivateZone=true
+
+# Associate additional VPCs (for cross-VPC access)
+aws route53 associate-vpc-with-hosted-zone \
+  --hosted-zone-id Z123456ABCDEF \
+  --vpc VPCRegion=us-east-1,VPCId=vpc-peer
+
+# Create CNAME to RDS
+aws route53 change-resource-record-sets \
+  --hosted-zone-id Z123456ABCDEF \
+  --change-batch '{
+    "Changes": [{
+      "Action": "CREATE",
+      "ResourceRecordSet": {
+        "Name": "prod-db.db.internal",
+        "Type": "CNAME", "TTL": 60,
+        "ResourceRecords": [{"Value": "mydb.xxxx.us-east-1.rds.amazonaws.com"}]
+      }
+    }]
+  }'
+```
+
+Clients connect to `prod-db.db.internal` — shorter, environment-aware, and can be updated for blue/green deployments without code changes.
+
+### CNAME for AD DNS (Windows auth)
+
+Windows auth requires Kerberos, which requires the server name to match an SPN in Active Directory. The RDS endpoint has no SPN. You must:
+
+1. Create a CNAME in your AD DNS pointing to the RDS endpoint
+   (e.g. `database-1.corp.example.com` → `mydb.xxxx.us-east-1.rds.amazonaws.com`)
+2. Register the SPN for the CNAME (RDS does this automatically for AWS Managed Microsoft AD)
+3. Clients connect to the CNAME, not the RDS endpoint
+
+See `ad-kerberos.md`.
+
+## NACLs
+
+Network ACLs are stateless and must explicitly allow:
+
+- Inbound 1433 from source CIDR
+- **Outbound ephemeral ports 1024-65535** (return traffic)
+
+The "outbound ephemeral ports" is the subtle one. Default NACLs allow all, so this rarely matters. Custom NACLs have broken RDS connections by allowing inbound 1433 but not the return traffic.
+
+## VPC endpoints for AWS services
+
+When Lambda/ECS in private subnets need to reach Secrets Manager without going over NAT:
+
+```bash
+aws ec2 create-vpc-endpoint \
+  --vpc-id vpc-xxxx \
+  --service-name com.amazonaws.us-east-1.secretsmanager \
+  --vpc-endpoint-type Interface \
+  --subnet-ids subnet-priv-a subnet-priv-b \
+  --security-group-ids sg-endpoint \
+  --private-dns-enabled
+```
+
+Endpoint SG inbound 443 from app SG.
+
+Common endpoints to create for RDS SQL Server workloads:
+
+- `secretsmanager` — fetch DB credentials
+- `kms` — decrypt customer-managed secret keys
+- `logs` — CloudWatch Logs for audit/metrics
+- `ec2` — if SDK calls describe-instances etc.
+- `s3` (gateway — free) — ECR image layer pulls, S3 integration
+- `ecr.api` + `ecr.dkr` — ECS/EKS image pulls
+
+## Testing connectivity
+
+### From an EC2 jump host
+
+```bash
+# TCP reachability
+nc -zv mydb.xxxx.us-east-1.rds.amazonaws.com 1433
+
+# DNS
+dig mydb.xxxx.us-east-1.rds.amazonaws.com
+# Should be 10.x.x.x (private) not 52.x.x.x (public)
+
+# TLS handshake
+openssl s_client -connect mydb.xxxx.us-east-1.rds.amazonaws.com:1433 \
+  -starttls mssql  # not all openssl versions support this
+```
+
+For full diagnostics including TDS/pre-login, use the bundled `scripts/test_connection.py`.
+
+### Common issues
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| DNS resolves to public IP cross-VPC | `AllowDnsResolutionFromRemoteVpc` off, or not associated with peer VPC | Enable flag or add PHZ association |
+| TCP refused from peer VPC | RDS SG using SG reference; needs CIDR | Add CIDR ingress rule |
+| Connection times out (15s+) | Route table missing route to peer CIDR | Add route via TGW/peering |
+| NAT gateway required from private subnet | No VPC endpoint for Secrets Manager | Create interface endpoint |
+| Cross-AZ latency noticed | RDS in one AZ, app in another | Deploy Multi-AZ cluster or co-locate |
+
+## Multi-AZ
+
+RDS Multi-AZ creates a standby in a different AZ. The endpoint automatically switches to the standby during failover. No code changes — just tune driver timeouts to handle the 60-120 second failover window.
+
+Pool settings for failover robustness:
+
+- HikariCP: `maxLifetime=1800000` (30 min), `connectionTestQuery="SELECT 1"`, `validationTimeout=5000`
+- SQLAlchemy: `pool_pre_ping=True, pool_recycle=1800`
+- .NET: `Connection Lifetime=300` in connection string
+- tedious/mssql: pool `idleTimeoutMillis: 600000`

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/nodejs.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/nodejs.md
@@ -1,0 +1,238 @@
+# Node.js — tedious (and mssql wrapper)
+
+Two options:
+
+- **`tedious`** — low-level pure-JS driver (no native deps). Direct control, works in Lambda out of the box.
+- **`mssql`** — higher-level wrapper around tedious, adds connection pooling and a friendlier API.
+
+Use `mssql` for most applications. Use raw `tedious` only when you need fine-grained control.
+
+## Install
+
+```bash
+npm install tedious        # low-level
+npm install mssql          # recommended — wrapper with pooling
+```
+
+## Minimal connection with mssql
+
+```javascript
+const sql = require('mssql');
+const { SecretsManagerClient, GetSecretValueCommand } = require("@aws-sdk/client-secrets-manager");
+
+async function connect() {
+  const sm = new SecretsManagerClient({ region: "us-east-1" });
+  const cmd = new GetSecretValueCommand({ SecretId: "rds/sqlserver/app" });
+  const { SecretString } = await sm.send(cmd);
+  const creds = JSON.parse(SecretString);
+
+  const pool = await sql.connect({
+    server: creds.host,
+    port: 1433,
+    database: creds.dbname,
+    user: creds.username,
+    password: creds.password,
+    options: {
+      encrypt: true,               // TLS required in prod
+      trustServerCertificate: false,
+      connectTimeout: 15000,       // ms
+      requestTimeout: 15000,
+    },
+    pool: {
+      max: 10,
+      min: 0,
+      idleTimeoutMillis: 30000,
+    },
+  });
+
+  const result = await pool.request().query("SELECT @@VERSION AS v");
+  console.log(result.recordset[0].v);
+  return pool;
+}
+```
+
+## Critical tedious/mssql gotchas
+
+| Gotcha | Why |
+|---|---|
+| `encrypt: true` is default in tedious 16+; not in older versions | Check your version |
+| `trustServerCertificate: false` requires RDS CA bundle | See below |
+| `port: 1433` as number, NOT string (opposite of pymssql) | tedious parses to number |
+| Pool `max` is per-process | Scale down for Lambda |
+| Connection events — listen for `'error'` | Otherwise silent failures |
+
+## TLS with cert validation
+
+```javascript
+const fs = require('fs');
+const tls = require('tls');
+
+const caBundle = fs.readFileSync('/etc/ssl/certs/global-bundle.pem', 'utf8');
+const caList = caBundle.split(/-----END CERTIFICATE-----\n?/)
+                       .filter(c => c.trim())
+                       .map(c => c + '-----END CERTIFICATE-----\n');
+
+const config = {
+  server: creds.host, port: 1433,
+  database: creds.dbname,
+  user: creds.username, password: creds.password,
+  options: {
+    encrypt: true,
+    trustServerCertificate: false,
+    cryptoCredentialsDetails: {
+      ca: caList,                  // RDS CA bundle
+      minVersion: 'TLSv1.2',
+    },
+  },
+};
+```
+
+## Windows auth (NTLM)
+
+tedious has NTLM support (Kerberos is limited):
+
+```javascript
+const config = {
+  server: "database-1.corp.example.com",
+  port: 1433,
+  database: "mydb",
+  authentication: {
+    type: "ntlm",
+    options: {
+      userName: "svc-app",
+      password: "secret",
+      domain: "CORP",
+    },
+  },
+  options: { encrypt: true, trustServerCertificate: false },
+};
+```
+
+For proper Kerberos, use a different stack (Java + JDBC, or .NET + IntegratedSecurity).
+
+## Lambda pattern
+
+Module-scope pool and secret caching:
+
+```javascript
+const sql = require('mssql');
+const { SecretsManagerClient, GetSecretValueCommand } =
+  require("@aws-sdk/client-secrets-manager");
+
+const sm = new SecretsManagerClient({});
+let poolPromise = null;
+
+async function getPool() {
+  if (poolPromise) return poolPromise;
+  poolPromise = (async () => {
+    const { SecretString } = await sm.send(new GetSecretValueCommand({
+      SecretId: process.env.SECRET_ARN,
+    }));
+    const c = JSON.parse(SecretString);
+    return sql.connect({
+      server: c.host, port: 1433,
+      database: c.dbname, user: c.username, password: c.password,
+      options: { encrypt: true, trustServerCertificate: false, connectTimeout: 5000 },
+      pool: { max: 2, min: 0, idleTimeoutMillis: 10000 },  // small — Lambda
+    });
+  })();
+  return poolPromise;
+}
+
+exports.handler = async (event) => {
+  const pool = await getPool();
+  const result = await pool.request().query("SELECT 1 AS ok");
+  return { statusCode: 200, body: JSON.stringify(result.recordset) };
+};
+```
+
+Use `@aws-sdk/client-secrets-manager` (AWS SDK v3). AWS SDK v2 (`aws-sdk` package) is deprecated and should not be used for new Lambda code.
+
+For high-concurrency Lambda, use RDS Proxy — see `rds-proxy.md`.
+
+## ECS / EKS
+
+For long-running Node.js services, use `mssql` with a larger pool:
+
+```javascript
+const pool = await sql.connect({
+  server: creds.host, port: 1433,
+  database: creds.dbname, user: creds.username, password: creds.password,
+  options: { encrypt: true, trustServerCertificate: false },
+  pool: {
+    max: 20, min: 2,
+    idleTimeoutMillis: 600000,    // 10 min
+    acquireTimeoutMillis: 30000,
+  },
+});
+
+// Handle pool errors
+pool.on('error', err => {
+  console.error('Pool error, reconnecting:', err);
+});
+
+// Health check endpoint
+app.get('/health', async (req, res) => {
+  try {
+    await pool.request().query("SELECT 1");
+    res.status(200).send("ok");
+  } catch (e) {
+    res.status(503).send("db unhealthy");
+  }
+});
+```
+
+## Secrets rotation
+
+When Secrets Manager rotates the password, active connections fail with error 18456 (login failed). Handle it:
+
+```javascript
+pool.on('error', async err => {
+  if (err.code === 'ELOGIN' || err.number === 18456) {
+    console.log('Credentials rotated — rebuilding pool');
+    await pool.close();
+    poolPromise = null;      // reset the lazy init
+  }
+});
+```
+
+## Verify
+
+```javascript
+const r = await pool.request().query(`
+  SELECT encrypt_option, auth_scheme, net_transport
+  FROM sys.dm_exec_connections WHERE session_id = @@SPID
+`);
+console.log(r.recordset[0]);
+```
+
+## Raw tedious (without mssql wrapper)
+
+When you need event-driven access:
+
+```javascript
+const { Connection, Request } = require('tedious');
+
+const conn = new Connection({
+  server: creds.host,
+  options: {
+    port: 1433, database: creds.dbname,
+    encrypt: true, trustServerCertificate: false,
+    connectTimeout: 15000,
+  },
+  authentication: {
+    type: "default",
+    options: { userName: creds.username, password: creds.password },
+  },
+});
+
+conn.on('connect', err => {
+  if (err) { console.error('connect failed', err); return; }
+  const req = new Request("SELECT 1 AS n", (err, rowCount) => { /* done */ });
+  req.on('row', cols => console.log(cols[0].value));
+  conn.execSql(req);
+});
+conn.connect();
+```
+
+No built-in pool — wrap in `tarn.js` or switch to `mssql`.

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/python.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/python.md
@@ -1,0 +1,178 @@
+# Python — pymssql and pyodbc
+
+Two Python drivers for RDS SQL Server. `pymssql` is simpler for pure SQL-auth workloads. `pyodbc` is required when you need Kerberos/Windows auth.
+
+## pymssql
+
+### Install
+
+```bash
+pip install pymssql
+# Linux: FreeTDS is bundled in the wheel
+# macOS: pip install pymssql (wheel available)
+# Windows: pip install pymssql (wheel available)
+```
+
+### Minimal connection
+
+```python
+import pymssql, os, json, boto3
+
+# Fetch creds from Secrets Manager
+sm = boto3.client("secretsmanager", region_name="us-east-1")
+creds = json.loads(sm.get_secret_value(SecretId="rds/sqlserver/app")["SecretString"])
+
+conn = pymssql.connect(
+    server=creds["host"],
+    port="1433",                 # string, NOT int — common bug
+    user=creds["username"],
+    password=creds["password"],
+    database=creds["dbname"],
+    tds_version="7.3",           # 7.3 for SQL Server 2008-2019, 7.4 for 2022+
+    encryption="require",        # not "request" — see below
+    login_timeout=10,
+)
+```
+
+### Critical pymssql gotchas
+
+| Gotcha | Why it matters |
+|---|---|
+| `port="1433"` must be a string | Passing `port=1433` (int) silently fails with "connection refused" on some versions |
+| Use `server=`, NOT `host=` | If both set, `host=` wins silently |
+| `tds_version` is mandatory | Default negotiation can pick TDS 4.2 → fails on modern RDS |
+| `encryption="require"` not `"request"` | `"request"` is opportunistic and can fall back to cleartext |
+| No native connection pool | Use SQLAlchemy or DBUtils for pooling |
+| No Kerberos support | Use pyodbc for AD auth |
+
+### TLS with cert validation
+
+Download RDS CA bundle and point pymssql at it:
+
+```bash
+curl -o global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+```
+
+```python
+conn = pymssql.connect(
+    server="mydb.xxxx.us-east-1.rds.amazonaws.com",
+    user="admin", password=pw, database="mydb",
+    tds_version="7.3",
+    encryption="require",
+)
+# pymssql on Linux uses the system CA bundle — put global-bundle.pem in
+# /etc/ssl/certs/ or set SSL_CERT_FILE env var
+```
+
+For strict validation set `SSL_CERT_FILE=/path/to/global-bundle.pem` before connecting.
+
+## pyodbc (needed for Kerberos)
+
+### Install
+
+```bash
+# Linux — install Microsoft ODBC Driver 18
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | \
+  sudo tee /etc/apt/sources.list.d/mssql-release.list
+sudo apt update && sudo ACCEPT_EULA=Y apt install -y msodbcsql18 unixodbc-dev
+pip install pyodbc
+```
+
+### SQL auth
+
+```python
+import pyodbc
+conn = pyodbc.connect(
+    "Driver={ODBC Driver 18 for SQL Server};"
+    "Server=mydb.xxxx.us-east-1.rds.amazonaws.com,1433;"
+    "Database=mydb;"
+    "Uid=admin;Pwd=secret;"
+    "Encrypt=Yes;"
+    "TrustServerCertificate=No;"
+)
+```
+
+### Windows auth (Kerberos)
+
+```python
+import pyodbc
+# Must be on a domain-joined host with valid TGT
+# Connect to the CNAME, NOT the RDS endpoint
+conn = pyodbc.connect(
+    "Driver={ODBC Driver 18 for SQL Server};"
+    "Server=database-1.corp.example.com,1433;"   # CNAME — Kerberos needs this
+    "Database=mydb;"
+    "Trusted_Connection=Yes;"
+    "Encrypt=Yes;"
+)
+```
+
+Verify Kerberos (not NTLM):
+
+```sql
+SELECT auth_scheme FROM sys.dm_exec_connections WHERE session_id = @@SPID
+-- Expected: KERBEROS
+```
+
+## Connection pooling
+
+### SQLAlchemy + pymssql (most common)
+
+```python
+from sqlalchemy import create_engine
+from sqlalchemy.pool import QueuePool
+
+engine = create_engine(
+    "mssql+pymssql://admin:secret@mydb.xxxx.us-east-1.rds.amazonaws.com:1433/mydb"
+    "?tds_version=7.3&encryption=require",
+    poolclass=QueuePool,
+    pool_size=5,
+    max_overflow=10,
+    pool_pre_ping=True,
+    pool_recycle=300,
+)
+```
+
+`pool_pre_ping=True` detects stale connections (e.g. after Multi-AZ failover). `pool_recycle=300` limits idle connection age.
+
+## Lambda-specific (pymssql)
+
+pymssql needs to be packaged for the Lambda Linux runtime. Either:
+
+- Use a Lambda layer with the pymssql wheel for `manylinux2014_x86_64`
+- Or build a container image based on `public.ecr.aws/lambda/python:3.12` + `pip install pymssql`
+
+```python
+# handler.py
+import pymssql, json, boto3, os
+
+sm = boto3.client("secretsmanager")
+SECRET = json.loads(sm.get_secret_value(SecretId=os.environ["SECRET_ARN"])["SecretString"])
+
+def handler(event, context):
+    conn = pymssql.connect(
+        server=SECRET["host"], port="1433",
+        user=SECRET["username"], password=SECRET["password"],
+        database=SECRET["dbname"],
+        tds_version="7.3", encryption="require", login_timeout=5,
+    )
+    # use conn...
+    conn.close()
+```
+
+For Lambda-level pooling, use RDS Proxy — see `rds-proxy.md`.
+
+## Verify the connection
+
+After any pymssql/pyodbc connection, run:
+
+```sql
+SELECT
+  encrypt_option,                  -- TRUE if TLS
+  auth_scheme,                     -- SQL, KERBEROS, or NTLM
+  net_transport,
+  client_net_address
+FROM sys.dm_exec_connections
+WHERE session_id = @@SPID
+```

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/rds-proxy.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/rds-proxy.md
@@ -1,0 +1,301 @@
+# RDS Proxy for SQL Server — IAM auth and connection pooling
+
+RDS Proxy sits between your apps and RDS SQL Server, providing:
+
+- **Connection pooling** at the proxy layer (reduces connection storms from Lambda/ECS/etc.)
+- **IAM authentication** — generate short-lived tokens instead of using passwords directly
+- **Improved resilience** — retain connections during Multi-AZ failovers (up to 66% faster)
+- **Credentials managed by proxy** — apps don't touch DB passwords
+
+## Prerequisites
+
+- RDS SQL Server instance (any edition)
+- Secrets Manager secret with the standard RDS JSON format
+- IAM role allowing the proxy to read the secret
+- VPC with subnets in at least 2 AZs for HA
+
+## Create the proxy
+
+### 1. IAM role for the proxy
+
+```bash
+# Trust policy
+aws iam create-role \
+  --role-name rds-proxy-sqlserver-role \
+  --assume-role-policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": {"Service": "rds.amazonaws.com"},
+      "Action": "sts:AssumeRole"
+    }]
+  }'
+
+# Permissions — get secret + decrypt
+aws iam put-role-policy \
+  --role-name rds-proxy-sqlserver-role \
+  --policy-name secret-access \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["secretsmanager:GetSecretValue"],
+        "Resource": "arn:aws:secretsmanager:us-east-1:111122223333:secret:rds/sqlserver/app-*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": ["kms:Decrypt"],
+        "Resource": "arn:aws:kms:us-east-1:111122223333:key/<kms-key-id>",
+        "Condition": {
+          "StringEquals": {"kms:ViaService": "secretsmanager.us-east-1.amazonaws.com"}
+        }
+      }
+    ]
+  }'
+```
+
+### 2. Create the proxy
+
+```bash
+aws rds create-db-proxy \
+  --db-proxy-name mydb-proxy \
+  --engine-family SQLSERVER \
+  --auth '[{
+    "AuthScheme": "SECRETS",
+    "SecretArn": "arn:aws:secretsmanager:us-east-1:111122223333:secret:rds/sqlserver/app-AbCdEf",
+    "IAMAuth": "REQUIRED",
+    "ClientPasswordAuthType": "SQL_SERVER_AUTHENTICATION"
+  }]' \
+  --role-arn arn:aws:iam::111122223333:role/rds-proxy-sqlserver-role \
+  --vpc-subnet-ids subnet-priv-a subnet-priv-b \
+  --vpc-security-group-ids sg-rds-proxy \
+  --require-tls
+```
+
+Important:
+
+- `--engine-family SQLSERVER` — must specify
+- `IAMAuth: REQUIRED` — clients must use IAM tokens (vs `DISABLED` for password passthrough)
+- `--require-tls` — enforce TLS to the proxy
+
+### 3. Register the DB instance
+
+```bash
+aws rds register-db-proxy-targets \
+  --db-proxy-name mydb-proxy \
+  --db-instance-identifiers mydb
+```
+
+Wait for the proxy to become `AVAILABLE`:
+
+```bash
+aws rds describe-db-proxies --db-proxy-name mydb-proxy \
+  --query 'DBProxies[0].Status'
+```
+
+### 4. Security groups
+
+- **Proxy SG** (sg-rds-proxy): inbound 1433 from app SG; outbound 1433 to RDS SG
+- **RDS SG**: inbound 1433 from proxy SG (no longer need direct app → RDS path)
+- **App SG**: outbound 1433 to proxy SG
+
+## Use IAM auth from apps
+
+### Python
+
+```python
+import boto3, pymssql
+
+rds = boto3.client("rds", region_name="us-east-1")
+proxy_endpoint = "mydb-proxy.proxy-xxxx.us-east-1.rds.amazonaws.com"
+
+# Token lasts 15 minutes
+token = rds.generate_db_auth_token(
+    DBHostname=proxy_endpoint,
+    Port=1433,
+    DBUsername="app_user",       # SQL login name, not IAM user
+    Region="us-east-1",
+)
+
+conn = pymssql.connect(
+    server=proxy_endpoint,
+    port="1433",
+    user="app_user",
+    password=token,              # IAM token as password
+    database="mydb",
+    tds_version="7.3",
+    encryption="require",
+)
+```
+
+### .NET
+
+```csharp
+using Amazon.RDS;
+using Amazon.RDS.Util;
+
+var token = RDSAuthTokenGenerator.GenerateAuthToken(
+    RegionEndpoint.USEast1,
+    "mydb-proxy.proxy-xxxx.us-east-1.rds.amazonaws.com",
+    1433,
+    "app_user"
+);
+
+var connStr = $"Server=mydb-proxy.proxy-xxxx.us-east-1.rds.amazonaws.com,1433;" +
+              $"Database=mydb;User Id=app_user;Password={token};" +
+              $"Encrypt=Mandatory;";
+```
+
+### Java
+
+```java
+RdsUtilities utilities = RdsUtilities.builder()
+    .region(Region.US_EAST_1)
+    .credentialsProvider(DefaultCredentialsProvider.create())
+    .build();
+
+String token = utilities.generateAuthenticationToken(builder -> builder
+    .hostname("mydb-proxy.proxy-xxxx.us-east-1.rds.amazonaws.com")
+    .port(1433)
+    .username("app_user")
+);
+
+String url = "jdbc:sqlserver://mydb-proxy.proxy-xxxx.us-east-1.rds.amazonaws.com:1433;"
+           + "databaseName=mydb;encrypt=true;";
+Properties props = new Properties();
+props.setProperty("user", "app_user");
+props.setProperty("password", token);
+```
+
+### Node.js
+
+```javascript
+const { Signer } = require("@aws-sdk/rds-signer");
+
+const signer = new Signer({
+  region: "us-east-1",
+  hostname: "mydb-proxy.proxy-xxxx.us-east-1.rds.amazonaws.com",
+  port: 1433,
+  username: "app_user",
+});
+
+const token = await signer.getAuthToken();
+
+const pool = await sql.connect({
+  server: "mydb-proxy.proxy-xxxx.us-east-1.rds.amazonaws.com",
+  port: 1433,
+  database: "mydb",
+  user: "app_user", password: token,
+  options: { encrypt: true, trustServerCertificate: false },
+});
+```
+
+## IAM permissions on the app
+
+The app's IAM role (instance profile / task role / Lambda execution role) needs:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["rds-db:connect"],
+    "Resource": "arn:aws:rds-db:us-east-1:111122223333:dbuser:prx-0123456789abcdef0/app_user"
+  }]
+}
+```
+
+The resource ARN format is `arn:aws:rds-db:<region>:<account>:dbuser:<proxy-resource-id>/<db-user>`. Get the proxy resource ID from:
+
+```bash
+aws rds describe-db-proxies --db-proxy-name mydb-proxy \
+  --query 'DBProxies[0].DBProxyArn'
+```
+
+## Token lifecycle
+
+- Tokens expire after **15 minutes**
+- Generate a fresh token for each new connection
+- Already-authenticated connections stay valid until idle timeout
+- For connection pools: regenerate the token on reconnect (wrap `getPool()` around token generation)
+
+## Password passthrough (alternative — no IAM)
+
+If you want RDS Proxy's pooling benefits without IAM tokens, set `IAMAuth: DISABLED`:
+
+```bash
+aws rds create-db-proxy ... \
+  --auth '[{
+    "AuthScheme": "SECRETS",
+    "SecretArn": "arn:...",
+    "IAMAuth": "DISABLED",
+    "ClientPasswordAuthType": "SQL_SERVER_AUTHENTICATION"
+  }]'
+```
+
+App connects with the SQL user and password from Secrets Manager (fetched normally). Proxy forwards to RDS using its own credentials from the secret. Apps still benefit from pooling and failover resilience.
+
+## Connection pooling at proxy
+
+Tune via `MaxConnectionsPercent` and `MaxIdleConnectionsPercent`:
+
+```bash
+aws rds modify-db-proxy-target-group \
+  --db-proxy-name mydb-proxy \
+  --target-group-name default \
+  --connection-pool-config '{
+    "MaxConnectionsPercent": 80,
+    "MaxIdleConnectionsPercent": 50,
+    "ConnectionBorrowTimeout": 120,
+    "SessionPinningFilters": []
+  }'
+```
+
+Percentages are of RDS's configured max connections. With MaxConnectionsPercent=80 and RDS max_connections=32000, proxy uses up to 25,600 connections.
+
+## Session pinning — SQL Server specific
+
+When a client uses session-state features, the proxy must **pin** the client to a specific backend connection for correctness. Common SQL Server pinning triggers:
+
+- `SET` statements (session variables, options)
+- Cursors with server-side cursors
+- Temporary tables (`#temp`)
+- `sp_set_session_context`
+- Prepared statements
+
+Pinned sessions don't benefit from pooling. Check pinning metrics in CloudWatch:
+
+```
+AWS/RDS namespace
+DatabaseConnectionsCurrentlySessionPinned
+```
+
+If pinning is high, review app code for unnecessary session state. Use `TRUNCATE` + temporary tables → permanent tables where possible.
+
+## When NOT to use RDS Proxy
+
+- Very simple apps with predictable, low connection counts
+- Apps that make heavy use of session state (can't benefit from pooling due to pinning)
+- Small instances where proxy cost (per-vCPU hourly) outweighs the benefit
+
+Check the [pricing page](https://aws.amazon.com/rds/proxy/pricing/) — for small apps, RDS Proxy is cost-additive; for Lambda-heavy workloads, it prevents connection storms and is usually net-positive.
+
+## Monitor
+
+Key CloudWatch metrics:
+
+- `DatabaseConnections` (at proxy target group)
+- `DatabaseConnectionsCurrentlySessionPinned`
+- `QueryDatabaseResponseLatency`
+- `ClientConnections` / `ClientConnectionsSetupFailedAuth`
+
+## Verify
+
+```python
+# Connect via proxy, then:
+cur = conn.cursor()
+cur.execute("SELECT @@SERVERNAME, system_user, auth_scheme FROM sys.dm_exec_connections WHERE session_id=@@SPID")
+print(cur.fetchone())
+# Returns the actual RDS server name (proxy is transparent), app_user, SQL (IAM tokens go in as SQL passwords)
+```

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/ssm-tunneling.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/ssm-tunneling.md
@@ -1,0 +1,184 @@
+# SSM port forwarding — RDS SQL Server from laptop
+
+For developers who need to connect SSMS, Azure Data Studio, or a local Python script to a private RDS SQL Server without enabling public access, VPN, or a bastion host with SSH.
+
+## Why SSM tunnel
+
+- RDS stays private — no public exposure
+- No SSH key management
+- IAM-audited via CloudTrail
+- Works through corporate firewalls (outbound 443 only)
+- Works on any laptop OS (macOS, Linux, Windows)
+
+## Prerequisites
+
+- EC2 jump host in the same VPC as RDS (or peered)
+- Jump host has:
+  - SSM agent running (Amazon Linux 2/2023 have it by default)
+  - IAM instance profile with `AmazonSSMManagedInstanceCore` managed policy
+  - SG outbound 1433 → RDS SG, outbound 443 → SSM endpoints
+- RDS SG inbound 1433 from jump host SG
+- Laptop: AWS CLI v2 + Session Manager plugin
+- User IAM identity has `ssm:StartSession` permission on the EC2 resource
+
+### Install Session Manager plugin
+
+```bash
+# macOS
+curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/mac/sessionmanager-bundle.zip" -o "sessionmanager-bundle.zip"
+unzip sessionmanager-bundle.zip
+sudo ./sessionmanager-bundle/install -i /usr/local/sessionmanagerplugin -b /usr/local/bin/session-manager-plugin
+
+# Linux (deb)
+curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
+sudo dpkg -i session-manager-plugin.deb
+
+# Windows
+# Download and run https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe
+
+# Verify
+session-manager-plugin
+```
+
+## Start the tunnel
+
+```bash
+aws ssm start-session \
+  --target i-0123456789abcdef0 \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{
+    "host": ["mydb.xxxx.us-east-1.rds.amazonaws.com"],
+    "portNumber": ["1433"],
+    "localPortNumber": ["11433"]
+  }'
+```
+
+Leave this running in a separate terminal. Connect to `localhost:11433` from your client.
+
+Using `11433` (not `1433`) avoids conflict with any local SQL Server Express installation.
+
+## Connect from various tools
+
+### SSMS (SQL Server Management Studio)
+
+- Server name: `localhost,11433` (**comma, not colon**)
+- Authentication: SQL Server Authentication
+- Login: admin (your RDS master user)
+- Password: from Secrets Manager
+- **Connection Properties → Connection** → "Encrypt connection" = checked
+- **Connection Properties → Connection** → "Trust server certificate" = checked (**dev only**, because cert CN won't match localhost)
+
+### Azure Data Studio
+
+- Connection type: Microsoft SQL Server
+- Server: `localhost,11433`
+- Encrypt: True
+- Trust server certificate: True (dev only)
+
+### Python (pymssql)
+
+```python
+import pymssql
+conn = pymssql.connect(
+    server="localhost",
+    port="11433",        # the local port you chose
+    user="admin",
+    password=pw,
+    database="mydb",
+    tds_version="7.3",
+    encryption="request",  # use "request" for tunnel — cert won't match localhost
+)
+```
+
+### sqlcmd
+
+```bash
+sqlcmd -S localhost,11433 -U admin -P "$PW" -d mydb \
+  -C                      # trust server certificate (dev only — cert CN mismatch expected)
+```
+
+### .NET / SqlClient
+
+```csharp
+var connStr = "Server=localhost,11433;Database=mydb;" +
+              "User Id=admin;Password=secret;" +
+              "Encrypt=Mandatory;" +
+              "TrustServerCertificate=True;";   // dev only — cert CN mismatch
+```
+
+## Why `TrustServerCertificate=True` through the tunnel
+
+The RDS certificate CN is `mydb.xxxx.us-east-1.rds.amazonaws.com` but your client connects to `localhost`. Default TLS behavior requires CN match — fails without `TrustServerCertificate=True` (or equivalent).
+
+**This is for dev tunnels only.** The tunnel itself is end-to-end encrypted via SSM (WebSocket over TLS to SSM endpoints, TCP to RDS inside the VPC). The TLS layer is a second encryption layer — trusting the cert through the tunnel only means you accept that the CN doesn't match `localhost`.
+
+**Production workloads must connect from VPC-resident compute** (EC2/ECS/Lambda in the same VPC) using the real endpoint with full cert validation.
+
+## Windows auth through the tunnel — don't
+
+SSM runs as the EC2 system account, not your user. `Integrated Security=True` through a tunnel will:
+
+- Connect as the EC2 system account (which has no AD identity) → NTLM fallback or fail
+- Not test anything meaningful about your user's domain credentials
+
+For Windows auth testing, RDP to a domain-joined EC2 and run SSMS there.
+
+## IAM policy for developers
+
+Limit `ssm:StartSession` to the specific document + instance:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "StartSessionPortForward",
+      "Effect": "Allow",
+      "Action": ["ssm:StartSession"],
+      "Resource": [
+        "arn:aws:ec2:us-east-1:111122223333:instance/i-0123456789abcdef0",
+        "arn:aws:ssm:us-east-1::document/AWS-StartPortForwardingSessionToRemoteHost"
+      ]
+    },
+    {
+      "Sid": "TerminateAndResume",
+      "Effect": "Allow",
+      "Action": ["ssm:TerminateSession", "ssm:ResumeSession"],
+      "Resource": "arn:aws:ssm:*:111122223333:session/${aws:username}-*"
+    }
+  ]
+}
+```
+
+## Troubleshooting the tunnel
+
+| Symptom | Cause |
+|---|---|
+| `TargetNotConnected` | EC2 SSM agent not running or IAM role missing `AmazonSSMManagedInstanceCore` |
+| Tunnel starts but `localhost:11433` connection refused | EC2 SG can't reach RDS (outbound 1433 not allowed, or RDS SG inbound missing) |
+| Tunnel starts, connects, then SSMS pre-login fails | TLS version mismatch — upgrade SSMS to 18.x+ |
+| Cert validation error with `TrustServerCertificate=False` | Set `TrustServerCertificate=True` — CN will never match localhost through a tunnel |
+
+Check SSM agent status from the jump host:
+
+```bash
+sudo systemctl status amazon-ssm-agent
+sudo tail -f /var/log/amazon/ssm/amazon-ssm-agent.log
+```
+
+## Verify the tunnel works end-to-end
+
+```bash
+# Terminal 1: start tunnel
+aws ssm start-session --target i-xxxx \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"host":["mydb.xxxx.us-east-1.rds.amazonaws.com"],"portNumber":["1433"],"localPortNumber":["11433"]}'
+
+# Terminal 2: test reachability
+nc -zv localhost 11433
+# Connection to localhost port 11433 [tcp/*] succeeded!
+
+# Terminal 2: SQL query
+sqlcmd -S localhost,11433 -U admin -P "$PW" -Q "SELECT @@SERVERNAME" -C
+# Returns RDS server name
+```

--- a/skills/specialized-skills/database-skills/rds-sqlserver/references/troubleshooting.md
+++ b/skills/specialized-skills/database-skills/rds-sqlserver/references/troubleshooting.md
@@ -1,0 +1,345 @@
+# Troubleshooting — RDS SQL Server Connection Errors
+
+## How to diagnose (order matters)
+
+1. **TCP reachability** — can you open a socket?
+2. **TLS handshake** — does the cert chain validate?
+3. **Login** — does authentication succeed?
+4. **Post-login** — does the query work?
+
+Most issues are at layer 1 (network). Start with `nc` / `Test-NetConnection` before worrying about drivers.
+
+## Login failed for user (error 18456)
+
+The most common SQL Server error. State codes tell you why (visible only in SQL Server's own error log):
+
+| State | Meaning | Typical fix |
+|---|---|---|
+| 2, 5 | Invalid userid | Login doesn't exist — `SELECT * FROM sys.server_principals WHERE name = 'user'` |
+| 6 | Windows login used as SQL | Use Windows auth, or create SQL login |
+| 7 | Login disabled | `ALTER LOGIN [x] ENABLE` |
+| 8 | Incorrect password | Fetch current password from Secrets Manager; check for rotation |
+| 9 | Invalid password (bad chars) | Password has chars the client couldn't transmit (check encoding) |
+| 11, 12 | Valid login but server access failure | Login doesn't have login permission — `GRANT CONNECT SQL TO [login]` |
+| 18 | Change password required | Login must change on next logon (policy) |
+| 38, 40 | DB not found / not accessible | Wrong `Database=` or user has no access to that DB |
+| 58 | Not configured for Windows auth (using Kerberos/NTLM on SQL-only server) | Enable Windows auth on RDS (domain join) |
+
+To read the SQL Server error log from RDS:
+
+```bash
+aws rds describe-db-log-files \
+  --db-instance-identifier mydb \
+  --filename-contains error
+
+aws rds download-db-log-file-portion \
+  --db-instance-identifier mydb \
+  --log-file-name "log/ERROR" \
+  --output text --query 'LogFileData' > error-log.txt
+grep "18456" error-log.txt   # find login failures with state
+```
+
+### Rotation-related 18456
+
+When Secrets Manager rotates the password, existing app connections (using cached creds) fail at next use. Symptoms:
+
+- Intermittent 18456 after 30-day rotation schedule
+- All replicas hit it around the same time
+- Fresh invocations succeed (they fetch the new secret)
+
+Fix: re-fetch the secret on 18456 and rebuild the connection pool.
+
+```python
+# SQLAlchemy pattern
+from sqlalchemy import event
+
+@event.listens_for(engine, "handle_error")
+def on_error(ctx):
+    if "18456" in str(ctx.original_exception):
+        _creds_cache.invalidate()   # force re-fetch on next connection
+```
+
+## Cannot generate SSPI context
+
+Kerberos authentication handshake failure. See `ad-kerberos.md` for full details. Quick diagnosis:
+
+```powershell
+# Client-side (Windows) — do you have a TGT?
+klist
+# Look for: MSSQLSvc/mydb.corp.example.com:1433
+
+# Does the CNAME resolve?
+Resolve-DnsName mydb.corp.example.com
+
+# Does the SPN exist?
+setspn -L <service-account>
+```
+
+Most common causes (in order):
+
+1. **Connected to RDS endpoint, not CNAME** → no SPN for endpoint → Kerberos fails
+2. **CNAME doesn't resolve** → DNS problem
+3. **SPN missing** → self-managed AD needs manual setspn
+4. **Clock skew > 5 min** from DC → NTP issue
+
+## auth_scheme shows NTLM instead of KERBEROS
+
+Kerberos attempted, fell back to NTLM. Same root cause analysis as SSPI errors:
+
+- Most likely: client connected to RDS endpoint rather than the CNAME
+- Fix: use CNAME
+- Verify after fix:
+
+```sql
+SELECT auth_scheme FROM sys.dm_exec_connections WHERE session_id = @@SPID
+-- Expected: KERBEROS
+```
+
+## Connection timeout (no specific error)
+
+The TCP connection couldn't be established. Check in order:
+
+### 1. Security groups
+
+```bash
+# RDS SG — inbound rules
+aws ec2 describe-security-groups --group-ids sg-rds-sqlserver \
+  --query 'SecurityGroups[0].IpPermissions'
+# Should show TCP 1433 with the app SG or client CIDR as source
+```
+
+Same VPC → use SG ID. Cross-VPC → use CIDR (SG refs don't cross VPC boundary).
+
+### 2. Route tables
+
+For cross-VPC connections:
+
+```bash
+aws ec2 describe-route-tables --route-table-ids rtb-xxxx \
+  --query 'RouteTables[0].Routes'
+# Must have a route to the RDS VPC CIDR via TGW/peering
+```
+
+### 3. NACLs (stateless — often forgotten)
+
+```bash
+aws ec2 describe-network-acls --filters Name=vpc-id,Values=vpc-xxxx
+```
+
+Check:
+
+- Inbound: allow 1433
+- Outbound: allow ephemeral ports 1024-65535 (return traffic)
+
+### 4. RDS instance state
+
+```bash
+aws rds describe-db-instances --db-instance-identifier mydb \
+  --query 'DBInstances[0].DBInstanceStatus'
+# Expected: available
+```
+
+If `modifying`, `rebooting`, `storage-full`, `failed` → check events for cause.
+
+### 5. Lambda in VPC
+
+Lambda without NAT/VPC endpoint can't reach Secrets Manager → hangs on `get_secret_value` before even attempting RDS. Check `lambda-vpc.md`.
+
+## Certificate validation errors
+
+### `.NET — Could not establish trust relationship for the SSL/TLS secure channel`
+
+Install RDS CA bundle:
+
+```powershell
+Import-Certificate -FilePath global-bundle.pem `
+  -CertStoreLocation Cert:\LocalMachine\Root
+```
+
+### `Java — PKIX path building failed`
+
+Client doesn't have RDS CA in truststore. See `encryption.md` for split-and-import pattern. The common mistake is using `keytool -import` on the multi-cert `global-bundle.pem` — keytool imports only the **first** cert.
+
+### `Python — SSL: CERTIFICATE_VERIFY_FAILED`
+
+Set `SSL_CERT_FILE=/path/to/global-bundle.pem` env var before connecting. For pymssql, also install the bundle in the system cert store.
+
+### `SSMS — A connection was successfully established with the server, but then an error occurred during the pre-login handshake`
+
+TLS version mismatch (client < 1.2, server requires 1.2+). Upgrade SSMS to 18.x or newer. Same error can be cert trust — check both.
+
+## SSL_SERVER_DN_MATCH errors through SSM tunnel
+
+Cert CN is the RDS endpoint, but client connects to `localhost` through the tunnel. Two options:
+
+### Dev only — trust without CN check
+
+```
+Server=localhost,11433;...;TrustServerCertificate=True;
+```
+
+```python
+# pymssql
+conn = pymssql.connect(..., encryption="request")  # less strict than "require"
+```
+
+### Better — for any non-trivial use
+
+Don't tunnel for production. Use VPC-resident compute (EC2/ECS/Lambda) with the real endpoint.
+
+## pymssql-specific errors
+
+### `pymssql.OperationalError: (20002, b'DB-Lib error message 20002, severity 9: Adaptive Server connection failed')`
+
+Generic — check:
+
+- `port="1433"` is a string, not int
+- `tds_version="7.3"` is set (default 4.2 fails on modern RDS)
+- `encryption="require"` (or force the server side to not require TLS for testing)
+
+### `pymssql.InterfaceError: Connection to the database failed for an unknown reason`
+
+Usually TLS handshake failure. Install `global-bundle.pem` in OS cert store.
+
+### `ImportError: DLL load failed` on Windows
+
+pymssql wheel missing FreeTDS. Switch to pyodbc on Windows.
+
+## .NET-specific errors
+
+### `A connection was successfully established... but then error occurred during pre-login handshake`
+
+Either TLS version or cert trust:
+
+- `.NET Framework < 4.7` defaults to TLS 1.0 → upgrade Framework or set `ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12`
+- Cert chain — install CA bundle
+
+### `The target principal name is incorrect. Cannot generate SSPI context`
+
+Windows auth — see SSPI section above.
+
+### `Login timeout expired`
+
+Connection timeout too short or network slow. Default is 15 seconds. Increase:
+`Server=...;Connection Timeout=30;`
+
+## Java / JDBC errors
+
+### `com.microsoft.sqlserver.jdbc.SQLServerException: The driver could not establish a secure connection`
+
+TLS issue. Either:
+
+- JDK version doesn't support TLS 1.2 — use JDK 11+
+- Truststore missing CA — build truststore from global-bundle.pem
+- JDK FIPS settings blocking RSA cipher — check `java.security` file
+
+### `PKIX path building failed`
+
+Truststore doesn't trust the RDS CA. Rebuild truststore with `keytool -import` on each cert from `global-bundle.pem` (split first — see `encryption.md`).
+
+### `Connection timed out: no further information`
+
+Network. Same TCP reachability checks as above.
+
+## Node.js / tedious errors
+
+### `ConnectionError: Failed to connect to ... in 15000ms`
+
+Default connect timeout too short. Increase:
+
+```javascript
+options: { connectTimeout: 30000 }
+```
+
+### `TypeError: Cannot read property 'Length' of undefined`
+
+Usually parse error on pre-login response. Often means plaintext connection to server that requires TLS, or vice versa. Check `options.encrypt` matches server config.
+
+### `RequestError: Invalid object name`
+
+Post-login — database/schema/table doesn't exist or user lacks permission. Not a connection issue.
+
+## Access denied to Secrets Manager from Lambda
+
+Lambda in VPC can't reach Secrets Manager endpoint:
+
+- No NAT gateway AND no VPC endpoint for secretsmanager
+- Create VPC endpoint (interface) in Lambda's subnets — see `networking.md`
+
+Or Lambda execution role missing permission:
+
+- `secretsmanager:GetSecretValue` on the secret ARN
+- `kms:Decrypt` on the CMK (if customer-managed)
+
+## Secrets not resolving in ECS task
+
+ECS `secrets` in container definition uses the **execution role**, not the task role:
+
+```json
+{
+  "executionRoleArn": "arn:aws:iam::111122223333:role/ecsTaskExecutionRole",
+  "taskRoleArn": "arn:aws:iam::111122223333:role/app-task-role",
+  "containerDefinitions": [{
+    "secrets": [{"name": "DB_SECRET", "valueFrom": "arn:aws:secretsmanager:..."}]
+  }]
+}
+```
+
+The **execution role** needs `secretsmanager:GetSecretValue` + `kms:Decrypt`. Most common ECS secrets misconfiguration.
+
+## Scripts for diagnosis
+
+The skill ships with:
+
+- `scripts/test_connection.py` — TCP + TLS + full login test (Linux/macOS from EC2 or laptop)
+- `scripts/test_connection.ps1` — Same but PowerShell (Windows EC2 via SSM or local)
+- `scripts/validate_ad_network.ps1` — AD domain + Kerberos diagnostics (Windows, domain-joined)
+
+Run from the **source** of the connection, not from your laptop (unless laptop is the source).
+
+```bash
+python3 test_connection.py --server mydb.xxxx.us-east-1.rds.amazonaws.com \
+  --user admin --password "$PW" --database mydb
+```
+
+## Verify connection state from SQL
+
+After any successful connection, run:
+
+```sql
+SELECT
+  session_id,
+  login_name,                     -- who's authenticated
+  auth_scheme,                    -- SQL, KERBEROS, NTLM
+  encrypt_option,                 -- TRUE = TLS
+  client_net_address,             -- client IP (proxy IP if using RDS Proxy)
+  net_transport,
+  client_interface_name,          -- driver name/version
+  protocol_type
+FROM sys.dm_exec_connections
+WHERE session_id = @@SPID
+```
+
+This is the fastest way to confirm:
+
+- Authentication worked and of what type
+- Encryption is active
+- Which driver is connected
+- Whether you're going through a proxy
+
+## Nothing works — escalation checklist
+
+When all obvious paths have been tried:
+
+- [ ] RDS instance `DBInstanceStatus == available`
+- [ ] RDS engine version supported (modern SQL Server — 2019+)
+- [ ] CloudWatch logs `rdsadmin/error` for server-side errors
+- [ ] `aws rds describe-events --source-identifier mydb --source-type db-instance` for recent events
+- [ ] Security group inbound: TCP 1433 from the right source (SG-ID same-VPC, CIDR cross-VPC)
+- [ ] VPC has `enableDnsSupport=true` and `enableDnsHostnames=true`
+- [ ] Client IAM permissions: `secretsmanager:GetSecretValue`, `kms:Decrypt`
+- [ ] Client can resolve endpoint to private IP (nslookup returns 10.x.x.x)
+- [ ] Client can reach port: `nc -zv <endpoint> 1433`
+- [ ] Client has RDS CA bundle (or equivalent) in trust store
+- [ ] Connection string uses correct driver-specific encrypt setting
+- [ ] If Windows auth: client is on a domain-joined host, CNAME resolves, SPN exists, `klist` shows TGT


### PR DESCRIPTION
## Description

Adds the `rds-sqlserver` skill to the public skills registry. This skill provides connectivity, authentication, and troubleshooting guidance for Amazon RDS for SQL Server.

**Skill coverage:**
- 4 language drivers: Python (pymssql/pyodbc), .NET (Microsoft.Data.SqlClient), Java (JDBC mssql-jdbc), Node.js (tedious)
- 5 deployment patterns: EC2, ECS Fargate, Lambda, EKS, laptop via SSM tunnel
- Authentication: SQL auth, Windows/Kerberos (AWS Managed Microsoft AD), IAM via RDS Proxy
- Troubleshooting: SSMS timeouts, SSPI context errors, NTLM fallback, login failures, TLS issues
- Safety guidance: resource tagging, downtime warnings, destructive-action refusal

15 files (1 SKILL.md + 14 references). No scripts included.

## Type of Change

- [ ] New plugin
- [x] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*