### PR TITLE
feat(aws-deployment): add CI/CD pipeline orchestration skill

### DIFF
--- a/skills/core-skills/aws-deployment/SKILL.md
+++ b/skills/core-skills/aws-deployment/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: aws-deployment
 description: "Configures CI/CD pipelines using AWS CodePipeline, CodeBuild, CodeDeploy, CodeConnections, and CodeArtifact. Covers CodePipeline V2 (triggers, variables, execution modes, cross-account), buildspec.yml (caching, VPC, Docker), CodeDeploy strategies (blue/green, canary, linear), CodeArtifact (private package registries, auth tokens, cross-account), and source connections (GitHub, GitLab, Bitbucket). Applies when CodePipeline, CodeBuild, CodeDeploy, CodeConnections, CodeArtifact, buildspec.yml, appspec.yml, or CI/CD pipeline orchestration is referenced. Does NOT cover: ECS Fargate services or task definitions (use aws-containers), CDK Pipelines or cdk deploy (use aws-cdk), sam deploy (use aws-serverless), Amplify deployments (use aws-amplify), or GitHub Actions/GitLab CI."
-owner_team: Pictos
-owner_cti: AWS/DevTools/MCP
-stages: [preprod, prod]
 version: 1
 metadata:
   service: [codepipeline, codebuild, codedeploy, codeconnections, codeartifact]

--- a/skills/core-skills/aws-deployment/SKILL.md
+++ b/skills/core-skills/aws-deployment/SKILL.md
@@ -2,11 +2,6 @@
 name: aws-deployment
 description: "Configures CI/CD pipelines using AWS CodePipeline, CodeBuild, CodeDeploy, CodeConnections, and CodeArtifact. Covers CodePipeline V2 (triggers, variables, execution modes, cross-account), buildspec.yml (caching, VPC, Docker), CodeDeploy strategies (blue/green, canary, linear), CodeArtifact (private package registries, auth tokens, cross-account), and source connections (GitHub, GitLab, Bitbucket). Applies when CodePipeline, CodeBuild, CodeDeploy, CodeConnections, CodeArtifact, buildspec.yml, appspec.yml, or CI/CD pipeline orchestration is referenced. Does NOT cover: ECS Fargate services or task definitions (use aws-containers), CDK Pipelines or cdk deploy (use aws-cdk), sam deploy (use aws-serverless), Amplify deployments (use aws-amplify), or GitHub Actions/GitLab CI."
 version: 1
-metadata:
-  service: [codepipeline, codebuild, codedeploy, codeconnections, codeartifact]
-  task: [deploy, debug, optimize]
-  persona: [developer, devops]
-  workload: [serverless, containers]
 ---
 
 # AWS Deploy (CI/CD)

