### PR TITLE
fix(aws-serverless): document dual-permission requirement for Lambda function URLs

### DIFF
--- a/plugins/aws-core/skills/aws-serverless/SKILL.md
+++ b/plugins/aws-core/skills/aws-serverless/SKILL.md
@@ -29,6 +29,7 @@ Domain expertise for building serverless applications on AWS. Covers Lambda conf
 | Step Functions, EventBridge, or orchestration | Read [orchestration.md](references/orchestration.md) |
 | Concurrency configuration | Read [concurrency.md](references/concurrency.md) |
 | API Gateway setup | Read [api-gateway.md](references/api-gateway.md) |
+| Configuring Function URLs | Read [deployment.md](references/deployment.md) § Setting up a Public Function URL |
 | Common anti-patterns | Read the anti-patterns section in [production.md](references/production.md) |
 | Starting with Powertools | Use [powertools-handler.py](assets/powertools-handler.py) as a template |
 | Lambda Managed Instances, LMI, capacity providers, EC2-backed Lambda, PerExecutionEnvironmentMaxConcurrency | Use the **aws-lambda-managed-instances** skill instead |
@@ -46,6 +47,6 @@ Domain expertise for building serverless applications on AWS. Covers Lambda conf
 | [orchestration.md](references/orchestration.md) | Step Functions, EventBridge rules/pipes/scheduler |
 | [concurrency.md](references/concurrency.md) | Reserved vs provisioned, scaling, ESM concurrency |
 | [architecture.md](references/architecture.md) | Patterns, reference architectures, service selection |
-| [deployment.md](references/deployment.md) | SAM/CDK resource types, globals, fast iteration |
+| [deployment.md](references/deployment.md) | SAM/CDK resource types, globals, Function URL setup, fast iteration |
 | [production.md](references/production.md) | Readiness checklist, observability, anti-patterns |
 | [troubleshooting.md](references/troubleshooting.md) | Error → cause → fix for all serverless services |

