### PR TITLE
feat(aws-network-monitoring): Add aws-network-monitoring skill

### DIFF
--- a/skills/specialized-skills/operations-skills/aws-network-monitoring/SKILL.md
+++ b/skills/specialized-skills/operations-skills/aws-network-monitoring/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: aws-network-monitoring
+description: >-
+  Installs, configures, and troubleshoots Network Flow Monitor agents on EC2 instances
+  to monitor network path health. Covers agent installation, IAM permissions, monitoring
+  network paths, and troubleshooting agents reporting no metrics, HTTP 403 errors, or
+  connectivity failures.
+version: 1
+metadata:
+  service: [network-flow-monitor, ec2, ssm, cloudwatch]
+  task: [deploy, debug]
+  persona: [developer, devops, network-engineer]
+  workload: [networking]
+---
+
+# AWS Network Monitoring
+
+## Overview
+
+Domain expertise for installing and configuring Amazon CloudWatch Network Flow
+Monitor agents on EC2 instances. Covers IAM permission setup, agent
+installation via SSM Distributor or command-line install, agent activation,
+verification, and troubleshooting.
+
+Network Flow Monitor agents are lightweight software that publish performance
+metrics (latency, packet loss) to the Network Flow Monitor backend, enabling
+monitoring of network path health between workloads.
+
+**Works best with** the [AWS MCP server](https://docs.aws.amazon.com/aws-mcp/) — enables running SSM commands, attaching IAM policies, and validating agent status directly. All guidance also works with standard AWS CLI access.
+
+## Routing
+
+| User need | Action |
+|-----------|--------|
+| Installing Network Flow Monitor agents on EC2 | Read [agent-install-ec2.md](references/agent-install-ec2.md) |
+| Configuring IAM for Network Flow Monitor agents | Read [agent-permissions.md](references/agent-permissions.md) |
+| Troubleshooting Network Flow Monitor agents (403, no metrics, connectivity) | Read [troubleshooting.md](references/troubleshooting.md) |
+| Spans multiple areas | Read the most specific reference first, then consult others as needed |
+
+## Files
+
+| File | Content |
+|------|---------|
+| [agent-install-ec2.md](references/agent-install-ec2.md) | End-to-end Network Flow Monitor agent installation via SSM Distributor, activation, verification |
+| [agent-permissions.md](references/agent-permissions.md) | IAM policy setup for Network Flow Monitor agent metric publishing |
+| [troubleshooting.md](references/troubleshooting.md) | Error → cause → fix for Network Flow Monitor agent issues (HTTP 403, missing metrics, connectivity) |
+
+## Supported versions
+
+For supported Linux distributions, kernel versions, and architectures, see the
+[AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-versions.html).
+Windows is not supported.
+
+## Security Considerations
+
+- **Least-privilege IAM**: Attach only `CloudWatchNetworkFlowMonitorAgentPublishPolicy` for publishing metrics and `AmazonSSMManagedInstanceCore` for SSM management. Do not use `*FullAccess` policies.
+- **Private subnets**: When the instance is in a private subnet, prefer VPC endpoints for SSM (`com.amazonaws.<region>.ssm`, `.ssmmessages`, `.ec2messages`) over a NAT gateway to keep traffic on the AWS network.
+- **Credential storage**: Never embed AWS credentials on the instance; the publish policy MUST be attached to the instance role, not configured as static keys.
+- **Audit trail**: Ensure CloudTrail is enabled in the account so SSM `SendCommand` invocations and IAM `AttachRolePolicy` actions performed during agent setup are logged for security investigations.
+- **References**: [CloudWatch Network Flow Monitor security](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-security.html), [IAM best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)

--- a/skills/specialized-skills/operations-skills/aws-network-monitoring/references/agent-install-ec2.md
+++ b/skills/specialized-skills/operations-skills/aws-network-monitoring/references/agent-install-ec2.md
@@ -1,0 +1,158 @@
+# EC2 Agent Installation Procedure
+
+Two install paths are supported. Prefer **SSM Distributor** when SSM is
+available — it lets you target many instances in one call (by tag, instance
+ID, or resource group) and integrates with the manage-agent document used to
+activate/deactivate agents. Use the **command-line** path when SSM is
+unavailable. Activation is only applicable for the SSM path; command-line-installed
+agents start publishing as soon as IAM permissions are in place.
+
+## Prerequisites
+
+- IAM permissions configured *before* install (see
+  [agent-permissions.md](agent-permissions.md)). Agents install successfully
+  without the policy but cannot publish metrics until it is attached.
+- Supported Linux distribution (see [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-versions.html))
+- For the SSM path: target EC2 instances must have SSM Agent installed and running
+
+## SSM Distributor install path
+
+## Step 1: Verify SSM connectivity
+
+```bash
+aws ssm describe-instance-information \
+  --filters "Key=InstanceIds,Values=<instance-id>" \
+  --query "InstanceInformationList[].{Id:InstanceId,Ping:PingStatus}" \
+  --output table
+```
+
+If instances don't appear, ensure the instance has the `AmazonSSMManagedInstanceCore` policy attached.
+
+## Step 2: Install the agent
+
+By instance ID:
+
+```bash
+aws ssm send-command \
+  --document-name "AWS-ConfigureAWSPackage" \
+  --targets "Key=instanceids,Values=<instance-id-1>,<instance-id-2>" \
+  --parameters '{"action":["Install"],"name":["AmazonCloudWatchNetworkFlowMonitorAgent"]}' \
+  --comment "Install Network Flow Monitor agent"
+```
+
+By tag:
+
+```bash
+aws ssm send-command \
+  --document-name "AWS-ConfigureAWSPackage" \
+  --targets "Key=tag:Environment,Values=<your-tag-value>" \
+  --parameters '{"action":["Install"],"name":["AmazonCloudWatchNetworkFlowMonitorAgent"]}' \
+  --comment "Install Network Flow Monitor agent on tagged instances"
+```
+
+## Step 3: Verify installation status
+
+```bash
+aws ssm list-command-invocations \
+  --command-id "<command-id-from-step-2>" \
+  --details \
+  --query "CommandInvocations[].{Instance:InstanceId,Status:Status}" \
+  --output table
+```
+
+## Step 4: Activate the agent
+
+```bash
+aws ssm send-command \
+  --document-name "AmazonCloudWatch-NetworkFlowMonitorManageAgent" \
+  --targets "Key=instanceids,Values=<instance-id-1>,<instance-id-2>" \
+  --parameters '{"Action":["Activate"]}' \
+  --comment "Activate Network Flow Monitor agent"
+```
+
+## Step 5: Verify the agent is publishing
+
+Wait 30-60 seconds (the agent publishes reports every 30 seconds by default,
+with up to 5 seconds of jitter), then check agent logs for successful HTTP
+responses:
+
+```bash
+sudo journalctl -u network-flow-monitor.service | grep HTTP
+```
+
+HTTP 200 responses to `networkflowmonitorreports.<region>.api.aws` confirm
+the agent is publishing successfully. Any other status code indicates an
+error — see [troubleshooting.md](troubleshooting.md).
+
+## Deactivate (without uninstalling)
+
+Deactivating stops metric publishing and the associated billing without
+removing the agent.
+
+```bash
+aws ssm send-command \
+  --document-name "AmazonCloudWatch-NetworkFlowMonitorManageAgent" \
+  --targets "Key=instanceids,Values=<instance-id>" \
+  --parameters '{"Action":["Deactivate"]}'
+```
+
+## Uninstall
+
+```bash
+aws ssm send-command \
+  --document-name "AWS-ConfigureAWSPackage" \
+  --targets "Key=instanceids,Values=<instance-id>" \
+  --parameters '{"action":["Uninstall"],"name":["AmazonCloudWatchNetworkFlowMonitorAgent"]}'
+```
+
+## Command-line install path (no SSM)
+
+Use when SSM is unavailable. Activation is **not applicable** to this path —
+the agent begins publishing as soon as the package is installed and the IAM
+policy is attached to the instance role.
+
+**Amazon Linux 2023 (package repository):**
+
+```bash
+sudo yum install network-flow-monitor-agent
+```
+
+**Amazon Linux 2023 (direct download by architecture):**
+
+```bash
+# x86_64
+sudo yum install https://networkflowmonitoragent.awsstatic.com/latest/x86_64/network-flow-monitor-agent.rpm
+
+# ARM64 (Graviton)
+sudo yum install https://networkflowmonitoragent.awsstatic.com/latest/arm64/network-flow-monitor-agent.rpm
+```
+
+**Debian / Ubuntu:**
+
+```bash
+# x86_64
+wget https://networkflowmonitoragent.awsstatic.com/latest/x86_64/network-flow-monitor-agent.deb
+sudo apt-get install ./network-flow-monitor-agent.deb
+
+# ARM64 (Graviton)
+wget https://networkflowmonitoragent.awsstatic.com/latest/arm64/network-flow-monitor-agent.deb
+sudo apt-get install ./network-flow-monitor-agent.deb
+```
+
+**Red Hat / CentOS / SUSE:**
+
+Use the same RPM as Amazon Linux 2023 above (substitute `zypper` for `yum` on
+SUSE). The SSM Distributor path also covers these distros and uses the same
+RPM internally.
+
+**Verify the agent is running:**
+
+```bash
+service network-flow-monitor status
+```
+
+The output should show `Loaded: ... enabled` and `Active: active (running)`.
+
+Attach `CloudWatchNetworkFlowMonitorAgentPublishPolicy` to the instance role
+(see [agent-permissions.md](agent-permissions.md)) so the agent can publish
+metrics.

--- a/skills/specialized-skills/operations-skills/aws-network-monitoring/references/agent-permissions.md
+++ b/skills/specialized-skills/operations-skills/aws-network-monitoring/references/agent-permissions.md
@@ -1,0 +1,52 @@
+# Agent Permissions Setup
+
+## Required Policy
+
+Attach the AWS managed policy `CloudWatchNetworkFlowMonitorAgentPublishPolicy` to the
+instance role used by your EC2 instances. Without this policy, the agent installs
+successfully but cannot publish metrics.
+
+**Policy ARN:** `arn:aws:iam::aws:policy/CloudWatchNetworkFlowMonitorAgentPublishPolicy`
+
+## Attach to existing role
+
+Find the instance role:
+
+```bash
+PROFILE_ARN=$(aws ec2 describe-instances \
+  --instance-ids <instance-id> \
+  --query "Reservations[].Instances[].IamInstanceProfile.Arn" \
+  --output text)
+
+PROFILE_NAME=$(echo $PROFILE_ARN | awk -F/ '{print $NF}')
+
+ROLE_NAME=$(aws iam get-instance-profile \
+  --instance-profile-name $PROFILE_NAME \
+  --query "InstanceProfile.Roles[0].RoleName" \
+  --output text)
+```
+
+Attach the policy:
+
+```bash
+aws iam attach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::aws:policy/CloudWatchNetworkFlowMonitorAgentPublishPolicy
+```
+
+## Instance has no instance role yet
+
+If the EC2 instance has no instance profile attached, use the
+`setting-up-ec2-instance-profiles` skill first to create the instance role and
+attach `AmazonSSMManagedInstanceCore`. Then return here and follow
+"Attach to existing role" above to add
+`CloudWatchNetworkFlowMonitorAgentPublishPolicy`.
+
+## Verify
+
+```bash
+aws iam list-attached-role-policies \
+  --role-name <role-name> \
+  --query "AttachedPolicies[?PolicyName=='CloudWatchNetworkFlowMonitorAgentPublishPolicy']" \
+  --output table
+```

--- a/skills/specialized-skills/operations-skills/aws-network-monitoring/references/troubleshooting.md
+++ b/skills/specialized-skills/operations-skills/aws-network-monitoring/references/troubleshooting.md
@@ -1,0 +1,81 @@
+# Troubleshooting Network Flow Monitor
+
+## SSM command fails or instance not reachable via SSM
+
+Verify the SSM Agent is running on the instance and the instance can reach
+SSM endpoints. For isolated subnets, ensure VPC endpoints for SSM
+(`com.amazonaws.<region>.ssm`, `.ssmmessages`, `.ec2messages`) are configured.
+The instance role also needs `AmazonSSMManagedInstanceCore` attached.
+
+## Agent installed but never activated (SSM path only)
+
+Installation and activation are separate steps when using the SSM Distributor
+path. After installing via SSM Distributor, you must explicitly activate the
+agent using the `AmazonCloudWatch-NetworkFlowMonitorManageAgent` SSM document
+with `Action: Activate`. See [agent-install-ec2.md](agent-install-ec2.md) Step 4.
+
+This does NOT apply to command-line installs (yum/apt-get). Agents installed
+via command-line begin publishing as soon as the package is installed and the
+IAM policy is attached — no activation step is needed.
+
+## Stopping and starting the agent
+
+```bash
+sudo service network-flow-monitor stop
+sudo service network-flow-monitor start
+```
+
+## Verify agent status
+
+```bash
+sudo service network-flow-monitor status
+```
+
+## Verify endpoint connectivity and IAM permissions
+
+Check agent logs for HTTP errors:
+
+```bash
+sudo journalctl -f -u network-flow-monitor.service | grep -i HTTP
+```
+
+Any status code other than 200 indicates an error.
+
+### HTTP 403 — Missing/insufficient IAM permissions
+
+```json
+{
+    "level": "INFO",
+    "message": "HTTP request complete",
+    "status": 403,
+    "target": "nfm_agent::reports::publisher_endpoint",
+    "timestamp": "XXXX"
+}
+```
+
+**Fix:** Attach `CloudWatchNetworkFlowMonitorAgentPublishPolicy` to the instance role. See [agent-permissions.md](agent-permissions.md).
+
+### Connection error — Network connectivity issue
+
+```json
+{
+    "level": "ERROR",
+    "message": "Error sending request: error sending request for url (https://networkflowmonitorreports.<region>.api.aws/publish)",
+    "target": "nfm_agent::reports::publisher_endpoint",
+    "timestamp": "XXXX"
+}
+```
+
+**Fix:** Verify connectivity to the Network Flow Monitor endpoint:
+
+```bash
+nc -zv networkflowmonitorreports.<region>.api.aws 443
+```
+
+Or perform an authenticated TLS check:
+
+```bash
+curl -v https://networkflowmonitorreports.<region>.api.aws/
+```
+
+If using private subnets, ensure a VPC endpoint or NAT gateway is configured for the Network Flow Monitor service endpoint.


### PR DESCRIPTION
Adds the aws-network-monitoring core skill covering Network Flow Monitor agent installation on EC2, IAM permission setup, and troubleshooting (HTTP 403, missing metrics, connectivity failures).

## Description

<!-- Describe the changes in this PR -->

## Type of Change

- [ ] New plugin
- [X] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