--- a/skills/core-skills/aws-deployment/SKILL.md
+++ b/skills/core-skills/aws-deployment/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: aws-deployment
+description: "Configures CI/CD pipelines using AWS CodePipeline, CodeBuild, CodeDeploy, CodeConnections, and CodeArtifact. Covers CodePipeline V2 (triggers, variables, execution modes, cross-account), buildspec.yml (caching, VPC, Docker), CodeDeploy strategies (blue/green, canary, linear), CodeArtifact (private package registries, auth tokens, cross-account), and source connections (GitHub, GitLab, Bitbucket). Applies when CodePipeline, CodeBuild, CodeDeploy, CodeConnections, CodeArtifact, buildspec.yml, appspec.yml, or CI/CD pipeline orchestration is referenced. Does NOT cover: ECS Fargate services or task definitions (use aws-containers), CDK Pipelines or cdk deploy (use aws-cdk), sam deploy (use aws-serverless), Amplify deployments (use aws-amplify), or GitHub Actions/GitLab CI."
+owner_team: Pictos
+owner_cti: AWS/DevTools/MCP
+stages: [preprod, prod]
+version: 1
+metadata:
+  service: [codepipeline, codebuild, codedeploy, codeconnections, codeartifact]
+  task: [deploy, debug, optimize]
+  persona: [developer, devops]
+  workload: [serverless, containers]
+---
+
+# AWS Deploy (CI/CD)
+
+**Works best with** the [AWS MCP server](https://docs.aws.amazon.com/aws-mcp/) for running CLI commands and validating configurations directly. All guidance also works with standard AWS CLI.
+
+## Critical Warnings
+
+**CodeConnections PENDING trap**: Connections created via CLI/CloudFormation remain `PENDING` indefinitely — MUST complete OAuth in the AWS Console. No API-only path exists.
+
+**Cross-account triple requirement**: Cross-account deploys need ALL THREE: (1) KMS key policy granting target account (use key ID, not alias), (2) S3 bucket policy for target account, (3) cross-account IAM role with trust policy. Missing any one = cryptic `Access Denied`.
+
+**CodeDeploy ApplicationStop uses PREVIOUS revision**: Broken stop scripts in a prior deployment block ALL future deploys. Make stop scripts idempotent (exit 0 if service absent). Unblock with `--ignore-application-stop-failures`.
+
+**CodeBuild VPC without NAT**: Builds in VPC subnets without NAT gateway hang at `DOWNLOAD_SOURCE` silently. Private subnets MUST have NAT gateway or VPC endpoints.
+
+**CodeConnections IAM**: Use `codeconnections:` prefix for API calls and IAM policy Actions. Resource ARNs must match exactly — new resources use `codeconnections` prefix, existing resources may use `codestar-connections` prefix. Specify both in Resource if you have mixed-age resources.
+
+**UseConnection is over-permissive**: `codeconnections:UseConnection` grants access to ALL repositories the connection can reach. MUST specify condition keys (`codeconnections:FullRepositoryId`, `codeconnections:ProviderAction`, `codeconnections:BranchName`) to limit CodeBuild to only the required repository.
+
+## How These Services Compose
+
+CodeConnections → CodeBuild → CodeDeploy, orchestrated by CodePipeline.
+
+| Layer | Service | Role |
+|-------|---------|------|
+| Source | CodeConnections | Authenticates to GitHub/GitLab/Bitbucket, delivers code |
+| Packages | CodeArtifact | Private package registry, dependency caching from public registries |
+| Build/Test | CodeBuild | Compiles, tests, packages artifacts |
+| Deploy | CodeDeploy | Deploys to EC2/ECS/Lambda with traffic shifting strategies |
+| Orchestrator | CodePipeline | Chains stages, manages transitions, approval gates |
+
+Default: V2 pipeline type with QUEUED execution mode. Use PARALLEL only when executions are fully independent.
+
+## Quick Navigation
+
+| You want to... | Go to |
+|----------------|-------|
+| Create a pipeline (V2, triggers, variables, modes) | [codepipeline.md](references/codepipeline.md) |
+| Connect GitHub/GitLab/Bitbucket source | [codeconnections.md](references/codeconnections.md) |
+| Write buildspec.yml / configure builds | [codebuild.md](references/codebuild.md) |
+| Set up private package registry for builds | [codeartifact.md](references/codeartifact.md) |
+| Configure deployment strategy (blue/green, canary) | [codedeploy.md](references/codedeploy.md) |
+| Cross-account or cross-region deployment | [codepipeline.md](references/codepipeline.md) |
+| Fix failing pipeline, build, or deployment | [troubleshooting.md](references/troubleshooting.md) |
+
+## Common Workflows
+
+| Task | Action | Reference |
+|------|--------|-----------|
+| Pipeline from GitHub to ECS | Create connection → CodeBuild Docker stage → CodeDeploy ECS blue/green | [codepipeline](references/codepipeline.md), [codedeploy](references/codedeploy.md) |
+| Pipeline stuck at source | Check connection status; if PENDING, complete OAuth in AWS Console | [troubleshooting](references/troubleshooting.md) |
+| Build timing out | Check VPC/NAT, increase `timeoutInMinutes`, verify Docker privileged mode | [codebuild](references/codebuild.md) |
+| Deploy to another account | Configure KMS + S3 bucket policy + cross-account role, add `RoleArn` to action | [codepipeline](references/codepipeline.md) |
+| Roll back failed deployment | Auto-rollback on alarm/failure; manual: `stop-deployment --auto-rollback-enabled` | [codedeploy](references/codedeploy.md) |
+| Lambda canary deployment | CodeBuild packages → CodeDeploy Lambda with canary traffic shifting | [codedeploy](references/codedeploy.md) |
+
+## Troubleshooting
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| `YAML_FILE_ERROR` in CodeBuild | Missing or malformed `runtime-versions` in buildspec (recommended for standard images) | Add `runtime-versions` block in install phase |
+| `file already exists` on CodeDeploy | Redeployment without overwrite config | Set `file_exists_behavior: OVERWRITE` |
+| Pipeline trigger not firing | File path filter checks only first 100 files in diff | Reduce path filter scope or merge smaller |
+| PARALLEL mode wrong revision | Race between event and source action | Use QUEUED mode for sequential consistency |
+| Docker: `Cannot connect to daemon` | Missing privileged mode | Set `privilegedMode: true` AND start dockerd in buildspec |
+| `CODEBUILD_CLONE_REF` permission error | CodeBuild role missing UseConnection | Add `codeconnections:UseConnection` to CodeBuild service role |
+| Deployment never completes | MinimumHealthyHosts too high for instance count | Ensure healthy threshold < total instances |
+| ECS deployment stuck | Health check failing on new task set | Verify target group health check path/port |
+
+## Security
+
+- MUST store secrets in Secrets Manager or Parameter Store; reference via CodeBuild `type: SECRETS_MANAGER` — MUST NOT embed in buildspec as PLAINTEXT
+- MUST use customer-managed KMS keys for cross-account artifact encryption (default encryption does not support cross-account)
+- SHOULD scope CodeBuild/CodeDeploy service roles to specific resource ARNs; MUST NOT use `*` for `s3:GetObject` or `kms:Decrypt`
+- MUST use CodeConnections (not personal access tokens) for source connections; OAuth tokens cannot be rotated automatically
+- See [CodePipeline security best practices](https://docs.aws.amazon.com/codepipeline/latest/userguide/security-best-practices.html) for comprehensive guidance
+
+## Not Covered
+
+| Topic | Use instead |
+|-------|-------------|
+| CDK Pipelines (`aws-cdk-lib/pipelines`) | `aws-cdk` |
+| `sam deploy` / SAM CLI | `aws-serverless` |
+| ECS service deployment config (circuit breaker, rolling params) | `aws-containers` |
+| GitHub Actions / GitLab CI | Third-party tools, not covered |

--- a/skills/core-skills/aws-deployment/references/codeartifact.md
+++ b/skills/core-skills/aws-deployment/references/codeartifact.md
@@ -1,0 +1,147 @@
+# CodeArtifact
+
+## Overview
+
+CodeArtifact is a managed package repository for use in CI/CD pipelines. It stores npm, pip, Maven, NuGet, Swift, Cargo, and generic packages. In the context of CI/CD, it serves as a private package cache and internal package registry that CodeBuild pulls dependencies from.
+
+## Key Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Domain | Top-level container for repositories. Applies cross-repo policies. One per organization typically. |
+| Repository | Stores packages. Can have upstream repositories (including external connections). |
+| External connection | Links a repository to a public registry (npmjs.com, pypi.org, Maven Central). Packages are cached on first fetch. |
+| Upstream repository | A repo can pull from another CodeArtifact repo (chaining). Packages flow downstream on demand. |
+
+## Using CodeArtifact in CodeBuild
+
+### Authentication
+
+CodeArtifact uses time-limited auth tokens (max 12 hours). In buildspec:
+
+```yaml
+phases:
+  pre_build:
+    commands:
+      - aws codeartifact login --tool npm --domain MY_DOMAIN --domain-owner ACCOUNT_ID --repository MY_REPO
+      - npm ci
+```
+
+For pip:
+```yaml
+      - aws codeartifact login --tool pip --domain MY_DOMAIN --domain-owner ACCOUNT_ID --repository MY_REPO
+      - pip install -r requirements.txt
+```
+
+For Maven/Gradle, use `get-authorization-token` and configure settings.xml/build.gradle:
+```yaml
+      - export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain MY_DOMAIN --domain-owner ACCOUNT_ID --query authorizationToken --output text)
+```
+
+### IAM Permissions for CodeBuild Role
+
+Minimum permissions for pulling packages:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "codeartifact:GetAuthorizationToken",
+    "codeartifact:GetRepositoryEndpoint",
+    "codeartifact:ReadFromRepository"
+  ],
+  "Resource": [
+    "arn:aws:codeartifact:REGION:ACCOUNT:domain/MY_DOMAIN",
+    "arn:aws:codeartifact:REGION:ACCOUNT:repository/MY_DOMAIN/MY_REPO"
+  ]
+}
+```
+
+Also requires `sts:GetServiceBearerToken` (for the auth token exchange):
+```json
+{
+  "Effect": "Allow",
+  "Action": "sts:GetServiceBearerToken",
+  "Resource": "*",
+  "Condition": {
+    "StringEquals": { "sts:AWSServiceName": "codeartifact.amazonaws.com" }
+  }
+}
+```
+
+### Publishing Packages (CI produces packages)
+
+Additional permission for publish:
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "codeartifact:PublishPackageVersion",
+    "codeartifact:PutPackageMetadata"
+  ],
+  "Resource": "arn:aws:codeartifact:REGION:ACCOUNT:package/MY_DOMAIN/MY_REPO/*"
+}
+```
+
+## Common Patterns
+
+### Private cache with public fallback
+
+```bash
+# Create domain with customer-managed KMS key (required for cross-account access)
+aws codeartifact create-domain --domain my-org --encryption-key arn:aws:kms:REGION:ACCOUNT:key/KEY_ID
+
+# Create repo with external connection to npmjs
+aws codeartifact create-repository --domain my-org --repository npm-store
+aws codeartifact associate-external-connection --domain my-org --repository npm-store --external-connection public:npmjs
+
+# Create internal repo that uses npm-store as upstream
+aws codeartifact create-repository --domain my-org --repository my-packages --upstreams repositoryName=npm-store
+```
+
+Packages are fetched from npmjs on first request and cached in npm-store. Internal packages are published directly to my-packages.
+
+### Cross-account access
+
+Set a domain policy to allow other accounts to read:
+```bash
+aws codeartifact put-domain-permissions-policy --domain my-org --policy-document file://policy.json
+```
+
+Or use repository policies for finer-grained control.
+
+## Pitfalls
+
+**Auth token expires after 12 hours**: The token from `login` or `get-authorization-token` has a maximum TTL of 12 hours. Long-running builds or pipelines that cache credentials will fail with 401/403. Always refresh the token in `pre_build`.
+
+**`login` sets global config**: `aws codeartifact login --tool npm` modifies `~/.npmrc` globally. In CodeBuild this is fine (ephemeral environment), but locally it overwrites existing registry config. Use `--namespace` or manual token setup for multi-registry scenarios.
+
+**Domain policy vs repository policy**: For cross-account access, you need BOTH — missing either causes AccessDenied. Domain policy: grants `codeartifact:GetAuthorizationToken` to the consuming account. Repository policy: grants `codeartifact:ReadFromRepository` to the consuming account. Plus identity-based policy on the consuming role. All three are required.
+
+**External connection limit**: Each repository can have only ONE external connection. Use upstream chaining to combine multiple public sources (e.g., one repo connected to npmjs, another to pypi, a third repo listing both as upstreams).
+
+**sts:GetServiceBearerToken missing**: The auth token exchange requires `sts:GetServiceBearerToken`. This is frequently missing from CodeBuild service roles because it's not an obvious CodeArtifact permission. Error message: "User is not authorized to perform: sts:GetServiceBearerToken".
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Unable to get authorization token` | Missing `sts:GetServiceBearerToken` | Add to CodeBuild service role with condition key |
+| `401 Unauthorized` during npm install | Token expired or login not run | Add `codeartifact login` to pre_build phase |
+| `Package not found` | External connection not configured or repo not upstream | Check upstream chain configuration |
+| `AccessDeniedException` on cross-account | Missing domain policy OR repository policy | Configure both domain and repository policies |
+| `ResourceNotFoundException` on publish | Wrong repository name or domain | Verify domain/repo names match exactly |
+
+## Security
+
+- MUST use a customer-managed KMS key for domain encryption (`--encryption-key`); the default AWS-managed key does NOT support cross-account access
+- Scope `codeartifact:ReadFromRepository` to specific repository ARNs; avoid `*`
+- Use domain policies (not just repository policies) for cross-account access grants
+- Enable CloudTrail for `codeartifact:*` API auditing — critical for cross-account scenarios to track who is accessing packages
+- Rotate auth tokens regularly; default 12-hour TTL is the maximum
+- See [CodeArtifact security best practices](https://docs.aws.amazon.com/codeartifact/latest/ug/security-best-practices.html)
+
+## Related
+
+- [codebuild.md](codebuild.md) for buildspec integration
+- [codepipeline.md](codepipeline.md) for pipeline stages

--- a/skills/core-skills/aws-deployment/references/codeartifact.md
+++ b/skills/core-skills/aws-deployment/references/codeartifact.md
@@ -28,12 +28,14 @@ phases:
 ```
 
 For pip:
+
 ```yaml
       - aws codeartifact login --tool pip --domain MY_DOMAIN --domain-owner ACCOUNT_ID --repository MY_REPO
       - pip install -r requirements.txt
 ```
 
 For Maven/Gradle, use `get-authorization-token` and configure settings.xml/build.gradle:
+
 ```yaml
       - export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain MY_DOMAIN --domain-owner ACCOUNT_ID --query authorizationToken --output text)
 ```