--- a/plugins/aws-core/skills/aws-serverless/references/deployment.md
+++ b/plugins/aws-core/skills/aws-serverless/references/deployment.md
@@ -7,6 +7,7 @@ Serverless-specific deployment patterns, resource types, and fast iteration tool
 - [SAM resource types](#sam-resource-types)
 - [SAM Globals section](#sam-globals-section)
 - [CDK serverless constructs](#cdk-serverless-constructs)
+- [Setting up a Public Function URL (auth type NONE)](#setting-up-a-public-function-url-auth-type-none)
 - [Fast iteration](#fast-iteration)
 
 ---
@@ -55,6 +56,59 @@ Prefer L2 constructs — they provide sensible defaults and least-privilege IAM 
 | `PythonFunction` | `@aws-cdk/aws-lambda-python-alpha` | Python — requires Docker for bundling |
 | `HttpApi` | `aws-cdk-lib/aws-apigatewayv2` | HTTP API with CORS, JWT auth |
 | `HttpLambdaIntegration` | `aws-cdk-lib/aws-apigatewayv2-integrations` | Connect Lambda to HttpApi |
+
+---
+
+## Setting up a Public Function URL (auth type NONE)
+
+Since October 2025, Lambda function URLs require **two** resource-based policy statements: `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`. Omitting either results in `403 Forbidden`.
+
+The console and SAM auto-create both statements when you set auth type to `NONE`. When using the CLI, CloudFormation, or Lambda API directly, you must add them manually:
+
+```bash
+# 1. Create the function URL
+aws lambda create-function-url-config \
+  --function-name my-func --auth-type NONE
+
+# 2. Grant InvokeFunctionUrl (required)
+aws lambda add-permission --function-name my-func \
+  --statement-id FunctionURLAllowPublicAccess \
+  --action lambda:InvokeFunctionUrl \
+  --principal "*" \
+  --function-url-auth-type NONE
+
+# 3. Grant InvokeFunction via URL (required since Oct 2025 — commonly missed)
+aws lambda add-permission --function-name my-func \
+  --statement-id FunctionURLInvokeAllowPublicAccess \
+  --action lambda:InvokeFunction \
+  --principal "*" \
+  --invoked-via-function-url
+```
+
+Why two statements? `lambda:InvokeFunctionUrl` authorizes the URL endpoint; `lambda:InvokeFunction` authorizes the actual execution. The `--invoked-via-function-url` flag adds a `lambda:InvokedViaFunctionUrl` condition key ensuring the function can only be invoked through the URL, not via the Invoke API.
+
+For `AWS_IAM` auth type, the same dual-permission requirement applies for cross-account access — replace `"*"` with the specific principal ARN and use `--function-url-auth-type AWS_IAM`. No auto-configuration occurs for `AWS_IAM` regardless of tooling.
+
+CloudFormation equivalent:
+
+```yaml
+# Both AWS::Lambda::Permission resources are required
+FunctionURLPermission:
+  Type: AWS::Lambda::Permission
+  Properties:
+    Action: lambda:InvokeFunctionUrl
+    FunctionName: !Ref MyFunction
+    Principal: "*"
+    FunctionUrlAuthType: NONE
+
+FunctionInvokePermission:
+  Type: AWS::Lambda::Permission
+  Properties:
+    Action: lambda:InvokeFunction
+    FunctionName: !Ref MyFunction
+    Principal: "*"
+    InvokedViaFunctionUrl: true
+```
 
 ---
 

--- a/plugins/aws-core/skills/aws-serverless/references/troubleshooting.md
+++ b/plugins/aws-core/skills/aws-serverless/references/troubleshooting.md
@@ -271,6 +271,22 @@ aws logs tail /aws/lambda/my-authorizer --since 1h --filter-pattern ERROR
 # Test rules in Count mode before switching to Block
 ```
 
+### Function URL 403 Forbidden (NONE auth type)
+
+**Error:** 403 Forbidden with `{"Message":"Forbidden"}` when calling a public function URL
+**Cause:** Missing `lambda:InvokeFunction` permission. Since October 2025, function URLs require both `lambda:InvokeFunctionUrl` AND `lambda:InvokeFunction` in the resource-based policy. The console and SAM auto-create both statements for NONE auth type; CLI, CloudFormation, and Lambda API users must add them manually. No auto-configuration occurs for AWS_IAM auth type regardless of tooling.
+
+```bash
+# Add the missing second permission
+aws lambda add-permission --function-name my-func \
+  --statement-id FunctionURLInvokeAllowPublicAccess \
+  --action lambda:InvokeFunction \
+  --principal "*" \
+  --invoked-via-function-url
+```
+
+**Verify:** `aws lambda get-policy --function-name my-func` should show two statements. See the "Setting up a Public Function URL" section in [deployment.md](deployment.md) for the complete setup sequence.
+
 ### CORS Errors
 
 **Error:** `blocked by CORS policy: No 'Access-Control-Allow-Origin' header`

--- a/skills/core-skills/aws-serverless/SKILL.md
+++ b/skills/core-skills/aws-serverless/SKILL.md
@@ -29,6 +29,7 @@ Domain expertise for building serverless applications on AWS. Covers Lambda conf
 | Step Functions, EventBridge, or orchestration | Read [orchestration.md](references/orchestration.md) |
 | Concurrency configuration | Read [concurrency.md](references/concurrency.md) |
 | API Gateway setup | Read [api-gateway.md](references/api-gateway.md) |
+| Configuring Function URLs | Read [deployment.md](references/deployment.md) § Setting up a Public Function URL |
 | Common anti-patterns | Read the anti-patterns section in [production.md](references/production.md) |
 | Starting with Powertools | Use [powertools-handler.py](assets/powertools-handler.py) as a template |
 | Lambda Managed Instances, LMI, capacity providers, EC2-backed Lambda, PerExecutionEnvironmentMaxConcurrency | Use the **aws-lambda-managed-instances** skill instead |
@@ -46,6 +47,6 @@ Domain expertise for building serverless applications on AWS. Covers Lambda conf
 | [orchestration.md](references/orchestration.md) | Step Functions, EventBridge rules/pipes/scheduler |
 | [concurrency.md](references/concurrency.md) | Reserved vs provisioned, scaling, ESM concurrency |
 | [architecture.md](references/architecture.md) | Patterns, reference architectures, service selection |
-| [deployment.md](references/deployment.md) | SAM/CDK resource types, globals, fast iteration |
+| [deployment.md](references/deployment.md) | SAM/CDK resource types, globals, Function URL setup, fast iteration |
 | [production.md](references/production.md) | Readiness checklist, observability, anti-patterns |
 | [troubleshooting.md](references/troubleshooting.md) | Error → cause → fix for all serverless services |

--- a/skills/core-skills/aws-serverless/references/deployment.md
+++ b/skills/core-skills/aws-serverless/references/deployment.md
@@ -7,6 +7,7 @@ Serverless-specific deployment patterns, resource types, and fast iteration tool
 - [SAM resource types](#sam-resource-types)
 - [SAM Globals section](#sam-globals-section)
 - [CDK serverless constructs](#cdk-serverless-constructs)
+- [Setting up a Public Function URL (auth type NONE)](#setting-up-a-public-function-url-auth-type-none)
 - [Fast iteration](#fast-iteration)
 
 ---
@@ -55,6 +56,59 @@ Prefer L2 constructs — they provide sensible defaults and least-privilege IAM 
 | `PythonFunction` | `@aws-cdk/aws-lambda-python-alpha` | Python — requires Docker for bundling |
 | `HttpApi` | `aws-cdk-lib/aws-apigatewayv2` | HTTP API with CORS, JWT auth |
 | `HttpLambdaIntegration` | `aws-cdk-lib/aws-apigatewayv2-integrations` | Connect Lambda to HttpApi |
+
+---
+
+## Setting up a Public Function URL (auth type NONE)
+
+Since October 2025, Lambda function URLs require **two** resource-based policy statements: `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`. Omitting either results in `403 Forbidden`.
+
+The console and SAM auto-create both statements when you set auth type to `NONE`. When using the CLI, CloudFormation, or Lambda API directly, you must add them manually:
+
+```bash
+# 1. Create the function URL
+aws lambda create-function-url-config \
+  --function-name my-func --auth-type NONE
+
+# 2. Grant InvokeFunctionUrl (required)
+aws lambda add-permission --function-name my-func \
+  --statement-id FunctionURLAllowPublicAccess \
+  --action lambda:InvokeFunctionUrl \
+  --principal "*" \
+  --function-url-auth-type NONE
+
+# 3. Grant InvokeFunction via URL (required since Oct 2025 — commonly missed)
+aws lambda add-permission --function-name my-func \
+  --statement-id FunctionURLInvokeAllowPublicAccess \
+  --action lambda:InvokeFunction \
+  --principal "*" \
+  --invoked-via-function-url
+```
+
+Why two statements? `lambda:InvokeFunctionUrl` authorizes the URL endpoint; `lambda:InvokeFunction` authorizes the actual execution. The `--invoked-via-function-url` flag adds a `lambda:InvokedViaFunctionUrl` condition key ensuring the function can only be invoked through the URL, not via the Invoke API.
+
+For `AWS_IAM` auth type, the same dual-permission requirement applies for cross-account access — replace `"*"` with the specific principal ARN and use `--function-url-auth-type AWS_IAM`. No auto-configuration occurs for `AWS_IAM` regardless of tooling.
+
+CloudFormation equivalent:
+
+```yaml
+# Both AWS::Lambda::Permission resources are required
+FunctionURLPermission:
+  Type: AWS::Lambda::Permission
+  Properties:
+    Action: lambda:InvokeFunctionUrl
+    FunctionName: !Ref MyFunction
+    Principal: "*"
+    FunctionUrlAuthType: NONE
+
+FunctionInvokePermission:
+  Type: AWS::Lambda::Permission
+  Properties:
+    Action: lambda:InvokeFunction
+    FunctionName: !Ref MyFunction
+    Principal: "*"
+    InvokedViaFunctionUrl: true
+```
 
 ---
 

--- a/skills/core-skills/aws-serverless/references/troubleshooting.md
+++ b/skills/core-skills/aws-serverless/references/troubleshooting.md
@@ -271,6 +271,22 @@ aws logs tail /aws/lambda/my-authorizer --since 1h --filter-pattern ERROR
 # Test rules in Count mode before switching to Block
 ```
 
+### Function URL 403 Forbidden (NONE auth type)
+
+**Error:** 403 Forbidden with `{"Message":"Forbidden"}` when calling a public function URL
+**Cause:** Missing `lambda:InvokeFunction` permission. Since October 2025, function URLs require both `lambda:InvokeFunctionUrl` AND `lambda:InvokeFunction` in the resource-based policy. The console and SAM auto-create both statements for NONE auth type; CLI, CloudFormation, and Lambda API users must add them manually. No auto-configuration occurs for AWS_IAM auth type regardless of tooling.
+
+```bash
+# Add the missing second permission
+aws lambda add-permission --function-name my-func \
+  --statement-id FunctionURLInvokeAllowPublicAccess \
+  --action lambda:InvokeFunction \
+  --principal "*" \
+  --invoked-via-function-url
+```
+
+**Verify:** `aws lambda get-policy --function-name my-func` should show two statements. See the "Setting up a Public Function URL" section in [deployment.md](deployment.md) for the complete setup sequence.
+
 ### CORS Errors
 
 **Error:** `blocked by CORS policy: No 'Access-Control-Allow-Origin' header`


### PR DESCRIPTION
## What

Documents the October 2025 change requiring **two** resource-based policy statements on Lambda function URLs — `lambda:InvokeFunctionUrl` **and** `lambda:InvokeFunction`. Omitting the second statement returns `403 Forbidden`, even for `NONE` auth type.

Changes to the `aws-serverless` skill:
- **deployment.md** — new "Setting up a Public Function URL (auth type NONE)" section with CLI and CloudFormation examples covering both `NONE` and `AWS_IAM` auth types, plus a Contents entry.
- **troubleshooting.md** — new "Function URL 403 Forbidden (NONE auth type)" entry with the fix and a verification command.
- **SKILL.md** — routing row for "Configuring Function URLs" and an updated files-index description.

Applied to **both** copies of the skill (the `skills/core-skills/` source tree and the bundled `plugins/aws-core/skills/` copy), which this repo keeps in lockstep.

## Why

The console and SAM auto-create both statements, but users deploying via the CLI, CloudFormation, or the Lambda API directly must add them manually. Missing the second statement is a common, hard-to-diagnose cause of 403s on otherwise-public function URLs.

## Verification

Every technical claim was checked against authoritative sources before applying:

| Claim | Source | Result |
|---|---|---|
| "Starting Oct 2025, function URLs require both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`" | Lambda dev guide — *Control access to function URLs* | Confirmed (verbatim) |
| NONE auto-created by console/SAM; manual for CLI/CFN/API; else 403 | same page | Confirmed |
| AWS_IAM: same dual-permission for cross-account, no auto-config | same page | Confirmed |
| `--invoked-via-function-url` CLI flag | installed AWS CLI v2.35.12 + docs example | Confirmed |
| `lambda:InvokedViaFunctionUrl` condition key | docs condition-keys section | Confirmed |
| CFN `AWS::Lambda::Permission` props `FunctionUrlAuthType` (`AWS_IAM\|NONE`) + `InvokedViaFunctionUrl` (Boolean) | CloudFormation resource reference | Confirmed |
| Statement IDs `FunctionURLAllowPublicAccess` / `FunctionURLInvokeAllowPublicAccess` | match the default resource-based policy Sids | Confirmed |