@@ -58,6 +60,7 @@ Minimum permissions for pulling packages:
 ```
 
 Also requires `sts:GetServiceBearerToken` (for the auth token exchange):
+
 ```json
 {
   "Effect": "Allow",
@@ -72,6 +75,7 @@ Also requires `sts:GetServiceBearerToken` (for the auth token exchange):
 ### Publishing Packages (CI produces packages)
 
 Additional permission for publish:
+
 ```json
 {
   "Effect": "Allow",
@@ -104,6 +108,7 @@ Packages are fetched from npmjs on first request and cached in npm-store. Intern
 ### Cross-account access
 
 Set a domain policy to allow other accounts to read:
+
 ```bash
 aws codeartifact put-domain-permissions-policy --domain my-org --policy-document file://policy.json
 ```

--- a/skills/core-skills/aws-deployment/references/codebuild.md
+++ b/skills/core-skills/aws-deployment/references/codebuild.md
@@ -1,0 +1,179 @@
+# CodeBuild
+
+## Source Configuration
+
+Code reaches CodeBuild via:
+- **Pipeline action** — CodePipeline passes artifacts (most common in CI/CD)
+- **Direct source** — CodeBuild pulls from CodeCommit, S3, GitHub, GitLab, or Bitbucket
+- **No source** — buildspec commands handle everything (e.g., `git clone` in install phase)
+
+When using CodePipeline, the source is passed as an input artifact. When using CodeBuild standalone, configure source in the project:
+
+```bash
+aws codebuild create-project --name my-project \
+  --source type=CODECOMMIT,location=https://git-codecommit.REGION.amazonaws.com/v1/repos/REPO \
+  --source-version main \
+  --service-role arn:aws:iam::ACCOUNT_ID:role/codebuild-role \
+  --artifacts type=NO_ARTIFACTS \
+  --environment type=LINUX_CONTAINER,computeType=BUILD_GENERAL1_SMALL,image=aws/codebuild/amazonlinux2-x86_64-standard:5.0
+```
+
+For GitHub/GitLab via CodeConnections, use `type=CODEPIPELINE` (pipeline manages source) or configure a webhook for standalone builds.
+
+## Phase Error Handling (on-failure)
+
+Each buildspec phase supports an `on-failure` attribute controlling behavior when commands fail:
+
+```yaml
+phases:
+  install:
+    on-failure: ABORT
+    commands:
+      - npm ci
+  build:
+    on-failure: CONTINUE
+    commands:
+      - npm run build
+  post_build:
+    on-failure: ABORT
+    commands:
+      - npm run package
+```
+
+| Strategy | Behavior |
+|----------|----------|
+| `ABORT` | Stop build immediately (default for install, pre_build, build) |
+| `CONTINUE` | Move to next phase even if commands fail |
+| `RETRY` | Retry failed command (default settings) |
+| `RETRY-n` | Retry up to n times (e.g., `RETRY-3`) |
+| `RETRY-regex` | Retry only if error matches regex pattern |
+| `RETRY-n-regex` | Retry up to n times only for matching errors |
+
+Use `RETRY-3-.*timeout.*` for transient network failures during dependency install.
+
+Note: `post_build` runs even if `build` phase failed. Gate post_build logic with the `CODEBUILD_BUILD_SUCCEEDING` env var.
+
+## VPC Configuration
+
+Required when builds access private resources (RDS, internal APIs).
+
+```bash
+aws codebuild create-project --name my-project \
+  --source type=CODEPIPELINE \
+  --service-role arn:aws:iam::ACCOUNT_ID:role/codebuild-role \
+  --vpc-config vpcId=VPC_ID,subnets=PRIVATE_SUBNET_1,PRIVATE_SUBNET_2,securityGroupIds=SG_ID
+```
+
+**CRITICAL: CodeBuild CANNOT assign public IPs in VPC.** Without a NAT gateway, builds hang silently at DOWNLOAD_SOURCE or dependency install with no error message.
+
+| Requirement | Consequence if Missing |
+|-------------|----------------------|
+| NAT gateway on private subnets | Build hangs indefinitely — no timeout error, just silence |
+| Private subnets only | Public subnets not supported for CodeBuild VPC |
+| S3 VPC endpoint | Artifact operations route through NAT (slow, costly) |
+| CloudWatch Logs VPC endpoint | Logs missing or delayed |
+
+Service role needs: `ec2:CreateNetworkInterface`, `ec2:DescribeNetworkInterfaces`, `ec2:DeleteNetworkInterface`, `ec2:CreateNetworkInterfacePermission`.
+
+**Security group**: Restrict egress to required destinations only (VPC endpoints, NAT gateway). Avoid `0.0.0.0/0` egress — scope to S3 prefix lists and specific internal CIDRs. Ingress should be empty unless builds require inbound connections.
+
+## Caching
+
+| Cache Type | Scope | Best For | Constraint |
+|------------|-------|----------|------------|
+| S3 | Across builds | Dependencies (node_modules, .m2, pip) | Network transfer cost |
+| Local - docker_layer_cache | Same host | Docker rebuilds | Best-effort on-demand; reliable on fleet |
+| Local - source_cache | Same host | Incremental git fetch | Best-effort on-demand; reliable on fleet |
+| Local - custom_cache | Same host | Arbitrary paths | Best-effort on-demand; reliable on fleet |
+
+S3 caching (works on-demand and fleet):
+```yaml
+cache:
+  paths:
+    - '/root/.npm/**/*'
+    - '/root/.m2/**/*'
+```
+
+Project config: `--cache type=S3,location=BUCKET/cache` (MUST enable SSE-KMS or SSE-S3 on the cache bucket — cached artifacts may contain dependency metadata)
+
+Local caching (reliable on fleet, best-effort on on-demand): `--cache type=LOCAL,modes=[LOCAL_DOCKER_LAYER_CACHE,LOCAL_SOURCE_CACHE]`
+
+**Key distinction:** S3 cache survives across any build host but costs network transfer. Local cache is instant (no transfer) but only works when consecutive builds land on the same host — guaranteed with fleet, probabilistic with on-demand.
+
+## Docker Image Builds
+
+For custom images or VPC builds: `privilegedMode: true` AND manual dockerd start. CodeBuild-managed standard images may have Docker pre-configured, but privileged mode is still required for Docker-in-Docker.
+
+```bash
+aws codebuild create-project --name docker-builder \
+  --environment type=LINUX_CONTAINER,computeType=BUILD_GENERAL1_MEDIUM,image=aws/codebuild/amazonlinux2-x86_64-standard:5.0,privilegedMode=true
+```
+
+Buildspec for Docker + ECR push:
+```yaml
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock &
+      - timeout 15 sh -c "until docker info; do sleep 1; done"
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_REPO_URI
+  build:
+    commands:
+      - docker build -t $IMAGE_REPO:$IMAGE_TAG .
+      - docker push $IMAGE_REPO:$IMAGE_TAG
+```
+
+## Secrets Reference
+
+Secrets Manager format in buildspec: `secret-id:json-key:version-stage:version-id` (last two optional).
+
+```yaml
+env:
+  parameter-store:
+    API_KEY: "/myapp/api-key"
+  secrets-manager:
+    DB_PASS: "myapp/db-creds:password"
+```
+
+IAM: `ssm:GetParameters` for Parameter Store, `secretsmanager:GetSecretValue` for Secrets Manager.
+
+## Logging
+
+Always enable CloudWatch Logs with KMS encryption (build logs may contain sensitive output):
+
+```bash
+--logs-config cloudWatchLogs={status=ENABLED,groupName=/aws/codebuild/PROJECT_NAME}
+```
+
+Encrypt the log group: `aws logs associate-kms-key --log-group-name /aws/codebuild/PROJECT_NAME --kms-key-id KEY_ARN`
+
+## Timeouts
+
+| Setting | Default | Maximum |
+|---------|---------|---------|
+| Build timeout | 60 min | 480 min (8 hours) |
+| Queued timeout | 480 min | 480 min |
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Build hangs in VPC | No NAT gateway on private subnet | Add NAT gateway to route table |
+| `Cannot connect to Docker daemon` | Privileged mode off or dockerd not started | Set `privilegedMode=true` AND start dockerd |
+| `CODEBUILD_CLONE_REF` auth failure | CodeBuild role missing UseConnection | Add `codeconnections:UseConnection` to CodeBuild service role |
+| `AccessDenied` on artifacts | Cross-region bucket | Artifact bucket MUST be same region as project |
+
+## Security
+
+- MUST scope service role to specific S3 buckets and ECR repos; avoid `*` resource
+- Enable SSE-KMS or SSE-S3 on cache buckets (cached artifacts may reveal application internals)
+- MUST NOT use `type: PLAINTEXT` environment variables for secrets — use `PARAMETER_STORE` or `SECRETS_MANAGER`
+- Use VPC endpoints to keep artifact and log traffic off the public internet
+- Enable CloudTrail for `codebuild:*` API auditing
+- See [CodeBuild security best practices](https://docs.aws.amazon.com/codebuild/latest/userguide/security-best-practices.html)
+
+## Related
+
+- [codepipeline.md](codepipeline.md) for pipeline build action configuration
+- [troubleshooting.md](troubleshooting.md) for additional error patterns

--- a/skills/core-skills/aws-deployment/references/codebuild.md
+++ b/skills/core-skills/aws-deployment/references/codebuild.md
@@ -3,6 +3,7 @@
 ## Source Configuration
 
 Code reaches CodeBuild via:
+
 - **Pipeline action** — CodePipeline passes artifacts (most common in CI/CD)
 - **Direct source** — CodeBuild pulls from CodeCommit, S3, GitHub, GitLab, or Bitbucket
 - **No source** — buildspec commands handle everything (e.g., `git clone` in install phase)
@@ -87,6 +88,7 @@ Service role needs: `ec2:CreateNetworkInterface`, `ec2:DescribeNetworkInterfaces
 | Local - custom_cache | Same host | Arbitrary paths | Best-effort on-demand; reliable on fleet |
 
 S3 caching (works on-demand and fleet):
+
 ```yaml
 cache:
   paths:
@@ -110,6 +112,7 @@ aws codebuild create-project --name docker-builder \
 ```
 
 Buildspec for Docker + ECR push:
+
 ```yaml
 version: 0.2
 phases:

--- a/skills/core-skills/aws-deployment/references/codeconnections.md
+++ b/skills/core-skills/aws-deployment/references/codeconnections.md
@@ -1,0 +1,172 @@
+# CodeConnections
+
+## Service Prefixes
+
+Two ARN prefixes coexist (service was rebranded from CodeStar Connections to CodeConnections):
+
+| Prefix | ARN Format |
+|--------|-----------|
+| `codeconnections` | `arn:aws:codeconnections:REGION:ACCOUNT:connection/UUID` |
+| `codestar-connections` | `arn:aws:codestar-connections:REGION:ACCOUNT:connection/UUID` |
+
+Both work in pipeline configurations. IAM policy prefix must match the resource ARN prefix.
+
+## Provider Comparison
+
+| Feature | GitHub | GitHub Enterprise | GitLab.com | GitLab Self-Managed | Bitbucket Cloud | Azure DevOps |
+|---------|--------|-------------------|------------|---------------------|-----------------|--------------|
+| Host resource required | No | Yes | No | Yes | No | No |
+| Auth mechanism | GitHub App | GitHub App | OAuth | OAuth | OAuth | OAuth |
+| Org owner required | Yes | Yes | No | No | No | No |
+| VPC endpoint needed | No | Yes (if private) | No | Yes | No | No |
+| Provider type value | `GitHub` | `GitHubEnterpriseServer` | `GitLab` | `GitLabSelfManaged` | `Bitbucket` | `AzureDevOps` |
+
+## Create a Connection
+
+```bash
+aws codeconnections create-connection \
+  --provider-type GitHub \
+  --connection-name my-github-connection \
+  --tags Key=managed_by,Value=aws-skills Key=skill,Value=deploy
+```
+
+For self-managed providers, use `--host-arn` instead of `--provider-type`:
+
+```bash
+aws codeconnections create-connection \
+  --host-arn arn:aws:codeconnections:REGION:ACCOUNT:host/HOST_ID \
+  --connection-name my-gitlab-sm-connection
+```
+
+Check status:
+
+```bash
+aws codeconnections get-connection --connection-arn CONNECTION_ARN \
+  --query "Connection.ConnectionStatus" --output text
+```
+
+## The PENDING State Trap
+
+Connections created via CLI/CloudFormation/CDK are **always** `PENDING`. There is NO API to complete authorization — the console OAuth handshake is mandatory.
+
+A PENDING connection:
+- Returns no errors from `create-connection`
+- Passes ARN validation in pipeline definitions
+- **Silently fails** when the pipeline fetches source
+
+## Authorize a Connection (Console Required)
+
+### GitHub / GitHub Enterprise
+
+1. AWS Console → **Developer Tools > Settings > Connections**
+2. Select PENDING connection → **Update pending connection**
+3. **Install a new app** (or select existing GitHub App)
+4. Browser redirects to GitHub — sign in as **organization owner**
+5. Select org, choose repos → **Install**
+6. Back in AWS Console → **Connect**
+
+**Pitfall**: Non-owner members get cookie errors or blank pages. GitHub App installation REQUIRES org owner role.
+
+### GitLab.com / GitLab Self-Managed
+
+1. AWS Console → **Developer Tools > Settings > Connections**
+2. Select PENDING connection → **Update pending connection**
+3. Redirects to GitLab → authorize the AWS application
+4. **Connect** to finalize
+
+### Bitbucket Cloud
+
+Same flow as GitLab: Console → select connection → redirect → authorize → Connect.
+
+### Verify
+
+```bash
+aws codeconnections get-connection --connection-arn CONNECTION_ARN \
+  --query "Connection.ConnectionStatus" --output text
+# Expected: AVAILABLE
+```
+
+## Create a Host Resource (Self-Managed Only)
+
+Required for GitHub Enterprise Server and GitLab Self-Managed. NOT needed for hosted providers.
+
+```bash
+aws codeconnections create-host \
+  --name my-gitlab-host \
+  --provider-type GitLabSelfManaged \
+  --provider-endpoint https://gitlab.internal.example.com \
+  --vpc-configuration VpcId=VPC_ID,SubnetIds=SUBNET_1,SUBNET_2,SecurityGroupIds=SG_ID,TlsCertificate=BASE64_PEM_CERT
+```
+
+`--vpc-configuration` required when endpoint is not publicly accessible. `TlsCertificate` accepts PEM-encoded CA cert (base64).
+
+Host creation is async — check status:
+
+```bash
+aws codeconnections get-host --host-arn HOST_ARN --query "Status" --output text
+# Wait for: AVAILABLE
+```
+
+## Connection Sharing
+
+A single connection serves unlimited pipelines within the same account and region. Create one connection per provider per account — do not create one per pipeline.
+
+Cross-account: share connections using AWS Resource Access Manager (RAM). See [sharing connections](https://docs.aws.amazon.com/dtconsole/latest/userguide/connections-share.html). Without RAM, each account needs its own connection.
+
+## IAM Configuration
+
+Use `codeconnections:` prefix for all Actions. The dual prefix only matters in the `Resource` field (to match existing ARNs):
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "codeconnections:UseConnection"
+  ],
+  "Resource": [
+    "arn:aws:codeconnections:REGION:ACCOUNT:connection/CONNECTION_UUID",
+    "arn:aws:codestar-connections:REGION:ACCOUNT:connection/OLD_CONNECTION_UUID"
+  ],
+  "Condition": {
+    "StringEquals": {
+      "codeconnections:FullRepositoryId": "org/repo"
+    }
+  }
+}
+```
+
+**CRITICAL: UseConnection is over-permissive without condition keys.** It grants access to ALL repositories the connection can reach. MUST specify conditions:
+
+| Condition Key | Purpose |
+|--------------|---------|
+| `codeconnections:FullRepositoryId` | Restrict to specific repo (e.g., `org/repo`) |
+| `codeconnections:ProviderAction` | Restrict operations (e.g., `read` only) |
+| `codeconnections:BranchName` | Restrict to specific branch |
+
+For pipeline service roles: minimum `codeconnections:UseConnection` with condition keys scoped to the repo.
+
+For CodeBuild roles using `CODEBUILD_CLONE_REF`: add `codeconnections:UseConnection` to the **CodeBuild** service role (not the pipeline role), with the same condition key scoping.
+
+## Common Errors
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| Pipeline fails "connection not available" | Connection PENDING | Complete OAuth in console |
+| Blank page / cookie error during GitHub auth | User not org owner | Have org owner perform installation |
+| `AccessDeniedException` on UseConnection | IAM only has one prefix | Add `codeconnections:UseConnection` and `codestar-connections:UseConnection` |
+| Host stuck in `VPC_CONFIG_FAILED_INITIALIZATION` | VPC/subnet/SG misconfiguration | Verify route to provider endpoint, validate TLS cert |
+| Pipeline trigger never fires | `sourceActionName` mismatch | Ensure trigger `sourceActionName` matches action `Name` exactly |
+| Repository not found | Wrong FullRepositoryId format | Use `org/repo` format (case-sensitive) |
+
+## Security
+
+- MUST scope UseConnection with condition keys (FullRepositoryId, ProviderAction) — without them, any repo accessible to the connection is exposed
+- Scope Resource to specific connection ARNs in production
+- Enable CloudTrail for `codeconnections:*` API auditing
+- Revoke connections when personnel with OAuth access leave the organization
+- Connections store OAuth tokens managed by AWS — prefer connections over manual PATs which cannot be auto-rotated
+
+## Related
+
+- [codepipeline.md](codepipeline.md) for source action and trigger configuration
+- [troubleshooting.md](troubleshooting.md) for pipeline-level debugging

--- a/skills/core-skills/aws-deployment/references/codeconnections.md
+++ b/skills/core-skills/aws-deployment/references/codeconnections.md
@@ -50,6 +50,7 @@ aws codeconnections get-connection --connection-arn CONNECTION_ARN \
 Connections created via CLI/CloudFormation/CDK are **always** `PENDING`. There is NO API to complete authorization — the console OAuth handshake is mandatory.
 
 A PENDING connection:
+
 - Returns no errors from `create-connection`
 - Passes ARN validation in pipeline definitions
 - **Silently fails** when the pipeline fetches source

--- a/skills/core-skills/aws-deployment/references/codedeploy.md
+++ b/skills/core-skills/aws-deployment/references/codedeploy.md
@@ -1,0 +1,257 @@
+# CodeDeploy
+
+## Deployment Strategy Comparison
+
+| Strategy | EC2/On-Premises | ECS | Lambda | Best For |
+|----------|----------------|-----|--------|----------|
+| In-place | Yes | No | No | Simple apps with acceptable downtime |
+| Blue/green | Yes (new ASG) | Yes (task set swap) | Yes (alias shift) | Zero-downtime with instant rollback |
+| Canary | No | Yes | Yes | High-risk changes needing validation window |
+| Linear | No | Yes | Yes | Gradual rollout with steady monitoring |
+| All-at-once | Yes | Yes | Yes | Non-production or low-risk changes |
+
+**Recommendation**: Blue/green for production EC2. Canary for ECS/Lambda production where you need a validation window.
+
+## EC2/On-Premises
+
+### appspec.yml
+
+```yaml
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /opt/myapp
+    overwrite: true
+permissions:
+  - object: /opt/myapp/bin
+    pattern: "*.sh"
+    owner: appuser
+    mode: 755
+    type:
+      - file
+hooks:
+  ApplicationStop:
+    - location: scripts/stop.sh
+      timeout: 120
+      runas: appuser
+  BeforeInstall:
+    - location: scripts/before_install.sh
+      timeout: 300
+  AfterInstall:
+    - location: scripts/after_install.sh
+      timeout: 300
+  ApplicationStart:
+    - location: scripts/start.sh
+      timeout: 120
+  ValidateService:
+    - location: scripts/validate.sh
+      timeout: 300
+```
+
+### EC2 Lifecycle Hooks (Ordered)
+
+**In-place deployment:**
+
+1. **ApplicationStop** — Runs PREVIOUS revision's stop script
+2. **DownloadBundle** — Agent-only; downloads revision
+3. **BeforeInstall** — Setup tasks (create dirs, decrypt)
+4. **Install** — Agent-only; copies files per `files` section
+5. **AfterInstall** — Post-install config (permissions, config generation)
+6. **ApplicationStart** — Start services
+7. **ValidateService** — Health checks, smoke tests
+
+**Additional hooks when a load balancer is configured (both in-place and blue/green):**
+
+1. **BeforeBlockTraffic** — Pre-deregistration on original instances
+2. **BlockTraffic** — Agent-only; deregisters from ELB
+3. **AfterBlockTraffic** — Cleanup on original instances
+4. *(Standard hooks 1-7 on replacement instances)*
+5. **BeforeAllowTraffic** — Pre-registration on replacement instances
+6. **AllowTraffic** — Agent-only; registers with ELB
+7. **AfterAllowTraffic** — Post-registration validation
+
+### EC2 Deployment Configurations
+
+| Configuration | Behavior |
+|---------------|----------|
+| CodeDeployDefault.OneAtATime | One instance at a time |
+| CodeDeployDefault.HalfAtATime | Up to half simultaneously |
+| CodeDeployDefault.AllAtOnce | All simultaneously |
+| Custom | Specify HOST_COUNT or FLEET_PERCENT threshold |
+
+### EC2 Pitfalls
+
+**ApplicationStop uses PREVIOUS revision's scripts**: Broken stop scripts block ALL future deployments. Fix: deploy a revision that only fixes the stop script, or remove `/opt/codedeploy-agent/deployment-root/` on affected instances and restart agent.
+
+**file_exists_behavior unset**: Redeploys fail with "file already exists." Always set in CreateDeployment: `OVERWRITE`, `RETAIN`, or `DISALLOW`.
+
+**Auto Scaling loop**: Failed deployments on new instances cause infinite provision-terminate cycle. Fix: suspend `Launch` on ASG, fix deployment, resume.
+
+**MinimumHealthyHosts miscalculation**: Setting 90% on 3 instances = 2.7 rounded to 3 — deployment can never proceed. Ensure at least one instance can be taken offline.
+
+## ECS (Blue/Green)
+
+ECS deployments always use blue/green. CodeDeploy creates a replacement task set, optionally routes test traffic, then shifts production traffic.
+
+### appspec.yml (ECS)
+
+```yaml
+version: 0.0
+Resources:
+  - TargetService:
+      Type: AWS::ECS::Service
+      Properties:
+        TaskDefinition: "arn:aws:ecs:REGION:ACCOUNT:task-definition/my-task:3"
+        LoadBalancerInfo:
+          ContainerName: "my-container"
+          ContainerPort: 8080
+        PlatformVersion: "LATEST"
+Hooks:
+  - BeforeInstall: "arn:aws:lambda:REGION:ACCOUNT:function:BeforeInstallHook"
+  - AfterInstall: "arn:aws:lambda:REGION:ACCOUNT:function:AfterInstallHook"
+  - AfterAllowTestTraffic: "arn:aws:lambda:REGION:ACCOUNT:function:TestTrafficHook"
+  - BeforeAllowTraffic: "arn:aws:lambda:REGION:ACCOUNT:function:BeforeTrafficHook"
+  - AfterAllowTraffic: "arn:aws:lambda:REGION:ACCOUNT:function:AfterTrafficHook"
+```
+
+### ECS Lifecycle Hooks (Ordered)
+
+1. **BeforeInstall** — Lambda (scriptable)
+2. **Install** — Agent-only; creates replacement task set, waits for stability
+3. **AfterInstall** — Lambda (scriptable); validate replacement task set
+4. **AllowTestTraffic** — Agent-only; routes test listener to replacement target group
+5. **AfterAllowTestTraffic** — Lambda (scriptable); test via test traffic port
+6. **BeforeAllowTraffic** — Lambda (scriptable); pre-cutover gate
+7. **AllowTraffic** — Agent-only; shifts production traffic per config
+8. **AfterAllowTraffic** — Lambda (scriptable); post-cutover validation
+
+Scriptable hooks: BeforeInstall, AfterInstall, AfterAllowTestTraffic, BeforeAllowTraffic, AfterAllowTraffic. All invoke Lambda functions (not shell scripts).
+
+### ECS Deployment Configurations
+
+| Configuration | Behavior |
+|---------------|----------|
+| CodeDeployDefault.ECSAllAtOnce | 100% immediately |
+| CodeDeployDefault.ECSCanary10Percent5Minutes | 10% for 5 min, then 100% |
+| CodeDeployDefault.ECSCanary10Percent15Minutes | 10% for 15 min, then 100% |
+| CodeDeployDefault.ECSLinear10PercentEvery1Minutes | 10% every 1 min |
+| CodeDeployDefault.ECSLinear10PercentEvery3Minutes | 10% every 3 min |
+
+### ECS Pitfalls
+
+**Lifecycle hook 1-hour timeout**: CodeDeploy waits up to 3600s for the `PutLifecycleEventHookExecutionStatus` callback. This is the CodeDeploy hook timeout, not the Lambda execution timeout (which is max 900s). If the Lambda doesn't call back within 1 hour, the hook fails.
+
+**Test listener required for AfterAllowTestTraffic**: Without a test listener on the ALB, this hook is skipped — no pre-production validation window.
+
+**Original task set termination**: Configure `terminationWaitTimeInMinutes` on deployment group. Default is 0 — original tasks terminated immediately after shift (no manual rollback window).
+
+## Lambda
+
+Traffic shifts between two function versions using an alias.
+
+### appspec.yml (Lambda)
+
+```yaml
+version: 0.0
+Resources:
+  - MyFunction:
+      Type: AWS::Lambda::Function
+      Properties:
+        Name: "my-function"
+        Alias: "live"
+        CurrentVersion: "1"
+        TargetVersion: "2"
+Hooks:
+  - BeforeAllowTraffic: "arn:aws:lambda:REGION:ACCOUNT:function:PreTrafficHook"
+  - AfterAllowTraffic: "arn:aws:lambda:REGION:ACCOUNT:function:PostTrafficHook"
+```
+
+### Lambda Lifecycle Hooks
+
+1. **BeforeAllowTraffic** — Validate new version (invoke directly, run tests)
+2. **AllowTraffic** — Agent-only; shifts alias traffic per config
+3. **AfterAllowTraffic** — Validate production behavior post-shift
+
+### Lambda Deployment Configurations
+
+| Configuration | Behavior |
+|---------------|----------|
+| CodeDeployDefault.LambdaAllAtOnce | 100% immediately |
+| CodeDeployDefault.LambdaCanary10Percent5Minutes | 10% for 5 min, then 100% |
+| CodeDeployDefault.LambdaCanary10Percent10Minutes | 10% for 10 min, then 100% |
+| CodeDeployDefault.LambdaLinear10PercentEvery1Minute | 10% every 1 min |
+| CodeDeployDefault.LambdaLinear10PercentEvery2Minutes | 10% every 2 min |
+| CodeDeployDefault.LambdaLinear10PercentEvery10Minutes | 10% every 10 min |
+
+## Rollback Configuration
+
+```bash
+aws deploy update-deployment-group \
+  --application-name MyApp \
+  --deployment-group-name MyDG \
+  --auto-rollback-configuration enabled=true,events=DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM
+```
+
+| Trigger | When |
+|---------|------|
+| DEPLOYMENT_FAILURE | Any deployment fails |
+| DEPLOYMENT_STOP_ON_ALARM | CloudWatch alarm breaches during deployment |
+| DEPLOYMENT_STOP_ON_REQUEST | Manual stop triggers rollback |
+
+ECS/Lambda: rollback re-routes traffic to original task set/version. EC2: rollback creates a NEW deployment with last known good revision.
+
+Manual rollback: `aws deploy stop-deployment --deployment-id ID --auto-rollback-enabled`
+
+**Recommendation**: Always enable DEPLOYMENT_STOP_ON_ALARM with error rate + latency alarms for production.
+
+## Creating Deployment Groups
+
+### EC2 Deployment Group
+
+```bash
+aws deploy create-deployment-group \
+  --application-name MyApp \
+  --deployment-group-name MyDG \
+  --deployment-config-name CodeDeployDefault.OneAtATime \
+  --ec2-tag-filters Key=Environment,Value=MyEnvironment,Type=KEY_AND_VALUE \
+  --service-role-arn arn:aws:iam::ACCOUNT:role/CodeDeployServiceRole \
+  --auto-rollback-configuration enabled=true,events=DEPLOYMENT_FAILURE,DEPLOYMENT_STOP_ON_ALARM
+```
+
+### ECS Deployment Group
+
+```bash
+aws deploy create-deployment-group \
+  --application-name MyECSApp \
+  --deployment-group-name MyECSDG \
+  --deployment-config-name CodeDeployDefault.ECSCanary10Percent5Minutes \
+  --service-role-arn arn:aws:iam::ACCOUNT:role/CodeDeployECSRole \
+  --ecs-services serviceName=my-service,clusterName=my-cluster \
+  --load-balancer-info "targetGroupPairInfoList=[{targetGroups=[{name=tg-blue},{name=tg-green}],prodTrafficRoute={listenerArns=[ALB_LISTENER_ARN]},testTrafficRoute={listenerArns=[TEST_LISTENER_ARN]}}]"
+```
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| "no instances were found" | Tag filters match zero instances | Verify EC2 tags match deployment group filters |
+| "too many individual instances failed" | MinimumHealthyHosts impossible | Recalculate threshold for fleet size |
+| "file already exists" | file_exists_behavior not set | Set OVERWRITE in CreateDeployment |
+| "agent was not able to receive the lifecycle event" | Agent not running | `sudo service codedeploy-agent status` |
+| "HEALTH_CONSTRAINTS" | Not enough healthy instances | Reduce minimumHealthyHosts or fix failing instances |
+
+## Security
+
+- Scope CodeDeploy service role to specific deployment groups and S3 artifact paths
+- Encrypt deployment artifacts in S3 (SSE-KMS recommended)
+- Enable CloudTrail for `codedeploy:*` API auditing
+- MUST NOT log secrets in appspec hook scripts (stdout is captured in deployment logs)
+- Encrypt CloudWatch Logs groups for CodeDeploy event logs with KMS
+- Configure CloudWatch alarms on error rate/latency metrics for use with `DEPLOYMENT_STOP_ON_ALARM`
+- See [CodeDeploy security best practices](https://docs.aws.amazon.com/codedeploy/latest/userguide/security-best-practices.html)
+
+## Related
+
+- [codepipeline.md](codepipeline.md) for CodeDeploy action in pipelines
+- [troubleshooting.md](troubleshooting.md) for additional error patterns

--- a/skills/core-skills/aws-deployment/references/codepipeline.md
+++ b/skills/core-skills/aws-deployment/references/codepipeline.md
@@ -1,0 +1,350 @@
+# CodePipeline V2
+
+## Creating a V2 Pipeline
+
+**Default: V2 pipeline type with QUEUED execution mode.**
+
+```
+aws codepipeline create-pipeline --pipeline '{
+  "name": "my-app-pipeline",
+  "pipelineType": "V2",
+  "executionMode": "QUEUED",
+  "roleArn": "arn:aws:iam::ACCOUNT_ID:role/pipeline-service-role",
+  "artifactStore": {
+    "type": "S3",
+    "location": "my-pipeline-artifacts-bucket",
+    "encryptionKey": {
+      "id": "arn:aws:kms:REGION:ACCOUNT_ID:key/KEY_ID",
+      "type": "KMS"
+    }
+  },
+  "stages": [
+    {
+      "name": "Source",
+      "actions": [{
+        "name": "Source",
+        "actionTypeId": {
+          "category": "Source",
+          "owner": "AWS",
+          "provider": "CodeStarSourceConnection",
+          "version": "1"
+        },
+        "outputArtifacts": [{"name": "SourceOutput"}],
+        "configuration": {
+          "ConnectionArn": "arn:aws:codeconnections:REGION:ACCOUNT_ID:connection/CONNECTION_ID",
+          "FullRepositoryId": "org/repo",
+          "BranchName": "main",
+          "OutputArtifactFormat": "CODE_ZIP"
+        },
+        "namespace": "SourceVariables"
+      }]
+    },
+    {
+      "name": "Build",
+      "actions": [{
+        "name": "Build",
+        "actionTypeId": {
+          "category": "Build",
+          "owner": "AWS",
+          "provider": "CodeBuild",
+          "version": "1"
+        },
+        "inputArtifacts": [{"name": "SourceOutput"}],
+        "outputArtifacts": [{"name": "BuildOutput"}],
+        "configuration": {
+          "ProjectName": "my-build-project"
+        },
+        "namespace": "BuildVariables"
+      }]
+    },
+    {
+      "name": "Deploy",
+      "actions": [{
+        "name": "Deploy",
+        "actionTypeId": {
+          "category": "Deploy",
+          "owner": "AWS",
+          "provider": "CodeDeploy",
+          "version": "1"
+        },
+        "inputArtifacts": [{"name": "BuildOutput"}],
+        "configuration": {
+          "ApplicationName": "my-app",
+          "DeploymentGroupName": "my-deployment-group"
+        }
+      }]
+    }
+  ]
+}'
+```
+
+### Deploy Action Providers
+
+CodePipeline supports multiple deploy providers beyond CodeDeploy:
+
+| Provider | Use Case |
+|----------|----------|
+| CodeDeploy | EC2/ECS/Lambda with traffic shifting strategies |
+| CloudFormation | Deploy CDK/SAM/CloudFormation stacks (action modes: CREATE_UPDATE, CHANGE_SET_*) |
+| S3 | Static asset uploads (web apps, config files) |
+| ECS | Direct ECS service update (rolling, no CodeDeploy) |
+| EKS | Kubernetes deployments |
+| AppConfig | Feature flags and configuration deployment |
+
+## V1 vs V2
+
+| Feature | V1 | V2 |
+|---------|----|----|
+| Execution modes | SUPERSEDED only | SUPERSEDED, QUEUED, PARALLEL |
+| Triggers | Polling or webhook | Push/PR filtering with globs |
+| Variables | Action output only | Pipeline-level + action output |
+| Stage conditions | Not available | Entry/success/failure conditions |
+| Rollback | Not available | Stage-level rollback |
+
+## Execution Modes
+
+| Mode | Behavior | Max Concurrent | Use When |
+|------|----------|----------------|----------|
+| SUPERSEDED | Newer replaces older at stage boundaries | 1 active | Only latest matters (default V1 behavior) |
+| QUEUED | FIFO order, each completes before next starts | 50 queued | Order matters (migrations, sequential deploys) |
+| PARALLEL | All run independently, no waiting | 50 concurrent | Independent feature branches, no shared state |
+
+**Pitfalls:**
+- PARALLEL loses rollback capability and source revision tracking — do not use for prod pipelines requiring rollback
+- Changing mode discards queued executions — stop pipeline first
+- QUEUED rejects execution 51 (not queued silently)
+
+## Triggers with Git Filtering
+
+### Push Trigger (deploy on main, only src/ changes)
+
+```json
+"triggers": [{
+  "providerType": "CodeStarSourceConnection",
+  "gitConfiguration": {
+    "sourceActionName": "Source",
+    "push": [{
+      "branches": {
+        "includes": ["main"],
+        "excludes": ["feature/*"]
+      },
+      "filePaths": {
+        "includes": ["src/**", "deploy/**"],
+        "excludes": ["docs/**", "*.md"]
+      }
+    }]
+  }
+}]
+```
+
+### Pull Request Trigger
+
+```json
+"triggers": [{
+  "providerType": "CodeStarSourceConnection",
+  "gitConfiguration": {
+    "sourceActionName": "Source",
+    "pullRequest": [{
+      "branches": { "includes": ["main"] },
+      "events": ["OPEN", "UPDATE"]
+    }]
+  }
+}]
+```
+
+### Tag Trigger
+
+```json
+"push": [{
+  "tags": {
+    "includes": ["release-*"],
+    "excludes": ["release-*-rc*"]
+  }
+}]
+```
+
+### Trigger Limits
+
+| Limit | Value |
+|-------|-------|
+| Triggers per pipeline | 50 |
+| Filters per trigger | 3 |
+| Glob patterns per includes/excludes | 8 each |
+| **File path evaluation limit** | **100 files** — commits exceeding this skip path filtering entirely |
+
+## Pipeline Variables
+
+### Pipeline-Level Variables
+
+Declare in pipeline definition:
+
+```json
+"variables": [
+  {"name": "DeployEnvironment", "defaultValue": "staging", "description": "Target environment"},
+  {"name": "SkipTests", "defaultValue": "false", "description": "Skip integration tests"}
+]
+```
+
+Reference in action configs: `#{variables.DeployEnvironment}`
+
+Override at execution:
+
+```
+aws codepipeline start-pipeline-execution \
+  --name my-pipeline \
+  --variables name=DeployEnvironment,value=production
+```
+
+### Action Output Variables (Namespace)
+
+Add `"namespace": "BuildVars"` to an action to expose its outputs.
+
+| Provider | Output Variables |
+|----------|-----------------|
+| CodeStarSourceConnection | CommitId, CommitMessage, BranchName, AuthorDate, ConnectionArn, FullRepositoryName |
+| CodeBuild | BuildId, BuildTag, ResolvedSourceVersion |
+| CloudFormation | StackId, all stack Outputs |
+| Lambda | FunctionOutput (custom JSON) |
+| Manual Approval | ApprovalStatus, ApprovalSummary, CustomData |
+
+Reference: `#{Namespace.VariableName}` — e.g., `#{SourceVariables.CommitId}`
+
+### Variable Limits
+
+| Limit | Value |
+|-------|-------|
+| Pipeline-level variables | 50 |
+| Variable value length | 1000 characters |
+| Output variables per compute action | 15 |
+| Total output size per action | 122,880 bytes (silently truncates if exceeded) |
+
+## Cross-Account Deployment
+
+Requires ALL THREE configured together:
+
+### Step 1: Customer-Managed KMS Key (Source Account)
+
+MUST use key ID or full ARN — aliases do not resolve cross-account.
+
+Key policy grants target account:
+
+```json
+{
+  "Sid": "AllowTargetAccountDecrypt",
+  "Effect": "Allow",
+  "Principal": {"AWS": "arn:aws:iam::TARGET_ACCOUNT_ID:root"},
+  "Action": ["kms:Decrypt", "kms:DescribeKey", "kms:Encrypt", "kms:GenerateDataKey*", "kms:ReEncrypt*"],
+  "Resource": "*",
+  "Condition": {
+    "ArnLike": {
+      "aws:PrincipalArn": "arn:aws:iam::TARGET_ACCOUNT_ID:role/cross-account-deploy-role"
+    }
+  }
+}
+```
+
+### Step 2: S3 Bucket Policy (Source Account)
+
+```json
+[
+  {
+    "Sid": "AllowTargetAccountAccess",
+    "Effect": "Allow",
+    "Principal": {"AWS": "arn:aws:iam::TARGET_ACCOUNT_ID:role/cross-account-deploy-role"},
+    "Action": ["s3:GetObject", "s3:GetObjectVersion", "s3:GetBucketVersioning", "s3:PutObject"],
+    "Resource": ["arn:aws:s3:::BUCKET", "arn:aws:s3:::BUCKET/*"]
+  },
+  {
+    "Sid": "DenyInsecureTransport",
+    "Effect": "Deny",
+    "Principal": "*",
+    "Action": "s3:*",
+    "Resource": ["arn:aws:s3:::BUCKET", "arn:aws:s3:::BUCKET/*"],
+    "Condition": {"Bool": {"aws:SecureTransport": "false"}}
+  }
+]
+```
+
+### Step 3: Cross-Account Role (Target Account)
+
+Trust policy:
+
+```json
+{
+  "Effect": "Allow",
+  "Principal": {"AWS": "arn:aws:iam::SOURCE_ACCOUNT_ID:root"},
+  "Action": "sts:AssumeRole",
+  "Condition": {
+    "ArnLike": {"aws:PrincipalArn": "arn:aws:iam::SOURCE_ACCOUNT_ID:role/pipeline-service-role"}
+  }
+}
+```
+
+### Step 4: Pipeline Action Configuration
+
+```json
+"artifactStore": {
+  "type": "S3",
+  "location": "BUCKET",
+  "encryptionKey": {"id": "arn:aws:kms:REGION:SOURCE_ACCOUNT_ID:key/KEY_ID", "type": "KMS"}
+},
+"actions": [{
+  "roleArn": "arn:aws:iam::TARGET_ACCOUNT_ID:role/cross-account-deploy-role",
+  ...
+}]
+```
+
+For cross-region: use `artifactStores` (plural) with per-region bucket and KMS key configuration.
+
+## Manual Approval Gates
+
+```json
+{
+  "name": "DeploymentApproval",
+  "actionTypeId": {"category": "Approval", "owner": "AWS", "provider": "Manual", "version": "1"},
+  "configuration": {
+    "NotificationArn": "arn:aws:sns:REGION:ACCOUNT_ID:pipeline-approvals",
+    "CustomData": "Deploy #{SourceVariables.CommitId}?",
+    "ExternalEntityLink": "https://staging.example.com"
+  }
+}
+```
+
+Approve via CLI:
+
+```
+aws codepipeline put-approval-result \
+  --pipeline-name my-pipeline \
+  --stage-name Production \
+  --action-name DeploymentApproval \
+  --token TOKEN_FROM_NOTIFICATION \
+  --result summary="Approved",status=Approved
+```
+
+**Timeout**: Default 7 days, configurable 5 min to 60 days. Token expires with timeout.
+
+**Security**: MUST encrypt the SNS topic with KMS (`aws sns set-topic-attributes --topic-arn ARN --attribute-name KmsMasterKeyId --attribute-value KEY_ARN`). MUST NOT include secrets, API keys, or credentials in CustomData. Verify commit messages contain no sensitive information before referencing them in CustomData. Restrict SNS topic subscriptions to authorized approvers only.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `InvalidStructureException` | Missing required field or bad JSON | Validate with `--cli-input-json file://pipeline.json` |
+| `StageNotRetryableException` | Stage not in Failed state | Only failed stages can be retried |
+| `InvalidActionDeclarationException` with KMS | Using alias cross-account | Use full key ARN |
+| Trigger fires on unrelated commits | >100 files touched, path filter skipped | Use branch filter as primary gate |
+| `PipelineExecutionNotStoppableException` | Execution in terminal state | Already finished, no action needed |
+
+## Security
+
+- MUST encrypt artifact bucket with customer-managed KMS key (shown in examples above)
+- Scope pipeline service role to specific resource ARNs; avoid `*` on sensitive actions
+- MUST encrypt SNS topics for approval notifications with KMS (CustomData may contain commit metadata)
+- Enable CloudTrail for `codepipeline:*` API auditing
+- See [CodePipeline security best practices](https://docs.aws.amazon.com/codepipeline/latest/userguide/security-best-practices.html)
+
+## Related
+
+- [codebuild.md](codebuild.md) for build action configuration
+- [codedeploy.md](codedeploy.md) for deployment strategies
+- [codeconnections.md](codeconnections.md) for source connection setup

--- a/skills/core-skills/aws-deployment/references/codepipeline.md
+++ b/skills/core-skills/aws-deployment/references/codepipeline.md
@@ -110,6 +110,7 @@ CodePipeline supports multiple deploy providers beyond CodeDeploy:
 | PARALLEL | All run independently, no waiting | 50 concurrent | Independent feature branches, no shared state |
 
 **Pitfalls:**
+
 - PARALLEL loses rollback capability and source revision tracking — do not use for prod pipelines requiring rollback
 - Changing mode discards queued executions — stop pipeline first
 - QUEUED rejects execution 51 (not queued silently)

--- a/skills/core-skills/aws-deployment/references/troubleshooting.md
+++ b/skills/core-skills/aws-deployment/references/troubleshooting.md
@@ -1,0 +1,116 @@
+# Troubleshooting
+
+## First Check These 5 Things
+
+1. **Connection status**: `aws codeconnections get-connection --connection-arn ARN` — if PENDING, complete OAuth in console
+2. **Pipeline state**: `aws codepipeline get-pipeline-state --name NAME` — find which action failed and why
+3. **Build logs**: `aws codebuild batch-get-builds --ids BUILD_ID` — check `phases` array for first failed phase
+4. **Deployment status**: `aws deploy get-deployment --deployment-id ID` — check `deploymentOverview` and `errorInformation`
+5. **Service role permissions**: `aws iam simulate-principal-policy --policy-source-arn ROLE_ARN --action-names ACTION` — verify IAM
+
+## Error Table
+
+### CodePipeline
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| `InternalError` on action | Artifact bucket wrong region or KMS permission denied | Ensure S3 bucket same region as pipeline; check KMS key policy |
+| `ActionConfigurationError` | Referenced resource deleted (CodeBuild project, deployment group) | Verify all resource names in action config still exist |
+| `AccessDeniedException` on action | Service role missing permissions for the action's provider | Add required permissions to pipeline service role |
+| Pipeline stuck InProgress | Disabled transition, waiting approval, or slow action | Check `get-pipeline-state` for `actionStates`; look for PENDING approval |
+| `PipelineExecutionNotStoppableException` | Execution in terminal state (Succeeded/Failed) | Already finished — no action needed |
+| `InvalidStructureException` on create/update | Malformed pipeline JSON | Validate JSON; check all required fields per action type |
+| `StageNotRetryableException` | Stage not in Failed state | Only failed stages can be retried |
+| `RevisionOutOfSyncException` | PARALLEL mode race between executions | Use QUEUED mode for sequential consistency |
+| Trigger fires on unrelated changes | File path filter skipped (>100 files in commit) | Add branch filter as primary gate |
+| Trigger never fires | sourceActionName mismatch or connection PENDING | Verify trigger config matches source action name exactly |
+| `AccessDenied` on cross-account action | Missing KMS/S3/IAM trust (need all three) | Verify: KMS key policy, S3 bucket policy, target role trust policy |
+
+### CodeBuild
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| `DOWNLOAD_SOURCE` failure | VPC without NAT, connection PENDING, or repo not found | Check VPC NAT gateway; verify connection AVAILABLE; check repo access |
+| `YAML_FILE_ERROR` | Missing `runtime-versions`, bad YAML syntax, or wrong filename | Add runtime-versions block; validate YAML; file must be `buildspec.yml` at root |
+| Build hangs indefinitely | VPC subnet without NAT gateway or S3 endpoint | Add NAT gateway to private subnet route table |
+| `Cannot connect to Docker daemon` | Privileged mode not enabled or dockerd not started | Set `privilegedMode=true` AND start dockerd in pre_build phase |
+| `BUILD_GENERAL1_SMALL not available` | Compute type not available in region or quota reached | Try different compute type or request quota increase |
+| Build timeout (default 60 min) | Long-running build or hanging dependency download | Increase `timeoutInMinutes`; check for network issues (VPC) |
+| `CODEBUILD_CLONE_REF` permission error | CodeBuild role missing UseConnection | Add `codeconnections:UseConnection` to CodeBuild service role (not pipeline role) |
+| `CLIENT_ERROR: unable to locate credentials` | Service role insufficient for operation | Check CodeBuild service role has needed permissions |
+| Artifacts not found by next stage | `base-directory` wrong or files pattern too restrictive | Verify `artifacts.base-directory` matches build output location |
+
+### CodeDeploy
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| "no instances were found" | Tag filters match zero instances or agent not running | Verify EC2 tags; check `codedeploy-agent` status on instances |
+| "specified key does not exist" | S3 revision artifact location wrong | Verify S3 path matches revision location in `create-deployment` |
+| `ApplicationStop` fails every deploy | Previous revision's stop script is broken | Deploy fix-only revision or use `--ignore-application-stop-failures` |
+| "file already exists at this location" | file_exists_behavior not set | Set `OVERWRITE` in deployment or appspec `files.overwrite: true` |
+| `InstanceLimitExceeded` | ASG scaling faster than deployment completes | Suspend ASG Launch process, fix deployment, resume |
+| "agent was not able to receive the lifecycle event" | Agent not running or network timeout | SSH to instance; `sudo service codedeploy-agent status`; check SG |
+| HEALTH_CONSTRAINTS error | Not enough healthy instances to proceed | Reduce minimumHealthyHosts or fix unhealthy instances |
+| ECS deployment stuck | Health check failing on replacement task set | Verify target group health check path and port match container |
+| ECS "replacement task set did not stabilize" | Task crashes on startup or resource limits | Check ECS task stopped reason; verify CPU/memory, image exists |
+| Lambda deployment failed at BeforeAllowTraffic | Validation Lambda errored or timed out | Check Lambda logs; ensure it calls `codedeploy:PutLifecycleEventHookExecutionStatus` |
+
+### CodeConnections
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| Connection stays PENDING | Created via CLI/CFN without console completion | Complete OAuth handshake in AWS Console |
+| "Unable to use Connection" | IAM policy only has one service prefix | Add `codeconnections:UseConnection` and `codestar-connections:UseConnection` |
+| Repository not found | Wrong FullRepositoryId format or no repo access | Use `org/repo` format (case-sensitive); verify app has repo access |
+| Host in VPC_CONFIG_FAILED_INITIALIZATION | Network or TLS issue | Verify VPC routes to provider endpoint; validate TLS certificate |
+| Cookie error during GitHub authorization | Non-owner attempting GitHub App install | Organization owner must perform the installation |
+
+## Diagnostic Commands
+
+```bash
+# Pipeline: Get execution history
+aws codepipeline list-pipeline-executions --pipeline-name NAME --max-items 5
+
+# Pipeline: Get action execution details
+aws codepipeline list-action-executions --pipeline-name NAME \
+  --filter pipelineExecutionId=EXEC_ID
+
+# Build: Get failed phase details
+aws codebuild batch-get-builds --ids BUILD_ID \
+  --query "builds[0].phases[?phaseStatus=='FAILED']"
+
+# Build: Stream logs (if CloudWatch configured)
+aws logs tail /aws/codebuild/PROJECT_NAME --follow
+
+# Deploy: Get deployment target status
+aws deploy list-deployment-targets --deployment-id DEPLOY_ID
+
+# Deploy: Get lifecycle event details for failed target
+aws deploy get-deployment-target --deployment-id DEPLOY_ID --target-id TARGET_ID
+
+# Connections: List all with status
+aws codeconnections list-connections --query "Connections[].[ConnectionName,ConnectionStatus]" --output table
+```
+
+## End-to-End Trace
+
+When a pipeline fails and you don't know which service caused it:
+
+1. `aws codepipeline get-pipeline-state --name NAME` → find failed stage/action
+2. Check `latestExecution.externalExecutionId` on the failed action — this is the build ID or deployment ID
+3. For build actions: `aws codebuild batch-get-builds --ids BUILD_ID`
+4. For deploy actions: `aws deploy get-deployment --deployment-id DEPLOY_ID`
+5. For source actions: `aws codeconnections get-connection --connection-arn ARN` (check status)
+
+## Related
+
+- [codepipeline.md](codepipeline.md) for pipeline-specific errors
+- [codebuild.md](codebuild.md) for build configuration issues
+- [codedeploy.md](codedeploy.md) for deployment strategy issues
+- [codeconnections.md](codeconnections.md) for connection setup issues
+
+## Security
+
+- MUST NOT include secrets, credentials, or sensitive data in diagnostic commands shared with users
+- Use CloudTrail to audit API calls across all CodeSuite services when investigating security incidents
+- Verify IAM permissions using `aws iam simulate-principal-policy` rather than granting broad access for debugging


### PR DESCRIPTION
## Summary

Adds the `aws-deployment` skill covering CI/CD pipeline orchestration with AWS CodePipeline, CodeBuild, CodeDeploy, CodeConnections, and CodeArtifact.

## What this skill helps with

- Setting up V2 pipelines with triggers, variables, and execution modes
- Configuring CodeBuild projects (VPC networking, Docker builds, caching, on-failure retry)
- CodeDeploy deployment strategies (blue/green, canary, linear) for EC2, ECS, and Lambda
- CodeConnections setup (GitHub, GitLab, Bitbucket) with proper IAM condition keys
- CodeArtifact authentication and cross-account package sharing
- Cross-account pipeline deployment
- Troubleshooting common CI/CD failures

## Test plan

- [x] 26 eval tests passing (5 mutation + 21 knowledge) across Claude Opus/Sonnet/Haiku
- [x] Selection tests: 100% accuracy, 0 regressions on existing skills
- [x] Pre-prod smoke test
- [ ] Production validation after merge