### PR TITLE
feat(aws-serverless): streamline skill and detail function URL use

### DIFF
--- a/plugins/aws-core/skills/aws-serverless/SKILL.md
+++ b/plugins/aws-core/skills/aws-serverless/SKILL.md
@@ -10,42 +10,47 @@ metadata:
 ---
 
 # AWS Serverless
-## Overview
 
-Domain expertise for building serverless applications on AWS. Covers Lambda configuration, API Gateway debugging, Step Functions orchestration, EventBridge patterns, event source mappings, concurrency tuning, cold start optimization, deployment with SAM/CDK, production readiness, and troubleshooting across all serverless services.
+Domain expertise for building serverless applications on AWS: Lambda, API Gateway, Step Functions, EventBridge, event source mappings, concurrency, cold starts, deployment, and troubleshooting.
 
-**Works best with** the [AWS MCP server](https://docs.aws.amazon.com/aws-mcp/) — enables running CLI commands, querying CloudWatch, and validating configurations directly. All guidance also works with standard AWS CLI access.
+**Works best with** the [AWS MCP server](https://docs.aws.amazon.com/aws-mcp/) — run CLI commands, query CloudWatch, validate configs directly. All guidance also works with standard AWS CLI access.
 
-**Note:** Reference files contain specific runtime versions, quota values, and feature matrices that may change. When precision matters (e.g., deploying to production, choosing a runtime, or checking a quota), confirm values against current AWS documentation rather than relying solely on the values in these files.
+## Specialized skills — check these first
 
-## Routing
+These cover capabilities and procedures the general references below do **not**. Several are specialized features or step-by-step tested procedures you would otherwise miss. Route to the matching skill before falling back to the references.
 
-| User need | Action |
-|-----------|--------|
-| Building a new serverless app | Read [architecture.md](references/architecture.md) for pattern selection, then [deployment.md](references/deployment.md) for SAM/CDK templates |
-| Debugging an error | Read [troubleshooting.md](references/troubleshooting.md) — starts with the 5 most common fixes |
-| Optimizing performance or cost | Read [lambda.md](references/lambda.md) for cold starts and memory tuning, [production.md](references/production.md) for readiness checklist |
-| Configuring event sources (SQS, DDB Streams, SNS) | Read [event-sources.md](references/event-sources.md) |
-| Step Functions, EventBridge, or orchestration | Read [orchestration.md](references/orchestration.md) |
-| Concurrency configuration | Read [concurrency.md](references/concurrency.md) |
-| API Gateway setup | Read [api-gateway.md](references/api-gateway.md) |
-| Common anti-patterns | Read the anti-patterns section in [production.md](references/production.md) |
-| Starting with Powertools | Use [powertools-handler.py](assets/powertools-handler.py) as a template |
-| Lambda Managed Instances, LMI, capacity providers, EC2-backed Lambda, PerExecutionEnvironmentMaxConcurrency | Use the **aws-lambda-managed-instances** skill instead |
-| Durable functions, durable execution, checkpoint-and-replay | Use the **aws-lambda-durable-functions** skill instead |
-| Firecracker microVMs, strong tenant isolation, sandboxed/untrusted code execution, long-lived sessions, suspend/resume, port-listening servers, snapshot-resumable compute | Use the **aws-lambda-microvms** skill instead |
-| Spans multiple areas | Read the most specific reference first, then consult others as needed |
+### Advanced Lambda compute (easy to overlook)
 
-## Files
+| Use this skill | When the workload involves |
+|---|---|
+| **aws-lambda-microvms** | Strong tenant isolation, sandboxed/untrusted code execution (AI agent code sandboxes, REPLs, notebooks, CI runners), long-lived sessions, suspend/resume with preserved state, port-listening servers (gRPC, WebSocket, custom TCP), Firecracker microVMs, snapshot-resumable compute, up to 8-hour lifetimes |
+| **aws-lambda-durable-functions** | Durable execution, checkpoint-and-replay, long-running multi-step workflows written as plain code (TS/Python/Java), automatic state persistence, saga pattern in code, human-in-the-loop callbacks, executions up to 1 year, `context.step`/`context.wait`/`context.invoke`, `withDurableExecution`, `durable-execution-sdk` |
+| **aws-lambda-managed-instances** | Lambda Managed Instances (LMI), capacity providers, EC2-backed Lambda, steady high-volume traffic (50M+ req/mo) wanting Savings Plans / Reserved Instance pricing, `PerExecutionEnvironmentMaxConcurrency`, `CapacityProviderConfig`, multi-concurrent execution environments |
 
-| File | Content |
-|------|---------|
-| [lambda.md](references/lambda.md) | Runtime, memory/CPU, cold starts, SnapStart, layers, containers |
-| [api-gateway.md](references/api-gateway.md) | REST vs HTTP API, stages, auth, throttling, mapping |
-| [event-sources.md](references/event-sources.md) | SQS, DDB Streams, SNS, S3, Kinesis triggers |
-| [orchestration.md](references/orchestration.md) | Step Functions, EventBridge rules/pipes/scheduler |
-| [concurrency.md](references/concurrency.md) | Reserved vs provisioned, scaling, ESM concurrency |
-| [architecture.md](references/architecture.md) | Patterns, reference architectures, service selection |
-| [deployment.md](references/deployment.md) | SAM/CDK resource types, globals, fast iteration |
-| [production.md](references/production.md) | Readiness checklist, observability, anti-patterns |
-| [troubleshooting.md](references/troubleshooting.md) | Error → cause → fix for all serverless services |
+### Step-by-step task procedures (tested CLI SOPs)
+
+| Use this skill | For the task |
+|---|---|
+| **connecting-lambda-to-api-gateway** | Wire an existing Lambda to a new REST/HTTP API: proxy integration, permissions, CORS, throttling, access logging, deployment |
+| **connecting-lambda-to-dynamodb** | Connect Lambda to DynamoDB: IAM execution role, read/write permissions, stream event source mapping |
+| **creating-api-gateway-stage** | Create an API Gateway stage with CloudWatch logging, X-Ray tracing, throttling, WAF association, and authorization |
+| **deploying-custom-domain-rest-api** | Deploy a Regional REST API with custom domain: ACM cert, Lambda backend, request authorizer, base path mapping, Route 53 DNS |
+| **debugging-lambda-timeouts** | Systematically diagnose a timing-out Lambda: config, CloudWatch logs/metrics, VPC, cold starts, memory, downstream calls |
+| **processing-s3-uploads-with-step-functions** | Deploy an event-driven workflow: S3 upload → EventBridge → Step Functions → Lambda (small files) or Fargate (large files), with VPC/ECR/ECS/IAM |
+
+## Routing (general references in this skill)
+
+| User need | Read |
+|-----------|------|
+| Building a new serverless app — pattern selection | [architecture.md](references/architecture.md) |
+| Lambda config, cold starts, SnapStart, memory, VPC, layers, Function URLs | [lambda.md](references/lambda.md) |
+| Concurrency (reserved, provisioned, ESM controls) | [concurrency.md](references/concurrency.md) |
+| Event sources (SQS, DynamoDB Streams, SNS, Kinesis), filtering, batch failures | [event-sources.md](references/event-sources.md) |
+| Step Functions, EventBridge rules/pipes/scheduler | [orchestration.md](references/orchestration.md) |
+| API Gateway quotas, authorizers, WebSocket | [api-gateway.md](references/api-gateway.md) |
+| SAM/CDK resource types and fast iteration | [deployment.md](references/deployment.md) |
+| Production readiness, observability, anti-patterns | [production.md](references/production.md) |
+| Debugging an error (exact string → cause → fix) | [troubleshooting.md](references/troubleshooting.md) |
+| Powertools handler template | [powertools-handler.py](assets/powertools-handler.py) |
+
+**Note:** Reference files contain specific runtime versions, quotas, and feature matrices that change. When precision matters (production, runtime choice, quotas), confirm against current AWS documentation. The references focus on values and gotchas that are easy to get wrong — not on basics.

--- a/plugins/aws-core/skills/aws-serverless/assets/powertools-handler.py
+++ b/plugins/aws-core/skills/aws-serverless/assets/powertools-handler.py
@@ -13,7 +13,8 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 tracer = Tracer()
-metrics = Metrics()
+# Namespace is required (or set POWERTOOLS_METRICS_NAMESPACE); flushing without one raises SchemaValidationError.
+metrics = Metrics(namespace="MyApp")
 persistence = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 
 # Idempotency key: "body" deduplicates identical payloads.

--- a/plugins/aws-core/skills/aws-serverless/references/api-gateway.md
+++ b/plugins/aws-core/skills/aws-serverless/references/api-gateway.md
@@ -1,21 +1,21 @@
 # API Gateway Reference
 
-Quick-reference for REST API, HTTP API, WebSocket API — debugging, configuration, and quotas.
+Exact quotas and the handful of gotchas worth pinning down. Assumes you know the basics: choose **REST API** when you need WAF / API keys / usage plans / request validation / built-in caching / edge-optimized / canary / VTL / resource policies, otherwise **HTTP API** (lower latency, native JWT, built-in CORS, auto-deploy); under Lambda **proxy** integration the **Lambda must return CORS headers** (the console "Enable CORS" button doesn't apply); the **#1 cause of 502** is a malformed proxy response (`body` must be a `JSON.stringify`'d string in the `{statusCode, headers, body}` shape); REST API has **no native generic JWT** (use Cognito or a Lambda authorizer), HTTP API has a **native JWT authorizer** for any OIDC IdP.
 
 ## Contents
 
-- [REST vs HTTP API Comparison](#rest-vs-http-api-comparison)
-- [CORS Debugging](#cors-debugging)
-- [Lambda Authorizers](#lambda-authorizers)
-- [Throttling and Quotas](#throttling-and-quotas)
+- [REST vs HTTP API comparison](#rest-vs-http-api-comparison)
+- [Integration timeouts and payloads](#integration-timeouts-and-payloads)
+- [Throttling and quotas](#throttling-and-quotas)
+- [Lambda authorizers](#lambda-authorizers)
 - [WebSocket APIs](#websocket-apis)
-- [502/504 Debugging](#502504-debugging)
+- [CORS gotchas](#cors-gotchas)
 
 ---
 
-## REST vs HTTP API Comparison
+## REST vs HTTP API comparison
 
-### Decision Tree
+Default to **HTTP API** (lower latency, lower cost, simpler); reach for **REST API** only when you need one of its exclusive features:
 
 ```
 Need any of these? → REST API
@@ -34,520 +34,100 @@ Need any of these? → REST API
 None of the above? → HTTP API (lower latency, simpler)
 ```
 
-### Feature Comparison
+---
 
-| Feature | REST API | HTTP API |
+## Integration timeouts and payloads
+
+| | REST API | HTTP API |
 |---|---|---|
-| **Latency** | Higher | Lower |
-| **Endpoint types** | Edge, Regional, Private | Regional only |
-| **AWS WAF** | Yes | No |
-| **API keys / usage plans** | Yes | No |
-| **Per-client throttling** | Yes | No |
-| **Request validation** | Yes | No |
-| **Body transformation (VTL)** | Yes | No |
-| **Parameter mapping** | Yes | Yes |
-| **Caching (built-in)** | Yes | No |
-| **Custom domains** | Yes | Yes |
-| **Lambda authorizers** | Yes (TOKEN + REQUEST) | Yes (REQUEST only) |
-| **JWT authorizers (native)** | No | Yes |
-| **IAM auth** | Yes | Yes |
-| **Cognito (native)** | Yes | Yes (via JWT) |
-| **Resource policies** | Yes | No |
-| **Mutual TLS** | Yes | Yes |
-| **CORS setup** | Manual OPTIONS method | Built-in config |
-| **Automatic deployments** | No | Yes |
-| **Canary deployments** | Yes | No |
-| **Custom gateway responses** | Yes | No |
-| **Execution logs** | Yes | No |
-| **Access logs (CloudWatch)** | Yes | Yes |
-| **Access logs (Firehose)** | Yes | No |
-| **X-Ray tracing** | Yes | No |
-| **Mock integrations** | Yes | No |
-| **Private integrations (NLB)** | Yes | Yes |
-| **Private integrations (ALB)** | Yes | Yes |
-| **Private integrations (Cloud Map)** | No | Yes |
-| **Response streaming** | Yes | No |
-| **Console test invocations** | Yes | No |
-| **Integration timeout** | 50ms–29s (configurable) | 30s hard max |
-| **Payload size** | 10 MB | 10 MB |
+| Integration timeout | 50ms–29s (default 29s; **raisable only for Regional/private**) | **30s hard max** (lowerable, not raisable) |
+| Payload size | 10 MB | 10 MB |
+| Endpoint types | Edge, Regional, Private | Regional only |
+| Response streaming | Yes (proxy, STREAM mode) | No |
 
-> **REST API streaming caveats:** Response streaming via REST API proxy integration does not support built-in caching, response transforms (VTL), or WAF inspection of streamed content. Idle timeouts apply, and a 2 MBps bandwidth cap applies after the first 10 MB (Function URLs apply the cap after 6 MB).
+> **REST API streaming caveats:** no built-in caching, no VTL transforms, no WAF inspection of streamed content; 2 MBps cap after the first 10 MB (Function URLs cap after 6 MB).
 
 ---
 
-## CORS Debugging
+## Throttling and quotas
 
-### Proxy vs Non-Proxy
+Throttling applies most-specific → least-specific: per-client/method (usage plan + API key, REST only) → per-method → account-level → AWS Regional (hard). Token bucket: empty bucket → `429 Too Many Requests`; burst allows temporary spikes.
 
-| Aspect | Proxy integration | Non-proxy integration |
-|---|---|---|
-| Who returns CORS headers? | **Your Lambda function** | **API Gateway** (method response) |
-| OPTIONS method needed? | Yes (or use mock) | Yes (mock integration) |
-| Where to configure? | In your code | In API Gateway console/IaC |
+### Account-level
 
-### Debugging Flowchart
-
-```
-"Cross-Origin Request Blocked"?
-│
-├─ YES → Which integration type?
-│  │
-│  ├─ PROXY → Lambda MUST return CORS headers
-│  │  ├─ Access-Control-Allow-Origin
-│  │  ├─ Access-Control-Allow-Methods
-│  │  └─ Access-Control-Allow-Headers
-│  │
-│  └─ NON-PROXY → Configure in API Gateway:
-│     ├─ Create OPTIONS method (mock integration)
-│     ├─ Add 200 response with CORS headers
-│     └─ Add CORS headers to actual method responses
-│
-├─ OPTIONS returning 200?
-│  ├─ NO  → OPTIONS method missing or misconfigured
-│  └─ YES → Check actual method response headers
-│
-└─ 502 on OPTIONS?
-   └─ Binary media types set to */* → fix below
-```
-
-### Common CORS Mistakes
-
-| # | Mistake | Fix |
-|---|---|---|
-| 1 | No CORS headers in Lambda (proxy integration) | Add headers to every Lambda response |
-| 2 | Missing OPTIONS method (REST API, non-proxy) | Create OPTIONS with mock integration |
-| 3 | Binary media types `*/*` breaks OPTIONS | Set `contentHandling: CONVERT_TO_TEXT` on OPTIONS |
-| 4 | `Allow-Origin: *` with `credentials: include` | Specify exact origin, not wildcard |
-| 5 | Not redeploying API after CORS changes | Redeploy the stage |
-| 6 | Missing `Allow-Headers` for custom headers | List all headers the client sends |
-| 7 | Gateway 4XX/5XX responses lack CORS headers | Add CORS headers to gateway responses |
-
-### Lambda CORS Headers — Python
-
-```python
-def handler(event, context):
-    return {
-        "statusCode": 200,
-        "headers": {
-            "Access-Control-Allow-Origin": "https://example.com",
-            "Access-Control-Allow-Methods": "OPTIONS,POST,GET,PUT,DELETE",
-            "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token",
-        },
-        "body": json.dumps({"message": "success"}),
-    }
-```
-
-### Lambda CORS Headers — TypeScript
-
-```typescript
-export const handler = async (event: any) => ({
-  statusCode: 200,
-  headers: {
-    "Access-Control-Allow-Origin": "https://example.com",
-    "Access-Control-Allow-Methods": "OPTIONS,POST,GET,PUT,DELETE",
-    "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token",
-  },
-  body: JSON.stringify({ message: "success" }),
-});
-```
-
-### Binary Media Types `*/*` Fix
+Confirm the current account-level steady-state RPS and burst limits for the Region rather than assuming a default — they vary by Region and are adjustable:
 
 ```bash
-# Fix OPTIONS integration request
-aws apigateway update-integration \
-  --rest-api-id API_ID --resource-id RES_ID \
-  --http-method OPTIONS \
-  --patch-operations op='replace',path='/contentHandling',value='CONVERT_TO_TEXT'
-
-# Fix OPTIONS integration response
-aws apigateway update-integration-response \
-  --rest-api-id API_ID --resource-id RES_ID \
-  --http-method OPTIONS --status-code 200 \
-  --patch-operations op='replace',path='/contentHandling',value='CONVERT_TO_TEXT'
+aws service-quotas get-service-quota --service-code apigateway --quota-code L-8A5B8E43
 ```
 
----
-
-## Lambda Authorizers
-
-### TOKEN vs REQUEST Authorizer
-
-| Feature | TOKEN | REQUEST |
-|---|---|---|
-| Identity source | Single header (bearer token) | Headers, query strings, stage vars, `$context` |
-| Cache key | Token header value | All specified identity sources |
-| Token validation regex | Yes | No |
-| Fine-grained policies | Limited | Yes (multiple sources) |
-| Available on | REST API only | REST API + HTTP API |
-| **Recommendation** | Legacy | **Preferred** |
-
-> **Use REQUEST authorizers for new APIs.** TOKEN is legacy.
-
-### Caching Behavior
-
-| Setting | Detail |
-|---|---|
-| Default TTL | 300 seconds |
-| Range | 0 (disabled) – 3600 seconds |
-| Cache key (TOKEN) | Header value from token source |
-| Cache key (REQUEST) | All specified identity sources combined |
-| **Critical** | Cached policy applies to **ALL methods/resources** |
-
-If any specified identity source is missing/null/empty → 401 returned **without** invoking Lambda.
-
-### REQUEST Authorizer — Python
-
-```python
-def lambda_handler(event, context):
-    token = event["headers"].get("Authorization", "")
-    is_authorized = verify_token(token)  # Your auth logic
-
-    return {
-        "principalId": "user",
-        "policyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-                "Action": "execute-api:Invoke",
-                "Effect": "Allow" if is_authorized else "Deny",
-                "Resource": event["methodArn"],
-            }],
-        },
-        "context": {"userId": "user", "scope": "read:items"},
-    }
-```
-
-### REQUEST Authorizer — TypeScript
-
-```typescript
-import { APIGatewayAuthorizerResult, APIGatewayRequestAuthorizerEvent } from "aws-lambda";
-
-export const handler = async (
-  event: APIGatewayRequestAuthorizerEvent
-): Promise<APIGatewayAuthorizerResult> => {
-  const token = event.headers?.Authorization ?? "";
-  const isAuthorized = verifyToken(token); // Your auth logic
-
-  return {
-    principalId: "user",
-    policyDocument: {
-      Version: "2012-10-17",
-      Statement: [{
-        Action: "execute-api:Invoke",
-        Effect: isAuthorized ? "Allow" : "Deny",
-        Resource: event.methodArn,
-      }],
-    },
-    context: { userId: "user", scope: "read:items" },
-  };
-};
-```
-
-### HTTP API JWT Authorizer (Native — No Lambda)
-
-No Lambda function needed. Configure directly on the API:
-
-```yaml
-# SAM / CloudFormation
-MyHttpApi:
-  Type: AWS::Serverless::HttpApi
-  Properties:
-    Auth:
-      DefaultAuthorizer: MyJwtAuth
-      Authorizers:
-        MyJwtAuth:
-          AuthorizationScopes:
-            - read:items
-          IdentitySource: $request.header.Authorization
-          JwtConfiguration:
-            issuer: https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc123
-            audience:
-              - my-client-id
-```
-
-Supports any OIDC-compliant IdP (Cognito, Auth0, Okta, etc.).
-
----
-
-## Throttling and Quotas
-
-### Throttling Hierarchy (Applied in Order)
-
-```
-Most specific → Least specific:
-
-1. Per-client / per-method  (usage plan + API key)   ← REST only
-2. Per-method               (stage method settings)
-3. Account-level            (all APIs in account/Region)
-4. AWS Regional             (hard limit, not changeable)
-```
-
-### Token Bucket Algorithm
-
-- Tokens added at steady-state rate (RPS)
-- Bucket holds up to burst capacity
-- Each request = 1 token
-- Empty bucket → `429 Too Many Requests`
-- Burst allows temporary spikes above steady-state
-
-### Account-Level Defaults
-
-| Quota | Default | Adjustable? |
-|---|---|---|
-| Steady-state RPS (per Region) | 10,000 | Yes |
-| Burst capacity | 5,000 | Set by AWS based on RPS |
-| Smaller Regions (Cape Town, Milan, Jakarta…) | 2,500 RPS / 1,250 burst | Yes |
-
-### REST API Quotas
+### REST API
 
 | Resource | Default | Adjustable? |
 |---|---|---|
-| Integration timeout | 50ms–29s (default 29s) | Yes (Regional/private only) |
-| Payload size | 10 MB | No |
-| Header value size | 10,240 bytes | No |
-| Cache TTL | 0–3600s | No |
 | Resources per API | 300 | Yes |
 | Stages per API | 10 | Yes |
 | API keys per account | 10,000 | No |
 | Usage plans per account | 300 | Yes |
 | Custom domains per Region | 120 | Yes |
+| Header value size | 10,240 bytes | No |
+| Cache TTL | 0–3600s | No |
 | Mapping template size | 300 KB | No |
 
-### HTTP API Quotas
+### HTTP API
 
 | Resource | Default | Adjustable? |
 |---|---|---|
-| Integration timeout | 30s max | No |
-| Payload size | 10 MB | No |
 | Routes per API | 300 | Yes |
 | Stages per API | 10 | Yes |
 | Integrations per API | 300 | No |
 | Custom domains per Region | 120 | Yes |
 | VPC links per Region | 10 | Yes |
 
-### Usage Plans (REST API Only)
+Client-side 429 handling: exponential backoff with jitter, respect `Retry-After`, rate-limit to stay under known limits.
 
-- Per-client rate limits (RPS) and burst limits via API keys
-- Daily/weekly/monthly quotas per key
-- Method-level throttling within a plan (e.g., `GET /pets` = 100 RPS)
+---
 
-### Client-Side 429 Handling
+## Lambda authorizers
 
-- Exponential backoff with jitter
-- Respect `Retry-After` header
-- Client-side rate limiting to stay under known limits
+| Feature | TOKEN | REQUEST |
+|---|---|---|
+| Identity source | Single header (bearer token) | Headers, query strings, stage vars, `$context` |
+| Cache key | Token header value | All specified identity sources combined |
+| Available on | REST API only | REST API + HTTP API |
+| Recommendation | Legacy | **Preferred for new APIs** |
+
+Caching: default TTL **300s** (range 0–3600). **A cached policy applies to ALL methods/resources.** If any specified identity source is missing/null/empty → **401 without invoking Lambda**.
+
+The authorizer must return an IAM policy: `{ principalId, policyDocument: { Version, Statement: [{ Action: "execute-api:Invoke", Effect: "Allow"|"Deny", Resource: methodArn }] }, context: {...} }`. HTTP API JWT authorizers need no Lambda — configure `issuer` + `audience` directly on the API.
 
 ---
 
 ## WebSocket APIs
 
-### Route Architecture
+Routes: `$connect` (auth, store connectionId), `$disconnect` (best-effort cleanup), `$default` (catch-all / non-JSON), plus custom routes selected by `$request.body.action`. Server pushes via the `@connections` API (`PostToConnectionCommand` / `post_to_connection`).
 
-```
-Client connects    → $connect    (auth, store connectionId)
-Client sends msg   → route selection → custom route or $default
-Server pushes data → @connections API (POST to connectionId)
-Client disconnects → $disconnect (cleanup connectionId)
-```
-
-### Route Selection
-
-- Expression: `$request.body.action` (routes on JSON `action` field)
-- Non-JSON messages → always `$default`
-
-### Predefined Routes
-
-| Route | When | Required? | Notes |
-|---|---|---|---|
-| `$connect` | Connection initiated | No | Auth here; connection pending until integration completes |
-| `$disconnect` | Connection closed | No | Best-effort; connection already closed |
-| `$default` | No matching route / non-JSON | No | Catch-all fallback |
-
-### Connection Management — Python
-
-```python
-import boto3, json
-
-dynamodb = boto3.resource("dynamodb")
-table = dynamodb.Table("WebSocketConnections")
-
-def connect_handler(event, context):
-    table.put_item(Item={"connectionId": event["requestContext"]["connectionId"]})
-    return {"statusCode": 200, "body": "Connected"}
-
-def send_to_client(endpoint_url, connection_id, data):
-    client = boto3.client("apigatewaymanagementapi", endpoint_url=endpoint_url)
-    client.post_to_connection(
-        ConnectionId=connection_id,
-        Data=json.dumps(data).encode("utf-8"),
-    )
-```
-
-### Connection Management — TypeScript
-
-```typescript
-import { ApiGatewayManagementApiClient, PostToConnectionCommand } from "@aws-sdk/client-apigatewaymanagementapi";
-
-async function sendToClient(endpoint: string, connectionId: string, data: object) {
-  const client = new ApiGatewayManagementApiClient({ endpoint });
-  await client.send(new PostToConnectionCommand({
-    ConnectionId: connectionId,
-    Data: Buffer.from(JSON.stringify(data)),
-  }));
-}
-```
-
-### WebSocket Quotas
-
-| Resource | Limit |
+| Limit | Value |
 |---|---|
 | Idle connection timeout | 10 minutes |
 | Max connection duration | 2 hours |
 | Message payload | 128 KB (hard limit) |
 
-### WebSocket Close Codes
+Close codes: **1001** idle/max-duration, 1003 unsupported binary, 1006 abnormal (no close frame), **1008** throttled, **1009** message too large, 1011 internal error, 1012 service restart.
 
-| Code | Meaning |
-|---|---|
-| 1001 | Idle timeout or max duration exceeded |
-| 1003 | Unsupported binary media type |
-| 1005 | No status code present (reserved, not sent on wire) |
-| 1006 | Abnormal closure — no close frame received |
-| 1008 | Throttled (too many requests) |
-| 1009 | Message exceeds size limit |
-| 1011 | Internal server error |
-| 1012 | Service restart |
+Store `connectionId` in DynamoDB with a **TTL attribute set to now + 7200s** (the 2-hour max duration) so stale connections are auto-cleaned even when `$disconnect` is missed — enable DynamoDB TTL on that attribute.
 
 ---
 
-## 502/504 Debugging
+## CORS gotchas
 
-### 502 Bad Gateway — Flowchart
+The common, non-obvious failures (basic header setup is well understood):
 
-```
-502 Bad Gateway
-│
-├─ Lambda proxy integration?
-│  └─ YES → Check response format (most common cause):
-│     ├─ statusCode: integer (string is coerced, missing defaults to 200)
-│     ├─ headers: object with string values
-│     ├─ body: string (JSON.stringify, not raw object)
-│     └─ Unhandled exception? → Check CloudWatch Logs
-│
-├─ Lambda authorizer?
-│  ├─ Must return valid IAM policy format
-│  ├─ Check authorizer Lambda logs
-│  └─ Authorizer timeout is separate from integration timeout
-│
-├─ HTTP integration?
-│  ├─ Backend reachable from API Gateway?
-│  ├─ Valid HTTP response from backend?
-│  └─ VPC link healthy? (private integration)
-│
-└─ Other causes:
-   ├─ Payload > 10 MB
-   ├─ Binary media types */* (breaks OPTIONS)
-   └─ Stage variable → wrong Lambda alias
-```
+| Mistake | Fix |
+|---|---|
+| Binary media types `*/*` break OPTIONS (502) | Set `contentHandling: CONVERT_TO_TEXT` on the OPTIONS integration |
+| `Allow-Origin: *` with `credentials: include` | Specify the exact origin, not a wildcard |
+| Not redeploying after CORS changes | Redeploy the stage |
+| Gateway 4XX/5XX responses lack CORS headers | Add CORS headers to gateway responses too |
 
-### Correct Lambda Response Format
-
-The **most common cause of 502** is an incorrect response format in Lambda proxy integrations.
-
-**Python — Correct:**
-
-```python
-def handler(event, context):
-    return {
-        "isBase64Encoded": False,           # boolean
-        "statusCode": 200,                  # integer, NOT string
-        "headers": {                        # object with string values
-            "Content-Type": "application/json",
-        },
-        "body": json.dumps({"key": "val"}) # MUST be string
-    }
-```
-
-**TypeScript — Correct:**
-
-```typescript
-export const handler = async (event: any) => ({
-  isBase64Encoded: false,
-  statusCode: 200,
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ key: "val" }),  // MUST be string
-});
-```
-
-**Common mistakes -> 502:**
-
-```python
-return {"statusCode": 200, "body": {"key": "val"}}     # body not a string -> 502
-return "just a string"                                   # not a JSON object -> 502
-# Note: string statusCode ("200") and missing statusCode are silently handled (no 502)
-```
-
-### 504 Timeout — Flowchart
-
-```
-504 Endpoint Request Timed Out
-│
-├─ Step 1: Enable CloudWatch logging
-│  ├─ REST: execution logs + access logs
-│  ├─ HTTP: access logs only
-│  └─ Include: $context.integrationLatency, $context.integration.status
-│
-├─ Step 2: Identify timeout source
-│  ├─ REST API: integration timeout configurable 50ms–29s
-│  ├─ HTTP API: 30s max (can be lowered, cannot be raised)
-│  └─ Was integration invoked?
-│     ├─ NO  → Transient network failure; retry
-│     └─ YES → Backend too slow
-│
-├─ Step 3: Reduce integration runtime
-│  ├─ Move non-critical work to async (SQS, Step Functions)
-│  ├─ Increase Lambda memory (faster CPU)
-│  ├─ Provisioned concurrency (eliminate cold starts)
-│  └─ Check downstream dependencies (DB, external APIs)
-│
-└─ Step 4: Increase timeout (REST only)
-   ├─ Request via Service Quotas console
-   ├─ Update integration timeout value AND redeploy
-   └─ Note: may reduce account throttle quota
-```
-
-### CloudWatch Insights Queries
-
-**Find all 5xx errors:**
-
-```
-fields @timestamp, @message, @logStream
-| filter status >= 500 and status < 600
-| sort @timestamp desc
-| display @timestamp, httpMethod, resourcePath, status, requestId
-```
-
-**Find timeout errors:**
-
-```
-fields @timestamp, @message
-| filter @message like "Execution failed due to a timeout error"
-| sort @timestamp desc
-```
-
-**Find slow integrations (>10s):**
-
-```
-fields @timestamp, integrationLatency, status, resourcePath
-| filter integrationLatency > 10000
-| sort integrationLatency desc
-```
-
-### Automated Troubleshooting
-
-**AWSSupport-TroubleshootAPIGatewayHttpErrors** — Systems Manager runbook:
-
-- Validates API, resource, operation, and stage
-- Analyzes CloudWatch logs automatically
-- Requires: `apigateway:GET`, `logs:GetQueryResults`, `logs:StartQuery`, `ssm:*`
-- Available in Systems Manager console → Automation
+For the full step-by-step procedure of wiring CORS, throttling, and access logging when connecting a Lambda, use the **connecting-lambda-to-api-gateway** skill (see SKILL.md routing). For 502/504 deep debugging, see [troubleshooting.md](troubleshooting.md).

--- a/plugins/aws-core/skills/aws-serverless/references/architecture.md
+++ b/plugins/aws-core/skills/aws-serverless/references/architecture.md
@@ -1,262 +1,123 @@
 # Serverless Architecture Patterns
 
-Reference architectures, pattern selection flowcharts, and service selection tables for common serverless workloads.
+Pattern selection and the opinionated service defaults / constraints for each. The patterns themselves are standard — the value here is the default-vs-alternative choices and the non-obvious constraints.
 
-## Contents
+## Pattern selection
 
-- [Pattern selection flowchart](#pattern-selection-flowchart)
-- [REST/HTTP API pattern](#resthttp-api-pattern)
-- [Event processing pattern](#event-processing-pattern)
-- [Orchestration pattern](#orchestration-pattern)
-- [Real-time streaming pattern](#real-time-streaming-pattern)
-- [Async fan-out pattern](#async-fan-out-pattern)
-- [Scheduled jobs pattern](#scheduled-jobs-pattern)
-- [Choosing between patterns](#choosing-between-patterns)
+| What you're building | Pattern |
+|---|---|
+| Synchronous request/response API | REST/HTTP API → Lambda → DynamoDB |
+| Processing events from a queue/stream/database | Event processing (SQS/Streams → Lambda) |
+| Multi-step workflow with branching/error handling | Orchestration (Step Functions) |
+| Real-time bidirectional / LLM streaming | WebSocket API or Function URL streaming |
+| One event → multiple independent consumers | Async fan-out (EventBridge / SNS) |
+| Recurring task on a schedule | EventBridge Scheduler → Lambda / Step Functions |
 
----
-
-## Pattern selection flowchart
-
-```
-What are you building?
-│
-├── Synchronous request/response API?
-│   └── REST/HTTP API pattern
-│
-├── Processing events from a queue/stream/database?
-│   └── Event processing pattern
-│
-├── Multi-step workflow with branching/error handling?
-│   └── Orchestration pattern
-│
-├── Real-time bidirectional communication or LLM streaming?
-│   └── Real-time streaming pattern
-│
-├── One event triggers multiple independent consumers?
-│   └── Async fan-out pattern
-│
-└── Recurring task on a schedule?
-    └── Scheduled jobs pattern
-```
+Most real apps combine several. Start with one (a CRUD API on DynamoDB covers most initial needs); add event processing for async work, orchestration for multi-step workflows, fan-out for cross-service comms.
 
 ---
 
 ## REST/HTTP API pattern
 
-```
-Client → API Gateway (HTTP API) → Lambda → DynamoDB
-                                         → S3 (binary storage)
-```
-
-**When:** CRUD APIs, mobile/web backends, microservices.
-
-**Service selection:**
+CRUD APIs, mobile/web backends, microservices.
 
 | Decision | Default | Alternative |
 |---|---|---|
-| API type | HTTP API (simpler) | REST API if you need WAF, caching, request validation, API keys |
-| Auth | JWT authorizer (HTTP API native) | Cognito (REST: native Cognito authorizer; HTTP: JWT authorizer), Lambda authorizer (custom logic) |
-| Database | DynamoDB (on-demand) | RDS Proxy + RDS if relational data needed |
-| File storage | S3 with presigned URLs | Direct upload via API Gateway (10 MB limit) |
-| Function pattern | One function per route | Lambdalith if team prefers Express/FastAPI style |
+| API type | HTTP API (simpler) | REST API for WAF, caching, request validation, API keys |
+| Auth | JWT authorizer (HTTP API native) | Cognito (REST native), Lambda authorizer (custom logic) |
+| Database | DynamoDB (on-demand) | RDS Proxy + RDS for relational data |
+| File storage | S3 presigned URLs | Direct upload via API Gateway (10 MB limit) |
+| Function pattern | One function per route | Lambdalith for Express/FastAPI migrations |
 
-**Key constraints:**
-
-- HTTP API: 30s hard timeout, no WAF, no caching, 10 MB payload
-- REST API: 29s default timeout (adjustable for Regional/private APIs), 10 MB payload
+Constraints: HTTP API 30s hard timeout, no WAF/caching; REST API 29s default (adjustable for Regional/private). Both 10 MB payload.
 
 ---
 
 ## Event processing pattern
 
-```
-Event source → SQS → Lambda → DynamoDB / S3
-                ↓
-              DLQ (failed messages)
-```
-
-**When:** Async workloads, decoupled producers/consumers, batch processing, file processing.
-
-**Service selection:**
+Async workloads, decoupled producers/consumers, batch/file processing.
 
 | Decision | Default | Alternative |
 |---|---|---|
-| Buffer | SQS standard queue | SQS FIFO if ordering matters (10 msg batch limit) |
-| Trigger | SQS event source mapping | S3 event notification → Lambda (file uploads) |
-| Change data capture | DynamoDB Streams → Lambda | EventBridge Pipes → Lambda (no ESM needed) |
+| Buffer | SQS standard | SQS FIFO if ordering matters (10-msg batch) |
+| Trigger | SQS ESM | S3 event notification → Lambda (file uploads) |
+| Change data capture | DynamoDB Streams → Lambda | EventBridge Pipes → Lambda (no ESM) |
 | Stream ingestion | SQS (simpler) | Kinesis (ordered replay, multiple consumers, high-throughput) |
-| Error handling | SQS redrive policy (DLQ) | On-failure destination (SQS/SNS/S3) for streams |
-| Concurrency control | MaximumConcurrency on ESM | Reserved concurrency on function |
-| Batch processing | ReportBatchItemFailures | Powertools Batch Processor utility |
+| Error handling | SQS redrive policy (DLQ) | On-failure destination for streams |
+| Concurrency control | `MaximumConcurrency` on ESM | Reserved concurrency on function |
 
-**Key constraints:**
-
-- SQS visibility timeout ≥ 6× function timeout
-- MaximumConcurrency and Provisioned Mode are mutually exclusive on same ESM
-- Enable partial batch failure reporting to avoid reprocessing successful messages
-- SQS event filtering automatically deletes unmatched messages (permanently — not sent to DLQ)
-
-**S3 trigger constraints:**
-
-- Recursive invocation risk: never write output to the same bucket/prefix that triggers the function
-- No native DLQ on S3 notifications — use Lambda async invocation DLQ instead
-- Use prefix/suffix filtering to limit which objects trigger the function
-- Consider EventBridge for S3 instead of S3 notifications (richer filtering, multiple targets)
-
-**DynamoDB Streams constraints:**
-
-- Max 2 Lambda consumers per stream shard (use EventBridge Pipes for more)
-- 24-hour stream retention — records expire and cannot be replayed after that
-- Ordering guaranteed per partition key, not globally
+Constraints: SQS visibility ≥ 6× function timeout; `MaximumConcurrency` and Provisioned Mode mutually exclusive on one ESM; SQS filter drops unmatched messages permanently. **S3 triggers:** never write output to the triggering bucket/prefix (recursion); no native DLQ (use Lambda async DLQ); consider EventBridge for S3 (richer filtering). **DynamoDB Streams:** max 2 consumers/shard, 24h retention, ordering per partition key only.
 
 ---
 
 ## Orchestration pattern
 
-```
-Trigger → Step Functions → Lambda (validate)
-                         → Choice (route by status)
-                         → Parallel (fan-out)
-                         → Lambda (aggregate) → DynamoDB
-```
-
-**When:** Multi-step workflows, saga transactions, approval chains, data pipelines, AI agent loops.
-
-**Service selection:**
+Multi-step workflows, saga transactions, approval chains, data pipelines, AI agent loops.
 
 | Decision | Default | Alternative |
 |---|---|---|
-| Workflow type | Standard (exactly-once, up to 1 year) | Express (<5 min, high-volume; async=at-least-once, sync=at-most-once) |
-| Simple data transforms | JSONata (inline, no Lambda needed) | Lambda task (complex logic) |
+| Workflow type | Standard (exactly-once, ≤ 1 year) | Express (< 5 min, high-volume) |
+| Simple transforms | JSONata (inline, no Lambda) | Lambda task (complex logic) |
 | Service calls | Direct SDK integration (200+ services) | Lambda intermediary (only if business logic needed) |
-| Human approval | .waitForTaskToken | Lambda durable functions waitForCallback |
+| Human approval | `.waitForTaskToken` | Lambda durable functions `waitForCallback` |
 | AI agent loops | Step Functions + Bedrock | Lambda durable functions (code-first, checkpointed) |
-| Error handling | Retry + Catch in ASL | Lambda durable functions try/catch in code |
 
-**Key constraints:**
-
-- 256 KB payload limit between states — use S3 for large data
-- Express: no .sync, no .waitForTaskToken, no Distributed Map, no Activities
-- 25,000 execution history entries (Standard) — split long workflows into child executions
-- Prefer direct SDK integrations over Lambda intermediary functions to reduce latency
+Constraints: 256 KiB between states (use S3 for large data); Express lacks `.sync`/`.waitForTaskToken`/Distributed Map/Activities; 25,000 history entries (Standard). See [orchestration.md](orchestration.md).
 
 ---
 
 ## Real-time streaming pattern
 
-```
-Client ←→ API Gateway WebSocket ←→ Lambda → DynamoDB (connections)
-                                          → Bedrock (LLM responses)
-```
-
-Or for LLM token streaming:
-
-```
-Client → Lambda Function URL (streaming) → Bedrock ConverseStream
-```
-
-**When:** Chat apps, live dashboards, notifications, LLM token streaming, multiplayer games.
-
-**Service selection:**
+Chat, live dashboards, notifications, LLM token streaming, multiplayer.
 
 | Decision | Default | Alternative |
 |---|---|---|
 | Bidirectional | API Gateway WebSocket | AppSync subscriptions (GraphQL) |
 | LLM streaming | Lambda Function URL + ConverseStream | REST API proxy with STREAM mode |
-| Connection state | DynamoDB (connectionId → metadata, enable TTL to clean up stale connections after 2-hour max duration) | ElastiCache (higher throughput) |
-| Auth | $connect route authorizer | Cognito + custom auth in Lambda |
+| Connection state | DynamoDB (connectionId → metadata, TTL to clean up after 2h max) | ElastiCache (higher throughput) |
+| Auth | `$connect` route authorizer | Cognito + custom auth in Lambda |
 
-**Key constraints:**
-
-- WebSocket: 10 min idle timeout, 2 hour max connection, 128 KB message (hard limit)
-- Function URL streaming: 200 MB limit, 2 MBps after first 6 MB, Node.js native support
-- Function URLs **MUST** use `AWS_IAM` auth type. For CloudFront integration, use Origin Access Control (OAC) to sign requests — do not set auth to `NONE`. If `NONE` is unavoidable for other reasons, authentication **MUST** be enforced at the edge (e.g., CloudFront + Lambda@Edge). No native JWT/Cognito support.
+Constraints: WebSocket 10-min idle / 2-hour max / 128 KB message; Function URL streaming 200 MB, 2 MBps after first 6 MB, Node.js native. **For streaming behind CloudFront, Function URLs should use `AWS_IAM` auth** — use Origin Access Control to sign requests rather than setting auth to `NONE`; if `NONE` is unavoidable, enforce auth at the edge (CloudFront + Lambda@Edge). (For a deliberately public, browser-reachable URL with no edge in front, `NONE` is the intended auth type — see [Function URLs in lambda.md](lambda.md#function-urls) for the required permissions.)
 
 ---
 
 ## Async fan-out pattern
 
-```
-Producer → EventBridge → Rule A → Lambda (process)
-                       → Rule B → Step Functions (workflow)
-                       → Rule C → SQS → Lambda (batch)
-```
-
-**When:** One event triggers multiple independent actions, event-driven microservices, cross-service communication.
-
-**Service selection:**
+One event → multiple independent actions; event-driven microservices.
 
 | Decision | Default | Alternative |
 |---|---|---|
 | Event router | EventBridge (content-based routing) | SNS (simpler fan-out, attribute/body filtering) |
-| Point-to-point | EventBridge Pipes (source→target, no Lambda intermediary) | SQS → Lambda ESM |
-| Schema management | EventBridge Schema Registry + Discovery | Manual schema documentation |
+| Point-to-point | EventBridge Pipes (no Lambda glue) | SQS → Lambda ESM |
+| Schema management | EventBridge Schema Registry + Discovery | Manual docs |
 | Cross-account | EventBridge cross-account rules | SNS cross-account subscriptions |
-| Scheduling | EventBridge Scheduler (cron/rate) | EventBridge rules (simpler but less flexible) |
+| Scheduling | EventBridge Scheduler (cron/rate) | EventBridge rules with schedule expression |
 
-**Key constraints:**
-
-- Use dedicated event bus per application domain (not the default bus)
-- EventBridge Pipes eliminates Lambda intermediary functions for source→target integrations
-- Be precise with event patterns — overly broad patterns risk loops
-- Configure DLQs on all targets
+Constraints: dedicated event bus per domain (not the default bus); be precise with patterns (broad patterns risk loops); DLQs on all targets.
 
 ---
 
 ## Scheduled jobs pattern
 
-```
-EventBridge Scheduler → Lambda (task)
-                      → Step Functions (complex workflow)
-```
-
-**When:** Cron jobs, periodic data sync, report generation, cleanup tasks.
-
-**Service selection:**
+Cron jobs, periodic sync, report generation, cleanup.
 
 | Decision | Default | Alternative |
 |---|---|---|
-| Scheduler | EventBridge Scheduler (flexible, one-time + recurring) | EventBridge rules with schedule expression (simpler) |
-| Short task (<15 min) | Lambda directly | — |
-| Long task (>15 min) | Step Functions (up to 1 year) | Lambda durable functions |
-| High frequency (<1 min) | Not supported natively | SQS delay queue + Lambda |
+| Scheduler | EventBridge Scheduler (flexible, one-time + recurring) | EventBridge rules schedule expression (simpler) |
+| Short task (< 15 min) | Lambda directly | — |
+| Long task (> 15 min) | Step Functions (≤ 1 year) | Lambda durable functions |
+| High frequency (< 1 min) | Not supported natively | SQS delay queue + Lambda |
 
-**Key constraints:**
-
-- Minimum schedule interval: 1 minute
-- Lambda max timeout: 15 minutes — use Step Functions for longer
-- Always make scheduled Lambda idempotent (scheduler guarantees at-least-once)
-- Use EventBridge Scheduler over EventBridge rules for new projects (more features, flexible time windows)
+Constraints: minimum interval 1 minute; always make scheduled Lambdas idempotent (at-least-once); prefer EventBridge Scheduler over rules for new projects (flexible time windows).
 
 ---
 
-## Choosing between patterns
+## Common combinations
 
-Most real applications combine multiple patterns:
-
-```
-                    ┌─ HTTP API ─── Lambda ─── DynamoDB
-Client ─── CloudFront ─┤
-                    └─ WebSocket ── Lambda ─── DynamoDB
-                                      │
-                                      ▼
-                              EventBridge
-                              ┌────┼────┐
-                              ▼    ▼    ▼
-                            SQS  SFN  Lambda
-                              │    │
-                              ▼    ▼
-                           Lambda  Bedrock
-```
-
-**Common combinations:**
-
-| Application | Patterns used |
+| Application | Patterns |
 |---|---|
 | SaaS API backend | REST API + Event processing + Scheduled jobs |
 | E-commerce | REST API + Orchestration (order saga) + Fan-out (notifications) |
 | Data pipeline | Scheduled jobs + Event processing + Orchestration |
 | AI chatbot | Real-time streaming + Orchestration (agent loop) |
 | IoT processing | Event processing + Fan-out + Scheduled jobs (aggregation) |
-
-**Begin with a single pattern and add more as requirements grow.** A CRUD API with DynamoDB covers most initial implementations. Add event processing when you need async work. Add orchestration when you need multi-step workflows. Add fan-out when you need cross-service communication.

--- a/plugins/aws-core/skills/aws-serverless/references/concurrency.md
+++ b/plugins/aws-core/skills/aws-serverless/references/concurrency.md
@@ -1,200 +1,86 @@
 # Lambda Concurrency Controls
 
-Four concurrency controls operate at different levels, solve different problems, and have complex interactions.
-
-## Contents
-
-- [The 4 concurrency types](#the-4-concurrency-types)
-- [Interaction matrix](#interaction-matrix)
-- [Decision scenarios](#decision-scenarios)
-- [Account limits and scaling](#account-limits-and-scaling)
-- [Common mistakes](#common-mistakes)
-- [SnapStart interaction](#snapstart-interaction)
-- [SAM/CDK examples](#samcdk-property-reference)
-
----
+Four concurrency controls operate at different levels with non-obvious interactions. The exact numbers and mutual-exclusivity rules below are the part that's easy to get wrong.
 
 ## The 4 concurrency types
 
-### 1. Reserved Concurrency
-Sets the **maximum** concurrent instances for a function and **reserves** that capacity from the account pool so no other function can consume it.
+1. **Reserved Concurrency** (scope: function) — sets the **max** concurrent instances AND reserves that capacity from the account pool. Setting to **0** fully throttles the function (emergency shutoff). Use to protect critical functions, cap to protect downstream, or kill-switch.
 
-- **Scope:** Function.
-- Reserve 400 → function always gets up to 400, never more. Others share the rest.
-- Setting to **0** completely throttles the function (emergency shutoff).
-- Use for: protecting critical functions, capping to protect downstream, emergency shutoff.
+2. **Provisioned Concurrency** (scope: published version or alias — **NOT `$LATEST`**) — pre-initializes environments so they're ready before requests arrive. Spills to on-demand (with cold starts) beyond the provisioned count. Combine with Application Auto Scaling (~70% target). Paid even when idle.
 
-### 2. Provisioned Concurrency
-Pre-initializes execution environments so they are **ready before requests arrive**.
+3. **Maximum Concurrency** (scope: per SQS ESM, range **2–1,000**) — caps how many concurrent instances one SQS ESM can invoke. Does **not** reserve anything; other triggers can still consume function concurrency.
 
-- **Scope:** Published version or alias (**NOT** `$LATEST`).
-- **Allocation rate:** Up to 6,000 environments per minute when provisioning.
-- Configure 100 on alias `PROD` → first 100 concurrent requests get sub-10ms startup.
-  Request 101+ spills to on-demand with cold starts.
-- **Account-level RPS quota**: RPS = 10 × account concurrency. For example, 1,000 account concurrency → 10,000 RPS cap across all functions. This is an account-level quota, not a per-instance throughput cap. Per-instance throughput = 1 / function duration.
-- Combine with **Application Auto Scaling** (target ~70% utilization).
-- Use for: user-facing APIs, functions with heavy init (ML models, DB pools).
+4. **Provisioned Mode — ESM** (SQS and Kafka/MSK) — allocates dedicated event pollers for an SQS/Kafka ESM with configurable min/max. Per-poller capacity is an **OR** envelope and differs by source: **SQS = 1 MB/s or 10 concurrent invokes**; **Kafka/MSK = 5 MB/s or 5 concurrent invokes**. Use for high-throughput or spiky traffic where standard ramp-up (5 → +300/min) is too slow.
 
-### 3. Maximum Concurrency
-Limits how many concurrent instances a **specific SQS event source mapping (ESM)** can invoke.
+## Key numbers and interactions
 
-- **Scope:** Per ESM. **Range:** 2–1,000. **Sources:** SQS only.
-- Does **not** reserve anything — other triggers can still consume function concurrency.
-- Use for: multiple SQS queues on one function, rate-limiting a specific queue.
-
-### 4. Provisioned Mode — ESM (Kafka 2024, SQS 2025)
-Allocates **dedicated event pollers** for an SQS or Kafka ESM with configurable min/max.
-
-- **Scope:** Per ESM.
-- Standard mode: ~5 pollers, +300/min, max 1,250 invokes. Provisioned mode: you control
-  min/max pollers. Each handles up to 1 MB/s, 10 concurrent invokes.
-- Use for: high-throughput SQS/Kafka, spiky traffic where standard ramp-up is too slow.
-
----
-
-## Interaction matrix
+- **Account RPS quota = 10 × account concurrency** (e.g. 1,000 concurrency → 10,000 RPS, across all functions). This is an account quota, not a per-instance cap. Per-instance throughput = 1 / function duration.
+- **Max reservable = account limit − 100.** Lambda always keeps 100 unreserved.
+- **Scaling rate: 1,000 new environments / 10s, per function**
+- Provisioned ≤ Reserved when both are set (reserved is the ceiling).
+- Provisioned counts against the account limit even when idle — monitor `ClaimedAccountConcurrency`.
 
 | Combination | OK? | Notes |
 |-------------|:---:|-------|
 | Reserved + Provisioned | Yes | Provisioned ≤ Reserved |
-| Reserved + Max Concurrency (ESM) | Yes | Reserved ≥ Σ(max concurrency across ESMs) |
-| Reserved + Provisioned Mode (ESM) | Yes | Independent layers |
-| Provisioned + Max Concurrency (ESM) | Yes | Different layers |
-| Provisioned + Provisioned Mode (ESM) | Yes | Warms envs vs warms pollers |
-| **Max Concurrency + Provisioned Mode (same ESM)** | No | **Mutually exclusive** |
-| **Provisioned Concurrency + SnapStart** | No | **Mutually exclusive** |
+| Reserved + Maximum Concurrency (ESM) | Yes | Reserved ≥ Σ(Maximum Concurrency across ESMs) |
+| Provisioned + Maximum Concurrency / Provisioned Mode (ESM) | Yes | Different layers |
+| **Maximum Concurrency + Provisioned Mode (same ESM)** | **No** | **Mutually exclusive** |
+| **Provisioned Concurrency + SnapStart** | **No** | **Mutually exclusive** |
 
-**Key rules:** Account limit is the hard ceiling. Reserved carves from the pool — Lambda
-always keeps **100 unreserved**. Provisioned ≤ Reserved when both set. Max Concurrency is
-advisory to the ESM, not the function.
+**At the limit:** Sync → 429. Async → retries up to 6h then DLQ. Streams → polling throttled, messages stay in source.
 
-```
-┌──────────────────────────────────────────────────────┐
-│  ACCOUNT: 1,000 concurrency                          │
-│  ┌─────────────────┐  ┌───────────────────────────┐  │
-│  │ RESERVED (400)   │  │ UNRESERVED POOL (600)     │  │
-│  │ ┌─────────────┐  │  │ Shared by all others      │  │
-│  │ │PROVISIONED  │  │  │ Must keep ≥100 always     │  │
-│  │ │(200 warm)   │  │  └───────────────────────────┘  │
-│  │ └─────────────┘  │                                 │
-│  │ + 200 on-demand  │  ESM LAYER (per mapping):       │
-│  └─────────────────┘  Max Concurrency — OR —          │
-│                        Provisioned Mode (not both)     │
-└──────────────────────────────────────────────────────┘
-```
-
----
-
-## Decision scenarios
-
-| Scenario | Reserved | Provisioned | Max Conc (ESM) | Prov Mode (ESM) |
-|----------|:--------:|:-----------:|:--------------:|:---------------:|
-| Protect critical API from starvation | Yes | — | — | — |
-| Cap function to protect downstream DB | Yes | — | — | — |
-| Eliminate cold starts for user-facing API | Optional | Yes | — | — |
-| Multiple SQS queues, prevent hogging | Yes | — | Yes | — |
-| High-throughput SQS, low-latency | Optional | Optional | — | Yes |
-| Kafka ESM with spiky traffic | — | — | — | Yes |
-| Predictable daily traffic | — | Yes+AutoScale | — | — |
-| Emergency shutoff | Yes (=0) | — | — | — |
-| Java/.NET heavy init | — | Yes or SnapStart | — | — |
-
-**A — Checkout API:** Reserved=200 + Provisioned=150 + Auto Scaling for peak.
-**B — 3 SQS queues → 1 function:** Reserved=300, Max Concurrency=100 per ESM.
-**C — Kafka stream (spiky):** Provisioned Mode min=5, max=50 pollers.
-**D — Batch job:** Reserved=50, no provisioned.
-
----
-
-## Account limits and scaling
-
-| Quota | Default | Adjustable? |
-|-------|---------|:-----------:|
-| Account concurrency | 1,000 / Region | Yes |
-| Reservable concurrency | Account − 100 | Scales |
-| RPS limit | 10 × concurrency | Scales |
-| Scaling rate | 1,000 envs / 10s / function | No |
-
-Scaling is per-function, continuously refilled, unused capacity does not accumulate.
-~50 seconds to reach 5,000 concurrency from zero.
-
-**At the limit:** Sync → 429. Async → retries up to 6h then DLQ. Streams → polling
-throttled, messages stay in source.
-
-**RPS constraint:** A 50ms function at 20,000 RPS needs only 1,000 concurrency but the RPS
-limit (10×1,000=10,000) throttles it. Request account concurrency = 2,000.
+**RPS gotcha:** a 50ms function at 20,000 RPS needs only 1,000 concurrency, but the RPS limit (10×1,000 = 10,000) throttles it. Request account concurrency = 2,000.
 
 ```bash
 aws service-quotas request-service-quota-increase \
   --service-code lambda --quota-code L-B99A9384 --desired-value 5000
 ```
 
----
+## Decision scenarios
+
+| Scenario | Reserved | Provisioned | Maximum Concurrency (ESM) | Prov Mode (ESM) |
+|----------|:--------:|:-----------:|:--------------:|:---------------:|
+| Protect critical API / cap downstream | Yes | — | — | — |
+| Eliminate cold starts (user-facing API) | Optional | Yes | — | — |
+| Multiple SQS queues, prevent hogging | Yes | — | Yes | — |
+| High-throughput SQS, low-latency | Optional | Optional | — | Yes |
+| Kafka/SQS ESM with spiky traffic | — | — | — | Yes |
+| Predictable daily traffic | — | Yes + AutoScale | — | — |
+| Emergency shutoff | Yes (=0) | — | — | — |
 
 ## Common mistakes
 
-1. **Reserved set to 0** — Blocks ALL invocations (429 TooManyRequestsException). Sometimes
-   set during an incident and not restored. If a function is throttled at low traffic, check
-   this first.
+1. **Reserved = 0 left over from an incident** — blocks ALL invocations (429). If a function throttles at low traffic, check this first.
+2. **Reserved too low** — reserve 50, need 80 → throttled at 51 even with spare account capacity.
+3. **Starving other functions** — reserved is subtracted even when unused; be conservative.
+4. **Provisioned without auto scaling** — paying for idle off-peak, spilling on-peak.
+5. **Provisioned on `$LATEST`** — doesn't work; publish a version, create an alias.
+6. **Maximum Concurrency > reserved** — ESM tries 100, function caps at 50. Ensure reserved ≥ Σ(Maximum Concurrency).
+7. **Confusing ESM Maximum Concurrency with reserved** — Maximum Concurrency reserves nothing; API Gateway can still consume all concurrency.
+8. **Forgetting the 100-unit buffer** — max reservable = account limit − 100.
 
-2. **Reserved too low** — Reserve 50, need 80 → throttled at 51 even with spare account
-   capacity. Fix: monitor `ConcurrentExecutions`, set above peak + buffer.
+## SnapStart vs Provisioned Concurrency
 
-3. **Starving other functions** — Reserve 800/1,000 → others share 200. Reserved is
-   subtracted even when unused. Fix: be conservative.
-
-4. **Provisioned without auto scaling** — Paying for idle envs off-peak, spilling on-peak.
-   Fix: Auto Scaling targeting ~70% `ProvisionedConcurrencyUtilization`.
-
-5. **Provisioned on `$LATEST`** — Doesn't work. Fix: publish a version, create an alias.
-
-6. **Max concurrency > reserved** — ESM tries 100, function caps at 50. Fix: ensure
-   `reserved ≥ Σ(max concurrency across ESMs)`.
-
-7. **Confusing ESM max with reserved** — Max concurrency doesn't reserve anything. API
-   Gateway can still consume all concurrency. Fix: use reserved on the function.
-
-8. **Both ESM controls on same ESM** — Mutually exclusive; API rejects it. Fix: choose one.
-
-9. **Forgetting 100-unit buffer** — Max reservable = account limit − 100.
-
-10. **Not tracking ClaimedAccountConcurrency** — Provisioned counts against account limit
-   even when idle. Monitor the metric.
-
----
-
-## SnapStart interaction
-
-| Aspect | SnapStart | Provisioned Concurrency |
-|--------|-----------|------------------------|
-| Cold start | Seconds → sub-second | Seconds → ~0 |
-| Runtimes | Java 11+, Python 3.12+, .NET 8+ | All |
-| Scales with traffic | Yes (snapshot restore) | Only up to provisioned count |
-
-> **SnapStart and Provisioned Concurrency are mutually exclusive on the same function.**
+> **Mutually exclusive on the same function.**
 
 ```
-Is runtime Java 11+, Python 3.12+, or .NET 8+?
+Runtime Java 11+ / Python 3.12+ / .NET 8+
 ├─ No  → Provisioned Concurrency
 └─ Yes
    ├─ Need guaranteed <50ms on EVERY request? → Provisioned Concurrency
    ├─ Need EFS or >512MB ephemeral storage?   → Provisioned Concurrency
-   └─ Otherwise → SnapStart first; if P99 still too high, switch to Provisioned Concurrency (they cannot coexist)
+   └─ Otherwise → SnapStart first; if P99 still too high, switch (they cannot coexist)
 ```
-
-Limitations: no EFS, no >512MB ephemeral, no container images, must handle uniqueness,
-re-validate network connections on restore.
-
----
 
 ## SAM/CDK property reference
 
-| Concurrency type | SAM property | CDK property |
+| Type | SAM | CDK |
 |---|---|---|
-| Reserved | `ReservedConcurrentExecutions: 100` | `reservedConcurrentExecutions: 100` |
-| Provisioned | `AutoPublishAlias: live` + `ProvisionedConcurrencyConfig.ProvisionedConcurrentExecutions: 50` | `new lambda.Alias({ provisionedConcurrentExecutions: 50 })` — must use alias, not `$LATEST` |
-| Maximum Concurrency (ESM) | `ScalingConfig.MaximumConcurrency: 50` | `maxConcurrency: 50` on `EventSourceMapping` |
-| Provisioned Mode (ESM) | `ProvisionedPollerConfig.MinimumPollers` / `MaximumPollers` | `provisionedPollerConfig: { minimumPollers, maximumPollers }` on `EventSourceMapping` |
+| Reserved | `ReservedConcurrentExecutions` | `reservedConcurrentExecutions` |
+| Provisioned | `AutoPublishAlias` + `ProvisionedConcurrencyConfig.ProvisionedConcurrentExecutions` | `new lambda.Alias({ provisionedConcurrentExecutions })` (alias, not `$LATEST`) |
+| Maximum Concurrency (ESM) | `ScalingConfig.MaximumConcurrency` | `maxConcurrency` on `EventSourceMapping` |
+| Provisioned Mode (ESM) | `ProvisionedPollerConfig.MinimumPollers` / `MaximumPollers` | `provisionedPollerConfig: { minimumPollers, maximumPollers }` |
 | SnapStart | `SnapStart.ApplyOn: PublishedVersions` + `AutoPublishAlias` | `snapStart: lambda.SnapStartConf.ON_PUBLISHED_VERSIONS` |
 
-Auto scaling for Provisioned Concurrency: `alias.addAutoScaling({ minCapacity, maxCapacity })` then `scaling.scaleOnUtilization({ utilizationTarget: 0.7 })`.
+Auto scaling: `alias.addAutoScaling({ minCapacity, maxCapacity })` then `scaling.scaleOnUtilization({ utilizationTarget: 0.7 })`.

--- a/plugins/aws-core/skills/aws-serverless/references/deployment.md
+++ b/plugins/aws-core/skills/aws-serverless/references/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Reference
 
-Serverless-specific deployment patterns, resource types, and fast iteration tools.
+Serverless-specific resource types and fast-iteration tools. For step-by-step deployment procedures (custom domain REST API, API Gateway stages, connecting Lambda to API Gateway/DynamoDB), use the specialized skills in SKILL.md's routing table.
 
 ## Contents
 

--- a/plugins/aws-core/skills/aws-serverless/references/event-sources.md
+++ b/plugins/aws-core/skills/aws-serverless/references/event-sources.md
@@ -1,484 +1,165 @@
 # Lambda Event Sources Reference
 
-Quick reference for Lambda event source mappings (ESMs), direct triggers, filtering, and error handling.
+Event source mapping (ESM) config parameters, scaling numbers, and filtering gotchas. Assumes you know the basics (SNS pushes asynchronously and is a direct trigger not an ESM; `ReportBatchItemFailures` returns `{batchItemFailures: [{itemIdentifier}]}`; unmatched SQS filter messages are permanently deleted; SQS visibility timeout ≥ 6× function timeout) — this file focuses on the exact values and edge cases.
 
 ## Contents
 
 - [SQS event source mapping](#sqs-event-source-mapping)
 - [DynamoDB Streams triggers](#dynamodb-streams-triggers)
-- [SNS subscriptions](#sns-subscriptions)
 - [Event filtering](#event-filtering)
 - [Partial batch failure reporting](#partial-batch-failure-reporting)
-- [Error handling strategies](#error-handling-strategies)
+- [Error handling and concurrency](#error-handling-and-concurrency)
 
 ---
 
 ## SQS event source mapping
 
-Lambda polls SQS using long polling and invokes your function **synchronously** with a batch of messages.
-
-### Configuration parameters
+Lambda long-polls SQS and invokes your function **synchronously** with a batch.
 
 | Parameter | Default | Range / Notes |
 |-----------|---------|---------------|
 | `BatchSize` | 10 | Standard: max 10,000. FIFO: max 10 |
-| `MaximumBatchingWindowInSeconds` | 0 | 0–300. Not supported for FIFO. Requires ≥ 1s when BatchSize > 10 |
-| `MaximumConcurrency` | — | 2–1,000. Per-ESM concurrency cap |
+| `MaximumBatchingWindowInSeconds` | 0 | 0–300. Not for FIFO. Requires ≥ 1s when BatchSize > 10 |
+| `MaximumConcurrency` | — | 2–1,000. Per-ESM cap |
 | `ProvisionedPollerConfig.MinimumPollers` | 2 | 2–200 |
-| `ProvisionedPollerConfig.MaximumPollers` | 200 | 2–2,000 |
+| `ProvisionedPollerConfig.MaximumPollers` | 200 | 1–2,000 |
 | `FilterCriteria` | — | Filters on `body` key only |
 | `FunctionResponseTypes` | — | Set to `ReportBatchItemFailures` |
 
-> **MaximumConcurrency and Provisioned Mode are mutually exclusive.** You cannot set both on the same ESM.
+> **MaximumConcurrency and Provisioned Mode are mutually exclusive** on the same ESM.
 
-### Batching behavior
+Lambda invokes when **any** of: batching window expires, batch size reached, or payload hits 6 MB.
 
-Lambda invokes when **any** condition is met:
+### Scaling
 
-1. Batching window expires
-2. Batch size reached
-3. Payload reaches 6 MB
+**Standard queues:** concurrency **starts at 5** concurrent invocations and scales up by **~300 per minute** to a **default maximum of 1,250** — so a sudden burst (e.g. a backlog of 10,000 messages) is not absorbed immediately; it takes several minutes to ramp. For high scale-out or high-throughput workloads, use **Provisioned Mode**, which starts higher, ramps significantly faster, and reaches a much larger ceiling. The 1,250 default is also bounded by account concurrency; confirm current account limits with `aws service-quotas get-service-quota --service-code lambda`.
 
-### Scaling behavior
-
-**Standard queues:**
-
-- Starts with **5** concurrent invocations
-- Scales up by **300/min**
-- Default maximum: **1,250** concurrent invocations
-- Provisioned mode: up to **20,000** (scales 3× faster at 1,000/min)
-
-**FIFO queues:**
-
-- Concurrency capped by the **lower** of: number of message group IDs or `MaximumConcurrency`
-- Messages delivered in order per message group ID
-
-### Error handling
-
-- Use the **SQS redrive policy** (native dead-letter queue (DLQ) on the queue) — not an ESM-level DLQ
-- Set visibility timeout to **≥ 6× function timeout** to prevent premature retry
-- On function error, entire batch becomes visible again after visibility timeout
-- On throttle, Lambda backs off; messages reappear after visibility timeout
-
-### SAM template
+**FIFO queues:** concurrency capped by the **lower** of (number of message group IDs, `MaximumConcurrency`); order preserved per group ID.
 
 ```yaml
-MyFunction:
-  Type: AWS::Serverless::Function
-  Properties:
-    Handler: index.handler
-    Runtime: nodejs22.x
-    Events:
-      SQSEvent:
-        Type: SQS
-        Properties:
-          Queue: !GetAtt MyQueue.Arn
-          BatchSize: 10
-          MaximumBatchingWindowInSeconds: 5
-          FunctionResponseTypes:
-            - ReportBatchItemFailures
-          ScalingConfig:
-            MaximumConcurrency: 50
-          FilterCriteria:
-            Filters:
-              - Pattern: '{"body": {"status": ["PENDING"]}}'
+# SAM
+Events:
+  SQSEvent:
+    Type: SQS
+    Properties:
+      Queue: !GetAtt MyQueue.Arn
+      BatchSize: 10
+      MaximumBatchingWindowInSeconds: 5
+      FunctionResponseTypes: [ReportBatchItemFailures]
+      ScalingConfig:
+        MaximumConcurrency: 50
+      FilterCriteria:
+        Filters:
+          - Pattern: '{"body": {"status": ["PENDING"]}}'
 ```
 
-### CDK example
-
-```typescript
-import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
-import * as sqs from 'aws-cdk-lib/aws-sqs';
-
-const dlq = new sqs.Queue(this, 'DLQ');
-const queue = new sqs.Queue(this, 'MyQueue', {
-  visibilityTimeout: Duration.seconds(300), // 6× function timeout
-  deadLetterQueue: { queue: dlq, maxReceiveCount: 3 },
-});
-
-fn.addEventSource(new SqsEventSource(queue, {
-  batchSize: 10,
-  maxBatchingWindow: Duration.seconds(5),
-  reportBatchItemFailures: true,
-  maxConcurrency: 50,
-}));
-```
+CDK: `fn.addEventSource(new SqsEventSource(queue, { batchSize, maxBatchingWindow, reportBatchItemFailures: true, maxConcurrency }))`. Harden the queue: `new sqs.Queue(this, 'MyQueue', { encryption: sqs.QueueEncryption.SQS_MANAGED, enforceSSL: true, ... })` (set the same on the DLQ).
 
 ---
 
 ## DynamoDB Streams triggers
 
-Lambda polls DynamoDB stream shards at **4 times per second**. Invokes synchronously with in-order processing at the partition-key level.
-
-### Configuration parameters
+Lambda polls stream shards **4×/second**; invokes synchronously, in-order per partition key.
 
 | Parameter | Default | Range / Notes |
 |-----------|---------|---------------|
 | `BatchSize` | 100 | Max 10,000 |
-| `MaximumBatchingWindowInSeconds` | 0 | 0–300 |
 | `StartingPosition` | — | `TRIM_HORIZON` (recommended) or `LATEST` |
 | `ParallelizationFactor` | 1 | 1–10. Concurrent batches per shard |
-| `BisectBatchOnFunctionError` | false | Split failed batch in half |
+| `BisectBatchOnFunctionError` | false | Split failed batch in half; does NOT consume retry quota |
 | `MaximumRetryAttempts` | -1 (infinite) | 0–10,000 |
-| `MaximumRecordAgeInSeconds` | -1 (infinite) | -1 to 604,800 (7 days) |
+| `MaximumRecordAgeInSeconds` | -1 (infinite) | -1 (infinite), or 60–604,800 (7 days); 0–59 rejected |
 | `DestinationConfig.OnFailure` | — | SQS, SNS, S3, or Kafka topic |
-| `FilterCriteria` | — | Filters on `dynamodb` key and metadata fields (e.g., `eventName`) |
-| `FunctionResponseTypes` | — | `ReportBatchItemFailures` |
-| `TumblingWindowInSeconds` | — | 0–900 for stateful aggregation |
+| `TumblingWindowInSeconds` | — | 0–900, for stateful aggregation |
 
 ### Key behaviors
 
-- **TRIM_HORIZON** recommended — `LATEST` may miss events during ESM creation
-- **Max 2 Lambda readers per shard** (single-region tables). Global tables: limit to 1
-- **ParallelizationFactor**: 100 shards × factor 10 = up to 1,000 concurrent invocations. Order maintained at partition-key level
-- **BisectBatchOnFunctionError** does NOT consume retry quota
-- DynamoDB stream retention is **24 hours** — a poison record can block a shard for that entire window without retry limits
-
-### SAM template
+- **Max 2 Lambda readers per shard** (single-region tables). Global tables: limit to **1**.
+- **TRIM_HORIZON** recommended — `LATEST` may miss events during ESM creation.
+- 100 shards × ParallelizationFactor 10 = up to **1,000 concurrent invocations** (order maintained at partition-key level).
+- **Stream retention is 24 hours** — a poison record can block a shard for that entire window if retries aren't bounded. Set `MaximumRetryAttempts` / `MaximumRecordAgeInSeconds` / `BisectBatchOnFunctionError`.
 
 ```yaml
-MyFunction:
-  Type: AWS::Serverless::Function
-  Properties:
-    Handler: index.handler
-    Runtime: nodejs22.x
-    Events:
-      DDBStream:
-        Type: DynamoDB
-        Properties:
-          Stream: !GetAtt MyTable.StreamArn
-          StartingPosition: TRIM_HORIZON
-          BatchSize: 100
-          MaximumBatchingWindowInSeconds: 5
-          ParallelizationFactor: 5
-          BisectBatchOnFunctionError: true
-          MaximumRetryAttempts: 3
-          MaximumRecordAgeInSeconds: 3600
-          FunctionResponseTypes:
-            - ReportBatchItemFailures
-          DestinationConfig:
-            OnFailure:
-              Destination: !GetAtt FailureQueue.Arn
-          FilterCriteria:
-            Filters:
-              - Pattern: '{"eventName": ["INSERT"]}'
+# SAM
+Events:
+  DynamoDBStream:
+    Type: DynamoDB
+    Properties:
+      Stream: !GetAtt MyTable.StreamArn
+      StartingPosition: TRIM_HORIZON
+      ParallelizationFactor: 5
+      BisectBatchOnFunctionError: true
+      MaximumRetryAttempts: 3
+      FunctionResponseTypes: [ReportBatchItemFailures]
+      DestinationConfig:
+        OnFailure:
+          Destination: !GetAtt FailureQueue.Arn
 ```
 
-### CDK example
+Encrypt the source table at rest — CDK `new dynamodb.Table(this, 'MyTable', { encryption: dynamodb.TableEncryption.AWS_MANAGED, ... })`, or a customer managed KMS key when compliance requires key control.
 
-```typescript
-import { DynamoEventSource, SqsDlq } from 'aws-cdk-lib/aws-lambda-event-sources';
-import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-
-const table = new dynamodb.Table(this, 'MyTable', {
-  partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
-  stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
-});
-
-fn.addEventSource(new DynamoEventSource(table, {
-  startingPosition: lambda.StartingPosition.TRIM_HORIZON,
-  batchSize: 100,
-  maxBatchingWindow: Duration.seconds(5),
-  parallelizationFactor: 5,
-  bisectBatchOnError: true,
-  retryAttempts: 3,
-  maxRecordAge: Duration.hours(1),
-  reportBatchItemFailures: true,
-  onFailure: new SqsDlq(dlq),
-}));
-```
-
----
-
-## SNS subscriptions
-
-SNS invokes Lambda **asynchronously** — it is a **direct trigger, NOT an event source mapping**. No polling involved; SNS pushes events to Lambda.
-
-### Key characteristics
-
-- **Standard topics only** (not FIFO)
-- At-least-once delivery — make functions idempotent
-- SNS retries at increasing intervals over several hours if Lambda is unreachable
-- Cross-account subscriptions supported
-
-### Filter policies
-
-Filter policies are managed by **SNS** (not Lambda `FilterCriteria`). Set `FilterPolicyScope` to control what is filtered:
-
-| Scope | Filters on |
-|-------|-----------|
-| `MessageAttributes` (default) | SNS message attributes |
-| `MessageBody` | JSON body content |
-
-```json
-{
-  "event_type": ["order_placed"],
-  "price_usd": [{"numeric": [">=", 100]}],
-  "store": [{"anything-but": "test_store"}]
-}
-```
-
-### SAM template
-
-```yaml
-ProcessorFunction:
-  Type: AWS::Serverless::Function
-  Properties:
-    Handler: processor.handler
-    Runtime: nodejs22.x
-    Events:
-      SNSEvent:
-        Type: SNS
-        Properties:
-          Topic: !Ref MyTopic
-          FilterPolicy:
-            event_type:
-              - order_placed
-          FilterPolicyScope: MessageAttributes
-```
-
-### CDK example
-
-```typescript
-import * as sns from 'aws-cdk-lib/aws-sns';
-import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
-
-topic.addSubscription(new subscriptions.LambdaSubscription(fn, {
-  filterPolicy: {
-    event_type: sns.SubscriptionFilter.stringFilter({
-      allowlist: ['order_placed'],
-    }),
-    price: sns.SubscriptionFilter.numericFilter({
-      greaterThanOrEqualTo: 100,
-    }),
-  },
-}));
-```
+SNS filter policies (not Lambda `FilterCriteria`) are SNS-managed; set `FilterPolicyScope` to `MessageAttributes` (default) or `MessageBody`.
 
 ---
 
 ## Event filtering
 
-Lambda `FilterCriteria` applies to event source mappings only (not SNS or other push triggers).
-
-### Supported sources and filter keys
+`FilterCriteria` applies to ESMs only (not SNS/push triggers).
 
 | Source | Filter key | Notes |
 |--------|-----------|-------|
-| SQS | `body` | Unmatched messages **automatically deleted** |
-| DynamoDB Streams | `dynamodb` and metadata fields | Does **NOT** support numeric operators |
+| SQS | `body` | Unmatched messages **automatically (permanently) deleted** |
+| DynamoDB Streams | `dynamodb` + metadata (e.g. `eventName`) | **Does NOT support numeric operators** |
 | Kinesis | `data` | Base64-decoded before filtering |
 | MSK / Kafka | `value` | — |
-| Amazon MQ | `data` | — |
 
-### Filter rules
+- Up to **5 filters** per ESM (request increase to 10). Multiple filters are **OR**'d; fields within one filter are **AND**'d.
+- **DynamoDB numeric filtering is unsupported** — numbers are stored as strings in the DynamoDB stream JSON. Use `{"S": [...]}`/`{"N": ["123"]}` string matches, not `{"numeric": [...]}`.
+- Format mismatch drops the record: if the incoming body is plain string but the filter is JSON (or vice versa), Lambda drops the message.
 
-- Up to **5 filters** per ESM (can request increase to 10)
-- Multiple filters are **ORed** — record matches if any filter matches
-- Fields within a single filter are **ANDed**
-
-### Filter rule operators
-
-| Operator | Syntax | Example |
-|----------|--------|---------|
-| Equals | `["value"]` | `"City": ["Seattle"]` |
-| Equals (ignore case) | `[{"equals-ignore-case": "value"}]` | `"City": [{"equals-ignore-case": "seattle"}]` |
-| Null | `[null]` | `"UserID": [null]` |
-| Empty | `[""]` | `"Name": [""]` |
-| Not | `[{"anything-but": ["value"]}]` | `"Weather": [{"anything-but": ["Raining"]}]` |
-| Numeric equals | `[{"numeric": ["=", 100]}]` | `"Price": [{"numeric": ["=", 100]}]` |
-| Numeric range | `[{"numeric": [">", 10, "<=", 20]}]` | `"Price": [{"numeric": [">", 10, "<=", 20]}]` |
-| Exists | `[{"exists": true}]` | `"Field": [{"exists": true}]` |
-| Prefix | `[{"prefix": "us-"}]` | `"Region": [{"prefix": "us-"}]` |
-| Suffix | `[{"suffix": ".png"}]` | `"FileName": [{"suffix": ".png"}]` |
-| Or (fields) | `"$or": [{...}, {...}]` | `"$or": [{"City": ["NY"]}, {"Day": ["Mon"]}]` |
-
-> **DynamoDB filtering does NOT support numeric operators.** Numbers are stored as strings in the DynamoDB JSON record.
-
-### Body/data format matching
-
-| Incoming format | Filter format | Result |
-|----------------|---------------|--------|
-| Plain string | Plain string | Filters normally |
-| Plain string | Valid JSON | Lambda drops the message |
-| Valid JSON | Plain string | Lambda drops the message |
-| Valid JSON | Valid JSON | Filters normally |
-
-### Filter examples
+Operators: `["value"]`, `{"equals-ignore-case"}`, `[null]`, `[""]`, `{"anything-but"}`, `{"numeric": [">", 10, "<=", 20]}`, `{"exists": true}`, `{"prefix"}`, `{"suffix"}`, `"$or": [...]`.
 
 ```yaml
-# SQS — filter on body field
-FilterCriteria:
-  Filters:
-    - Pattern: '{"body": {"RequestCode": ["BBBB"]}}'
-
-# DynamoDB — INSERT events only
+# DynamoDB — INSERT events only / by NewImage attribute (string match, not numeric)
 FilterCriteria:
   Filters:
     - Pattern: '{"eventName": ["INSERT"]}'
-
-# DynamoDB — filter by NewImage attribute
-FilterCriteria:
-  Filters:
     - Pattern: '{"dynamodb": {"NewImage": {"status": {"S": ["ACTIVE"]}}}}'
-
-# Kinesis — filter decoded data
-FilterCriteria:
-  Filters:
-    - Pattern: '{"data": {"status": ["ACTIVE"]}}'
 ```
 
 ---
 
 ## Partial batch failure reporting
 
-Enable by setting `FunctionResponseTypes` to `["ReportBatchItemFailures"]`.
+Set `FunctionResponseTypes: [ReportBatchItemFailures]` and return the failed identifiers.
 
-### SQS — return failed messageId values
+- **SQS:** return failed `messageId` values in `batchItemFailures`.
+- **Streams (DynamoDB/Kinesis):** return the failed `SequenceNumber`; Lambda checkpoints at the **lowest** returned sequence number and retries everything from that point.
+- **FIFO:** stop after the first failure; return that message plus all unprocessed ones (preserves ordering).
 
-```javascript
-export const handler = async (event) => {
-  const batchItemFailures = [];
-  for (const record of event.Records) {
-    try {
-      await processMessage(record);
-    } catch (error) {
-      batchItemFailures.push({ itemIdentifier: record.messageId });
-    }
-  }
-  return { batchItemFailures };
-};
-```
+Response edge cases that cause a **complete batch retry**: `itemIdentifier` empty/null, a bad key name, or any unhandled exception. An empty/null `batchItemFailures` = complete success.
 
-### Streams — return failed SequenceNumber values
+Streams interaction: an unhandled **exception** triggers `BisectBatchOnFunctionError` (no response returned, so `ReportBatchItemFailures` has no effect); a **success with `batchItemFailures`** checkpoints at the lowest failed sequence number.
 
-For DynamoDB Streams and Kinesis, Lambda uses the **lowest sequence number** as the checkpoint and retries everything from that point.
-
-```javascript
-export const handler = async (event) => {
-  for (const record of event.Records) {
-    try {
-      await processRecord(record);
-    } catch (e) {
-      return {
-        batchItemFailures: [
-          { itemIdentifier: record.dynamodb.SequenceNumber },
-          // Kinesis: { itemIdentifier: record.kinesis.sequenceNumber }
-        ],
-      };
-    }
-  }
-  return { batchItemFailures: [] };
-};
-```
-
-### Python with Powertools Batch Processor
-
-```python
-from aws_lambda_powertools.utilities.batch import (
-    BatchProcessor, EventType, process_partial_response,
-)
-
-processor = BatchProcessor(event_type=EventType.SQS)
-
-def record_handler(record):
-    payload = record.body
-    # process payload...
-
-def lambda_handler(event, context):
-    return process_partial_response(
-        event=event, record_handler=record_handler,
-        processor=processor, context=context,
-    )
-```
-
-### FIFO queue behavior
-
-- **Stop processing after the first failure**
-- Return all failed and unprocessed messages in `batchItemFailures`
-- This preserves message ordering within the group
-
-### Success/failure conditions
-
-| Response | Interpretation |
-|----------|---------------|
-| Empty `batchItemFailures` list | Complete success |
-| Null `batchItemFailures` or empty `EventResponse` | Complete success |
-| `itemIdentifier` is empty string or null | **Complete failure** (entire batch retried) |
-| Bad key name in `itemIdentifier` | **Complete failure** |
-| Unhandled exception | **Complete failure** |
-
-### Interaction with BisectBatchOnFunctionError (streams)
-
-- Function **errors** (unhandled exception): `BisectBatchOnFunctionError` splits the batch in half for retry. `ReportBatchItemFailures` has no effect since no response was returned.
-- Function **succeeds** with `batchItemFailures`: Lambda checkpoints at the lowest failed sequence number and retries from that point. If `BisectBatchOnFunctionError` is also enabled, the batch is bisected at the returned sequence number.
+The Powertools Batch Processor (`process_partial_response`) handles all of this — prefer it over hand-rolled loops. See [assets/powertools-handler.py](../assets/powertools-handler.py).
 
 ---
 
-## Error handling strategies
+## Error handling and concurrency
 
-### SQS
-
-| Strategy | Configuration | When to use |
-|----------|--------------|-------------|
-| SQS redrive policy (DLQ) | `maxReceiveCount` on the queue | Always — catches poison messages |
-| Partial batch failures | `ReportBatchItemFailures` | Batches with mix of good/bad messages |
-| Visibility timeout | Set to ≥ 6× function timeout | Always — prevents premature retry |
-| MaximumConcurrency | `ScalingConfig` on ESM | Protect downstream resources |
-
-### DynamoDB Streams / Kinesis
-
-| Strategy | Configuration | When to use |
-|----------|--------------|-------------|
-| BisectBatchOnFunctionError | `true` | Isolate bad records in large batches |
-| Partial batch failures | `ReportBatchItemFailures` | Avoid reprocessing successful records |
-| Maximum retry attempts | `MaximumRetryAttempts` | Limit retries to prevent shard blocking |
-| Maximum record age | `MaximumRecordAgeInSeconds` | Skip stale records |
-| On-failure destination | `DestinationConfig.OnFailure` | Capture failed records for analysis |
-| Parallelization factor | `ParallelizationFactor` | Reduce blast radius per shard |
-
-### ESM (polling) vs direct trigger (push)
-
-| Aspect | ESM (SQS, DDB, Kinesis) | Async push (SNS, S3) | Sync push (API Gateway) |
-|--------|--------------------------|----------------------|-------------------------|
-| Invocation | Synchronous (Lambda polls) | Asynchronous (service pushes) | Synchronous (service pushes) |
-| Batching | Yes (configurable) | No (single event) | No (single event) |
-| Event filtering | Lambda `FilterCriteria` | SNS filter policies (SNS-managed) | N/A |
-| Error handling | Partial batch, bisect, retry config | 2 automatic retries, DLQ/destination | Error returned directly to caller, no automatic retry |
-| Ordering | Supported (streams, FIFO) | Not guaranteed | N/A (request/response) |
+| Source | Key strategies |
+|--------|---------------|
+| SQS | Redrive policy / DLQ (`maxReceiveCount`) always; `ReportBatchItemFailures`; visibility ≥ 6× timeout; `MaximumConcurrency` to protect downstream |
+| DynamoDB/Kinesis | `BisectBatchOnFunctionError`; `ReportBatchItemFailures`; `MaximumRetryAttempts` + `MaximumRecordAgeInSeconds` (prevent shard blocking); `OnFailure` destination; `ParallelizationFactor` to reduce blast radius |
 
 ### Concurrency formulas
 
 ```
 SQS (default):     min(1250, MaximumConcurrency, ReservedConcurrency)
 SQS (provisioned):  MaximumPollers × 10
-DDB/Kinesis:        number_of_shards × ParallelizationFactor
+DynamoDB/Kinesis:   number_of_shards × ParallelizationFactor
 ```
 
 ### Idempotency
 
-All event sources deliver at least once — duplicates can occur. Use Powertools idempotency utility:
-
-```python
-from aws_lambda_powertools.utilities.batch import (
-    BatchProcessor, EventType, process_partial_response,
-)
-from aws_lambda_powertools.utilities.idempotency import (
-    IdempotencyConfig, DynamoDBPersistenceLayer, idempotent_function,
-)
-
-processor = BatchProcessor(event_type=EventType.SQS)
-persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-config = IdempotencyConfig(event_key_jmespath="messageId")
-
-@idempotent_function(config=config, persistence_store=persistence_layer, data_keyword_argument="record")
-def record_handler(record):
-    # process record...
-    pass
-
-def lambda_handler(event, context):
-    return process_partial_response(
-        event=event, record_handler=record_handler,
-        processor=processor, context=context,
-    )
-```
+All event sources deliver at-least-once — duplicates happen. Make handlers idempotent (Powertools Idempotency utility, keyed e.g. on SQS `messageId`). See [production.md](production.md#idempotency).

--- a/plugins/aws-core/skills/aws-serverless/references/lambda.md
+++ b/plugins/aws-core/skills/aws-serverless/references/lambda.md
@@ -1,16 +1,15 @@
 # AWS Lambda Reference
 
-Specific values, limits, constraints, and code that complement general Lambda knowledge.
+Quotas, constraints, and gotchas that are easy to get wrong. Assumes you already know Lambda basics (packaging, layer paths, VPC-has-no-public-IP, Graviton ≈ 34% better price-performance, Powertools APIs) — this file focuses on the values and edge cases that trip up implementations.
 
 ## Contents
 
 - [Cold Start Optimization](#cold-start-optimization)
-- [Packaging](#packaging)
 - [Memory and Timeout Tuning](#memory-and-timeout-tuning)
 - [VPC Connectivity](#vpc-connectivity)
-- [Execution Roles](#execution-roles)
 - [Runtime Lifecycle](#runtime-lifecycle)
-- [Powertools for AWS Lambda](#powertools-for-aws-lambda)
+- [Function URLs](#function-urls)
+- [Powertools and Packaging](#powertools-and-packaging)
 
 ---
 
@@ -21,28 +20,23 @@ Specific values, limits, constraints, and code that complement general Lambda kn
 Snapshots the initialized execution environment (Firecracker microVM memory + disk) and restores from cache instead of cold-booting.
 
 **Supported runtimes:** Java 11+, Python 3.12+, .NET 8+
-**NOT supported:** Node.js, Ruby, container images, OS-only runtimes
 
 **Constraints:**
 
-- Mutually exclusive with Provisioned Concurrency
+- **Mutually exclusive with Provisioned Concurrency** (cannot set both on one function)
 - Mutually exclusive with Amazon EFS
 - Ephemeral storage must be ≤ 512 MB
 - Only works on published versions (not `$LATEST`)
-- Java: no additional SnapStart overhead
-- Python/.NET: caching charge (based on memory, minimum 3 hours) + per-restore charge
+- Java: no additional SnapStart charge. Python/.NET: caching charge (by memory, min 3 hours) + per-restore charge
 
-**Restoration considerations:**
+**Restoration gotchas** (snapshot is reused across restores):
 
-- Generate unique IDs/secrets in the handler, not during init (snapshot reuse)
+- Generate unique IDs/secrets in the handler, not during init
 - Re-establish network connections in the handler (connections are stale after restore)
 - Refresh cached timestamps/credentials in the handler
 
-**CDK example (Python):**
-
 ```python
-from aws_cdk import aws_lambda as lambda_
-
+# CDK (Python)
 fn = lambda_.Function(self, "MyFunction",
     runtime=lambda_.Runtime.PYTHON_3_13,
     handler="index.handler",
@@ -57,492 +51,139 @@ version = fn.current_version
 Pre-initializes execution environments that stay warm permanently.
 
 - A single instance handles one concurrent request at a time; throughput per instance = 1 / function duration
-- Account-level RPS quota: 10 × total concurrency (applies across all invocations, not per instance)
-- Supports auto-scaling via Application Auto Scaling
+- **Account-level RPS quota: 10 × total concurrency** (applies across all invocations, not per instance)
+- Supports auto-scaling via Application Auto Scaling (target ~70% utilization)
 - Lambda can scale beyond provisioned count using on-demand instances
 - **Paid even when idle** — disable in dev/staging
-
-```typescript
-const fn = new lambda.Function(this, 'MyFunction', {
-  runtime: lambda.Runtime.NODEJS_22_X,
-  handler: 'index.handler',
-  code: lambda.Code.fromAsset('lambda'),
-});
-
-const version = fn.currentVersion;
-const alias = new lambda.Alias(this, 'ProdAlias', {
-  aliasName: 'prod',
-  version,
-  provisionedConcurrentExecutions: 10,
-});
-```
-
-### Graviton (arm64)
-
-- **Up to 34% better price-performance** compared to x86 (per AWS)
-- Supported for all Lambda managed runtimes
-- Set `architecture: lambda_.Architecture.ARM_64` in CDK
 
 ### Strategy Selection
 
 | Scenario | Strategy |
 |---|---|
 | Java/Python/.NET with heavy init | SnapStart |
-| Strict <50ms cold start | Provisioned Concurrency |
+| Strict <50ms cold start, or need EFS / >512MB ephemeral | Provisioned Concurrency |
 | Tolerant of occasional cold starts | On-demand + minimize package |
 | Predictable traffic | Provisioned Concurrency + auto-scaling |
 | General optimization | arm64 (Graviton) |
 
 ---
 
-## Packaging
-
-### Decision Tree
-
-```
-Need > 250 MB uncompressed?
-  └─ YES → Container image (up to 10 GB)
-  └─ NO
-      ├─ Sharing deps across multiple functions?
-      │   └─ YES → Lambda layers
-      └─ NO
-          ├─ Simple function, few deps → .zip
-          └─ Native binaries, complex build → Container image
-```
-
-### Size Limits
-
-| Package Type | Limit |
-|---|---|
-| .zip compressed | 50 MB |
-| .zip uncompressed (including layers) | 250 MB |
-| Container image | 10 GB |
-| Layers per function | 5 |
-
-### Layer Paths by Runtime
-
-| Runtime | Layer Path |
-|---|---|
-| Python | `python/` or `python/lib/python3.x/site-packages/` |
-| Node.js | `nodejs/node_modules/` |
-| Java | `java/lib/` |
-| Ruby | `ruby/gems/3.4.0/` or `ruby/lib/` |
-| All runtimes | `bin/` (PATH), `lib/` (LD_LIBRARY_PATH) |
-
-**Layer constraints:**
-
-- Layers count toward the 250 MB unzipped limit
-- Layers only work with .zip deployments, NOT container images
-- Not recommended for Go/Rust — bundle deps in the deployment package
-- Multiple layers with conflicting dependency versions cause subtle bugs; merge order matters
-
-### Container Image Dockerfile
-
-```dockerfile
-FROM public.ecr.aws/lambda/python:3.13
-
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-COPY app.py ${LAMBDA_TASK_ROOT}
-
-CMD ["app.handler"]
-```
-
-- Use official AWS base images from `public.ecr.aws/lambda/`
-- Container images do NOT support Lambda layers
-- SnapStart is NOT supported with container images
-
-### Python Build Tips
-
-Use `uv` for dependency installation — **10-100x faster than pip**:
-
-```bash
-uv pip install -r requirements.txt --target ./package
-```
-
-Cross-platform build flags (when building on non-Linux):
-
-```bash
-pip install -r requirements.txt \
-  --target ./package \
-  --platform manylinux2014_x86_64 \
-  --only-binary=:all:
-```
-
-Use `manylinux2014_aarch64` for arm64. Exclude `__pycache__`, `.pyc`, tests, docs.
-
----
-
 ## Memory and Timeout Tuning
 
-### Memory
+### Memory → CPU
 
 | Parameter | Value |
 |---|---|
-| Minimum | 128 MB |
-| Maximum | 10,240 MB (10 GB) |
-| Increment | 1 MB |
-| Default | 128 MB |
-| 1 vCPU at | 1,769 MB |
+| Range | 128 MB – 10,240 MB (1 MB increments), default 128 MB |
+| **1 vCPU at** | **1,769 MB** |
 | ~5.8 vCPUs at | 10,240 MB |
 
-CPU scales linearly with memory. Doubling memory doubles CPU. **Over-provisioning memory can improve performance** — faster execution = less total duration.
+CPU scales linearly with memory — doubling memory doubles CPU. **Over-provisioning memory often lowers cost** (faster execution = less billed duration). Start at 256–512 MB; tune with [AWS Lambda Power Tuning](https://github.com/alexcasalboni/aws-lambda-power-tuning) against `Max Memory Used` in REPORT lines.
 
-**Tuning process:**
+### Ephemeral storage (/tmp)
 
-1. Start at 256–512 MB (128 MB only for trivial event routers)
-2. Monitor `Max Memory Used` in CloudWatch REPORT lines
-3. Use **AWS Lambda Power Tuning** (open-source Step Functions tool):
-
-```bash
-aws stepfunctions start-execution \
-  --state-machine-arn arn:aws:states:REGION:ACCOUNT:stateMachine:powerTuningStateMachine \
-  --input '{
-    "lambdaARN": "arn:aws:lambda:REGION:ACCOUNT:function:my-function",
-    "powerValues": [128, 256, 512, 1024, 1769, 3008],
-    "num": 50,
-    "payload": "{\"test\": true}"
-  }'
-```
-
-### Ephemeral Storage (/tmp)
-
-| Parameter | Value |
-|---|---|
-| Minimum / Default | 512 MB |
-| Maximum | 10,240 MB (10 GB) |
-| Extra cost | Above 512 MB |
-
-- Content **persists across warm invocations** (use as transient cache)
-- Content is NOT cleared after invoke failures
-- SnapStart requires ≤ 512 MB ephemeral storage
+- 512 MB (default/min) – 10,240 MB; extra cost above 512 MB
+- Persists across warm invocations (transient cache); NOT cleared after invoke failures
+- SnapStart requires ≤ 512 MB
 
 ### Timeout
 
-| Parameter | Value |
-|---|---|
-| Minimum | 1 second |
-| Maximum | 900 seconds (15 minutes) |
-| Default | 3 seconds |
+- Range 1s – 900s (15 min); **default is 3s** — always set it explicitly
 
 **Critical integration limits:**
 
-- API Gateway REST API: **29s default** (adjustable for Regional/private APIs since June 2024; edge-optimized remains 29s max)
-- API Gateway HTTP API: **30-second hard limit**
-- SQS visibility timeout must be **≥ 6× function timeout** (AWS recommendation)
+- **API Gateway REST API: 29s default** — adjustable higher for Regional/private APIs; **edge-optimized remains 29s max**
+- **API Gateway HTTP API: 30s hard limit** (cannot be raised)
+- SQS visibility timeout should be **≥ 6× function timeout**
 
-### Other Limits
+### Other limits worth knowing
 
 | Resource | Limit |
 |---|---|
-| Environment variables (total) | 4 KB |
 | Sync invocation payload (request/response) | 6 MB each |
 | Async invocation payload | 1 MB |
-| Streamed response | 200 MB (first 6 MB uncapped, then 2 MBps) |
-| File descriptors | 1,024 |
-| Processes/threads | 1,024 |
-| Concurrent executions (default) | 1,000 per region (soft limit) |
-| Scaling rate | 1,000 new environments every 10s per function |
-| Function code storage (.zip) | 75 GB per region (soft limit) |
+| Streamed response | 200 MB (2 MBps after first 6 MB) |
+| Environment variables (total) | 4 KB |
+| Concurrent executions (default) | 1,000 per region (soft) |
+| Scaling rate | 1,000 new environments / 10s, per function |
 
 ---
 
 ## VPC Connectivity
 
-### Hyperplane ENI
+Lambda uses **Hyperplane ENIs** — shared across functions that use the same subnet + security group combination (NOT per-function). Each ENI supports ~65,000 connections.
 
-Lambda uses **Hyperplane Elastic Network Interfaces** (shared, not per-function):
+- First-time ENI creation can take **several minutes** (function stays `Pending`)
+- ENIs reclaimed after **14 days of inactivity** (function goes `Inactive`); removing VPC config takes up to **20 minutes**
 
-- Shared across functions using the same subnet + security group combination
-- Each ENI supports **65,000 connections/ports**
-- First-time ENI creation: **several minutes** (function stays in `Pending`)
-- ENIs reclaimed after **14 days of inactivity** (function goes `Inactive`)
-- Removing VPC config takes up to **20 minutes** for ENI cleanup
-- Default quota: **500 Hyperplane ENIs per VPC** (Lambda-specific soft limit, can be increased). The broader VPC ENI service quota is **5,000 per region** by default.
-
-### Internet Access Patterns
-
-**Lambda in a VPC NEVER gets a public IP**, even in a public subnet.
-
-**Pattern 1: Private Subnet + NAT Gateway** (most common)
-
-```
-Lambda → Private Subnet → Route Table → NAT Gateway → IGW → Internet
-```
-
-- Deploy in each AZ for HA
-
-**Pattern 2: VPC Endpoints** (for AWS services)
-
-```
-Lambda → Private Subnet → VPC Endpoint → AWS Service
-```
-
-- **Gateway endpoints:** S3, DynamoDB
-- **Interface endpoints:** STS, Secrets Manager, SQS, etc.
-- Traffic stays on AWS network — lower latency
-
-#### Pattern 3: IPv6 Egress-Only Internet Gateway
-
-```
-Lambda → Dual-Stack Subnet → Egress-Only IGW → Internet (IPv6)
-```
-
-- Eliminates NAT Gateway for IPv6 traffic
-- Requires dual-stack subnets and IPv6-capable endpoints
-- Set `Ipv6AllowedForDualStack=true` in function config
-
-### Required IAM Permissions
-
-VPC-attached functions need `AWSLambdaVPCAccessExecutionRole` managed policy or equivalent EC2 network interface permissions.
-
-### Best Practices
-
-- Reuse subnet + security group combos across functions to share ENIs
-- Use multiple subnets across AZs for HA
-- Prefer VPC endpoints over NAT Gateway for AWS service access
-- Don't attach to VPC unless accessing private resources (RDS, ElastiCache, etc.)
-
----
-
-## Execution Roles
-
-One execution role per function. Key Lambda-specific managed policies:
-
-| Policy | Grants |
-|---|---|
-| `AWSLambdaBasicExecutionRole` | CloudWatch Logs only |
-| `AWSLambdaVPCAccessExecutionRole` | VPC ENI management |
-| `AWSLambdaDynamoDBExecutionRole` | DynamoDB Streams |
-| `AWSLambdaSQSQueueExecutionRole` | SQS polling |
-| `AWSLambdaKinesisExecutionRole` | Kinesis Streams |
+Reuse subnet + SG combos to share ENIs. Prefer **VPC endpoints** (gateway: S3, DynamoDB; interface: STS, Secrets Manager, SQS, …) over NAT Gateway for AWS-service access — lower latency, traffic stays on the AWS backbone. Don't attach to a VPC unless you need private resources (RDS, ElastiCache). VPC-attached functions need `AWSLambdaVPCAccessExecutionRole`.
 
 ---
 
 ## Runtime Lifecycle
 
-### Phases
-
 ```
-┌─────────┐    ┌─────────┐    ┌──────────┐
-│  INIT   │───▶│ INVOKE  │───▶│ SHUTDOWN │
-│         │    │(repeat) │    │          │
-└─────────┘    └─────────┘    └──────────┘
+INIT ──▶ INVOKE (repeat) ──▶ SHUTDOWN          [+ RESTORE phase for SnapStart]
 ```
 
-**Init Phase** (3 sub-phases: extension init → runtime init → function init):
+**Init phase** (extension init → runtime init → function init):
 
-- On-demand timeout: **10 seconds**
-- Provisioned/SnapStart timeout: **up to 15 minutes**
-- If init exceeds 10s on-demand, Lambda retries at first invocation using the function's configured timeout
+- **On-demand init timeout: 10s.** If exceeded, Lambda retries at first invocation using the function's configured timeout.
+- **Provisioned/SnapStart init timeout: up to 15 minutes.**
 
-**Invoke Phase:**
+**Shutdown phase:** 0 ms (no extensions), 500 ms (internal only), 2,000 ms (external extensions); SIGKILL if not done in time.
 
-- Limited by function timeout (max 900s)
-- Each environment handles **one concurrent invocation** at a time
+**Restore phase (SnapStart):** 10s timeout for restore + after-restore hooks.
 
-**Shutdown Phase:**
+### Warm-start reuse
 
-- 0 ms (no extensions), 500 ms (internal only), 2,000 ms (external extensions)
-- SIGKILL if extensions don't respond in time
+Objects initialized outside the handler persist across invocations (SDK clients, DB connections, `/tmp`). Gotchas:
 
-**Restore Phase** (SnapStart only):
-
-- Resumes from cached snapshot
-- 10-second timeout for restore + after-restore hooks
-
-### Execution Environment Reuse (Warm Starts)
-
-Objects initialized outside the handler persist across invocations:
-
-- SDK clients, DB connections, cached data all survive
-- `/tmp` content persists (512 MB–10 GB)
-- Background processes resume on next invocation
-- **Workers have a maximum lease lifetime of ~14 hours** (observed behavior, not a documented SLA — do not depend on this value)
-- Environments terminated periodically for maintenance even under continuous load
-
-**Common pitfall:** Global variables persist — stale DB connections, expired credentials, and leaked state across invocations cause subtle production bugs.
-
-### Extensions
-
-- **Internal:** Run in the runtime process (APM agents)
-- **External:** Separate processes alongside the runtime
-- Use Extensions API and Telemetry API for lifecycle events, logs, metrics, traces
+- **Execution environments are recycled periodically** for maintenance even under continuous load — never assume an environment (or its warmed state) lives indefinitely.
+- **Global variables persist** — stale DB connections, expired credentials, and leaked state across invocations cause subtle production bugs. Refresh connections/credentials in the handler.
 
 ---
 
-## Powertools for AWS Lambda
+## Function URLs
 
-Official AWS toolkit for Lambda best practices. Available for Python, TypeScript, Java, .NET.
+A Function URL is a dedicated HTTPS endpoint on a single function — no API Gateway. Use for internal service-to-service (IAM auth), Lambdalith + CloudFront, response streaming, or webhook receivers. There's **no built-in rate limiting, WAF, or request validation** (front with CloudFront/API Gateway if you need those). Choose **API Gateway** instead for public APIs needing rate limiting, JWT/Cognito auth, multi-function routing, request validation, or WAF without CloudFront.
 
-**Performance note:** Powertools adds cold start overhead. Use selective imports when cold start matters:
+Invoking a Function URL **always requires `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`** — granting only `InvokeFunctionUrl` returns **HTTP 403** even with `AuthType=NONE`. The two `AuthType` options differ in *how* those permissions are supplied:
 
-```python
-# Instead of: from aws_lambda_powertools import Logger, Tracer, Metrics
-# Import only what you need if cold start is critical
-from aws_lambda_powertools import Logger
+### `AuthType=AWS_IAM` (non-public — prefer for production)
+
+Only callers with valid AWS credentials that sign requests with **SigV4** can invoke; unauthenticated requests get **403**.
+
+- **Same-account caller:** grant the two actions in the caller's **identity-based policy** *or* the function's resource-based policy — a resource-based policy is **optional** if the caller's identity policy already allows them (this is why an admin/broad identity policy invokes with no resource policy on the function).
+- **Cross-account caller:** requires **both** an identity-based policy on the caller **and** a resource-based policy on the function.
+- For CloudFront in front, use **Origin Access Control** to sign requests rather than `NONE`.
+
+### `AuthType=NONE` (public)
+
+Lambda does no auth — the resource-based policy alone gates access, so it must grant **public** access. Only use when the endpoint must be reachable by unauthenticated clients (e.g. a browser hitting the URL directly) with no CloudFront/edge auth in front; it exposes the function to anyone with the URL, so pair it with in-code auth, throttling, and monitoring. The console and SAM add both required statements automatically; with the CLI/API add each yourself (two separate `add-permission` calls):
+
+```bash
+# Statement 1: allow invoking via the Function URL (public)
+aws lambda add-permission --function-name my-function \
+  --statement-id FunctionURLAllowPublicAccess \
+  --action lambda:InvokeFunctionUrl --principal '*' \
+  --function-url-auth-type NONE
+
+# Statement 2: REQUIRED — allow the underlying invoke, scoped to URL calls
+aws lambda add-permission --function-name my-function \
+  --statement-id FunctionURLInvokeAllowPublicAccess \
+  --action lambda:InvokeFunction --principal '*' \
+  --invoked-via-function-url
 ```
 
-### Core Utilities
+The `lambda:InvokedViaFunctionUrl` condition on statement 2 (set by `--invoked-via-function-url`) restricts that grant to Function URL calls, so it does not open direct `Invoke` access. See [Lambda function URL auth](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html).
 
-| Utility | Purpose |
-|---|---|
-| Logger | Structured JSON logging with correlation IDs |
-| Tracer | X-Ray tracing with decorators/middleware |
-| Metrics | CloudWatch metrics via Embedded Metric Format (EMF) |
-| Idempotency | Make handlers idempotent using DynamoDB |
-| Batch Processing | Partial failure handling for SQS, Kinesis, DynamoDB Streams |
-| Event Handler | Routing for API Gateway, ALB, Function URLs, AppSync |
-| Parameters | Retrieve/cache SSM, Secrets Manager, AppConfig, DynamoDB values |
+## Powertools and Packaging
 
-### Environment Variables
+Use **Powertools for AWS Lambda** (Python, TypeScript, Java, .NET) for structured logging, X-Ray tracing, EMF metrics, idempotency, batch processing, event handling, and parameter caching. The APIs are well-documented at [docs.powertools.aws.dev](https://docs.powertools.aws.dev/lambda/); for a ready-to-use Python handler with Logger + Tracer + Metrics + Idempotency wired, start from [assets/powertools-handler.py](../assets/powertools-handler.py).
 
-| Variable | Purpose |
-|---|---|
-| `POWERTOOLS_SERVICE_NAME` | Service name for logs, metrics, traces |
-| `POWERTOOLS_METRICS_NAMESPACE` | CloudWatch metrics namespace |
-| `POWERTOOLS_LOG_LEVEL` | Logging level (DEBUG, INFO, WARNING, ERROR) |
-| `POWERTOOLS_TRACE_DISABLED` | Disable tracing (useful for tests) |
-| `POWERTOOLS_DEV` | Dev mode (pretty-print JSON, verbose errors) |
+Powertools adds cold-start overhead — use selective imports when cold start is critical.
 
-### Python: Logger + Tracer + Metrics
+**Useful Powertools env vars:** `POWERTOOLS_SERVICE_NAME`, `POWERTOOLS_METRICS_NAMESPACE`, `POWERTOOLS_LOG_LEVEL`, `POWERTOOLS_TRACE_DISABLED` (tests), `POWERTOOLS_DEV` (pretty-print).
 
-```python
-from aws_lambda_powertools import Logger, Tracer, Metrics
-from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
-
-logger = Logger()
-tracer = Tracer()
-metrics = Metrics()
-
-@logger.inject_lambda_context(log_event=False)
-@tracer.capture_lambda_handler
-@metrics.log_metrics(capture_cold_start_metric=True)
-def handler(event: dict, context: LambdaContext) -> dict:
-    logger.info("Processing order", order_id=event.get("order_id"))
-    metrics.add_metric(name="OrdersProcessed", unit=MetricUnit.Count, value=1)
-    result = process_order(event)
-    return {"statusCode": 200, "body": result}
-
-@tracer.capture_method
-def process_order(event: dict) -> str:
-    return "processed"
-```
-
-### TypeScript: Logger + Tracer + Metrics
-
-```typescript
-import { Logger } from '@aws-lambda-powertools/logger';
-import { Tracer } from '@aws-lambda-powertools/tracer';
-import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
-import middy from '@middy/core';
-import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware';
-import { captureLambdaHandler } from '@aws-lambda-powertools/tracer/middleware';
-import { logMetrics } from '@aws-lambda-powertools/metrics/middleware';
-
-const logger = new Logger({ serviceName: 'orderService' });
-const tracer = new Tracer({ serviceName: 'orderService' });
-const metrics = new Metrics({ namespace: 'OrderApp', serviceName: 'orderService' });
-
-const lambdaHandler = async (event: any) => {
-  logger.info('Processing order', { orderId: event.orderId });
-  metrics.addMetric('OrdersProcessed', MetricUnit.Count, 1);
-  const result = await processOrder(event);
-  return { statusCode: 200, body: JSON.stringify(result) };
-};
-
-export const handler = middy(lambdaHandler)
-  .use(injectLambdaContext(logger, { logEvent: false }))
-  .use(captureLambdaHandler(tracer))
-  .use(logMetrics(metrics, { captureColdStartMetric: true }));
-```
-
-### Python: Idempotency
-
-```python
-from aws_lambda_powertools.utilities.idempotency import (
-    DynamoDBPersistenceLayer,
-    idempotent,
-)
-
-persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-
-@idempotent(persistence_store=persistence_layer)
-def handler(event: dict, context) -> dict:
-    payment = process_payment(event)
-    return {"payment_id": payment.id, "status": "success"}
-```
-
-### TypeScript: Idempotency
-
-```typescript
-import { makeIdempotent } from '@aws-lambda-powertools/idempotency';
-import { DynamoDBPersistenceLayer } from '@aws-lambda-powertools/idempotency/dynamodb';
-
-const persistenceStore = new DynamoDBPersistenceLayer({
-  tableName: 'IdempotencyTable',
-});
-
-const processPayment = async (event: { paymentId: string; amount: number }) => {
-  return { paymentId: event.paymentId, status: 'success' };
-};
-
-export const handler = makeIdempotent(processPayment, {
-  persistenceStore,
-});
-```
-
-### Python: Batch Processing (SQS Partial Failures)
-
-```python
-from aws_lambda_powertools.utilities.batch import (
-    BatchProcessor,
-    EventType,
-    process_partial_response,
-)
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-
-processor = BatchProcessor(event_type=EventType.SQS)
-
-def record_handler(record: SQSRecord):
-    payload = record.json_body
-    process_item(payload)
-
-def handler(event, context):
-    return process_partial_response(
-        event=event,
-        record_handler=record_handler,
-        processor=processor,
-        context=context,
-    )
-```
-
-### TypeScript: Batch Processing (SQS Partial Failures)
-
-```typescript
-import {
-  BatchProcessor,
-  EventType,
-  processPartialResponse,
-} from '@aws-lambda-powertools/batch';
-import type { SQSRecord, SQSHandler } from 'aws-lambda';
-
-const processor = new BatchProcessor(EventType.SQS);
-
-const recordHandler = async (record: SQSRecord): Promise<void> => {
-  const payload = JSON.parse(record.body);
-  await processItem(payload);
-};
-
-export const handler: SQSHandler = async (event, context) => {
-  return processPartialResponse(event, recordHandler, processor, {
-    context,
-  });
-};
-```
-
-### Asset Reference
-
-For a ready-to-use Python handler with Powertools wired, read [assets/powertools-handler.py](../assets/powertools-handler.py).
+**Packaging quick facts:** 50 MB zipped / 250 MB unzipped (incl. layers) → switch to container image (10 GB) past that. Max 5 layers/function; layers don't work with container images. Use `uv pip install` (10–100× faster than pip) and `--platform manylinux2014_{x86_64,aarch64} --only-binary=:all:` for cross-platform builds, or let `sam build` handle it. See [troubleshooting.md](troubleshooting.md) for size/import errors.

--- a/plugins/aws-core/skills/aws-serverless/references/orchestration.md
+++ b/plugins/aws-core/skills/aws-serverless/references/orchestration.md
@@ -1,20 +1,18 @@
 # Orchestration Reference
 
-AWS Step Functions and Amazon EventBridge patterns and configuration.
+Step Functions and EventBridge decision matrices, error semantics, and limits. Assumes you can write Amazon States Language (Saga/Parallel/Map/Choice JSON) and EventBridge patterns — this file focuses on the choices and gotchas.
 
 ## Contents
 
-- [Step Functions Standard vs Express](#step-functions-standard-vs-express)
-- [State machine patterns](#state-machine-patterns)
+- [Standard vs Express](#standard-vs-express)
+- [State machine limits and patterns](#state-machine-limits-and-patterns)
 - [Error handling](#error-handling)
-- [EventBridge rules and patterns](#eventbridge-rules-and-patterns)
-- [EventBridge Pipes](#eventbridge-pipes)
+- [EventBridge rules, pipes, and patterns](#eventbridge-rules-pipes-and-patterns)
+- [Step Functions vs Lambda durable functions](#step-functions-vs-lambda-durable-functions)
 
 ---
 
-## Step Functions Standard vs Express
-
-### Decision Matrix
+## Standard vs Express
 
 | Dimension | Standard | Express |
 |---|---|---|
@@ -25,425 +23,108 @@ AWS Step Functions and Amazon EventBridge patterns and configuration.
 | `.waitForTaskToken` | Supported | **Not supported** |
 | Distributed Map | Supported | **Not supported** |
 | Activities | Supported | **Not supported** |
-| Idempotency | Automatic (execution name unique for 90 days) | Not managed |
+| Idempotency | Automatic (execution name unique 90 days) | Not managed |
 
-Express sub-types:
+Express sub-types: **Async** (fire-and-forget, results via CloudWatch Logs); **Sync** (blocks until completion, invokable from API Gateway/Lambda/`StartSyncExecution`, 5-min max).
 
-- **Asynchronous**: Fire-and-forget. Results via CloudWatch Logs.
-- **Synchronous**: Blocks until completion. Invokable from API Gateway, Lambda, or `StartSyncExecution`. 5-min max.
-
-| Use Case | Type |
+| Use case | Type |
 |---|---|
-| Long-running orchestration, `.sync`/callback patterns | Standard |
-| Non-idempotent operations (payments, exactly-once) | Standard |
+| Long-running, `.sync`/callback, non-idempotent (payments) | Standard |
 | Distributed Map (large-scale parallel) | Standard |
 | High-volume event processing (IoT, streaming) | Express |
 | API-backed synchronous microservice orchestration | Synchronous Express |
 
 ---
 
-## State Machine Patterns
+## State machine limits and patterns
 
-### Saga Pattern (Compensating Transactions)
+- **Payload limit: 256 KiB between states** — store large data in S3, pass S3 keys.
+- **Inline Map:** max **40 concurrent** iterations, same execution.
+- **Distributed Map:** up to **10,000 parallel child executions**, reads from S3 (JSON/CSV/inventory), supports `ItemBatcher`/`ItemReader`/`ResultWriter`. **Standard workflows only.**
+- **25,000 execution-history entries** (Standard) — split long workflows into child executions.
+- **Parallel state output is an array** (one element per branch); all branches must succeed or the state fails.
+- **Choice state:** always include a `Default` branch.
 
-Each step has a corresponding undo step invoked on failure via `Catch`. Compensations chain in reverse.
-
-```json
-{
-  "Comment": "Saga pattern — book travel",
-  "StartAt": "BookHotel",
-  "States": {
-    "BookHotel": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:book-hotel",
-      "TimeoutSeconds": 30,
-      "Catch": [{
-        "ErrorEquals": ["States.ALL"],
-        "ResultPath": "$.BookHotelError",
-        "Next": "NotifyFailure"
-      }],
-      "Next": "BookFlight"
-    },
-    "BookFlight": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:book-flight",
-      "TimeoutSeconds": 30,
-      "Catch": [{
-        "ErrorEquals": ["States.ALL"],
-        "ResultPath": "$.BookFlightError",
-        "Next": "CancelHotel"
-      }],
-      "Next": "BookCar"
-    },
-    "BookCar": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:book-car",
-      "TimeoutSeconds": 30,
-      "Catch": [{
-        "ErrorEquals": ["States.ALL"],
-        "ResultPath": "$.BookCarError",
-        "Next": "CancelFlight"
-      }],
-      "Next": "ConfirmBooking"
-    },
-    "CancelFlight": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:cancel-flight",
-      "Next": "CancelHotel"
-    },
-    "CancelHotel": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:cancel-hotel",
-      "Next": "NotifyFailure"
-    },
-    "NotifyFailure": {
-      "Type": "Fail",
-      "Error": "SagaFailed",
-      "Cause": "One or more bookings failed; compensations executed"
-    },
-    "ConfirmBooking": { "Type": "Succeed" }
-  }
-}
-```
-
-### Parallel State
-
-Executes branches concurrently. **Output is an array** with one element per branch. All branches must succeed or the entire Parallel state fails. Supports `Retry` and `Catch`.
-
-```json
-{
-  "Type": "Parallel",
-  "Branches": [
-    {
-      "StartAt": "ProcessImages",
-      "States": {
-        "ProcessImages": {
-          "Type": "Task",
-          "Resource": "arn:aws:lambda:us-east-1:123456789012:function:process-images",
-          "End": true
-        }
-      }
-    },
-    {
-      "StartAt": "ProcessMetadata",
-      "States": {
-        "ProcessMetadata": {
-          "Type": "Task",
-          "Resource": "arn:aws:lambda:us-east-1:123456789012:function:process-metadata",
-          "End": true
-        }
-      }
-    }
-  ],
-  "Next": "AggregateResults"
-}
-```
-
-### Map State
-
-**Inline Map**: Iterates over an array in the same execution. Max **40 concurrent** iterations.
-
-```json
-{
-  "Type": "Map",
-  "ItemsPath": "$.orders",
-  "MaxConcurrency": 10,
-  "ItemProcessor": {
-    "ProcessorConfig": { "Mode": "INLINE" },
-    "StartAt": "ProcessOrder",
-    "States": {
-      "ProcessOrder": {
-        "Type": "Task",
-        "Resource": "arn:aws:lambda:us-east-1:123456789012:function:process-order",
-        "End": true
-      }
-    }
-  },
-  "Next": "Done"
-}
-```
-
-**Distributed Map**: Up to **10,000 parallel child executions**. Reads from S3 (JSON, CSV, S3 inventory). Supports `ItemBatcher`, `ItemReader`, `ResultWriter`. **Standard workflows only.**
-
-### Choice State
-
-Routes execution based on input conditions. Always include a `Default` branch.
-
-Comparison operators: `StringEquals`, `StringMatches`, `NumericGreaterThan`, `NumericLessThanEquals`, `BooleanEquals`, `IsPresent`, `IsNull`, `TimestampEquals`, and `Path` variants.
-
-```json
-{
-  "Type": "Choice",
-  "Choices": [
-    { "Variable": "$.orderTotal", "NumericGreaterThan": 1000, "Next": "HighValueOrder" },
-    { "Variable": "$.isPrime", "BooleanEquals": true, "Next": "PrimeProcessing" }
-  ],
-  "Default": "StandardProcessing"
-}
-```
-
-### Agentic AI Loop Pattern (Tool Use)
-
-Model outputs a structured response indicating a tool call or final answer. Choice state routes accordingly. Tool results feed back in a loop.
-
-```json
-{
-  "Comment": "Agentic AI loop with tool use",
-  "QueryLanguage": "JSONata",
-  "StartAt": "InvokeModel",
-  "States": {
-    "InvokeModel": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::bedrock:invokeModel",
-      "Arguments": {
-        "ModelId": "global.anthropic.claude-sonnet-4-6",
-        "Body": {
-          "anthropic_version": "bedrock-2023-05-31",
-          "max_tokens": 4096,
-          "messages": "{% $states.input.messages %}"
-        },
-        "ContentType": "application/json",
-        "Accept": "application/json"
-      },
-      "Next": "CheckAction"
-    },
-    "CheckAction": {
-      "Type": "Choice",
-      "Choices": [
-        { "Condition": "{% $states.input.Body.stop_reason = 'tool_use' %}", "Next": "ExecuteTool" }
-      ],
-      "Default": "ReturnResult"
-    },
-    "ExecuteTool": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:execute-tool",
-      "TimeoutSeconds": 60,
-      "Next": "InvokeModel"
-    },
-    "ReturnResult": { "Type": "Succeed" }
-  }
-}
-```
+Common patterns (write the ASL directly): **Saga** (each step has a compensating undo via `Catch`, chained in reverse); **Parallel** (concurrent branches); **Map** (iterate an array); **Agentic AI loop** (`bedrock:invokeModel` → Choice on `stop_reason = 'tool_use'` → execute tool → loop). Prefer **direct SDK integrations** (200+ services) over Lambda intermediaries to cut latency, and prefer **JSONata** for inline transforms over a Lambda task.
 
 ---
 
-## Error Handling
+## Error handling
 
-### Built-in Error Names
+### Built-in error names
 
-| Error Name | Description | Retriable? |
-|---|---|---|
-| `States.ALL` | Wildcard — matches any error | Yes |
-| `States.TaskFailed` | Wildcard for task errors (except `States.Timeout`) | Yes |
-| `States.Timeout` | Task exceeded `TimeoutSeconds` or `HeartbeatSeconds` | Yes |
-| `States.HeartbeatTimeout` | No heartbeat within `HeartbeatSeconds` | Yes |
-| `States.Permissions` | Insufficient IAM privileges | Yes |
-| `States.DataLimitExceeded` | Payload exceeds 256 KiB — **terminal** | **No** |
-| `States.Runtime` | Invalid JSONPath, null payload — **terminal** | **No** |
-| `States.ItemReaderFailed` | Map couldn't read from ItemReader source | Yes |
-| `States.ResultWriterFailed` | Map couldn't write to ResultWriter destination | Yes |
+| Error Name | Retriable? | Notes |
+|---|:---:|---|
+| `States.ALL` | Yes | Wildcard — but does **NOT** match the two terminal errors below |
+| `States.TaskFailed` | Yes | Wildcard for task errors (except `States.Timeout`) |
+| `States.Timeout` / `States.HeartbeatTimeout` | Yes | Exceeded `TimeoutSeconds` / missed `HeartbeatSeconds` |
+| `States.Permissions` | Yes | Insufficient IAM privileges |
+| `States.DataLimitExceeded` | **No** | Payload > 256 KiB — **terminal** |
+| `States.Runtime` | **No** | Invalid JSONPath, null payload — **terminal** |
+| `States.ItemReaderFailed` / `States.ResultWriterFailed` | Yes | Map source/destination errors |
 
-`States.ALL` does **not** match `States.DataLimitExceeded` or `States.Runtime`.
+> **`States.ALL` does NOT catch `States.DataLimitExceeded` or `States.Runtime`.** These are terminal and must be designed around, not retried.
 
-### Retry Configuration
-
-Available on `Task`, `Parallel`, and `Map` states. Retries are attempted before catchers.
+### Retry config
 
 ```json
 "Retry": [
-  {
-    "ErrorEquals": ["States.Timeout"],
-    "IntervalSeconds": 3,
-    "MaxAttempts": 2,
-    "BackoffRate": 2.0,
-    "MaxDelaySeconds": 30,
-    "JitterStrategy": "FULL"
-  },
-  {
-    "ErrorEquals": ["Lambda.ServiceException", "Lambda.SdkClientException"],
-    "IntervalSeconds": 1,
-    "MaxAttempts": 3,
-    "BackoffRate": 2.0
-  },
-  {
-    "ErrorEquals": ["States.ALL"],
-    "IntervalSeconds": 1,
-    "MaxAttempts": 3,
-    "BackoffRate": 2.0
-  }
+  { "ErrorEquals": ["States.Timeout"], "IntervalSeconds": 3, "MaxAttempts": 2,
+    "BackoffRate": 2.0, "MaxDelaySeconds": 30, "JitterStrategy": "FULL" },
+  { "ErrorEquals": ["Lambda.ServiceException", "Lambda.SdkClientException"],
+    "IntervalSeconds": 1, "MaxAttempts": 3, "BackoffRate": 2.0 },
+  { "ErrorEquals": ["States.ALL"], "IntervalSeconds": 1, "MaxAttempts": 3, "BackoffRate": 2.0 }
 ]
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `ErrorEquals` | (required) | Array of error names to match |
-| `IntervalSeconds` | 1 | Initial wait before first retry |
-| `MaxAttempts` | 3 | Max retries; 0 = never retry |
-| `BackoffRate` | 2.0 | Multiplier for exponential backoff |
-| `MaxDelaySeconds` | — | Cap on computed backoff interval |
-| `JitterStrategy` | `"NONE"` | `"FULL"` randomizes wait between 0 and computed interval |
+Defaults: `IntervalSeconds` 1, `MaxAttempts` 3 (0 = never), `BackoffRate` 2.0, `JitterStrategy` `"NONE"`.
 
-Rules:
+Rules and best practices:
 
-- `States.ALL` must be **last** in the Retry array
-- Retries count as state transitions (billed in Standard workflows)
-- `States.Runtime` and `States.DataLimitExceeded` **cannot be retried**
-- Use `JitterStrategy: "FULL"` to prevent thundering herd
-
-### Catch (Fallback States)
-
-```json
-"Catch": [
-  {
-    "ErrorEquals": ["CustomBusinessError"],
-    "ResultPath": "$.error-info",
-    "Next": "HandleBusinessError"
-  },
-  {
-    "ErrorEquals": ["States.ALL"],
-    "ResultPath": "$.error-info",
-    "Next": "GenericErrorHandler"
-  }
-]
-```
-
-- `ResultPath` preserves original input alongside the error (e.g., `"$.error-info"`)
-- Without `ResultPath`, error output replaces entire input
-- Retries are attempted first; catchers apply only after retries are exhausted
-
-### Error handling best practices
-
-1. **Always set `TimeoutSeconds`** on every Task state
-2. **Always retry Lambda service exceptions**: `Lambda.ServiceException`, `Lambda.SdkClientException`
-3. **Use `HeartbeatSeconds`** for long-running tasks
-4. **Combine Retry + Catch**: Retry transient, Catch permanent
-5. **Use `JitterStrategy: "FULL"`** to prevent thundering herd
-6. **Listen for execution failures via EventBridge** for top-level failures
+- `States.ALL` must be **last** in the Retry array; retries are attempted **before** catchers.
+- Retries count as state transitions (billed in Standard).
+- Always set `TimeoutSeconds` on every Task; always retry `Lambda.ServiceException` / `Lambda.SdkClientException`.
+- Use `JitterStrategy: "FULL"` to prevent thundering herd; `HeartbeatSeconds` for long tasks.
+- `Catch` with `ResultPath: "$.error-info"` preserves the original input alongside the error (without it, error output replaces the input).
+- Listen for top-level execution failures via EventBridge (`source: aws.states`, `detail-type: Step Functions Execution Status Change`, `status: [FAILED, TIMED_OUT, ABORTED]`).
 
 ---
 
-## EventBridge Rules and Patterns
+## EventBridge rules, pipes, and patterns
 
-### Event Pattern Structure
+### Event patterns
 
-All specified fields must match (AND). Values within an array are OR'd.
+All specified fields must match (AND); values within an array are OR'd. Operators: exact `["value"]`, `{"prefix"}`, `{"suffix"}`, `{"anything-but"}`, `{"numeric": [">", 0, "<=", 100]}`, `{"exists": true}`, `{"wildcard": "prod-*-east"}`.
 
-```json
-{
-  "source": ["aws.ec2"],
-  "detail-type": ["EC2 Instance State-change Notification"],
-  "detail": { "state": ["terminated", "stopped"] }
-}
-```
+### Best practices
 
-### Advanced Pattern Operators
-
-| Operator | Syntax | Description |
-|---|---|---|
-| Exact match | `["value"]` | Field equals value |
-| Prefix | `[{"prefix": "prod-"}]` | Starts with string |
-| Suffix | `[{"suffix": ".json"}]` | Ends with string |
-| Anything-but | `[{"anything-but": ["val"]}]` | Not in list |
-| Numeric range | `[{"numeric": [">", 0, "<=", 100]}]` | Numeric comparison |
-| Exists | `[{"exists": true}]` | Field must be present |
-| Wildcard | `[{"wildcard": "prod-*-east"}]` | Glob-style matching |
-
-### EventBridge best practices
-
-1. **Dedicated event bus per application domain** — default bus for AWS service events only
-2. **Be precise with patterns** — broad patterns increase risk of infinite loops
-3. **One target per rule** — simplifies debugging and IAM permissions
-4. **Use DLQs on targets** — capture failed event deliveries
-5. **Use the EventBridge Sandbox** to test patterns before deploying
-
-### Step Functions Status Change Events
-
-Step Functions emits to the default bus automatically:
-
-```json
-{
-  "source": ["aws.states"],
-  "detail-type": ["Step Functions Execution Status Change"],
-  "detail": { "status": ["FAILED", "TIMED_OUT", "ABORTED"] }
-}
-```
-
-### Integration Patterns
-
-**SFN → EventBridge** (publish events from a workflow):
-
-```json
-{
-  "Type": "Task",
-  "QueryLanguage": "JSONata",
-  "Resource": "arn:aws:states:::events:putEvents",
-  "Arguments": {
-    "Entries": [{
-      "Detail": { "orderId": "{% $states.input.orderId %}", "status": "PROCESSED" },
-      "DetailType": "OrderProcessed",
-      "EventBusName": "my-app-bus",
-      "Source": "my-app.orders"
-    }]
-  },
-  "Next": "Done"
-}
-```
-
-**EventBridge → SFN**: Rule target is the state machine ARN. Event payload becomes execution input.
-
-**Fan-out**: Single event triggers multiple workflows via multiple rules on the same bus.
-
----
-
-## EventBridge Pipes
-
-### Architecture
-
-```
-Source → [Filter] → [Enrichment] → [Transform] → Target
-```
-
-Eliminates intermediary Lambda functions for point-to-point integrations.
-
-### Supported Sources
-
-| Source | Notes |
-|---|---|
-| Amazon SQS | Standard and FIFO queues |
-| Amazon Kinesis Data Streams | Shard-level polling |
-| Amazon DynamoDB Streams | Change data capture |
-| Amazon MSK / Self-managed Kafka | Topic-level consumption |
-| Amazon MQ | ActiveMQ and RabbitMQ |
-
-### Enrichment Options
-
-Lambda, API Gateway, EventBridge API Destinations, Step Functions (Synchronous Express).
-
-### Key Features
-
-- **Filtering**: Event patterns filter at the source — pay only for matched events
-- **Ordering**: Maintains event ordering within batches
-- **Built-in retry + DLQ**: Source-level retry with dead-letter queue support
+1. **Dedicated event bus per application domain** — default bus for AWS service events only.
+2. **Be precise with patterns** — broad patterns risk infinite loops.
+3. **One target per rule** — simplifies debugging and IAM.
+4. **DLQs on all targets.**
+5. Use the EventBridge Sandbox to test patterns before deploying.
 
 ### Pipes vs Rules
 
 | Dimension | Pipes | Rules |
 |---|---|---|
 | Topology | Point-to-point (1→1) | Fan-out (1→N) |
-| Sources | SQS, Kinesis, DDB Streams, MSK, MQ | Any event on a bus |
-| Enrichment | Built-in | Not built-in |
-| Use case | Replace Lambda glue | Event routing and distribution |
+| Flow | Source → Filter → Enrichment → Transform → Target | Event routing on a bus |
+| Sources | SQS, Kinesis, DynamoDB Streams, MSK, MQ | Any event on a bus |
+| Enrichment | Built-in (Lambda, API GW, API Destinations, Sync Express SFN) | Not built-in |
+| Use case | **Replace Lambda glue** for source→target | Event routing and distribution |
+
+Pipes filtering happens **at the source** — you pay only for matched events — with built-in retry + DLQ.
 
 ---
 
-## Lambda durable functions vs Step Functions
+## Step Functions vs Lambda durable functions
 
-Lambda durable functions let you write reliable multi-step workflows as plain code (TypeScript, Python, Java) with automatic checkpointing — the SDK persists each step's result and replays from the checkpoint on interruption, enabling executions up to 1 year with zero compute during waits. Use the **aws-lambda-durable-functions** skill for full guidance.
+Lambda durable functions let you write reliable multi-step workflows as **plain code** (TS/Python/Java) with automatic checkpointing — the SDK persists each step and replays from the checkpoint on interruption, enabling executions up to 1 year with zero compute during waits. **For full guidance use the aws-lambda-durable-functions skill** (see SKILL.md routing).
 
 | Question | Lambda durable functions | Step Functions |
 |---|---|---|
-| Primary focus? | Application logic in Lambda | Orchestration across AWS services |
-| Programming model? | Standard code (TS/Python/Java) | Amazon States Language (ASL) or visual designer |
-| AWS service integrations? | Primarily Lambda | 200+ native integrations |
-| Who reads the workflow? | Developers | Non-technical stakeholders |
-| Best for? | Distributed transactions, stateful logic, AI agent loops | Business process automation, multi-service orchestration |
+| Programming model | Standard code (TS/Python/Java) | Amazon States Language / visual designer |
+| AWS service integrations | Primarily Lambda | 200+ native integrations |
+| Who reads the workflow | Developers | Non-technical stakeholders too |
+| Best for | Distributed transactions, stateful logic, AI agent loops | Business process automation, multi-service orchestration |

--- a/plugins/aws-core/skills/aws-serverless/references/production.md
+++ b/plugins/aws-core/skills/aws-serverless/references/production.md
@@ -1,15 +1,13 @@
 # Production-Ready Serverless on AWS
 
-Quick-reference for shipping Lambda workloads to production. Covers the pre-deployment checklist, architecture trade-offs, and operational patterns for production traffic.
+Pre-deployment checklist, architecture trade-offs, and operational patterns. Concise on purpose — the value here is the structured checklist and opinionated defaults, not API syntax.
 
 ## Contents
 
 - [Production readiness checklist](#production-readiness-checklist)
 - [Architecture decisions](#architecture-decisions)
 - [Observability](#observability)
-- [Security hardening](#security-hardening)
-- [Testing strategies](#testing-strategies)
-- [Idempotency patterns](#idempotency-patterns)
+- [Idempotency](#idempotency)
 - [Response streaming](#response-streaming)
 - [Anti-patterns](#anti-patterns)
 
@@ -17,365 +15,134 @@ Quick-reference for shipping Lambda workloads to production. Covers the pre-depl
 
 ## Production readiness checklist
 
-Walk through every item before the first production deployment.
-
 ### Compute
 
-- [ ] Memory right-sized (use AWS Lambda Power Tuning or load testing)
-- [ ] Timeout set explicitly (P99 + buffer, never the 3 s default)
-- [ ] Reserved concurrency configured to protect downstream systems
-- [ ] Dead-letter queue (DLQ) or on-failure destination for every async invocation
-- [ ] Environment variables for all config (bucket names, table names, endpoints)
-- [ ] Code signing enabled (if compliance requires it)
-- [ ] SDK clients initialized outside handler (reuse across warm invocations)
-- [ ] Deployment package size minimized (exclude tests, docs, unused dependencies)
+- [ ] Memory right-sized (Power Tuning / load test)
+- [ ] Timeout set explicitly (P99 + buffer — never the 3s default)
+- [ ] Reserved concurrency set to protect downstream
+- [ ] DLQ / on-failure destination on every async invocation and ESM
+- [ ] Config via env vars; SDK clients initialized outside the handler
+- [ ] Deployment package minimized (exclude tests, docs, unused deps)
 
 ### Observability
 
-- [ ] Structured JSON logging via Powertools Logger
-- [ ] X-Ray active tracing enabled
-- [ ] Custom metrics emitted via Embedded Metric Format (EMF)
-- [ ] CloudWatch Alarms on Errors, Throttles, Duration P99, IteratorAge, ConcurrentExecutions, DLQ depth
-- [ ] Log retention policy set — do not leave at unlimited
-- [ ] Correlation IDs propagated to downstream services
-- [ ] Lambda Insights enabled for system-level metrics (CPU, memory, network)
+- [ ] Structured JSON logging (Powertools Logger) + correlation IDs propagated
+- [ ] X-Ray active tracing
+- [ ] Custom metrics via EMF
+- [ ] Alarms on Errors, Throttles, Duration P99, IteratorAge, ConcurrentExecutions, DLQ depth (see below)
+- [ ] Log retention set — **not** unlimited
+- [ ] Log group encryption with customer managed KMS key when compliance requires it
+- [ ] Lambda Insights enabled
 
 ### Security
 
-- [ ] One IAM execution role per function, scoped to exact resource ARNs
-- [ ] No secrets in environment variables — use Secrets Manager / SSM with caching
-- [ ] Input validation on every event payload (JSON Schema, Zod, Pydantic)
-- [ ] VPC placement only when required (RDS, ElastiCache); VPC endpoints for AWS services
-- [ ] GuardDuty Lambda Protection enabled
-- [ ] Security Hub Lambda controls enabled
-- [ ] Dependency scanning in CI (`npm audit`, `pip-audit`, Snyk)
-- [ ] Amazon Inspector Lambda scanning enabled
+- [ ] One IAM role per function, scoped to exact resource ARNs
+- [ ] No secrets in env vars — Secrets Manager / SSM (SecureString) with Powertools caching
+- [ ] Input validation at the handler boundary (Zod / Pydantic / Powertools Validation)
+- [ ] VPC only when required (RDS, ElastiCache); VPC endpoints for AWS services
+- [ ] GuardDuty Lambda Protection, Security Hub Lambda controls, Inspector Lambda scanning, CI dependency scanning
 - [ ] Function URLs use `AWS_IAM` auth (not `NONE`) in production
+- [ ] SQS queues use SSE-KMS for encryption at rest when compliance requires customer managed keys (SSE-SQS is enabled by default)
+- [ ] DynamoDB tables use customer managed KMS keys when compliance requires key control (AWS owned encryption is enabled by default)
+- [ ] Enforce HTTPS-only access with `aws:SecureTransport` condition in resource policies (S3 buckets, SQS queues)
 
 ### Reliability
 
-- [ ] Every handler is idempotent
-- [ ] Partial batch failure reporting enabled (SQS, Kinesis, DynamoDB Streams)
-- [ ] `BisectBatchOnFunctionError` enabled for stream sources (isolates poison records)
-- [ ] Retry config tuned — `MaximumRetryAttempts`, `MaximumEventAgeInSeconds`
-- [ ] Circuit breakers on downstream HTTP calls
-- [ ] Reserved concurrency = 0 documented as emergency kill switch
-- [ ] Graceful error handling — catch, log, and return meaningful errors (no unhandled exceptions)
+- [ ] Every handler idempotent
+- [ ] Partial batch failure reporting (SQS, Kinesis, DynamoDB Streams)
+- [ ] `BisectBatchOnFunctionError` for stream sources
+- [ ] Retry config tuned (`MaximumRetryAttempts`, `MaximumEventAgeInSeconds`)
+- [ ] Reserved concurrency = 0 documented as the emergency kill switch
+- [ ] No unhandled exceptions — catch, log, return meaningful errors
 
 ### Deployment
 
-- [ ] Aliases + weighted traffic shifting (or CodeDeploy canary/linear)
-- [ ] Rollback alarms wired into the deployment pipeline
-- [ ] All infrastructure defined in code (CDK, SAM, or CloudFormation)
-- [ ] Separate AWS accounts for dev, staging, production
-- [ ] Automated smoke tests run post-deployment before full traffic shift
-- [ ] Pre-traffic hooks (BeforeAllowTraffic) validate function health before shifting
+- [ ] Aliases + weighted shifting (or CodeDeploy canary/linear) with rollback alarms
+- [ ] All infra in code (CDK/SAM/CloudFormation)
+- [ ] Separate accounts for dev/staging/prod
+- [ ] Post-deploy smoke tests + pre-traffic hooks before full shift
 
 ---
 
 ## Architecture decisions
 
-### Monolith Lambda vs micro-Lambda
+### Lambdalith vs micro-Lambda
 
-| Aspect | Lambdalith (single function) | Micro-Lambda (function per route) |
-|---|---|---|
-| Cold starts | One function to warm; larger package | Many functions; smaller, faster init |
-| IAM granularity | Single broad role | Per-function least-privilege |
-| Deployment | Everything together; simpler CI/CD | Independent; more pipeline complexity |
-| Observability | One log group; harder per-route metrics | Per-function metrics, alarms, logs |
-| Scaling | Single concurrency pool | Independent scaling + reserved concurrency per function |
-| DX | Familiar Express/FastAPI style | More AWS-native; requires IaC discipline |
-
-**Guidance**: Prefer micro-Lambda for greenfield (least privilege, independent scaling, granular observability). Use Lambdalith when migrating existing Express/FastAPI apps or when team size makes deployment simplicity more valuable than granularity.
-
-### Function URLs vs API Gateway
-
-| Feature | Function URLs | API Gateway (HTTP API) | API Gateway (REST API) |
-|---|---|---|---|
-| Auth | IAM only (or in-code) | IAM, JWT, Lambda authorizers | IAM, Cognito, Lambda authorizers, API keys |
-| Rate limiting | None built-in | Built-in throttling | Throttling + usage plans |
-| Response streaming | Yes (native) | No | Yes (proxy integration) |
-| Custom domains | Via CloudFront | Built-in | Built-in |
-| WAF | No (use CloudFront) | No (use CloudFront) | Yes |
-| Request validation | None | None | JSON Schema |
-| Caching | Via CloudFront | None | Built-in |
-| WebSocket | No | No | No (separate WebSocket API required) |
-
-**Use Function URLs** for: internal service-to-service (IAM auth), Lambdalith + CloudFront, streaming, webhook receivers.
-
-**Use API Gateway** for: public APIs needing rate limiting, JWT/Cognito auth, multi-function path routing, WAF without CloudFront.
+Prefer **micro-Lambda** (function per route) for greenfield: per-function least-privilege IAM, independent scaling + reserved concurrency, granular observability, smaller/faster cold starts. Use a **Lambdalith** when migrating an existing Express/FastAPI app or when a small team values deployment simplicity over granularity.
 
 ### Reserved vs Provisioned Concurrency
 
-| Aspect | Reserved Concurrency | Provisioned Concurrency |
-|---|---|---|
-| Purpose | Guarantee capacity + protect downstream | Eliminate cold starts |
-| Cold starts | Still possible | Eliminated (pre-warmed) |
-| Throttling | Throttles at the limit | Spills to on-demand beyond provisioned |
-| Use case | Protect a database; guarantee capacity | Latency-sensitive APIs; payment processing |
-
-Decision flow:
-
-1. **Need to limit scaling** → Reserved concurrency
-2. **Need to eliminate cold starts** → Provisioned concurrency (try SnapStart first — no additional cost for Java; caching + restore charges for Python/.NET)
-3. **Need both** → Set provisioned ≤ reserved; reserved acts as the ceiling
+Reserved = guarantee capacity + protect downstream (cold starts still possible, throttles at the limit). Provisioned = eliminate cold starts (spills to on-demand beyond the count). Need both → provisioned ≤ reserved. Try **SnapStart** before Provisioned for Java/Python 3.12+/.NET 8+ (no cost for Java). See [concurrency.md](concurrency.md).
 
 ---
 
 ## Observability
 
-### Powertools setup (Python / TypeScript / Java / .NET)
+Use Powertools **Logger** (structured JSON, auto correlation IDs), **Tracer** (wraps X-Ray, auto-captures SDK/HTTP calls; annotate traces with business keys), **Metrics** (EMF — zero latency, writes to stdout vs ~5–20ms for synchronous `PutMetricData`; avoid `PutMetricData` in hot paths).
 
-**Logger** — structured JSON, correlation IDs injected automatically, log level via env var.
+### Minimum alarm set (every production function)
 
-**Tracer** — wraps X-Ray SDK; auto-captures AWS SDK calls, HTTP requests, handler. Add custom subsegments for critical paths. Annotate traces with business keys (customer ID, order ID) for filtering.
+| Alarm | Metric | Threshold | Why |
+|---|---|---|---|
+| Error rate | `Errors / Invocations` | > 1% | Bugs / upstream failures |
+| Throttles | `Throttles` | > 0 | Concurrency limit hit |
+| Duration P99 | `Duration` P99 | > 80% of timeout | Catch slow functions before timeout |
+| Iterator age | `IteratorAge` | > 60s | Stream processing falling behind |
+| Concurrent executions | `ConcurrentExecutions` | > 80% of reserved | Approaching throttle threshold |
+| DLQ depth | SQS `ApproximateNumberOfMessagesVisible` | > 0 | Failed messages accumulating |
 
-**Metrics** — emits via Embedded Metric Format. Zero latency impact.
+Set **log retention** when creating log groups — the default is "never expire."
 
-### EMF vs PutMetricData
+### Testing
 
-| | EMF (Powertools Metrics) | `PutMetricData` API |
-|---|---|---|
-| Latency impact | Zero — writes to stdout | Synchronous API call (~5–20 ms) |
-| Complexity | One-liner with Powertools | Manual batching, error handling |
-| Recommendation | **Use this** | Avoid in hot paths |
-
-### Minimum alarm set
-
-Set these six alarms on every production function:
-
-| Alarm | Metric | Threshold | Period | Why |
-|---|---|---|---|---|
-| Error rate | `Errors / Invocations` | > 1 % | 5 min | Catch bugs and upstream failures |
-| Throttles | `Throttles` | > 0 | 5 min | Concurrency limit hit |
-| Duration P99 | `Duration` P99 | > 80 % of timeout | 5 min | Catch slow functions before timeout |
-| Iterator age | `IteratorAge` | > 60 s | 5 min | Stream processing falling behind |
-| Concurrent executions | `ConcurrentExecutions` | > 80 % of reserved | 5 min | Approaching throttle threshold |
-| DLQ depth | SQS `ApproximateNumberOfMessagesVisible` | > 0 | 5 min | Failed messages accumulating |
-
-### Log retention
-
-Set retention when creating log groups. Defaults to "never expire" — storage accumulates continuously. Choose a retention period based on your compliance and debugging needs.
+Serverless apps are mostly about **service integrations**, not complex business logic — so the **integration layer (tested in the cloud) is the most valuable**, with few unit tests (pure logic) and few E2E. Structure handlers as thin adapters calling pure functions. Don't rely on LocalStack/DynamoDB Local as primary testing (they diverge on IAM, quotas, error codes); don't mock AWS SDK calls for integration tests. Iterate fast with `sam sync` / `cdk watch`; give each developer an isolated stack.
 
 ---
 
-## Security hardening
+## Idempotency
 
-### One role per function
+Lambda guarantees **at-least-once** — duplicates come from async retries, SQS visibility expiry, stream replays, client retries, Step Functions task retries. Use the **Powertools Idempotency** utility (Python/TS/Java/.NET), backed by a DynamoDB table with TTL.
 
-Never share IAM roles across functions. Scope every policy to specific resource ARNs:
+Table: `id` (hash of idempotency key) + `status` (INPROGRESS/COMPLETED/EXPIRED), `data` (cached response), `expiration` (TTL).
 
-```yaml
-# Good
-Effect: Allow
-Action: dynamodb:PutItem
-Resource: arn:aws:dynamodb:us-east-1:123456789012:table/OrdersTable
+Idempotency key by source:
 
-# Bad
-Effect: Allow
-Action: dynamodb:*
-Resource: "*"
-```
-
-Use IAM Access Analyzer to identify unused permissions and generate least-privilege policies.
-
-### Secrets management
-
-- Store in **Secrets Manager** or **SSM Parameter Store** (SecureString)
-- Cache in the execution environment with **Powertools Parameters** (avoids API call per invocation)
-- Rotate automatically via Secrets Manager rotation Lambdas
-- Environment variables are visible in the Lambda console and API — never put secrets there
-
-### Input validation
-
-Validate at the handler boundary before business logic runs:
-
-| Language | Library |
-|---|---|
-| TypeScript | Zod, io-ts, JSON Schema |
-| Python | Pydantic, Powertools Validation (JSON Schema) |
-| Java | Bean Validation (JSR 380), JSON Schema |
-
-Powertools Validation supports envelope extraction for API Gateway, SQS, EventBridge, etc.
-
-### VPC: endpoints over NAT Gateway
-
-If your function must be in a VPC, use **VPC endpoints** for AWS service access instead of NAT Gateway:
-
-| | VPC Endpoint | NAT Gateway |
-|---|---|---|
-| Latency | Lower (stays on AWS backbone) | Higher (extra hop) |
-
-Create endpoints for: DynamoDB (gateway), S3 (gateway), SQS, Secrets Manager, SSM, KMS.
-
----
-
-## Testing strategies
-
-### The serverless testing pyramid (inverted)
-
-```
-        ┌─────────────┐
-        │   E2E Tests  │  Few — full workflow verification
-        ├─────────────┤
-        │ Integration  │  Many — THIS IS THE MOST VALUABLE LAYER
-        │  (in cloud)  │  Test real service interactions
-        ├─────────────┤
-        │  Unit Tests  │  Fast — pure business logic only
-        └─────────────┘
-```
-
-Serverless apps are primarily about service integrations, not complex business logic. Integration tests in the cloud detect the most impactful defects.
-
-### Structure code for testability
-
-```
-handler (thin adapter)
-  → extract + validate event
-  → call business logic (pure functions — unit test these)
-  → call AWS services (integration test these in the cloud)
-```
-
-### What to test where
-
-| Layer | What | How |
-|---|---|---|
-| Unit | Business logic (calculations, transforms, validation) | Local, fast, mocked dependencies |
-| Integration | Service contracts (DynamoDB reads/writes, SQS send/receive, IAM permissions) | Deploy to AWS, test against real services |
-| E2E | Full workflows (API → Lambda → DynamoDB → Stream → Lambda → SQS) | Dedicated staging environment; poll for async side effects |
-
-### Fast iteration
-
-- **`sam sync`** — hot-deploys code changes to AWS in seconds
-- **`cdk watch`** — watches for file changes and auto-deploys
-- Each developer gets an isolated test stack (separate account or prefixed stack name)
-
-### What NOT to do
-
-- Don't rely on LocalStack / DynamoDB Local as primary testing — they diverge from real AWS (IAM, quotas, error codes)
-- Don't mock AWS SDK calls for integration tests — you'll miss permission and config issues
-- Don't skip cloud testing because "it's slow" — use `sam sync` / `cdk watch`
-
----
-
-## Idempotency patterns
-
-Lambda guarantees **at-least-once** execution. Duplicates happen from: async retries, SQS visibility timeout expiry, stream shard replays, client retries on timeout, Step Functions task retries.
-
-### Powertools Idempotency utility
-
-Uses DynamoDB to track processed events. Available for Python, TypeScript, Java, .NET.
-
-**Python:**
-
-```python
-from aws_lambda_powertools.utilities.idempotency import (
-    DynamoDBPersistenceLayer, idempotent
-)
-
-persistence = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-
-@idempotent(persistence_store=persistence)
-def handler(event, context):
-    payment = process_payment(event)
-    return {"statusCode": 200, "body": payment}
-```
-
-**TypeScript:**
-
-```typescript
-import { makeIdempotent } from "@aws-lambda-powertools/idempotency";
-import { DynamoDBPersistenceLayer } from "@aws-lambda-powertools/idempotency/dynamodb";
-
-const persistence = new DynamoDBPersistenceLayer({ tableName: "IdempotencyTable" });
-
-export const handler = makeIdempotent(async (event) => {
-  const payment = await processPayment(event);
-  return { statusCode: 200, body: JSON.stringify(payment) };
-}, { persistenceStore: persistence });
-```
-
-### DynamoDB table design
-
-```
-Table: IdempotencyTable
-  PK: id (String)          — hash of the idempotency key
-  Attributes:
-    status:     INPROGRESS | COMPLETED | EXPIRED
-    data:       cached response payload
-    expiration: TTL epoch timestamp
-  TTL attribute: expiration
-```
-
-### Choosing the idempotency key
-
-| Event source | Key |
+| Source | Key |
 |---|---|
 | SQS | `messageId` |
-| EventBridge | `detail.id` or composite of event fields |
+| EventBridge | `detail.id` or composite |
 | DynamoDB Streams | `eventID` |
-| API Gateway / Function URL | `Idempotency-Key` header or request body hash |
+| API Gateway / Function URL | `Idempotency-Key` header or body hash |
 | Step Functions | Execution ID + task token |
 
-### TTL for cleanup
-
-Set TTL based on how long duplicates can arrive. Typical values:
-
-- API retries: 1 hour
-- SQS retries: match the queue's `maxReceiveCount` × visibility timeout
-- Stream replays: 24 hours (Kinesis retention default)
-
-DynamoDB automatically deletes expired items (typically within a few days of TTL expiry).
+TTL ≈ how long duplicates can arrive (API retries ~1h; SQS ≈ `maxReceiveCount` × visibility; stream replays ~24h).
 
 ---
 
 ## Response streaming
 
-### When to use
+Use for payloads > 6 MB (buffered limit), TTFB-sensitive responses, SSE, LLM token streaming, or large file generation.
 
-| Use case | Why streaming helps |
-|---|---|
-| Large payloads (> 6 MB) | Buffered limit is 6 MB; streaming supports up to 200 MB |
-| TTFB-sensitive responses | Client sees partial data immediately (HTML shell, then content) |
-| Server-sent events (SSE) | Real-time updates to browser clients |
-| LLM / AI token streaming | Stream tokens as generated (conversational AI-style) |
-| Large file generation | CSV/PDF rows streamed as produced |
+- **Function URLs** are simplest; REST API also supports streaming (proxy, STREAM mode); **HTTP API does not**.
+- **200 MB** response limit; **2 MBps** cap after the first 6 MB.
+- Billed for full duration even if the client disconnects.
+- Node.js has native support (`awslambda.streamifyResponse` + `awslambda.HttpResponseStream.from`); other runtimes need a custom runtime or Lambda Web Adapter.
+- **Not supported for VPC-attached functions via Function URL** — use the `InvokeWithResponseStream` API instead.
 
-### Constraints
+Don't stream small JSON (< 6 MB) — buffered is simpler.
 
-- **Function URLs** are simplest for streaming. REST API also supports streaming via proxy integration with STREAM transfer mode. HTTP API does **not** support streaming.
-- **200 MB** response limit
-- **2 MBps** bandwidth cap after the first 6 MB
-- Billed for full function duration even if client disconnects
-- Node.js has native support; other runtimes use custom runtime or Lambda Web Adapter
-- **Function URL streaming is NOT supported for VPC-attached functions.** Use the `InvokeWithResponseStream` API as an alternative.
+---
 
-### Node.js example
+## Anti-patterns
 
-```javascript
-export const handler = awslambda.streamifyResponse(
-  async (event, responseStream, context) => {
-    const metadata = {
-      statusCode: 200,
-      headers: { "Content-Type": "text/html" },
-    };
-    responseStream = awslambda.HttpResponseStream.from(responseStream, metadata);
-
-    responseStream.write("<html><body>");
-    for (const chunk of generateContent()) {
-      responseStream.write(chunk);
-    }
-    responseStream.write("</body></html>");
-    responseStream.end();
-  }
-);
-```
-
-### When NOT to use
-
-- Small JSON responses (< 6 MB) — buffered is simpler
-- When you need API Gateway features (rate limiting, caching, WAF) without CloudFront
-- VPC-based functions needing Function URL streaming (use `InvokeWithResponseStream` API instead)
+- **Lambda calling Lambda synchronously** — doubles latency, tight coupling, fragile error handling. Decouple via SQS, or use Step Functions when you need the result.
+- **Unintentional monolithic handler** — routing stuffed into one function without weighing trade-offs prevents independent scaling and broadens IAM blast radius. Choose Lambdalith vs micro-Lambda deliberately (see above).
+- **Secrets in env vars** — visible in console/API, 4 KB total cap. Use Secrets Manager with Powertools caching.
+- **Skipping idempotency** — at-least-once delivery causes duplicate records.
+- **VPC when not needed** — adds cold-start latency. Only for private resources; use VPC endpoints for AWS services.
+- **Default 3s timeout** — legitimate requests fail silently. Set SDK/HTTP client timeouts shorter than the Lambda timeout for meaningful errors.
+- **Missing DLQ** — failed async invocations / ESM messages are discarded silently.
+- **Log retention = forever** — storage accumulates continuously.
 
 ---
 
@@ -384,110 +151,6 @@ export const handler = awslambda.streamifyResponse(
 - [AWS Lambda Best Practices](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html)
 - [Lambda Concurrency and Scaling](https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html)
 - [Response Streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)
-- [How to Test Serverless Functions](https://docs.aws.amazon.com/lambda/latest/dg/testing-guide.html)
+- [Testing serverless functions](https://docs.aws.amazon.com/lambda/latest/dg/testing-guide.html)
 - [Serverless Applications Lens — Well-Architected](https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/welcome.html)
 - [Powertools for AWS Lambda](https://docs.powertools.aws.dev/lambda/)
-
----
-
-## Anti-patterns
-
-Common mistakes that cause production issues in serverless applications. Each pairs the problem with the correct alternative.
-
-### Avoid: Lambda calling Lambda synchronously
-
-Synchronous Lambda-to-Lambda invocation doubles latency, creates tight coupling, and makes error handling fragile.
-
-```python
-# BAD: Direct synchronous invocation
-lambda_client.invoke(FunctionName='downstream', InvocationType='RequestResponse', Payload=json.dumps(event))
-```
-
-### Instead: Use Step Functions or SQS
-
-```python
-# GOOD: Decouple via SQS
-sqs.send_message(QueueUrl=QUEUE_URL, MessageBody=json.dumps(event))
-```
-
-Or use Step Functions for orchestration when you need the result.
-
----
-
-### Avoid: Monolithic handler without intentional design
-
-Routing logic stuffed into a single handler without considering trade-offs prevents independent scaling, broadens IAM blast radius, and increases cold start times.
-
-```python
-# BAD: One function handling all routes without considering trade-offs
-def handler(event, context):
-    path = event['path']
-    if path == '/users': return handle_users(event)
-    elif path == '/orders': return handle_orders(event)
-    elif path == '/products': return handle_products(event)
-```
-
-### Instead: Choose deliberately
-
-For greenfield projects, prefer one function per route (least privilege, independent scaling, granular observability). For migrations from Express/FastAPI or small teams prioritizing deployment simplicity, a Lambdalith is a valid choice — see [Architecture decisions](#architecture-decisions) for trade-offs.
-
----
-
-### Avoid: Secrets in environment variables
-
-Visible in console and API, 4 KB total limit for all environment variables combined.
-
-```python
-# BAD: Secret in env var
-db_password = os.environ['DB_PASSWORD']
-```
-
-### Instead: Use Secrets Manager with Powertools caching
-
-```python
-# GOOD: Cached secret retrieval
-from aws_lambda_powertools.utilities import parameters
-db_password = parameters.get_secret("my-db-secret", max_age=300)
-```
-
----
-
-### Avoid: Skipping idempotency
-
-Lambda delivers at-least-once; duplicates cause duplicate records.
-
-### Instead: Use Powertools Idempotency
-
-```python
-from aws_lambda_powertools.utilities.idempotency import idempotent, DynamoDBPersistenceLayer
-
-persistence = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-
-@idempotent(persistence_store=persistence)
-def handler(event, context):
-    return process_payment(event)
-```
-
----
-
-### Avoid: VPC when not needed
-
-Adds cold start latency. Only attach Lambda to a VPC for private resources (RDS, ElastiCache, Elasticsearch). Use VPC endpoints for AWS service access instead.
-
----
-
-### Avoid: Default 3s timeout
-
-Legitimate requests fail silently. Set timeout based on load-test P99 + buffer. Set SDK/HTTP client timeouts shorter than Lambda timeout to get meaningful errors instead of generic timeouts.
-
----
-
-### Avoid: Missing DLQ
-
-Failed async invocations and event source messages are discarded without notification. Configure dead-letter queues on all async invocations and event source mappings.
-
----
-
-### Avoid: CloudWatch Logs retention = forever
-
-Storage accumulates continuously. Set a retention period — do not leave at unlimited.

--- a/plugins/aws-core/skills/aws-serverless/references/troubleshooting.md
+++ b/plugins/aws-core/skills/aws-serverless/references/troubleshooting.md
@@ -1,711 +1,164 @@
 # Serverless Troubleshooting Reference
 
-Actionable error lookup tables: exact error string → cause → fix with CLI commands.
-
-## Contents
-
-- [Quick fixes](#quick-fixes)
-- [Lambda Error Lookup](#lambda-error-lookup)
-- [API Gateway Error Lookup](#api-gateway-error-lookup)
-- [Step Functions Error Lookup](#step-functions-error-lookup)
-- [SAM/CDK Error Lookup](#samcdk-error-lookup)
-- [Timeout Debugging](#timeout-debugging)
-- [OOM Debugging](#out-of-memory-oom-debugging)
-- [Throttling Diagnosis](#throttling-diagnosis)
-- [CloudWatch Logs Insights Queries](#cloudwatch-logs-insights-queries)
-- [X-Ray Tracing](#x-ray-tracing)
-
----
+Error → cause → fix, focused on non-obvious gotchas and exact CLI commands. The five most common fixes are first.
 
 ## Quick fixes
 
-### 502 Bad Gateway from API Gateway
-Lambda proxy integration requires `{ statusCode: int, headers: {}, body: "string" }`.
-The `body` must be a string (`JSON.stringify()`), not an object. API Gateway returns 502 when it cannot parse the Lambda response — the function ran successfully but the response shape was wrong. Note: string statusCode (e.g., "200") is silently coerced to integer, and missing statusCode defaults to 200.
-
-### CORS errors
-With Lambda proxy integration, Lambda must return CORS headers — the API Gateway console "Enable CORS" button does not work for Lambda proxy integration. Add `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers` to every Lambda response including errors. For HTTP API, use the built-in `CorsConfiguration` instead. CORS is enforced by the browser, not the server — missing headers cause the browser to block the response even though the API call succeeded.
-
-### Lambda timeout + API Gateway 504
-API Gateway has a hard integration timeout: REST API default 29s (configurable 50ms–29s; Regional/private APIs can request higher), HTTP API max 30s (can be lowered, cannot be raised). This is independent of Lambda's 15-min limit. The 504 means API Gateway gave up waiting, not that Lambda failed. For long operations, return 202 immediately, process via SQS or Step Functions, poll or use WebSocket for results.
-
-### VPC Lambda cannot reach internet
-Lambda in a VPC needs a **private** subnet + NAT Gateway in a **public** subnet. Placing Lambda in a public subnet does NOT give it a public IP — Lambda never gets a public IP regardless of subnet type because Lambda's network interface is managed by the service and doesn't support public IP assignment. For AWS services only, use VPC endpoints (free for S3 and DynamoDB gateway endpoints).
-
-### ImportModuleError / MODULE_NOT_FOUND
-Handler path doesn't match file structure, or dependencies weren't bundled. Lambda extracts code to `/var/task` and layers to `/opt` — if the handler path doesn't match the file's location relative to `/var/task`, the runtime can't find it. Python: `pip install -r requirements.txt -t ./package --platform manylinux2014_x86_64 --only-binary=:all:`. Node: verify `exports.handler` exists and `node_modules` is included. Use `sam build` to handle cross-platform packaging automatically.
+- **502 Bad Gateway (proxy):** Lambda response must be `{ statusCode: int, headers: {}, body: "string" }`. `body` must be a `JSON.stringify`'d **string**, not an object. The function ran fine — only the response shape was wrong. (String statusCode is coerced. Under **HTTP API** payload format 2.0 a missing statusCode defaults to 200, but under **REST** proxy a missing statusCode is itself a malformed response and triggers the 502.)
+- **CORS errors:** under proxy integration the **Lambda** returns CORS headers on **every** response including errors; the console "Enable CORS" button doesn't apply. HTTP API: use `CorsConfiguration`. CORS is browser-enforced — the API call itself succeeded. **Never use `AllowOrigin: '*'` in production** — wildcard CORS is a security risk (CWE-942); specify your exact domain (e.g. `https://app.example.com`).
+- **504 from API Gateway:** integration timeout (REST 29s default; HTTP 30s max), independent of Lambda's 15-min limit. For long ops: return 202 immediately, process via SQS/Step Functions, poll or use WebSocket.
+- **VPC Lambda can't reach internet:** needs **private** subnet + NAT Gateway in a **public** subnet. A public subnet does NOT give Lambda a public IP. For AWS services use VPC endpoints (free for S3/DynamoDB gateway endpoints).
+- **ImportModuleError / MODULE_NOT_FOUND:** handler path doesn't match file structure, or deps weren't bundled for the right platform. Python: `pip install -r requirements.txt -t ./package --platform manylinux2014_x86_64 --only-binary=:all:`. Use `sam build` for cross-platform packaging.
 
 ---
 
-## Lambda Error Lookup
-
-### Runtime.ImportModuleError
-
-**Error:** `Runtime.ImportModuleError: Unable to import module 'lambda_function': No module named 'lambda_function'`
-**Cause:** Handler references a module missing from the deployment package.
-
-```bash
-pip install -r requirements.txt -t ./package
-cd package && zip -r ../deployment.zip . && cd .. && zip deployment.zip lambda_function.py
-# Or: sam build && sam deploy
-```
-
-### Runtime.HandlerNotFound
-
-**Error:** `Runtime.HandlerNotFound: Handler 'handler' missing on module 'function'`
-**Cause:** File exists but function/method name doesn't match handler setting.
-
-```bash
-aws lambda update-function-configuration --function-name my-func --handler app.lambda_handler
-# Python: file.function  Node: file.export  Java: package.Class::method
-```
-
-### Task timed out
-
-**Error:** `Task timed out after 3.00 seconds`
-**Cause:** Execution exceeded configured timeout. Slow downstream calls, low memory/CPU, or VPC delays.
-
-```bash
-aws lambda update-function-configuration --function-name my-func --timeout 30
-aws lambda update-function-configuration --function-name my-func --memory-size 512
-# Set SDK/HTTP timeouts shorter than Lambda timeout for meaningful errors
-```
-
-### Runtime.OutOfMemory (OOM)
-
-**Error:** `Runtime.OutOfMemory: ... signal: killed` or `Runtime exited without providing a reason`
-**Cause:** Function exceeded allocated memory — kernel sent SIGKILL.
-
-```bash
-# Check REPORT lines: Max Memory Used vs Memory Size
-aws lambda update-function-configuration --function-name my-func --memory-size 1024
-# Stream large files instead of loading into memory; bound global caches
-```
-
-### AccessDeniedException
-
-**Error:** `AccessDeniedException: ... not authorized to perform: lambda:InvokeFunction`
-**Cause:** Calling IAM principal lacks `lambda:InvokeFunction` permission.
-
-```bash
-aws lambda add-permission --function-name my-func \
-  --statement-id AllowInvoke --action lambda:InvokeFunction \
-  --principal s3.amazonaws.com --source-arn arn:aws:s3:::my-bucket
-```
-
-### TooManyRequestsException
-
-**Error:** `TooManyRequestsException: Rate Exceeded.`
-**Cause:** Function exceeded account concurrency limit (default 1,000).
-
-```bash
-aws lambda get-account-settings
-aws service-quotas request-service-quota-increase \
-  --service-code lambda --quota-code L-B99A9384 --desired-value 3000
-aws lambda put-function-concurrency --function-name my-func --reserved-concurrent-executions 100
-```
-
-### InvalidParameterValueException (size)
-
-**Error:** `Unzipped size must be smaller than 262144000 bytes`
-**Cause:** Package exceeds 50 MB zipped / 250 MB unzipped.
-
-```bash
-find ./package -name "*.pyc" -delete && find ./package -name "*.dist-info" -type d -exec rm -rf {} +
-aws lambda publish-layer-version --layer-name my-deps --zip-file fileb://layer.zip --compatible-runtimes python3.13
-# Or upload via S3, or switch to container image packaging (10 GB limit)
-```
-
-### ETIMEDOUT (VPC)
-
-**Error:** `Error: connect ETIMEDOUT 176.32.98.189:443`
-**Cause:** VPC Lambda can't reach internet — missing NAT Gateway or VPC Endpoint.
-
-```bash
-aws ec2 describe-route-tables --filters "Name=association.subnet-id,Values=subnet-xxx"
-aws ec2 create-route --route-table-id rtb-xxx --destination-cidr-block 0.0.0.0/0 --nat-gateway-id nat-xxx
-# Or use VPC Endpoints for AWS services:
-aws ec2 create-vpc-endpoint --vpc-id vpc-xxx --service-name com.amazonaws.us-east-1.s3 --route-table-ids rtb-xxx
-```
-
-### MODULE_NOT_FOUND
-
-**Error:** `Error: Cannot find module 'my-module'`
-**Cause:** Node.js dependency missing — not bundled or built on incompatible platform.
-
-```bash
-npm install --production
-sam build --use-container  # for native modules
-unzip -l deployment.zip | grep my-module  # verify inclusion
-```
+## Lambda errors (gotchas)
 
 ### RecursiveInvocationException
 
-**Error:** `RecursiveInvocationException: Recursive invocation detected`
-**Cause:** Function writes to a resource that triggers itself again (~16 invocations before halt).
+A function writes to a resource that re-triggers it (Lambda halts after ~16 loops).
 
 ```bash
-# Emergency stop
+# Emergency stop:
 aws lambda put-function-concurrency --function-name my-func --reserved-concurrent-executions 0
-# Fix: use separate input/output buckets or prefix filters in trigger config
+# Fix: separate input/output buckets, or prefix filters in the trigger config
 ```
 
-### SnapStart Errors
+### SnapStart errors
 
-**Error:** `SnapStartException` / `SnapStartNotReadyException` / `SnapStartTimeoutException`
-**Cause:** SnapStart failed during snapshot — init threw exception or uses non-snapshottable resources (e.g., open network connections).
+`SnapStartException` / `SnapStartNotReadyException` / `SnapStartTimeoutException` — init threw, or it uses non-snapshottable resources (open network connections).
 
 ```bash
 aws lambda get-function --function-name my-func --query 'Configuration.SnapStart'
-# Java: Use CRaC hooks — beforeCheckpoint() to close connections, afterRestore() to reopen
-# Python: Use snapshot_restore runtime hooks to re-establish connections after restore
-# .NET: Use SnapshotRestore register hooks for before-snapshot and after-restore actions
+# Java:   CRaC hooks — beforeCheckpoint() closes connections, afterRestore() reopens
+# Python: snapshot_restore runtime hooks to re-establish connections after restore
+# .NET:   SnapshotRestore.Register hooks for before-snapshot / after-restore
 ```
 
 ### Sandbox.Timedout
 
-**Error:** `Sandbox.Timedout`
-**Cause:** Function exceeded its timeout. In newer runtimes, this covers both init-phase and invoke-phase timeouts. A suppressed init failure consumes the invoke timeout.
-
-```bash
-aws lambda update-function-configuration --function-name my-func --timeout 60 --memory-size 1024
-# Move heavy initialization to lazy loading inside the handler
-```
+Exceeded the timeout. In newer runtimes this covers **both** init-phase and invoke-phase timeouts — a suppressed init failure consumes the invoke timeout. Move heavy init to lazy loading inside the handler; raise `--timeout`/`--memory-size`.
 
 ### ENILimitReachedException
 
-**Error:** `ENILimitReachedException`
-**Cause:** VPC reached network interface quota. Lambda Hyperplane ENIs have a default quota of 500 per VPC (see lambda.md); the overall VPC ENI quota is 5,000 per region. Check which limit applies.
+VPC hit its network-interface quota. Two limits can apply — the Lambda-specific Hyperplane ENI-per-VPC quota and the broader VPC ENI-per-Region quota — so check which one was reached (Service Quotas / `describe-account-attributes`).
 
 ```bash
 aws service-quotas request-service-quota-increase --service-code vpc --quota-code L-DF5E4CA3 --desired-value 10000
-# Consolidate functions to use same subnet + security group combinations
+# Consolidate functions onto the same subnet + security group combinations
 ```
 
-### InvalidZipFileException
-
-**Error:** `InvalidZipFileException: Could not unzip uploaded file.`
-**Cause:** Invalid ZIP or handler nested in subdirectory instead of at root.
+### TooManyRequestsException / throttling
 
 ```bash
-unzip -t deployment.zip  # verify integrity
-cd my-folder && zip -r ../deployment.zip . && cd ..  # files at root, not nested
+aws lambda get-account-settings
+aws service-quotas request-service-quota-increase --service-code lambda --quota-code L-B99A9384 --desired-value 3000
+aws lambda put-function-concurrency --function-name my-func --reserved-concurrent-executions 100
 ```
+
+Throttle behavior by invocation type: **Sync (API GW)** → 429 (may surface as 500); **Async (S3, SNS)** → auto-retries up to 6h; **SQS** → returns to queue, backs off; **Kinesis/DynamoDB Streams** → retries batch, blocks shard.
 
 ### CodeStorageExceededException
 
-**Error:** `CodeStorageExceededException: Code storage limit exceeded.`
-**Cause:** Account exceeded 75 GB code storage per region (all versions + layers).
-
-```bash
-aws lambda list-versions-by-function --function-name my-func
-aws lambda delete-function --function-name my-func --qualifier 1
-aws lambda list-layers  # delete unused layers too
-```
+Account exceeded its per-Region code storage quota (unzipped; all versions + layers). Check the current limit with `aws service-quotas get-service-quota --service-code lambda --quota-code L-2ACBD22F` (it is adjustable and has changed over time). Delete old versions and unused layers (`aws lambda list-versions-by-function`, `delete-function --qualifier`).
 
 ---
 
-## API Gateway Error Lookup
+## API Gateway errors (gotchas)
 
-### Malformed Lambda Proxy Response (502)
-
-**Error:** `Malformed Lambda proxy response` → 502
-**Cause:** Lambda response missing required format — `body` must be a string, response must be a JSON object (not a plain string or array).
-
-```python
-return {"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": json.dumps({"msg": "ok"})}
-```
-
-```javascript
-return { statusCode: 200, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ msg: "ok" }) };
-```
-
-### Missing Authentication Token (403)
-
-**Error:** `403 Forbidden: Missing Authentication Token`
-**Cause:** URL doesn't match any resource/method, or API not deployed to stage. Usually routing, not auth.
-
-```bash
-aws apigateway create-deployment --rest-api-id abc123 --stage-name prod
-# Verify: https://{api-id}.execute-api.{region}.amazonaws.com/{stage}/{resource}
-```
-
-### Invalid Permissions on Lambda (500)
-
-**Error:** `Invalid permissions on Lambda function`
-**Cause:** API Gateway lacks `lambda:InvokeFunction` permission on the target function.
-
-```bash
-aws lambda add-permission --function-name my-func --statement-id apigw-invoke \
-  --action lambda:InvokeFunction --principal apigateway.amazonaws.com \
-  --source-arn "arn:aws:execute-api:us-east-1:123456789012:api-id/*/GET/resource"
-```
-
-### Endpoint Request Timed Out (504)
-
-**Error:** `Endpoint request timed out` → 504
-**Cause:** Lambda didn't respond within 29s (REST) / 30s (HTTP) integration timeout.
-
-```bash
-aws lambda update-function-configuration --function-name my-func --memory-size 1024
-# For long operations: return 202 immediately, process async, poll for results
-```
-
-### Authorizer Unauthorized (401)
-
-**Error:** `Unauthorized` (401)
-**Cause:** Lambda authorizer returned deny, threw error, or timed out.
-
-```bash
-aws logs tail /aws/lambda/my-authorizer --since 1h --filter-pattern ERROR
-# Verify authorizer returns: { principalId, policyDocument: { Statement: [{ Effect: "Allow" }] } }
-```
-
-### WAF Access Denied (403)
-
-**Error:** `403 Forbidden` with `x-amzn-errortype: ForbiddenException`
-**Cause:** AWS WAF rule matched — IP denylist, rate limit, or injection detection.
-
-```bash
-# Check WAF sampled requests in console to identify blocking rule
-# Test rules in Count mode before switching to Block
-```
-
-### CORS Errors
-
-**Error:** `blocked by CORS policy: No 'Access-Control-Allow-Origin' header`
-**Cause:** Lambda proxy integration must return CORS headers; HTTP APIs can configure at API level.
-
-```yaml
-# SAM Globals
-Globals:
-  Api:
-    Cors:
-      AllowOrigin: "'*'"
-      AllowMethods: "'GET,POST,OPTIONS'"
-      AllowHeaders: "'Content-Type,Authorization'"
-```
-
-```bash
-# HTTP API
-aws apigatewayv2 update-api --api-id abc123 \
-  --cors-configuration AllowOrigins="*",AllowMethods="GET,POST",AllowHeaders="Content-Type"
-```
-
-### Internal Server Error — Lambda Throttled (500)
-
-**Error:** 500 with CloudWatch log `Lambda invocation failed with status 429`
-**Cause:** Lambda throttled but API Gateway surfaces as 500.
-
-```bash
-# Increase Lambda concurrency (see TooManyRequestsException above)
-aws apigateway update-stage --rest-api-id abc123 --stage-name prod \
-  --patch-operations op=replace,path=/*/*/throttling/rateLimit,value=1000
-```
+| Error | Cause | Fix |
+|---|---|---|
+| `403 Missing Authentication Token` | URL doesn't match a resource/method, or API not deployed | Usually routing, not auth — verify path and `create-deployment` to the stage |
+| `Invalid permissions on Lambda function` (500) | API GW lacks `lambda:InvokeFunction` | `aws lambda add-permission --principal apigateway.amazonaws.com --source-arn "arn:aws:execute-api:...:api-id/*/GET/resource"` (add `--source-account <account-id>` to scope cross-service triggers like S3 to your account) |
+| `Unauthorized` (401) | Lambda authorizer denied/errored/timed out | Check authorizer logs; verify it returns a valid Allow policy |
+| `403` + `x-amzn-errortype: ForbiddenException` | WAF rule matched | Check WAF sampled requests; test rules in Count mode first |
+| 500 with log `status 429` | Lambda throttled, surfaced as 500 | Increase Lambda concurrency |
 
 ---
 
-## Step Functions Error Lookup
+## Step Functions errors
 
-### States.TaskFailed
-
-**Error:** `States.TaskFailed`
-**Cause:** Task failed — unhandled Lambda exception, service error, or missing permissions.
-
-```json
-"Retry": [{"ErrorEquals": ["States.TaskFailed","Lambda.ServiceException","Lambda.SdkClientException"], "IntervalSeconds": 2, "MaxAttempts": 3, "BackoffRate": 2.0}],
-"Catch": [{"ErrorEquals": ["States.TaskFailed"], "Next": "HandleError", "ResultPath": "$.error"}]
-```
-
-### States.Timeout
-
-**Error:** `States.Timeout`
-**Cause:** Task exceeded `TimeoutSeconds` or missed `HeartbeatSeconds` deadline.
-
-```json
-{"Type": "Task", "Resource": "arn:aws:lambda:...", "TimeoutSeconds": 300, "HeartbeatSeconds": 60, "Next": "NextState"}
-```
-
-### States.DataLimitExceeded
-
-**Error:** `States.DataLimitExceeded`
-**Cause:** State input/output exceeded 256 KB. Cannot be caught by `States.ALL`.
-
-**Fix:** Store large data in S3, pass only S3 keys between states. Use `InputPath`/`OutputPath` to filter.
-
-### ExecutionAlreadyExists
-
-**Error:** `ExecutionAlreadyExists`
-**Cause:** Execution name must be unique per state machine for 90 days.
-
-```bash
-aws stepfunctions start-execution --state-machine-arn arn:aws:states:... \
-  --name "exec-$(date +%s)" --input '{}'
-# Or omit --name for auto-generated names
-```
-
-### States.Permissions
-
-**Error:** `States.Permissions: insufficient privileges`
-**Cause:** Execution role lacks permission to invoke target service.
-
-```bash
-aws iam list-attached-role-policies --role-name StepFunctionsRole
-# Add lambda:InvokeFunction, dynamodb:PutItem, etc. to the execution role
-```
+| Error | Cause / Fix |
+|---|---|
+| `States.TaskFailed` | Add `Retry` for `States.TaskFailed`/`Lambda.ServiceException`/`Lambda.SdkClientException`; `Catch` to a handler |
+| `States.Timeout` | Set `TimeoutSeconds` (and `HeartbeatSeconds` for long tasks) |
+| `States.DataLimitExceeded` | Input/output > 256 KiB — **cannot be caught by `States.ALL`**. Store in S3, pass keys |
+| `ExecutionAlreadyExists` | Names unique per state machine for 90 days — use `--name "exec-$(date +%s)"` or omit `--name` |
+| `States.Permissions` | Execution role lacks target-service permission |
 
 ---
 
-## SAM/CDK Error Lookup
+## SAM/CDK errors
 
-### Stale Build Cache
-
-**Error:** `sam build` uses old dependencies after updating requirements.txt, or `--clear-cache` flag unrecognized.
-**Cause:** SAM caches build artifacts. There is no `--clear-cache` flag.
+### Stale build cache
 
 ```bash
-sam build --no-cached              # Force clean build (correct flag)
-rm -rf .aws-sam/cache              # Or manually delete cache directory
+sam build --no-cached        # correct flag — there is NO --clear-cache
+rm -rf .aws-sam/cache        # or delete the cache directory
 ```
 
 ### PythonPipBuilder:ResolveDependencies
 
-**Error:** `PythonPipBuilder:ResolveDependencies - pip install returned a non-zero exit code`
-**Cause:** Dependency version conflicts or missing native libraries.
+Version conflicts or missing native libs: `sam build --use-container --no-cached`; use binary wheels (`psycopg2-binary`).
 
-```bash
-sam build --use-container --no-cached
-# Use binary wheels: psycopg2-binary instead of psycopg2
-```
+### CDK NodejsFunction: `Cannot find module 'esbuild'`
 
-### DockerBuildFailed
+`npm install --save-dev esbuild`.
 
-**Error:** `DockerBuildFailed: Docker build failed.`
-**Cause:** Docker not running or Dockerfile errors.
-
-```bash
-docker info  # verify running
-sudo systemctl start docker  # start if needed
-```
-
-### Cannot find module 'esbuild'
-
-**Error:** `Cannot find module 'esbuild'`
-**Cause:** CDK `NodejsFunction` needs esbuild for bundling.
-
-```bash
-npm install --save-dev esbuild
-```
-
-### CREATE_FAILED
-
-**Error:** `CREATE_FAILED: AWS::Lambda::Function`
-**Cause:** Invalid runtime, missing S3 code, role not ready, or package too large.
+### CREATE_FAILED / UPDATE_ROLLBACK_FAILED
 
 ```bash
 aws cloudformation describe-stack-events --stack-name my-stack \
   --query "StackEvents[?ResourceStatus=='CREATE_FAILED'].[LogicalResourceId,ResourceStatusReason]" --output table
-```
-
-### UPDATE_ROLLBACK_FAILED
-
-**Error:** `UPDATE_ROLLBACK_FAILED`
-**Cause:** Update failed and rollback also failed — resource manually deleted or permissions changed.
-
-```bash
-aws cloudformation continue-update-rollback --stack-name my-stack
+# Rollback also failed (resource manually deleted / perms changed):
 aws cloudformation continue-update-rollback --stack-name my-stack --resources-to-skip MyFunction
 ```
 
-### Security Constraints Not Satisfied
+### Circular dependency
 
-**Error:** `Security Constraints Not Satisfied`
-**Cause:** SAM template missing required properties (Handler, Runtime, CodeUri).
+`Circular dependency between resources: [MyFunction, MyRole, ...]` — break the cycle by giving the function an explicit `FunctionName` and referencing the hardcoded ARN (`!Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:my-function-name"`) instead of `!Ref`/`!GetAtt`, or extract the IAM role/policy into a separate resource.
 
-```bash
-sam validate --lint
-```
+### Other quick ones
 
-### CDK Bootstrap Required
-
-**Error:** `This stack uses assets, so the toolkit stack must be deployed`
-**Cause:** Target account/region not bootstrapped.
-
-```bash
-cdk bootstrap aws://123456789012/us-east-1
-```
-
-### Circular Dependency
-
-**Error:** `Circular dependency between resources: [MyFunction, MyRole, ...]`
-**Cause:** Resources reference each other in a cycle.
-
-```yaml
-# Break cycle: give the function an explicit name and hardcode the ARN
-MyFunction:
-  Type: AWS::Lambda::Function
-  Properties:
-    FunctionName: my-function-name  # explicit name
-
-MyRole:
-  Type: AWS::IAM::Role
-  Properties:
-    Policies:
-      - PolicyDocument:
-          Statement:
-            - Effect: Allow
-              Action: lambda:InvokeFunction
-              # No ${MyFunction} reference — no implicit dependency
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:my-function-name"
-# Or restructure to eliminate the cycle (extract IAM role/policy into a separate resource)
-```
+- `DockerBuildFailed` → `docker info` / start Docker.
+- `Security Constraints Not Satisfied` (missing Handler/Runtime/CodeUri) → `sam validate --lint`.
+- `This stack uses assets, so the toolkit stack must be deployed` → `cdk bootstrap aws://ACCOUNT/REGION`.
 
 ---
 
-## Timeout Debugging
+## Diagnostics
+
+For systematic timeout investigation (config → logs → metrics → VPC → cold start → memory → downstream), use the **debugging-lambda-timeouts** skill (see SKILL.md routing).
+
+CloudWatch Logs Insights run against `/aws/lambda/FUNCTION_NAME` (API Gateway uses the access log group). Useful fields on `@type = "REPORT"` lines: `@initDuration` (cold start), `@duration`, `@billedDuration`, `@maxMemoryUsed`, `@memorySize`. Examples:
 
 ```
-Function times out
-├── INIT phase? (Sandbox.Timedout)
-│   ├── YES → Increase timeout + memory, lazy-load heavy deps
-│   └── NO → INVOKE phase
-│       ├── Timeout ≈ avg duration? → Set to 2-3x average
-│       ├── Calling external services? → Set SDK timeouts < Lambda timeout
-│       ├── CPU-bound? → Increase memory (1,769 MB = 1 vCPU)
-│       └── VPC? → Check NAT Gateway / security group / VPC Endpoints
-```
+# Cold start rate + init latency
+filter @type="REPORT" | stats count() as total, sum(ispresent(@initDuration)) as coldStarts,
+  avg(@initDuration) as avgInitMs, pct(@initDuration,99) as p99InitMs by bin(1h)
 
-```bash
-aws lambda get-function-configuration --function-name my-func --query '[Timeout,MemorySize]'
-aws cloudwatch get-metric-statistics --namespace AWS/Lambda --metric-name Duration \
-  --dimensions Name=FunctionName,Value=my-func --period 300 --statistics Average Maximum \
-  --start-time $(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%S) --end-time $(date -u +%Y-%m-%dT%H:%M:%S)
-# For percentiles, use a separate call:
-aws cloudwatch get-metric-statistics --namespace AWS/Lambda --metric-name Duration \
-  --dimensions Name=FunctionName,Value=my-func --period 300 --extended-statistics p99 \
-  --start-time $(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%S) --end-time $(date -u +%Y-%m-%dT%H:%M:%S)
-```
+# Out-of-memory (>90% used)
+filter @type="REPORT" | filter @maxMemoryUsed/@memorySize > 0.9
+  | fields @timestamp, @requestId, @maxMemoryUsed/1e6 as usedMB | sort @timestamp desc
 
----
+# Latency percentiles
+filter @type="REPORT" | stats pct(@duration,50) as p50, pct(@duration,90) as p90,
+  pct(@duration,99) as p99, max(@duration) as max by bin(1h)
 
-## Out-of-Memory (OOM) Debugging
-
-```
-Runtime.OutOfMemory / signal: killed
-├── Check REPORT: Max Memory Used ≈ Memory Size? → OOM confirmed
-├── Immediate? → Payload/dependency too large → increase memory
-├── Gradual? → Memory leak → check global vars accumulating across warm invocations
-└── Fix: increase memory, stream large files, bound caches
-```
-
-| Memory (MB) | vCPUs | Use Case |
-|-------------|-------|----------|
-| 128 | ~0.08 | Simple transforms |
-| 512 | ~0.3 | Moderate processing |
-| 1,769 | 1.0 | CPU-intensive single-threaded |
-| 3,538 | 2.0 | Multi-threaded |
-| 10,240 | ~5.8 | Heavy compute, ML inference |
-
----
-
-## Throttling Diagnosis
-
-| Concept | Default | Notes |
-|---------|---------|-------|
-| Account concurrency | 1,000/region | Request increase via Service Quotas |
-| Reserved concurrency | None | Guarantees AND caps function concurrency |
-| Concurrency scaling rate | 1,000 envs/10s | Per function, uniform across regions |
-
-| Invocation Type | Throttle Behavior |
-|-----------------|-------------------|
-| Synchronous (API GW) | Returns 429 (API GW may show 500) |
-| Async (S3, SNS) | Auto-retries up to 6 hours |
-| SQS trigger | Returns to queue, backs off |
-| Kinesis/DDB Streams | Retries batch, blocks shard |
-
-```bash
-aws lambda get-account-settings
-aws cloudwatch get-metric-statistics --namespace AWS/Lambda --metric-name Throttles \
-  --dimensions Name=FunctionName,Value=my-func --period 60 --statistics Sum \
-  --start-time $(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%S) --end-time $(date -u +%Y-%m-%dT%H:%M:%S)
-```
-
----
-
-## CloudWatch Logs Insights Queries
-
-Run against `/aws/lambda/FUNCTION_NAME`. For API Gateway, use the access log group.
-
-### Cold Starts
-
-```
-filter @type = "REPORT" | filter ispresent(@initDuration)
-| stats count() as coldStarts, avg(@initDuration) as avgInitMs, max(@initDuration) as maxInitMs, pct(@initDuration, 99) as p99InitMs by bin(1h)
-```
-
-### Cold Start Percentage
-
-```
-filter @type = "REPORT"
-| stats count() as total, sum(ispresent(@initDuration)) as coldStarts, sum(ispresent(@initDuration)) * 100.0 / count() as pct by bin(1h)
-```
-
-### Errors by Type
-
-```
-filter @message like /(?i)error|exception/
-| parse @message /(?<errorType>[A-Za-z]+Error|[A-Za-z]+Exception)/
-| stats count() as cnt by errorType | sort cnt desc
-```
-
-### Timeouts
-
-```
-filter @message like /Task timed out/ | stats count() as timeouts by bin(1h) | sort bin desc
-```
-
-### Memory Utilization
-
-```
-filter @type = "REPORT"
-| stats max(@memorySize/1e6) as provisionedMB, avg(@maxMemoryUsed/1e6) as avgUsedMB, max(@maxMemoryUsed/1e6) as maxUsedMB, pct(@maxMemoryUsed/1e6, 99) as p99UsedMB
-```
-
-### Out-of-Memory Detection (>90% memory)
-
-```
-filter @type = "REPORT" | filter @maxMemoryUsed / @memorySize > 0.9
-| fields @timestamp, @requestId, @maxMemoryUsed/1e6 as usedMB, @memorySize/1e6 as allocatedMB | sort @timestamp desc | limit 50
-```
-
-### Overprovisioned Memory (<50% used)
-
-```
-filter @type = "REPORT"
-| stats max(@memorySize/1e6) as provMB, max(@maxMemoryUsed/1e6) as peakMB, max(@maxMemoryUsed)*100.0/max(@memorySize) as pct
-| filter pct < 50
-```
-
-### Memory Growth (Leak Detection)
-
-```
-filter @type = "REPORT" | stats avg(@maxMemoryUsed/1e6) as avgMemMB by bin(5m) | sort bin asc
-```
-
-### Latency Percentiles
-
-```
-filter @type = "REPORT"
-| stats avg(@duration) as avg, pct(@duration,50) as p50, pct(@duration,90) as p90, pct(@duration,95) as p95, pct(@duration,99) as p99, max(@duration) as max by bin(1h)
-```
-
-### Slowest Invocations
-
-```
-filter @type = "REPORT"
-| fields @timestamp, @requestId, @duration, @maxMemoryUsed/1000000 as memMB, ispresent(@initDuration) as coldStart
-| sort @duration desc | limit 20
-```
-
-### API Gateway 5xx
-
-```
+# API Gateway 5xx (access log group)
 filter status >= 500 | stats count() as errors by status, path, httpMethod | sort errors desc
 ```
 
-### API Gateway 5xx Over Time
+### Memory ↔ vCPU (for OOM / CPU tuning)
 
-```
-filter status >= 500 | stats count() by bin(5m) | sort bin desc
-```
+| Memory | vCPUs | Use case |
+|---|---|---|
+| 128 MB | ~0.08 | Simple transforms |
+| 512 MB | ~0.3 | Moderate processing |
+| 1,769 MB | 1.0 | CPU-intensive single-threaded |
+| 3,538 MB | 2.0 | Multi-threaded |
+| 10,240 MB | ~5.8 (up to 6 vCPU) | Heavy compute / ML inference |
 
-### Throttle Events
+### X-Ray
 
-```
-filter @message like /Rate Exceeded|TooManyRequestsException|Throttl/
-| fields @timestamp, @requestId, @message | sort @timestamp desc | limit 50
-```
-
-### Billed Duration
-
-```
-filter @type = "REPORT"
-| stats count() as invocations, sum(@billedDuration)/1000 as totalBilledSec, avg(@billedDuration) as avgBilledMs by bin(1d)
-```
-
-### Error Messages with Request IDs
-
-```
-filter @message like /(?i)error|exception|fail/
-| fields @timestamp, @requestId, @message | sort @timestamp desc | limit 50
-```
-
----
-
-## X-Ray Tracing
-
-### Enable in SAM
-
-```yaml
-Globals:
-  Function:
-    Tracing: Active
-```
-
-### Enable in CDK
-
-```typescript
-new lambda.Function(this, 'Fn', {
-  tracing: lambda.Tracing.ACTIVE,  // adds AWSXRayDaemonWriteAccess automatically
-});
-```
-
-### Required IAM
-`AWSXRayDaemonWriteAccess` managed policy on the execution role. SAM/CDK add this automatically.
-
-### Default Sampling
-1 request/second (reservoir) + 5% of additional requests.
-
-### Instrument SDK Calls
-
-```python
-from aws_xray_sdk.core import patch_all
-patch_all()
-```
-
-```javascript
-// SDK v3 (Node.js 18+)
-const { captureAWSv3Client } = require('aws-xray-sdk-core');
-const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
-const ddb = captureAWSv3Client(new DynamoDBClient({}));
-```
-
-### Query Traces
-
-```bash
-aws xray get-trace-summaries --start-time $(date -u -d '1 hour ago' +%s) --end-time $(date -u +%s) \
-  --filter-expression 'service("my-func") AND fault'
-aws xray batch-get-traces --trace-ids "1-xxx-yyy"
-```
-
-### Enable for API Gateway
-
-```yaml
-Resources:
-  MyApi:
-    Type: AWS::Serverless::Api
-    Properties:
-      StageName: prod
-      TracingEnabled: true
-```
-
-### Enable for Step Functions
-
-```yaml
-Resources:
-  MyStateMachine:
-    Type: AWS::Serverless::StateMachine
-    Properties:
-      Tracing:
-        Enabled: true
-```
+Enable via SAM `Tracing: Active` (Function) / `TracingEnabled: true` (Api) or CDK `tracing: lambda.Tracing.ACTIVE` (adds `AWSXRayDaemonWriteAccess` automatically). Default sampling: 1 req/s reservoir + 5%. Instrument SDK calls with `patch_all()` (Python) / `captureAWSv3Client` (Node).

--- a/skills/core-skills/aws-serverless/SKILL.md
+++ b/skills/core-skills/aws-serverless/SKILL.md
@@ -10,42 +10,47 @@ metadata:
 ---
 
 # AWS Serverless
-## Overview
 
-Domain expertise for building serverless applications on AWS. Covers Lambda configuration, API Gateway debugging, Step Functions orchestration, EventBridge patterns, event source mappings, concurrency tuning, cold start optimization, deployment with SAM/CDK, production readiness, and troubleshooting across all serverless services.
+Domain expertise for building serverless applications on AWS: Lambda, API Gateway, Step Functions, EventBridge, event source mappings, concurrency, cold starts, deployment, and troubleshooting.
 
-**Works best with** the [AWS MCP server](https://docs.aws.amazon.com/aws-mcp/) — enables running CLI commands, querying CloudWatch, and validating configurations directly. All guidance also works with standard AWS CLI access.
+**Works best with** the [AWS MCP server](https://docs.aws.amazon.com/aws-mcp/) — run CLI commands, query CloudWatch, validate configs directly. All guidance also works with standard AWS CLI access.
 
-**Note:** Reference files contain specific runtime versions, quota values, and feature matrices that may change. When precision matters (e.g., deploying to production, choosing a runtime, or checking a quota), confirm values against current AWS documentation rather than relying solely on the values in these files.
+## Specialized skills — check these first
 
-## Routing
+These cover capabilities and procedures the general references below do **not**. Several are specialized features or step-by-step tested procedures you would otherwise miss. Route to the matching skill before falling back to the references.
 
-| User need | Action |
-|-----------|--------|
-| Building a new serverless app | Read [architecture.md](references/architecture.md) for pattern selection, then [deployment.md](references/deployment.md) for SAM/CDK templates |
-| Debugging an error | Read [troubleshooting.md](references/troubleshooting.md) — starts with the 5 most common fixes |
-| Optimizing performance or cost | Read [lambda.md](references/lambda.md) for cold starts and memory tuning, [production.md](references/production.md) for readiness checklist |
-| Configuring event sources (SQS, DDB Streams, SNS) | Read [event-sources.md](references/event-sources.md) |
-| Step Functions, EventBridge, or orchestration | Read [orchestration.md](references/orchestration.md) |
-| Concurrency configuration | Read [concurrency.md](references/concurrency.md) |
-| API Gateway setup | Read [api-gateway.md](references/api-gateway.md) |
-| Common anti-patterns | Read the anti-patterns section in [production.md](references/production.md) |
-| Starting with Powertools | Use [powertools-handler.py](assets/powertools-handler.py) as a template |
-| Lambda Managed Instances, LMI, capacity providers, EC2-backed Lambda, PerExecutionEnvironmentMaxConcurrency | Use the **aws-lambda-managed-instances** skill instead |
-| Durable functions, durable execution, checkpoint-and-replay | Use the **aws-lambda-durable-functions** skill instead |
-| Firecracker microVMs, strong tenant isolation, sandboxed/untrusted code execution, long-lived sessions, suspend/resume, port-listening servers, snapshot-resumable compute | Use the **aws-lambda-microvms** skill instead |
-| Spans multiple areas | Read the most specific reference first, then consult others as needed |
+### Advanced Lambda compute (easy to overlook)
 
-## Files
+| Use this skill | When the workload involves |
+|---|---|
+| **aws-lambda-microvms** | Strong tenant isolation, sandboxed/untrusted code execution (AI agent code sandboxes, REPLs, notebooks, CI runners), long-lived sessions, suspend/resume with preserved state, port-listening servers (gRPC, WebSocket, custom TCP), Firecracker microVMs, snapshot-resumable compute, up to 8-hour lifetimes |
+| **aws-lambda-durable-functions** | Durable execution, checkpoint-and-replay, long-running multi-step workflows written as plain code (TS/Python/Java), automatic state persistence, saga pattern in code, human-in-the-loop callbacks, executions up to 1 year, `context.step`/`context.wait`/`context.invoke`, `withDurableExecution`, `durable-execution-sdk` |
+| **aws-lambda-managed-instances** | Lambda Managed Instances (LMI), capacity providers, EC2-backed Lambda, steady high-volume traffic (50M+ req/mo) wanting Savings Plans / Reserved Instance pricing, `PerExecutionEnvironmentMaxConcurrency`, `CapacityProviderConfig`, multi-concurrent execution environments |
 
-| File | Content |
-|------|---------|
-| [lambda.md](references/lambda.md) | Runtime, memory/CPU, cold starts, SnapStart, layers, containers |
-| [api-gateway.md](references/api-gateway.md) | REST vs HTTP API, stages, auth, throttling, mapping |
-| [event-sources.md](references/event-sources.md) | SQS, DDB Streams, SNS, S3, Kinesis triggers |
-| [orchestration.md](references/orchestration.md) | Step Functions, EventBridge rules/pipes/scheduler |
-| [concurrency.md](references/concurrency.md) | Reserved vs provisioned, scaling, ESM concurrency |
-| [architecture.md](references/architecture.md) | Patterns, reference architectures, service selection |
-| [deployment.md](references/deployment.md) | SAM/CDK resource types, globals, fast iteration |
-| [production.md](references/production.md) | Readiness checklist, observability, anti-patterns |
-| [troubleshooting.md](references/troubleshooting.md) | Error → cause → fix for all serverless services |
+### Step-by-step task procedures (tested CLI SOPs)
+
+| Use this skill | For the task |
+|---|---|
+| **connecting-lambda-to-api-gateway** | Wire an existing Lambda to a new REST/HTTP API: proxy integration, permissions, CORS, throttling, access logging, deployment |
+| **connecting-lambda-to-dynamodb** | Connect Lambda to DynamoDB: IAM execution role, read/write permissions, stream event source mapping |
+| **creating-api-gateway-stage** | Create an API Gateway stage with CloudWatch logging, X-Ray tracing, throttling, WAF association, and authorization |
+| **deploying-custom-domain-rest-api** | Deploy a Regional REST API with custom domain: ACM cert, Lambda backend, request authorizer, base path mapping, Route 53 DNS |
+| **debugging-lambda-timeouts** | Systematically diagnose a timing-out Lambda: config, CloudWatch logs/metrics, VPC, cold starts, memory, downstream calls |
+| **processing-s3-uploads-with-step-functions** | Deploy an event-driven workflow: S3 upload → EventBridge → Step Functions → Lambda (small files) or Fargate (large files), with VPC/ECR/ECS/IAM |
+
+## Routing (general references in this skill)
+
+| User need | Read |
+|-----------|------|
+| Building a new serverless app — pattern selection | [architecture.md](references/architecture.md) |
+| Lambda config, cold starts, SnapStart, memory, VPC, layers, Function URLs | [lambda.md](references/lambda.md) |
+| Concurrency (reserved, provisioned, ESM controls) | [concurrency.md](references/concurrency.md) |
+| Event sources (SQS, DynamoDB Streams, SNS, Kinesis), filtering, batch failures | [event-sources.md](references/event-sources.md) |
+| Step Functions, EventBridge rules/pipes/scheduler | [orchestration.md](references/orchestration.md) |
+| API Gateway quotas, authorizers, WebSocket | [api-gateway.md](references/api-gateway.md) |
+| SAM/CDK resource types and fast iteration | [deployment.md](references/deployment.md) |
+| Production readiness, observability, anti-patterns | [production.md](references/production.md) |
+| Debugging an error (exact string → cause → fix) | [troubleshooting.md](references/troubleshooting.md) |
+| Powertools handler template | [powertools-handler.py](assets/powertools-handler.py) |
+
+**Note:** Reference files contain specific runtime versions, quotas, and feature matrices that change. When precision matters (production, runtime choice, quotas), confirm against current AWS documentation. The references focus on values and gotchas that are easy to get wrong — not on basics.

--- a/skills/core-skills/aws-serverless/assets/powertools-handler.py
+++ b/skills/core-skills/aws-serverless/assets/powertools-handler.py
@@ -13,7 +13,8 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 
 logger = Logger()
 tracer = Tracer()
-metrics = Metrics()
+# Namespace is required (or set POWERTOOLS_METRICS_NAMESPACE); flushing without one raises SchemaValidationError.
+metrics = Metrics(namespace="MyApp")
 persistence = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
 
 # Idempotency key: "body" deduplicates identical payloads.

--- a/skills/core-skills/aws-serverless/references/api-gateway.md
+++ b/skills/core-skills/aws-serverless/references/api-gateway.md
@@ -1,21 +1,21 @@
 # API Gateway Reference
 
-Quick-reference for REST API, HTTP API, WebSocket API — debugging, configuration, and quotas.
+Exact quotas and the handful of gotchas worth pinning down. Assumes you know the basics: choose **REST API** when you need WAF / API keys / usage plans / request validation / built-in caching / edge-optimized / canary / VTL / resource policies, otherwise **HTTP API** (lower latency, native JWT, built-in CORS, auto-deploy); under Lambda **proxy** integration the **Lambda must return CORS headers** (the console "Enable CORS" button doesn't apply); the **#1 cause of 502** is a malformed proxy response (`body` must be a `JSON.stringify`'d string in the `{statusCode, headers, body}` shape); REST API has **no native generic JWT** (use Cognito or a Lambda authorizer), HTTP API has a **native JWT authorizer** for any OIDC IdP.
 
 ## Contents
 
-- [REST vs HTTP API Comparison](#rest-vs-http-api-comparison)
-- [CORS Debugging](#cors-debugging)
-- [Lambda Authorizers](#lambda-authorizers)
-- [Throttling and Quotas](#throttling-and-quotas)
+- [REST vs HTTP API comparison](#rest-vs-http-api-comparison)
+- [Integration timeouts and payloads](#integration-timeouts-and-payloads)
+- [Throttling and quotas](#throttling-and-quotas)
+- [Lambda authorizers](#lambda-authorizers)
 - [WebSocket APIs](#websocket-apis)
-- [502/504 Debugging](#502504-debugging)
+- [CORS gotchas](#cors-gotchas)
 
 ---
 
-## REST vs HTTP API Comparison
+## REST vs HTTP API comparison
 
-### Decision Tree
+Default to **HTTP API** (lower latency, lower cost, simpler); reach for **REST API** only when you need one of its exclusive features:
 
 ```
 Need any of these? → REST API
@@ -34,520 +34,100 @@ Need any of these? → REST API
 None of the above? → HTTP API (lower latency, simpler)
 ```
 
-### Feature Comparison
+---
 
-| Feature | REST API | HTTP API |
+## Integration timeouts and payloads
+
+| | REST API | HTTP API |
 |---|---|---|
-| **Latency** | Higher | Lower |
-| **Endpoint types** | Edge, Regional, Private | Regional only |
-| **AWS WAF** | Yes | No |
-| **API keys / usage plans** | Yes | No |
-| **Per-client throttling** | Yes | No |
-| **Request validation** | Yes | No |
-| **Body transformation (VTL)** | Yes | No |
-| **Parameter mapping** | Yes | Yes |
-| **Caching (built-in)** | Yes | No |
-| **Custom domains** | Yes | Yes |
-| **Lambda authorizers** | Yes (TOKEN + REQUEST) | Yes (REQUEST only) |
-| **JWT authorizers (native)** | No | Yes |
-| **IAM auth** | Yes | Yes |
-| **Cognito (native)** | Yes | Yes (via JWT) |
-| **Resource policies** | Yes | No |
-| **Mutual TLS** | Yes | Yes |
-| **CORS setup** | Manual OPTIONS method | Built-in config |
-| **Automatic deployments** | No | Yes |
-| **Canary deployments** | Yes | No |
-| **Custom gateway responses** | Yes | No |
-| **Execution logs** | Yes | No |
-| **Access logs (CloudWatch)** | Yes | Yes |
-| **Access logs (Firehose)** | Yes | No |
-| **X-Ray tracing** | Yes | No |
-| **Mock integrations** | Yes | No |
-| **Private integrations (NLB)** | Yes | Yes |
-| **Private integrations (ALB)** | Yes | Yes |
-| **Private integrations (Cloud Map)** | No | Yes |
-| **Response streaming** | Yes | No |
-| **Console test invocations** | Yes | No |
-| **Integration timeout** | 50ms–29s (configurable) | 30s hard max |
-| **Payload size** | 10 MB | 10 MB |
+| Integration timeout | 50ms–29s (default 29s; **raisable only for Regional/private**) | **30s hard max** (lowerable, not raisable) |
+| Payload size | 10 MB | 10 MB |
+| Endpoint types | Edge, Regional, Private | Regional only |
+| Response streaming | Yes (proxy, STREAM mode) | No |
 
-> **REST API streaming caveats:** Response streaming via REST API proxy integration does not support built-in caching, response transforms (VTL), or WAF inspection of streamed content. Idle timeouts apply, and a 2 MBps bandwidth cap applies after the first 10 MB (Function URLs apply the cap after 6 MB).
+> **REST API streaming caveats:** no built-in caching, no VTL transforms, no WAF inspection of streamed content; 2 MBps cap after the first 10 MB (Function URLs cap after 6 MB).
 
 ---
 
-## CORS Debugging
+## Throttling and quotas
 
-### Proxy vs Non-Proxy
+Throttling applies most-specific → least-specific: per-client/method (usage plan + API key, REST only) → per-method → account-level → AWS Regional (hard). Token bucket: empty bucket → `429 Too Many Requests`; burst allows temporary spikes.
 
-| Aspect | Proxy integration | Non-proxy integration |
-|---|---|---|
-| Who returns CORS headers? | **Your Lambda function** | **API Gateway** (method response) |
-| OPTIONS method needed? | Yes (or use mock) | Yes (mock integration) |
-| Where to configure? | In your code | In API Gateway console/IaC |
+### Account-level
 
-### Debugging Flowchart
-
-```
-"Cross-Origin Request Blocked"?
-│
-├─ YES → Which integration type?
-│  │
-│  ├─ PROXY → Lambda MUST return CORS headers
-│  │  ├─ Access-Control-Allow-Origin
-│  │  ├─ Access-Control-Allow-Methods
-│  │  └─ Access-Control-Allow-Headers
-│  │
-│  └─ NON-PROXY → Configure in API Gateway:
-│     ├─ Create OPTIONS method (mock integration)
-│     ├─ Add 200 response with CORS headers
-│     └─ Add CORS headers to actual method responses
-│
-├─ OPTIONS returning 200?
-│  ├─ NO  → OPTIONS method missing or misconfigured
-│  └─ YES → Check actual method response headers
-│
-└─ 502 on OPTIONS?
-   └─ Binary media types set to */* → fix below
-```
-
-### Common CORS Mistakes
-
-| # | Mistake | Fix |
-|---|---|---|
-| 1 | No CORS headers in Lambda (proxy integration) | Add headers to every Lambda response |
-| 2 | Missing OPTIONS method (REST API, non-proxy) | Create OPTIONS with mock integration |
-| 3 | Binary media types `*/*` breaks OPTIONS | Set `contentHandling: CONVERT_TO_TEXT` on OPTIONS |
-| 4 | `Allow-Origin: *` with `credentials: include` | Specify exact origin, not wildcard |
-| 5 | Not redeploying API after CORS changes | Redeploy the stage |
-| 6 | Missing `Allow-Headers` for custom headers | List all headers the client sends |
-| 7 | Gateway 4XX/5XX responses lack CORS headers | Add CORS headers to gateway responses |
-
-### Lambda CORS Headers — Python
-
-```python
-def handler(event, context):
-    return {
-        "statusCode": 200,
-        "headers": {
-            "Access-Control-Allow-Origin": "https://example.com",
-            "Access-Control-Allow-Methods": "OPTIONS,POST,GET,PUT,DELETE",
-            "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token",
-        },
-        "body": json.dumps({"message": "success"}),
-    }
-```
-
-### Lambda CORS Headers — TypeScript
-
-```typescript
-export const handler = async (event: any) => ({
-  statusCode: 200,
-  headers: {
-    "Access-Control-Allow-Origin": "https://example.com",
-    "Access-Control-Allow-Methods": "OPTIONS,POST,GET,PUT,DELETE",
-    "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token",
-  },
-  body: JSON.stringify({ message: "success" }),
-});
-```
-
-### Binary Media Types `*/*` Fix
+Confirm the current account-level steady-state RPS and burst limits for the Region rather than assuming a default — they vary by Region and are adjustable:
 
 ```bash
-# Fix OPTIONS integration request
-aws apigateway update-integration \
-  --rest-api-id API_ID --resource-id RES_ID \
-  --http-method OPTIONS \
-  --patch-operations op='replace',path='/contentHandling',value='CONVERT_TO_TEXT'
-
-# Fix OPTIONS integration response
-aws apigateway update-integration-response \
-  --rest-api-id API_ID --resource-id RES_ID \
-  --http-method OPTIONS --status-code 200 \
-  --patch-operations op='replace',path='/contentHandling',value='CONVERT_TO_TEXT'
+aws service-quotas get-service-quota --service-code apigateway --quota-code L-8A5B8E43
 ```
 
----
-
-## Lambda Authorizers
-
-### TOKEN vs REQUEST Authorizer
-
-| Feature | TOKEN | REQUEST |
-|---|---|---|
-| Identity source | Single header (bearer token) | Headers, query strings, stage vars, `$context` |
-| Cache key | Token header value | All specified identity sources |
-| Token validation regex | Yes | No |
-| Fine-grained policies | Limited | Yes (multiple sources) |
-| Available on | REST API only | REST API + HTTP API |
-| **Recommendation** | Legacy | **Preferred** |
-
-> **Use REQUEST authorizers for new APIs.** TOKEN is legacy.
-
-### Caching Behavior
-
-| Setting | Detail |
-|---|---|
-| Default TTL | 300 seconds |
-| Range | 0 (disabled) – 3600 seconds |
-| Cache key (TOKEN) | Header value from token source |
-| Cache key (REQUEST) | All specified identity sources combined |
-| **Critical** | Cached policy applies to **ALL methods/resources** |
-
-If any specified identity source is missing/null/empty → 401 returned **without** invoking Lambda.
-
-### REQUEST Authorizer — Python
-
-```python
-def lambda_handler(event, context):
-    token = event["headers"].get("Authorization", "")
-    is_authorized = verify_token(token)  # Your auth logic
-
-    return {
-        "principalId": "user",
-        "policyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-                "Action": "execute-api:Invoke",
-                "Effect": "Allow" if is_authorized else "Deny",
-                "Resource": event["methodArn"],
-            }],
-        },
-        "context": {"userId": "user", "scope": "read:items"},
-    }
-```
-
-### REQUEST Authorizer — TypeScript
-
-```typescript
-import { APIGatewayAuthorizerResult, APIGatewayRequestAuthorizerEvent } from "aws-lambda";
-
-export const handler = async (
-  event: APIGatewayRequestAuthorizerEvent
-): Promise<APIGatewayAuthorizerResult> => {
-  const token = event.headers?.Authorization ?? "";
-  const isAuthorized = verifyToken(token); // Your auth logic
-
-  return {
-    principalId: "user",
-    policyDocument: {
-      Version: "2012-10-17",
-      Statement: [{
-        Action: "execute-api:Invoke",
-        Effect: isAuthorized ? "Allow" : "Deny",
-        Resource: event.methodArn,
-      }],
-    },
-    context: { userId: "user", scope: "read:items" },
-  };
-};
-```
-
-### HTTP API JWT Authorizer (Native — No Lambda)
-
-No Lambda function needed. Configure directly on the API:
-
-```yaml
-# SAM / CloudFormation
-MyHttpApi:
-  Type: AWS::Serverless::HttpApi
-  Properties:
-    Auth:
-      DefaultAuthorizer: MyJwtAuth
-      Authorizers:
-        MyJwtAuth:
-          AuthorizationScopes:
-            - read:items
-          IdentitySource: $request.header.Authorization
-          JwtConfiguration:
-            issuer: https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc123
-            audience:
-              - my-client-id
-```
-
-Supports any OIDC-compliant IdP (Cognito, Auth0, Okta, etc.).
-
----
-
-## Throttling and Quotas
-
-### Throttling Hierarchy (Applied in Order)
-
-```
-Most specific → Least specific:
-
-1. Per-client / per-method  (usage plan + API key)   ← REST only
-2. Per-method               (stage method settings)
-3. Account-level            (all APIs in account/Region)
-4. AWS Regional             (hard limit, not changeable)
-```
-
-### Token Bucket Algorithm
-
-- Tokens added at steady-state rate (RPS)
-- Bucket holds up to burst capacity
-- Each request = 1 token
-- Empty bucket → `429 Too Many Requests`
-- Burst allows temporary spikes above steady-state
-
-### Account-Level Defaults
-
-| Quota | Default | Adjustable? |
-|---|---|---|
-| Steady-state RPS (per Region) | 10,000 | Yes |
-| Burst capacity | 5,000 | Set by AWS based on RPS |
-| Smaller Regions (Cape Town, Milan, Jakarta…) | 2,500 RPS / 1,250 burst | Yes |
-
-### REST API Quotas
+### REST API
 
 | Resource | Default | Adjustable? |
 |---|---|---|
-| Integration timeout | 50ms–29s (default 29s) | Yes (Regional/private only) |
-| Payload size | 10 MB | No |
-| Header value size | 10,240 bytes | No |
-| Cache TTL | 0–3600s | No |
 | Resources per API | 300 | Yes |
 | Stages per API | 10 | Yes |
 | API keys per account | 10,000 | No |
 | Usage plans per account | 300 | Yes |
 | Custom domains per Region | 120 | Yes |
+| Header value size | 10,240 bytes | No |
+| Cache TTL | 0–3600s | No |
 | Mapping template size | 300 KB | No |
 
-### HTTP API Quotas
+### HTTP API
 
 | Resource | Default | Adjustable? |
 |---|---|---|
-| Integration timeout | 30s max | No |
-| Payload size | 10 MB | No |
 | Routes per API | 300 | Yes |
 | Stages per API | 10 | Yes |
 | Integrations per API | 300 | No |
 | Custom domains per Region | 120 | Yes |
 | VPC links per Region | 10 | Yes |
 
-### Usage Plans (REST API Only)
+Client-side 429 handling: exponential backoff with jitter, respect `Retry-After`, rate-limit to stay under known limits.
 
-- Per-client rate limits (RPS) and burst limits via API keys
-- Daily/weekly/monthly quotas per key
-- Method-level throttling within a plan (e.g., `GET /pets` = 100 RPS)
+---
 
-### Client-Side 429 Handling
+## Lambda authorizers
 
-- Exponential backoff with jitter
-- Respect `Retry-After` header
-- Client-side rate limiting to stay under known limits
+| Feature | TOKEN | REQUEST |
+|---|---|---|
+| Identity source | Single header (bearer token) | Headers, query strings, stage vars, `$context` |
+| Cache key | Token header value | All specified identity sources combined |
+| Available on | REST API only | REST API + HTTP API |
+| Recommendation | Legacy | **Preferred for new APIs** |
+
+Caching: default TTL **300s** (range 0–3600). **A cached policy applies to ALL methods/resources.** If any specified identity source is missing/null/empty → **401 without invoking Lambda**.
+
+The authorizer must return an IAM policy: `{ principalId, policyDocument: { Version, Statement: [{ Action: "execute-api:Invoke", Effect: "Allow"|"Deny", Resource: methodArn }] }, context: {...} }`. HTTP API JWT authorizers need no Lambda — configure `issuer` + `audience` directly on the API.
 
 ---
 
 ## WebSocket APIs
 
-### Route Architecture
+Routes: `$connect` (auth, store connectionId), `$disconnect` (best-effort cleanup), `$default` (catch-all / non-JSON), plus custom routes selected by `$request.body.action`. Server pushes via the `@connections` API (`PostToConnectionCommand` / `post_to_connection`).
 
-```
-Client connects    → $connect    (auth, store connectionId)
-Client sends msg   → route selection → custom route or $default
-Server pushes data → @connections API (POST to connectionId)
-Client disconnects → $disconnect (cleanup connectionId)
-```
-
-### Route Selection
-
-- Expression: `$request.body.action` (routes on JSON `action` field)
-- Non-JSON messages → always `$default`
-
-### Predefined Routes
-
-| Route | When | Required? | Notes |
-|---|---|---|---|
-| `$connect` | Connection initiated | No | Auth here; connection pending until integration completes |
-| `$disconnect` | Connection closed | No | Best-effort; connection already closed |
-| `$default` | No matching route / non-JSON | No | Catch-all fallback |
-
-### Connection Management — Python
-
-```python
-import boto3, json
-
-dynamodb = boto3.resource("dynamodb")
-table = dynamodb.Table("WebSocketConnections")
-
-def connect_handler(event, context):
-    table.put_item(Item={"connectionId": event["requestContext"]["connectionId"]})
-    return {"statusCode": 200, "body": "Connected"}
-
-def send_to_client(endpoint_url, connection_id, data):
-    client = boto3.client("apigatewaymanagementapi", endpoint_url=endpoint_url)
-    client.post_to_connection(
-        ConnectionId=connection_id,
-        Data=json.dumps(data).encode("utf-8"),
-    )
-```
-
-### Connection Management — TypeScript
-
-```typescript
-import { ApiGatewayManagementApiClient, PostToConnectionCommand } from "@aws-sdk/client-apigatewaymanagementapi";
-
-async function sendToClient(endpoint: string, connectionId: string, data: object) {
-  const client = new ApiGatewayManagementApiClient({ endpoint });
-  await client.send(new PostToConnectionCommand({
-    ConnectionId: connectionId,
-    Data: Buffer.from(JSON.stringify(data)),
-  }));
-}
-```
-
-### WebSocket Quotas
-
-| Resource | Limit |
+| Limit | Value |
 |---|---|
 | Idle connection timeout | 10 minutes |
 | Max connection duration | 2 hours |
 | Message payload | 128 KB (hard limit) |
 
-### WebSocket Close Codes
+Close codes: **1001** idle/max-duration, 1003 unsupported binary, 1006 abnormal (no close frame), **1008** throttled, **1009** message too large, 1011 internal error, 1012 service restart.
 
-| Code | Meaning |
-|---|---|
-| 1001 | Idle timeout or max duration exceeded |
-| 1003 | Unsupported binary media type |
-| 1005 | No status code present (reserved, not sent on wire) |
-| 1006 | Abnormal closure — no close frame received |
-| 1008 | Throttled (too many requests) |
-| 1009 | Message exceeds size limit |
-| 1011 | Internal server error |
-| 1012 | Service restart |
+Store `connectionId` in DynamoDB with a **TTL attribute set to now + 7200s** (the 2-hour max duration) so stale connections are auto-cleaned even when `$disconnect` is missed — enable DynamoDB TTL on that attribute.
 
 ---
 
-## 502/504 Debugging
+## CORS gotchas
 
-### 502 Bad Gateway — Flowchart
+The common, non-obvious failures (basic header setup is well understood):
 
-```
-502 Bad Gateway
-│
-├─ Lambda proxy integration?
-│  └─ YES → Check response format (most common cause):
-│     ├─ statusCode: integer (string is coerced, missing defaults to 200)
-│     ├─ headers: object with string values
-│     ├─ body: string (JSON.stringify, not raw object)
-│     └─ Unhandled exception? → Check CloudWatch Logs
-│
-├─ Lambda authorizer?
-│  ├─ Must return valid IAM policy format
-│  ├─ Check authorizer Lambda logs
-│  └─ Authorizer timeout is separate from integration timeout
-│
-├─ HTTP integration?
-│  ├─ Backend reachable from API Gateway?
-│  ├─ Valid HTTP response from backend?
-│  └─ VPC link healthy? (private integration)
-│
-└─ Other causes:
-   ├─ Payload > 10 MB
-   ├─ Binary media types */* (breaks OPTIONS)
-   └─ Stage variable → wrong Lambda alias
-```
+| Mistake | Fix |
+|---|---|
+| Binary media types `*/*` break OPTIONS (502) | Set `contentHandling: CONVERT_TO_TEXT` on the OPTIONS integration |
+| `Allow-Origin: *` with `credentials: include` | Specify the exact origin, not a wildcard |
+| Not redeploying after CORS changes | Redeploy the stage |
+| Gateway 4XX/5XX responses lack CORS headers | Add CORS headers to gateway responses too |
 
-### Correct Lambda Response Format
-
-The **most common cause of 502** is an incorrect response format in Lambda proxy integrations.
-
-**Python — Correct:**
-
-```python
-def handler(event, context):
-    return {
-        "isBase64Encoded": False,           # boolean
-        "statusCode": 200,                  # integer, NOT string
-        "headers": {                        # object with string values
-            "Content-Type": "application/json",
-        },
-        "body": json.dumps({"key": "val"}) # MUST be string
-    }
-```
-
-**TypeScript — Correct:**
-
-```typescript
-export const handler = async (event: any) => ({
-  isBase64Encoded: false,
-  statusCode: 200,
-  headers: { "Content-Type": "application/json" },
-  body: JSON.stringify({ key: "val" }),  // MUST be string
-});
-```
-
-**Common mistakes -> 502:**
-
-```python
-return {"statusCode": 200, "body": {"key": "val"}}     # body not a string -> 502
-return "just a string"                                   # not a JSON object -> 502
-# Note: string statusCode ("200") and missing statusCode are silently handled (no 502)
-```
-
-### 504 Timeout — Flowchart
-
-```
-504 Endpoint Request Timed Out
-│
-├─ Step 1: Enable CloudWatch logging
-│  ├─ REST: execution logs + access logs
-│  ├─ HTTP: access logs only
-│  └─ Include: $context.integrationLatency, $context.integration.status
-│
-├─ Step 2: Identify timeout source
-│  ├─ REST API: integration timeout configurable 50ms–29s
-│  ├─ HTTP API: 30s max (can be lowered, cannot be raised)
-│  └─ Was integration invoked?
-│     ├─ NO  → Transient network failure; retry
-│     └─ YES → Backend too slow
-│
-├─ Step 3: Reduce integration runtime
-│  ├─ Move non-critical work to async (SQS, Step Functions)
-│  ├─ Increase Lambda memory (faster CPU)
-│  ├─ Provisioned concurrency (eliminate cold starts)
-│  └─ Check downstream dependencies (DB, external APIs)
-│
-└─ Step 4: Increase timeout (REST only)
-   ├─ Request via Service Quotas console
-   ├─ Update integration timeout value AND redeploy
-   └─ Note: may reduce account throttle quota
-```
-
-### CloudWatch Insights Queries
-
-**Find all 5xx errors:**
-
-```
-fields @timestamp, @message, @logStream
-| filter status >= 500 and status < 600
-| sort @timestamp desc
-| display @timestamp, httpMethod, resourcePath, status, requestId
-```
-
-**Find timeout errors:**
-
-```
-fields @timestamp, @message
-| filter @message like "Execution failed due to a timeout error"
-| sort @timestamp desc
-```
-
-**Find slow integrations (>10s):**
-
-```
-fields @timestamp, integrationLatency, status, resourcePath
-| filter integrationLatency > 10000
-| sort integrationLatency desc
-```
-
-### Automated Troubleshooting
-
-**AWSSupport-TroubleshootAPIGatewayHttpErrors** — Systems Manager runbook:
-
-- Validates API, resource, operation, and stage
-- Analyzes CloudWatch logs automatically
-- Requires: `apigateway:GET`, `logs:GetQueryResults`, `logs:StartQuery`, `ssm:*`
-- Available in Systems Manager console → Automation
+For the full step-by-step procedure of wiring CORS, throttling, and access logging when connecting a Lambda, use the **connecting-lambda-to-api-gateway** skill (see SKILL.md routing). For 502/504 deep debugging, see [troubleshooting.md](troubleshooting.md).

--- a/skills/core-skills/aws-serverless/references/architecture.md
+++ b/skills/core-skills/aws-serverless/references/architecture.md
@@ -1,262 +1,123 @@
 # Serverless Architecture Patterns
 
-Reference architectures, pattern selection flowcharts, and service selection tables for common serverless workloads.
+Pattern selection and the opinionated service defaults / constraints for each. The patterns themselves are standard — the value here is the default-vs-alternative choices and the non-obvious constraints.
 
-## Contents
+## Pattern selection
 
-- [Pattern selection flowchart](#pattern-selection-flowchart)
-- [REST/HTTP API pattern](#resthttp-api-pattern)
-- [Event processing pattern](#event-processing-pattern)
-- [Orchestration pattern](#orchestration-pattern)
-- [Real-time streaming pattern](#real-time-streaming-pattern)
-- [Async fan-out pattern](#async-fan-out-pattern)
-- [Scheduled jobs pattern](#scheduled-jobs-pattern)
-- [Choosing between patterns](#choosing-between-patterns)
+| What you're building | Pattern |
+|---|---|
+| Synchronous request/response API | REST/HTTP API → Lambda → DynamoDB |
+| Processing events from a queue/stream/database | Event processing (SQS/Streams → Lambda) |
+| Multi-step workflow with branching/error handling | Orchestration (Step Functions) |
+| Real-time bidirectional / LLM streaming | WebSocket API or Function URL streaming |
+| One event → multiple independent consumers | Async fan-out (EventBridge / SNS) |
+| Recurring task on a schedule | EventBridge Scheduler → Lambda / Step Functions |
 
----
-
-## Pattern selection flowchart
-
-```
-What are you building?
-│
-├── Synchronous request/response API?
-│   └── REST/HTTP API pattern
-│
-├── Processing events from a queue/stream/database?
-│   └── Event processing pattern
-│
-├── Multi-step workflow with branching/error handling?
-│   └── Orchestration pattern
-│
-├── Real-time bidirectional communication or LLM streaming?
-│   └── Real-time streaming pattern
-│
-├── One event triggers multiple independent consumers?
-│   └── Async fan-out pattern
-│
-└── Recurring task on a schedule?
-    └── Scheduled jobs pattern
-```
+Most real apps combine several. Start with one (a CRUD API on DynamoDB covers most initial needs); add event processing for async work, orchestration for multi-step workflows, fan-out for cross-service comms.
 
 ---
 
 ## REST/HTTP API pattern
 
-```
-Client → API Gateway (HTTP API) → Lambda → DynamoDB
-                                         → S3 (binary storage)
-```
-
-**When:** CRUD APIs, mobile/web backends, microservices.
-
-**Service selection:**
+CRUD APIs, mobile/web backends, microservices.
 
 | Decision | Default | Alternative |
 |---|---|---|
-| API type | HTTP API (simpler) | REST API if you need WAF, caching, request validation, API keys |
-| Auth | JWT authorizer (HTTP API native) | Cognito (REST: native Cognito authorizer; HTTP: JWT authorizer), Lambda authorizer (custom logic) |
-| Database | DynamoDB (on-demand) | RDS Proxy + RDS if relational data needed |
-| File storage | S3 with presigned URLs | Direct upload via API Gateway (10 MB limit) |
-| Function pattern | One function per route | Lambdalith if team prefers Express/FastAPI style |
+| API type | HTTP API (simpler) | REST API for WAF, caching, request validation, API keys |
+| Auth | JWT authorizer (HTTP API native) | Cognito (REST native), Lambda authorizer (custom logic) |
+| Database | DynamoDB (on-demand) | RDS Proxy + RDS for relational data |
+| File storage | S3 presigned URLs | Direct upload via API Gateway (10 MB limit) |
+| Function pattern | One function per route | Lambdalith for Express/FastAPI migrations |
 
-**Key constraints:**
-
-- HTTP API: 30s hard timeout, no WAF, no caching, 10 MB payload
-- REST API: 29s default timeout (adjustable for Regional/private APIs), 10 MB payload
+Constraints: HTTP API 30s hard timeout, no WAF/caching; REST API 29s default (adjustable for Regional/private). Both 10 MB payload.
 
 ---
 
 ## Event processing pattern
 
-```
-Event source → SQS → Lambda → DynamoDB / S3
-                ↓
-              DLQ (failed messages)
-```
-
-**When:** Async workloads, decoupled producers/consumers, batch processing, file processing.
-
-**Service selection:**
+Async workloads, decoupled producers/consumers, batch/file processing.
 
 | Decision | Default | Alternative |
 |---|---|---|
-| Buffer | SQS standard queue | SQS FIFO if ordering matters (10 msg batch limit) |
-| Trigger | SQS event source mapping | S3 event notification → Lambda (file uploads) |
-| Change data capture | DynamoDB Streams → Lambda | EventBridge Pipes → Lambda (no ESM needed) |
+| Buffer | SQS standard | SQS FIFO if ordering matters (10-msg batch) |
+| Trigger | SQS ESM | S3 event notification → Lambda (file uploads) |
+| Change data capture | DynamoDB Streams → Lambda | EventBridge Pipes → Lambda (no ESM) |
 | Stream ingestion | SQS (simpler) | Kinesis (ordered replay, multiple consumers, high-throughput) |
-| Error handling | SQS redrive policy (DLQ) | On-failure destination (SQS/SNS/S3) for streams |
-| Concurrency control | MaximumConcurrency on ESM | Reserved concurrency on function |
-| Batch processing | ReportBatchItemFailures | Powertools Batch Processor utility |
+| Error handling | SQS redrive policy (DLQ) | On-failure destination for streams |
+| Concurrency control | `MaximumConcurrency` on ESM | Reserved concurrency on function |
 
-**Key constraints:**
-
-- SQS visibility timeout ≥ 6× function timeout
-- MaximumConcurrency and Provisioned Mode are mutually exclusive on same ESM
-- Enable partial batch failure reporting to avoid reprocessing successful messages
-- SQS event filtering automatically deletes unmatched messages (permanently — not sent to DLQ)
-
-**S3 trigger constraints:**
-
-- Recursive invocation risk: never write output to the same bucket/prefix that triggers the function
-- No native DLQ on S3 notifications — use Lambda async invocation DLQ instead
-- Use prefix/suffix filtering to limit which objects trigger the function
-- Consider EventBridge for S3 instead of S3 notifications (richer filtering, multiple targets)
-
-**DynamoDB Streams constraints:**
-
-- Max 2 Lambda consumers per stream shard (use EventBridge Pipes for more)
-- 24-hour stream retention — records expire and cannot be replayed after that
-- Ordering guaranteed per partition key, not globally
+Constraints: SQS visibility ≥ 6× function timeout; `MaximumConcurrency` and Provisioned Mode mutually exclusive on one ESM; SQS filter drops unmatched messages permanently. **S3 triggers:** never write output to the triggering bucket/prefix (recursion); no native DLQ (use Lambda async DLQ); consider EventBridge for S3 (richer filtering). **DynamoDB Streams:** max 2 consumers/shard, 24h retention, ordering per partition key only.
 
 ---
 
 ## Orchestration pattern
 
-```
-Trigger → Step Functions → Lambda (validate)
-                         → Choice (route by status)
-                         → Parallel (fan-out)
-                         → Lambda (aggregate) → DynamoDB
-```
-
-**When:** Multi-step workflows, saga transactions, approval chains, data pipelines, AI agent loops.
-
-**Service selection:**
+Multi-step workflows, saga transactions, approval chains, data pipelines, AI agent loops.
 
 | Decision | Default | Alternative |
 |---|---|---|
-| Workflow type | Standard (exactly-once, up to 1 year) | Express (<5 min, high-volume; async=at-least-once, sync=at-most-once) |
-| Simple data transforms | JSONata (inline, no Lambda needed) | Lambda task (complex logic) |
+| Workflow type | Standard (exactly-once, ≤ 1 year) | Express (< 5 min, high-volume) |
+| Simple transforms | JSONata (inline, no Lambda) | Lambda task (complex logic) |
 | Service calls | Direct SDK integration (200+ services) | Lambda intermediary (only if business logic needed) |
-| Human approval | .waitForTaskToken | Lambda durable functions waitForCallback |
+| Human approval | `.waitForTaskToken` | Lambda durable functions `waitForCallback` |
 | AI agent loops | Step Functions + Bedrock | Lambda durable functions (code-first, checkpointed) |
-| Error handling | Retry + Catch in ASL | Lambda durable functions try/catch in code |
 
-**Key constraints:**
-
-- 256 KB payload limit between states — use S3 for large data
-- Express: no .sync, no .waitForTaskToken, no Distributed Map, no Activities
-- 25,000 execution history entries (Standard) — split long workflows into child executions
-- Prefer direct SDK integrations over Lambda intermediary functions to reduce latency
+Constraints: 256 KiB between states (use S3 for large data); Express lacks `.sync`/`.waitForTaskToken`/Distributed Map/Activities; 25,000 history entries (Standard). See [orchestration.md](orchestration.md).
 
 ---
 
 ## Real-time streaming pattern
 
-```
-Client ←→ API Gateway WebSocket ←→ Lambda → DynamoDB (connections)
-                                          → Bedrock (LLM responses)
-```
-
-Or for LLM token streaming:
-
-```
-Client → Lambda Function URL (streaming) → Bedrock ConverseStream
-```
-
-**When:** Chat apps, live dashboards, notifications, LLM token streaming, multiplayer games.
-
-**Service selection:**
+Chat, live dashboards, notifications, LLM token streaming, multiplayer.
 
 | Decision | Default | Alternative |
 |---|---|---|
 | Bidirectional | API Gateway WebSocket | AppSync subscriptions (GraphQL) |
 | LLM streaming | Lambda Function URL + ConverseStream | REST API proxy with STREAM mode |
-| Connection state | DynamoDB (connectionId → metadata, enable TTL to clean up stale connections after 2-hour max duration) | ElastiCache (higher throughput) |
-| Auth | $connect route authorizer | Cognito + custom auth in Lambda |
+| Connection state | DynamoDB (connectionId → metadata, TTL to clean up after 2h max) | ElastiCache (higher throughput) |
+| Auth | `$connect` route authorizer | Cognito + custom auth in Lambda |
 
-**Key constraints:**
-
-- WebSocket: 10 min idle timeout, 2 hour max connection, 128 KB message (hard limit)
-- Function URL streaming: 200 MB limit, 2 MBps after first 6 MB, Node.js native support
-- Function URLs **MUST** use `AWS_IAM` auth type. For CloudFront integration, use Origin Access Control (OAC) to sign requests — do not set auth to `NONE`. If `NONE` is unavoidable for other reasons, authentication **MUST** be enforced at the edge (e.g., CloudFront + Lambda@Edge). No native JWT/Cognito support.
+Constraints: WebSocket 10-min idle / 2-hour max / 128 KB message; Function URL streaming 200 MB, 2 MBps after first 6 MB, Node.js native. **For streaming behind CloudFront, Function URLs should use `AWS_IAM` auth** — use Origin Access Control to sign requests rather than setting auth to `NONE`; if `NONE` is unavoidable, enforce auth at the edge (CloudFront + Lambda@Edge). (For a deliberately public, browser-reachable URL with no edge in front, `NONE` is the intended auth type — see [Function URLs in lambda.md](lambda.md#function-urls) for the required permissions.)
 
 ---
 
 ## Async fan-out pattern
 
-```
-Producer → EventBridge → Rule A → Lambda (process)
-                       → Rule B → Step Functions (workflow)
-                       → Rule C → SQS → Lambda (batch)
-```
-
-**When:** One event triggers multiple independent actions, event-driven microservices, cross-service communication.
-
-**Service selection:**
+One event → multiple independent actions; event-driven microservices.
 
 | Decision | Default | Alternative |
 |---|---|---|
 | Event router | EventBridge (content-based routing) | SNS (simpler fan-out, attribute/body filtering) |
-| Point-to-point | EventBridge Pipes (source→target, no Lambda intermediary) | SQS → Lambda ESM |
-| Schema management | EventBridge Schema Registry + Discovery | Manual schema documentation |
+| Point-to-point | EventBridge Pipes (no Lambda glue) | SQS → Lambda ESM |
+| Schema management | EventBridge Schema Registry + Discovery | Manual docs |
 | Cross-account | EventBridge cross-account rules | SNS cross-account subscriptions |
-| Scheduling | EventBridge Scheduler (cron/rate) | EventBridge rules (simpler but less flexible) |
+| Scheduling | EventBridge Scheduler (cron/rate) | EventBridge rules with schedule expression |
 
-**Key constraints:**
-
-- Use dedicated event bus per application domain (not the default bus)
-- EventBridge Pipes eliminates Lambda intermediary functions for source→target integrations
-- Be precise with event patterns — overly broad patterns risk loops
-- Configure DLQs on all targets
+Constraints: dedicated event bus per domain (not the default bus); be precise with patterns (broad patterns risk loops); DLQs on all targets.
 
 ---
 
 ## Scheduled jobs pattern
 
-```
-EventBridge Scheduler → Lambda (task)
-                      → Step Functions (complex workflow)
-```
-
-**When:** Cron jobs, periodic data sync, report generation, cleanup tasks.
-
-**Service selection:**
+Cron jobs, periodic sync, report generation, cleanup.
 
 | Decision | Default | Alternative |
 |---|---|---|
-| Scheduler | EventBridge Scheduler (flexible, one-time + recurring) | EventBridge rules with schedule expression (simpler) |
-| Short task (<15 min) | Lambda directly | — |
-| Long task (>15 min) | Step Functions (up to 1 year) | Lambda durable functions |
-| High frequency (<1 min) | Not supported natively | SQS delay queue + Lambda |
+| Scheduler | EventBridge Scheduler (flexible, one-time + recurring) | EventBridge rules schedule expression (simpler) |
+| Short task (< 15 min) | Lambda directly | — |
+| Long task (> 15 min) | Step Functions (≤ 1 year) | Lambda durable functions |
+| High frequency (< 1 min) | Not supported natively | SQS delay queue + Lambda |
 
-**Key constraints:**
-
-- Minimum schedule interval: 1 minute
-- Lambda max timeout: 15 minutes — use Step Functions for longer
-- Always make scheduled Lambda idempotent (scheduler guarantees at-least-once)
-- Use EventBridge Scheduler over EventBridge rules for new projects (more features, flexible time windows)
+Constraints: minimum interval 1 minute; always make scheduled Lambdas idempotent (at-least-once); prefer EventBridge Scheduler over rules for new projects (flexible time windows).
 
 ---
 
-## Choosing between patterns
+## Common combinations
 
-Most real applications combine multiple patterns:
-
-```
-                    ┌─ HTTP API ─── Lambda ─── DynamoDB
-Client ─── CloudFront ─┤
-                    └─ WebSocket ── Lambda ─── DynamoDB
-                                      │
-                                      ▼
-                              EventBridge
-                              ┌────┼────┐
-                              ▼    ▼    ▼
-                            SQS  SFN  Lambda
-                              │    │
-                              ▼    ▼
-                           Lambda  Bedrock
-```
-
-**Common combinations:**
-
-| Application | Patterns used |
+| Application | Patterns |
 |---|---|
 | SaaS API backend | REST API + Event processing + Scheduled jobs |
 | E-commerce | REST API + Orchestration (order saga) + Fan-out (notifications) |
 | Data pipeline | Scheduled jobs + Event processing + Orchestration |
 | AI chatbot | Real-time streaming + Orchestration (agent loop) |
 | IoT processing | Event processing + Fan-out + Scheduled jobs (aggregation) |
-
-**Begin with a single pattern and add more as requirements grow.** A CRUD API with DynamoDB covers most initial implementations. Add event processing when you need async work. Add orchestration when you need multi-step workflows. Add fan-out when you need cross-service communication.

--- a/skills/core-skills/aws-serverless/references/concurrency.md
+++ b/skills/core-skills/aws-serverless/references/concurrency.md
@@ -1,200 +1,86 @@
 # Lambda Concurrency Controls
 
-Four concurrency controls operate at different levels, solve different problems, and have complex interactions.
-
-## Contents
-
-- [The 4 concurrency types](#the-4-concurrency-types)
-- [Interaction matrix](#interaction-matrix)
-- [Decision scenarios](#decision-scenarios)
-- [Account limits and scaling](#account-limits-and-scaling)
-- [Common mistakes](#common-mistakes)
-- [SnapStart interaction](#snapstart-interaction)
-- [SAM/CDK examples](#samcdk-property-reference)
-
----
+Four concurrency controls operate at different levels with non-obvious interactions. The exact numbers and mutual-exclusivity rules below are the part that's easy to get wrong.
 
 ## The 4 concurrency types
 
-### 1. Reserved Concurrency
-Sets the **maximum** concurrent instances for a function and **reserves** that capacity from the account pool so no other function can consume it.
+1. **Reserved Concurrency** (scope: function) — sets the **max** concurrent instances AND reserves that capacity from the account pool. Setting to **0** fully throttles the function (emergency shutoff). Use to protect critical functions, cap to protect downstream, or kill-switch.
 
-- **Scope:** Function.
-- Reserve 400 → function always gets up to 400, never more. Others share the rest.
-- Setting to **0** completely throttles the function (emergency shutoff).
-- Use for: protecting critical functions, capping to protect downstream, emergency shutoff.
+2. **Provisioned Concurrency** (scope: published version or alias — **NOT `$LATEST`**) — pre-initializes environments so they're ready before requests arrive. Spills to on-demand (with cold starts) beyond the provisioned count. Combine with Application Auto Scaling (~70% target). Paid even when idle.
 
-### 2. Provisioned Concurrency
-Pre-initializes execution environments so they are **ready before requests arrive**.
+3. **Maximum Concurrency** (scope: per SQS ESM, range **2–1,000**) — caps how many concurrent instances one SQS ESM can invoke. Does **not** reserve anything; other triggers can still consume function concurrency.
 
-- **Scope:** Published version or alias (**NOT** `$LATEST`).
-- **Allocation rate:** Up to 6,000 environments per minute when provisioning.
-- Configure 100 on alias `PROD` → first 100 concurrent requests get sub-10ms startup.
-  Request 101+ spills to on-demand with cold starts.
-- **Account-level RPS quota**: RPS = 10 × account concurrency. For example, 1,000 account concurrency → 10,000 RPS cap across all functions. This is an account-level quota, not a per-instance throughput cap. Per-instance throughput = 1 / function duration.
-- Combine with **Application Auto Scaling** (target ~70% utilization).
-- Use for: user-facing APIs, functions with heavy init (ML models, DB pools).
+4. **Provisioned Mode — ESM** (SQS and Kafka/MSK) — allocates dedicated event pollers for an SQS/Kafka ESM with configurable min/max. Per-poller capacity is an **OR** envelope and differs by source: **SQS = 1 MB/s or 10 concurrent invokes**; **Kafka/MSK = 5 MB/s or 5 concurrent invokes**. Use for high-throughput or spiky traffic where standard ramp-up (5 → +300/min) is too slow.
 
-### 3. Maximum Concurrency
-Limits how many concurrent instances a **specific SQS event source mapping (ESM)** can invoke.
+## Key numbers and interactions
 
-- **Scope:** Per ESM. **Range:** 2–1,000. **Sources:** SQS only.
-- Does **not** reserve anything — other triggers can still consume function concurrency.
-- Use for: multiple SQS queues on one function, rate-limiting a specific queue.
-
-### 4. Provisioned Mode — ESM (Kafka 2024, SQS 2025)
-Allocates **dedicated event pollers** for an SQS or Kafka ESM with configurable min/max.
-
-- **Scope:** Per ESM.
-- Standard mode: ~5 pollers, +300/min, max 1,250 invokes. Provisioned mode: you control
-  min/max pollers. Each handles up to 1 MB/s, 10 concurrent invokes.
-- Use for: high-throughput SQS/Kafka, spiky traffic where standard ramp-up is too slow.
-
----
-
-## Interaction matrix
+- **Account RPS quota = 10 × account concurrency** (e.g. 1,000 concurrency → 10,000 RPS, across all functions). This is an account quota, not a per-instance cap. Per-instance throughput = 1 / function duration.
+- **Max reservable = account limit − 100.** Lambda always keeps 100 unreserved.
+- **Scaling rate: 1,000 new environments / 10s, per function**
+- Provisioned ≤ Reserved when both are set (reserved is the ceiling).
+- Provisioned counts against the account limit even when idle — monitor `ClaimedAccountConcurrency`.
 
 | Combination | OK? | Notes |
 |-------------|:---:|-------|
 | Reserved + Provisioned | Yes | Provisioned ≤ Reserved |
-| Reserved + Max Concurrency (ESM) | Yes | Reserved ≥ Σ(max concurrency across ESMs) |
-| Reserved + Provisioned Mode (ESM) | Yes | Independent layers |
-| Provisioned + Max Concurrency (ESM) | Yes | Different layers |
-| Provisioned + Provisioned Mode (ESM) | Yes | Warms envs vs warms pollers |
-| **Max Concurrency + Provisioned Mode (same ESM)** | No | **Mutually exclusive** |
-| **Provisioned Concurrency + SnapStart** | No | **Mutually exclusive** |
+| Reserved + Maximum Concurrency (ESM) | Yes | Reserved ≥ Σ(Maximum Concurrency across ESMs) |
+| Provisioned + Maximum Concurrency / Provisioned Mode (ESM) | Yes | Different layers |
+| **Maximum Concurrency + Provisioned Mode (same ESM)** | **No** | **Mutually exclusive** |
+| **Provisioned Concurrency + SnapStart** | **No** | **Mutually exclusive** |
 
-**Key rules:** Account limit is the hard ceiling. Reserved carves from the pool — Lambda
-always keeps **100 unreserved**. Provisioned ≤ Reserved when both set. Max Concurrency is
-advisory to the ESM, not the function.
+**At the limit:** Sync → 429. Async → retries up to 6h then DLQ. Streams → polling throttled, messages stay in source.
 
-```
-┌──────────────────────────────────────────────────────┐
-│  ACCOUNT: 1,000 concurrency                          │
-│  ┌─────────────────┐  ┌───────────────────────────┐  │
-│  │ RESERVED (400)   │  │ UNRESERVED POOL (600)     │  │
-│  │ ┌─────────────┐  │  │ Shared by all others      │  │
-│  │ │PROVISIONED  │  │  │ Must keep ≥100 always     │  │
-│  │ │(200 warm)   │  │  └───────────────────────────┘  │
-│  │ └─────────────┘  │                                 │
-│  │ + 200 on-demand  │  ESM LAYER (per mapping):       │
-│  └─────────────────┘  Max Concurrency — OR —          │
-│                        Provisioned Mode (not both)     │
-└──────────────────────────────────────────────────────┘
-```
-
----
-
-## Decision scenarios
-
-| Scenario | Reserved | Provisioned | Max Conc (ESM) | Prov Mode (ESM) |
-|----------|:--------:|:-----------:|:--------------:|:---------------:|
-| Protect critical API from starvation | Yes | — | — | — |
-| Cap function to protect downstream DB | Yes | — | — | — |
-| Eliminate cold starts for user-facing API | Optional | Yes | — | — |
-| Multiple SQS queues, prevent hogging | Yes | — | Yes | — |
-| High-throughput SQS, low-latency | Optional | Optional | — | Yes |
-| Kafka ESM with spiky traffic | — | — | — | Yes |
-| Predictable daily traffic | — | Yes+AutoScale | — | — |
-| Emergency shutoff | Yes (=0) | — | — | — |
-| Java/.NET heavy init | — | Yes or SnapStart | — | — |
-
-**A — Checkout API:** Reserved=200 + Provisioned=150 + Auto Scaling for peak.
-**B — 3 SQS queues → 1 function:** Reserved=300, Max Concurrency=100 per ESM.
-**C — Kafka stream (spiky):** Provisioned Mode min=5, max=50 pollers.
-**D — Batch job:** Reserved=50, no provisioned.
-
----
-
-## Account limits and scaling
-
-| Quota | Default | Adjustable? |
-|-------|---------|:-----------:|
-| Account concurrency | 1,000 / Region | Yes |
-| Reservable concurrency | Account − 100 | Scales |
-| RPS limit | 10 × concurrency | Scales |
-| Scaling rate | 1,000 envs / 10s / function | No |
-
-Scaling is per-function, continuously refilled, unused capacity does not accumulate.
-~50 seconds to reach 5,000 concurrency from zero.
-
-**At the limit:** Sync → 429. Async → retries up to 6h then DLQ. Streams → polling
-throttled, messages stay in source.
-
-**RPS constraint:** A 50ms function at 20,000 RPS needs only 1,000 concurrency but the RPS
-limit (10×1,000=10,000) throttles it. Request account concurrency = 2,000.
+**RPS gotcha:** a 50ms function at 20,000 RPS needs only 1,000 concurrency, but the RPS limit (10×1,000 = 10,000) throttles it. Request account concurrency = 2,000.
 
 ```bash
 aws service-quotas request-service-quota-increase \
   --service-code lambda --quota-code L-B99A9384 --desired-value 5000
 ```
 
----
+## Decision scenarios
+
+| Scenario | Reserved | Provisioned | Maximum Concurrency (ESM) | Prov Mode (ESM) |
+|----------|:--------:|:-----------:|:--------------:|:---------------:|
+| Protect critical API / cap downstream | Yes | — | — | — |
+| Eliminate cold starts (user-facing API) | Optional | Yes | — | — |
+| Multiple SQS queues, prevent hogging | Yes | — | Yes | — |
+| High-throughput SQS, low-latency | Optional | Optional | — | Yes |
+| Kafka/SQS ESM with spiky traffic | — | — | — | Yes |
+| Predictable daily traffic | — | Yes + AutoScale | — | — |
+| Emergency shutoff | Yes (=0) | — | — | — |
 
 ## Common mistakes
 
-1. **Reserved set to 0** — Blocks ALL invocations (429 TooManyRequestsException). Sometimes
-   set during an incident and not restored. If a function is throttled at low traffic, check
-   this first.
+1. **Reserved = 0 left over from an incident** — blocks ALL invocations (429). If a function throttles at low traffic, check this first.
+2. **Reserved too low** — reserve 50, need 80 → throttled at 51 even with spare account capacity.
+3. **Starving other functions** — reserved is subtracted even when unused; be conservative.
+4. **Provisioned without auto scaling** — paying for idle off-peak, spilling on-peak.
+5. **Provisioned on `$LATEST`** — doesn't work; publish a version, create an alias.
+6. **Maximum Concurrency > reserved** — ESM tries 100, function caps at 50. Ensure reserved ≥ Σ(Maximum Concurrency).
+7. **Confusing ESM Maximum Concurrency with reserved** — Maximum Concurrency reserves nothing; API Gateway can still consume all concurrency.
+8. **Forgetting the 100-unit buffer** — max reservable = account limit − 100.
 
-2. **Reserved too low** — Reserve 50, need 80 → throttled at 51 even with spare account
-   capacity. Fix: monitor `ConcurrentExecutions`, set above peak + buffer.
+## SnapStart vs Provisioned Concurrency
 
-3. **Starving other functions** — Reserve 800/1,000 → others share 200. Reserved is
-   subtracted even when unused. Fix: be conservative.
-
-4. **Provisioned without auto scaling** — Paying for idle envs off-peak, spilling on-peak.
-   Fix: Auto Scaling targeting ~70% `ProvisionedConcurrencyUtilization`.
-
-5. **Provisioned on `$LATEST`** — Doesn't work. Fix: publish a version, create an alias.
-
-6. **Max concurrency > reserved** — ESM tries 100, function caps at 50. Fix: ensure
-   `reserved ≥ Σ(max concurrency across ESMs)`.
-
-7. **Confusing ESM max with reserved** — Max concurrency doesn't reserve anything. API
-   Gateway can still consume all concurrency. Fix: use reserved on the function.
-
-8. **Both ESM controls on same ESM** — Mutually exclusive; API rejects it. Fix: choose one.
-
-9. **Forgetting 100-unit buffer** — Max reservable = account limit − 100.
-
-10. **Not tracking ClaimedAccountConcurrency** — Provisioned counts against account limit
-   even when idle. Monitor the metric.
-
----
-
-## SnapStart interaction
-
-| Aspect | SnapStart | Provisioned Concurrency |
-|--------|-----------|------------------------|
-| Cold start | Seconds → sub-second | Seconds → ~0 |
-| Runtimes | Java 11+, Python 3.12+, .NET 8+ | All |
-| Scales with traffic | Yes (snapshot restore) | Only up to provisioned count |
-
-> **SnapStart and Provisioned Concurrency are mutually exclusive on the same function.**
+> **Mutually exclusive on the same function.**
 
 ```
-Is runtime Java 11+, Python 3.12+, or .NET 8+?
+Runtime Java 11+ / Python 3.12+ / .NET 8+
 ├─ No  → Provisioned Concurrency
 └─ Yes
    ├─ Need guaranteed <50ms on EVERY request? → Provisioned Concurrency
    ├─ Need EFS or >512MB ephemeral storage?   → Provisioned Concurrency
-   └─ Otherwise → SnapStart first; if P99 still too high, switch to Provisioned Concurrency (they cannot coexist)
+   └─ Otherwise → SnapStart first; if P99 still too high, switch (they cannot coexist)
 ```
-
-Limitations: no EFS, no >512MB ephemeral, no container images, must handle uniqueness,
-re-validate network connections on restore.
-
----
 
 ## SAM/CDK property reference
 
-| Concurrency type | SAM property | CDK property |
+| Type | SAM | CDK |
 |---|---|---|
-| Reserved | `ReservedConcurrentExecutions: 100` | `reservedConcurrentExecutions: 100` |
-| Provisioned | `AutoPublishAlias: live` + `ProvisionedConcurrencyConfig.ProvisionedConcurrentExecutions: 50` | `new lambda.Alias({ provisionedConcurrentExecutions: 50 })` — must use alias, not `$LATEST` |
-| Maximum Concurrency (ESM) | `ScalingConfig.MaximumConcurrency: 50` | `maxConcurrency: 50` on `EventSourceMapping` |
-| Provisioned Mode (ESM) | `ProvisionedPollerConfig.MinimumPollers` / `MaximumPollers` | `provisionedPollerConfig: { minimumPollers, maximumPollers }` on `EventSourceMapping` |
+| Reserved | `ReservedConcurrentExecutions` | `reservedConcurrentExecutions` |
+| Provisioned | `AutoPublishAlias` + `ProvisionedConcurrencyConfig.ProvisionedConcurrentExecutions` | `new lambda.Alias({ provisionedConcurrentExecutions })` (alias, not `$LATEST`) |
+| Maximum Concurrency (ESM) | `ScalingConfig.MaximumConcurrency` | `maxConcurrency` on `EventSourceMapping` |
+| Provisioned Mode (ESM) | `ProvisionedPollerConfig.MinimumPollers` / `MaximumPollers` | `provisionedPollerConfig: { minimumPollers, maximumPollers }` |
 | SnapStart | `SnapStart.ApplyOn: PublishedVersions` + `AutoPublishAlias` | `snapStart: lambda.SnapStartConf.ON_PUBLISHED_VERSIONS` |
 
-Auto scaling for Provisioned Concurrency: `alias.addAutoScaling({ minCapacity, maxCapacity })` then `scaling.scaleOnUtilization({ utilizationTarget: 0.7 })`.
+Auto scaling: `alias.addAutoScaling({ minCapacity, maxCapacity })` then `scaling.scaleOnUtilization({ utilizationTarget: 0.7 })`.

--- a/skills/core-skills/aws-serverless/references/deployment.md
+++ b/skills/core-skills/aws-serverless/references/deployment.md
@@ -1,6 +1,6 @@
 # Deployment Reference
 
-Serverless-specific deployment patterns, resource types, and fast iteration tools.
+Serverless-specific resource types and fast-iteration tools. For step-by-step deployment procedures (custom domain REST API, API Gateway stages, connecting Lambda to API Gateway/DynamoDB), use the specialized skills in SKILL.md's routing table.
 
 ## Contents
 

--- a/skills/core-skills/aws-serverless/references/event-sources.md
+++ b/skills/core-skills/aws-serverless/references/event-sources.md
@@ -1,484 +1,165 @@
 # Lambda Event Sources Reference
 
-Quick reference for Lambda event source mappings (ESMs), direct triggers, filtering, and error handling.
+Event source mapping (ESM) config parameters, scaling numbers, and filtering gotchas. Assumes you know the basics (SNS pushes asynchronously and is a direct trigger not an ESM; `ReportBatchItemFailures` returns `{batchItemFailures: [{itemIdentifier}]}`; unmatched SQS filter messages are permanently deleted; SQS visibility timeout ≥ 6× function timeout) — this file focuses on the exact values and edge cases.
 
 ## Contents
 
 - [SQS event source mapping](#sqs-event-source-mapping)
 - [DynamoDB Streams triggers](#dynamodb-streams-triggers)
-- [SNS subscriptions](#sns-subscriptions)
 - [Event filtering](#event-filtering)
 - [Partial batch failure reporting](#partial-batch-failure-reporting)
-- [Error handling strategies](#error-handling-strategies)
+- [Error handling and concurrency](#error-handling-and-concurrency)
 
 ---
 
 ## SQS event source mapping
 
-Lambda polls SQS using long polling and invokes your function **synchronously** with a batch of messages.
-
-### Configuration parameters
+Lambda long-polls SQS and invokes your function **synchronously** with a batch.
 
 | Parameter | Default | Range / Notes |
 |-----------|---------|---------------|
 | `BatchSize` | 10 | Standard: max 10,000. FIFO: max 10 |
-| `MaximumBatchingWindowInSeconds` | 0 | 0–300. Not supported for FIFO. Requires ≥ 1s when BatchSize > 10 |
-| `MaximumConcurrency` | — | 2–1,000. Per-ESM concurrency cap |
+| `MaximumBatchingWindowInSeconds` | 0 | 0–300. Not for FIFO. Requires ≥ 1s when BatchSize > 10 |
+| `MaximumConcurrency` | — | 2–1,000. Per-ESM cap |
 | `ProvisionedPollerConfig.MinimumPollers` | 2 | 2–200 |
-| `ProvisionedPollerConfig.MaximumPollers` | 200 | 2–2,000 |
+| `ProvisionedPollerConfig.MaximumPollers` | 200 | 1–2,000 |
 | `FilterCriteria` | — | Filters on `body` key only |
 | `FunctionResponseTypes` | — | Set to `ReportBatchItemFailures` |
 
-> **MaximumConcurrency and Provisioned Mode are mutually exclusive.** You cannot set both on the same ESM.
+> **MaximumConcurrency and Provisioned Mode are mutually exclusive** on the same ESM.
 
-### Batching behavior
+Lambda invokes when **any** of: batching window expires, batch size reached, or payload hits 6 MB.
 
-Lambda invokes when **any** condition is met:
+### Scaling
 
-1. Batching window expires
-2. Batch size reached
-3. Payload reaches 6 MB
+**Standard queues:** concurrency **starts at 5** concurrent invocations and scales up by **~300 per minute** to a **default maximum of 1,250** — so a sudden burst (e.g. a backlog of 10,000 messages) is not absorbed immediately; it takes several minutes to ramp. For high scale-out or high-throughput workloads, use **Provisioned Mode**, which starts higher, ramps significantly faster, and reaches a much larger ceiling. The 1,250 default is also bounded by account concurrency; confirm current account limits with `aws service-quotas get-service-quota --service-code lambda`.
 
-### Scaling behavior
-
-**Standard queues:**
-
-- Starts with **5** concurrent invocations
-- Scales up by **300/min**
-- Default maximum: **1,250** concurrent invocations
-- Provisioned mode: up to **20,000** (scales 3× faster at 1,000/min)
-
-**FIFO queues:**
-
-- Concurrency capped by the **lower** of: number of message group IDs or `MaximumConcurrency`
-- Messages delivered in order per message group ID
-
-### Error handling
-
-- Use the **SQS redrive policy** (native dead-letter queue (DLQ) on the queue) — not an ESM-level DLQ
-- Set visibility timeout to **≥ 6× function timeout** to prevent premature retry
-- On function error, entire batch becomes visible again after visibility timeout
-- On throttle, Lambda backs off; messages reappear after visibility timeout
-
-### SAM template
+**FIFO queues:** concurrency capped by the **lower** of (number of message group IDs, `MaximumConcurrency`); order preserved per group ID.
 
 ```yaml
-MyFunction:
-  Type: AWS::Serverless::Function
-  Properties:
-    Handler: index.handler
-    Runtime: nodejs22.x
-    Events:
-      SQSEvent:
-        Type: SQS
-        Properties:
-          Queue: !GetAtt MyQueue.Arn
-          BatchSize: 10
-          MaximumBatchingWindowInSeconds: 5
-          FunctionResponseTypes:
-            - ReportBatchItemFailures
-          ScalingConfig:
-            MaximumConcurrency: 50
-          FilterCriteria:
-            Filters:
-              - Pattern: '{"body": {"status": ["PENDING"]}}'
+# SAM
+Events:
+  SQSEvent:
+    Type: SQS
+    Properties:
+      Queue: !GetAtt MyQueue.Arn
+      BatchSize: 10
+      MaximumBatchingWindowInSeconds: 5
+      FunctionResponseTypes: [ReportBatchItemFailures]
+      ScalingConfig:
+        MaximumConcurrency: 50
+      FilterCriteria:
+        Filters:
+          - Pattern: '{"body": {"status": ["PENDING"]}}'
 ```
 
-### CDK example
-
-```typescript
-import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
-import * as sqs from 'aws-cdk-lib/aws-sqs';
-
-const dlq = new sqs.Queue(this, 'DLQ');
-const queue = new sqs.Queue(this, 'MyQueue', {
-  visibilityTimeout: Duration.seconds(300), // 6× function timeout
-  deadLetterQueue: { queue: dlq, maxReceiveCount: 3 },
-});
-
-fn.addEventSource(new SqsEventSource(queue, {
-  batchSize: 10,
-  maxBatchingWindow: Duration.seconds(5),
-  reportBatchItemFailures: true,
-  maxConcurrency: 50,
-}));
-```
+CDK: `fn.addEventSource(new SqsEventSource(queue, { batchSize, maxBatchingWindow, reportBatchItemFailures: true, maxConcurrency }))`. Harden the queue: `new sqs.Queue(this, 'MyQueue', { encryption: sqs.QueueEncryption.SQS_MANAGED, enforceSSL: true, ... })` (set the same on the DLQ).
 
 ---
 
 ## DynamoDB Streams triggers
 
-Lambda polls DynamoDB stream shards at **4 times per second**. Invokes synchronously with in-order processing at the partition-key level.
-
-### Configuration parameters
+Lambda polls stream shards **4×/second**; invokes synchronously, in-order per partition key.
 
 | Parameter | Default | Range / Notes |
 |-----------|---------|---------------|
 | `BatchSize` | 100 | Max 10,000 |
-| `MaximumBatchingWindowInSeconds` | 0 | 0–300 |
 | `StartingPosition` | — | `TRIM_HORIZON` (recommended) or `LATEST` |
 | `ParallelizationFactor` | 1 | 1–10. Concurrent batches per shard |
-| `BisectBatchOnFunctionError` | false | Split failed batch in half |
+| `BisectBatchOnFunctionError` | false | Split failed batch in half; does NOT consume retry quota |
 | `MaximumRetryAttempts` | -1 (infinite) | 0–10,000 |
-| `MaximumRecordAgeInSeconds` | -1 (infinite) | -1 to 604,800 (7 days) |
+| `MaximumRecordAgeInSeconds` | -1 (infinite) | -1 (infinite), or 60–604,800 (7 days); 0–59 rejected |
 | `DestinationConfig.OnFailure` | — | SQS, SNS, S3, or Kafka topic |
-| `FilterCriteria` | — | Filters on `dynamodb` key and metadata fields (e.g., `eventName`) |
-| `FunctionResponseTypes` | — | `ReportBatchItemFailures` |
-| `TumblingWindowInSeconds` | — | 0–900 for stateful aggregation |
+| `TumblingWindowInSeconds` | — | 0–900, for stateful aggregation |
 
 ### Key behaviors
 
-- **TRIM_HORIZON** recommended — `LATEST` may miss events during ESM creation
-- **Max 2 Lambda readers per shard** (single-region tables). Global tables: limit to 1
-- **ParallelizationFactor**: 100 shards × factor 10 = up to 1,000 concurrent invocations. Order maintained at partition-key level
-- **BisectBatchOnFunctionError** does NOT consume retry quota
-- DynamoDB stream retention is **24 hours** — a poison record can block a shard for that entire window without retry limits
-
-### SAM template
+- **Max 2 Lambda readers per shard** (single-region tables). Global tables: limit to **1**.
+- **TRIM_HORIZON** recommended — `LATEST` may miss events during ESM creation.
+- 100 shards × ParallelizationFactor 10 = up to **1,000 concurrent invocations** (order maintained at partition-key level).
+- **Stream retention is 24 hours** — a poison record can block a shard for that entire window if retries aren't bounded. Set `MaximumRetryAttempts` / `MaximumRecordAgeInSeconds` / `BisectBatchOnFunctionError`.
 
 ```yaml
-MyFunction:
-  Type: AWS::Serverless::Function
-  Properties:
-    Handler: index.handler
-    Runtime: nodejs22.x
-    Events:
-      DDBStream:
-        Type: DynamoDB
-        Properties:
-          Stream: !GetAtt MyTable.StreamArn
-          StartingPosition: TRIM_HORIZON
-          BatchSize: 100
-          MaximumBatchingWindowInSeconds: 5
-          ParallelizationFactor: 5
-          BisectBatchOnFunctionError: true
-          MaximumRetryAttempts: 3
-          MaximumRecordAgeInSeconds: 3600
-          FunctionResponseTypes:
-            - ReportBatchItemFailures
-          DestinationConfig:
-            OnFailure:
-              Destination: !GetAtt FailureQueue.Arn
-          FilterCriteria:
-            Filters:
-              - Pattern: '{"eventName": ["INSERT"]}'
+# SAM
+Events:
+  DynamoDBStream:
+    Type: DynamoDB
+    Properties:
+      Stream: !GetAtt MyTable.StreamArn
+      StartingPosition: TRIM_HORIZON
+      ParallelizationFactor: 5
+      BisectBatchOnFunctionError: true
+      MaximumRetryAttempts: 3
+      FunctionResponseTypes: [ReportBatchItemFailures]
+      DestinationConfig:
+        OnFailure:
+          Destination: !GetAtt FailureQueue.Arn
 ```
 
-### CDK example
+Encrypt the source table at rest — CDK `new dynamodb.Table(this, 'MyTable', { encryption: dynamodb.TableEncryption.AWS_MANAGED, ... })`, or a customer managed KMS key when compliance requires key control.
 
-```typescript
-import { DynamoEventSource, SqsDlq } from 'aws-cdk-lib/aws-lambda-event-sources';
-import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-
-const table = new dynamodb.Table(this, 'MyTable', {
-  partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
-  stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
-});
-
-fn.addEventSource(new DynamoEventSource(table, {
-  startingPosition: lambda.StartingPosition.TRIM_HORIZON,
-  batchSize: 100,
-  maxBatchingWindow: Duration.seconds(5),
-  parallelizationFactor: 5,
-  bisectBatchOnError: true,
-  retryAttempts: 3,
-  maxRecordAge: Duration.hours(1),
-  reportBatchItemFailures: true,
-  onFailure: new SqsDlq(dlq),
-}));
-```
-
----
-
-## SNS subscriptions
-
-SNS invokes Lambda **asynchronously** — it is a **direct trigger, NOT an event source mapping**. No polling involved; SNS pushes events to Lambda.
-
-### Key characteristics
-
-- **Standard topics only** (not FIFO)
-- At-least-once delivery — make functions idempotent
-- SNS retries at increasing intervals over several hours if Lambda is unreachable
-- Cross-account subscriptions supported
-
-### Filter policies
-
-Filter policies are managed by **SNS** (not Lambda `FilterCriteria`). Set `FilterPolicyScope` to control what is filtered:
-
-| Scope | Filters on |
-|-------|-----------|
-| `MessageAttributes` (default) | SNS message attributes |
-| `MessageBody` | JSON body content |
-
-```json
-{
-  "event_type": ["order_placed"],
-  "price_usd": [{"numeric": [">=", 100]}],
-  "store": [{"anything-but": "test_store"}]
-}
-```
-
-### SAM template
-
-```yaml
-ProcessorFunction:
-  Type: AWS::Serverless::Function
-  Properties:
-    Handler: processor.handler
-    Runtime: nodejs22.x
-    Events:
-      SNSEvent:
-        Type: SNS
-        Properties:
-          Topic: !Ref MyTopic
-          FilterPolicy:
-            event_type:
-              - order_placed
-          FilterPolicyScope: MessageAttributes
-```
-
-### CDK example
-
-```typescript
-import * as sns from 'aws-cdk-lib/aws-sns';
-import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
-
-topic.addSubscription(new subscriptions.LambdaSubscription(fn, {
-  filterPolicy: {
-    event_type: sns.SubscriptionFilter.stringFilter({
-      allowlist: ['order_placed'],
-    }),
-    price: sns.SubscriptionFilter.numericFilter({
-      greaterThanOrEqualTo: 100,
-    }),
-  },
-}));
-```
+SNS filter policies (not Lambda `FilterCriteria`) are SNS-managed; set `FilterPolicyScope` to `MessageAttributes` (default) or `MessageBody`.
 
 ---
 
 ## Event filtering
 
-Lambda `FilterCriteria` applies to event source mappings only (not SNS or other push triggers).
-
-### Supported sources and filter keys
+`FilterCriteria` applies to ESMs only (not SNS/push triggers).
 
 | Source | Filter key | Notes |
 |--------|-----------|-------|
-| SQS | `body` | Unmatched messages **automatically deleted** |
-| DynamoDB Streams | `dynamodb` and metadata fields | Does **NOT** support numeric operators |
+| SQS | `body` | Unmatched messages **automatically (permanently) deleted** |
+| DynamoDB Streams | `dynamodb` + metadata (e.g. `eventName`) | **Does NOT support numeric operators** |
 | Kinesis | `data` | Base64-decoded before filtering |
 | MSK / Kafka | `value` | — |
-| Amazon MQ | `data` | — |
 
-### Filter rules
+- Up to **5 filters** per ESM (request increase to 10). Multiple filters are **OR**'d; fields within one filter are **AND**'d.
+- **DynamoDB numeric filtering is unsupported** — numbers are stored as strings in the DynamoDB stream JSON. Use `{"S": [...]}`/`{"N": ["123"]}` string matches, not `{"numeric": [...]}`.
+- Format mismatch drops the record: if the incoming body is plain string but the filter is JSON (or vice versa), Lambda drops the message.
 
-- Up to **5 filters** per ESM (can request increase to 10)
-- Multiple filters are **ORed** — record matches if any filter matches
-- Fields within a single filter are **ANDed**
-
-### Filter rule operators
-
-| Operator | Syntax | Example |
-|----------|--------|---------|
-| Equals | `["value"]` | `"City": ["Seattle"]` |
-| Equals (ignore case) | `[{"equals-ignore-case": "value"}]` | `"City": [{"equals-ignore-case": "seattle"}]` |
-| Null | `[null]` | `"UserID": [null]` |
-| Empty | `[""]` | `"Name": [""]` |
-| Not | `[{"anything-but": ["value"]}]` | `"Weather": [{"anything-but": ["Raining"]}]` |
-| Numeric equals | `[{"numeric": ["=", 100]}]` | `"Price": [{"numeric": ["=", 100]}]` |
-| Numeric range | `[{"numeric": [">", 10, "<=", 20]}]` | `"Price": [{"numeric": [">", 10, "<=", 20]}]` |
-| Exists | `[{"exists": true}]` | `"Field": [{"exists": true}]` |
-| Prefix | `[{"prefix": "us-"}]` | `"Region": [{"prefix": "us-"}]` |
-| Suffix | `[{"suffix": ".png"}]` | `"FileName": [{"suffix": ".png"}]` |
-| Or (fields) | `"$or": [{...}, {...}]` | `"$or": [{"City": ["NY"]}, {"Day": ["Mon"]}]` |
-
-> **DynamoDB filtering does NOT support numeric operators.** Numbers are stored as strings in the DynamoDB JSON record.
-
-### Body/data format matching
-
-| Incoming format | Filter format | Result |
-|----------------|---------------|--------|
-| Plain string | Plain string | Filters normally |
-| Plain string | Valid JSON | Lambda drops the message |
-| Valid JSON | Plain string | Lambda drops the message |
-| Valid JSON | Valid JSON | Filters normally |
-
-### Filter examples
+Operators: `["value"]`, `{"equals-ignore-case"}`, `[null]`, `[""]`, `{"anything-but"}`, `{"numeric": [">", 10, "<=", 20]}`, `{"exists": true}`, `{"prefix"}`, `{"suffix"}`, `"$or": [...]`.
 
 ```yaml
-# SQS — filter on body field
-FilterCriteria:
-  Filters:
-    - Pattern: '{"body": {"RequestCode": ["BBBB"]}}'
-
-# DynamoDB — INSERT events only
+# DynamoDB — INSERT events only / by NewImage attribute (string match, not numeric)
 FilterCriteria:
   Filters:
     - Pattern: '{"eventName": ["INSERT"]}'
-
-# DynamoDB — filter by NewImage attribute
-FilterCriteria:
-  Filters:
     - Pattern: '{"dynamodb": {"NewImage": {"status": {"S": ["ACTIVE"]}}}}'
-
-# Kinesis — filter decoded data
-FilterCriteria:
-  Filters:
-    - Pattern: '{"data": {"status": ["ACTIVE"]}}'
 ```
 
 ---
 
 ## Partial batch failure reporting
 
-Enable by setting `FunctionResponseTypes` to `["ReportBatchItemFailures"]`.
+Set `FunctionResponseTypes: [ReportBatchItemFailures]` and return the failed identifiers.
 
-### SQS — return failed messageId values
+- **SQS:** return failed `messageId` values in `batchItemFailures`.
+- **Streams (DynamoDB/Kinesis):** return the failed `SequenceNumber`; Lambda checkpoints at the **lowest** returned sequence number and retries everything from that point.
+- **FIFO:** stop after the first failure; return that message plus all unprocessed ones (preserves ordering).
 
-```javascript
-export const handler = async (event) => {
-  const batchItemFailures = [];
-  for (const record of event.Records) {
-    try {
-      await processMessage(record);
-    } catch (error) {
-      batchItemFailures.push({ itemIdentifier: record.messageId });
-    }
-  }
-  return { batchItemFailures };
-};
-```
+Response edge cases that cause a **complete batch retry**: `itemIdentifier` empty/null, a bad key name, or any unhandled exception. An empty/null `batchItemFailures` = complete success.
 
-### Streams — return failed SequenceNumber values
+Streams interaction: an unhandled **exception** triggers `BisectBatchOnFunctionError` (no response returned, so `ReportBatchItemFailures` has no effect); a **success with `batchItemFailures`** checkpoints at the lowest failed sequence number.
 
-For DynamoDB Streams and Kinesis, Lambda uses the **lowest sequence number** as the checkpoint and retries everything from that point.
-
-```javascript
-export const handler = async (event) => {
-  for (const record of event.Records) {
-    try {
-      await processRecord(record);
-    } catch (e) {
-      return {
-        batchItemFailures: [
-          { itemIdentifier: record.dynamodb.SequenceNumber },
-          // Kinesis: { itemIdentifier: record.kinesis.sequenceNumber }
-        ],
-      };
-    }
-  }
-  return { batchItemFailures: [] };
-};
-```
-
-### Python with Powertools Batch Processor
-
-```python
-from aws_lambda_powertools.utilities.batch import (
-    BatchProcessor, EventType, process_partial_response,
-)
-
-processor = BatchProcessor(event_type=EventType.SQS)
-
-def record_handler(record):
-    payload = record.body
-    # process payload...
-
-def lambda_handler(event, context):
-    return process_partial_response(
-        event=event, record_handler=record_handler,
-        processor=processor, context=context,
-    )
-```
-
-### FIFO queue behavior
-
-- **Stop processing after the first failure**
-- Return all failed and unprocessed messages in `batchItemFailures`
-- This preserves message ordering within the group
-
-### Success/failure conditions
-
-| Response | Interpretation |
-|----------|---------------|
-| Empty `batchItemFailures` list | Complete success |
-| Null `batchItemFailures` or empty `EventResponse` | Complete success |
-| `itemIdentifier` is empty string or null | **Complete failure** (entire batch retried) |
-| Bad key name in `itemIdentifier` | **Complete failure** |
-| Unhandled exception | **Complete failure** |
-
-### Interaction with BisectBatchOnFunctionError (streams)
-
-- Function **errors** (unhandled exception): `BisectBatchOnFunctionError` splits the batch in half for retry. `ReportBatchItemFailures` has no effect since no response was returned.
-- Function **succeeds** with `batchItemFailures`: Lambda checkpoints at the lowest failed sequence number and retries from that point. If `BisectBatchOnFunctionError` is also enabled, the batch is bisected at the returned sequence number.
+The Powertools Batch Processor (`process_partial_response`) handles all of this — prefer it over hand-rolled loops. See [assets/powertools-handler.py](../assets/powertools-handler.py).
 
 ---
 
-## Error handling strategies
+## Error handling and concurrency
 
-### SQS
-
-| Strategy | Configuration | When to use |
-|----------|--------------|-------------|
-| SQS redrive policy (DLQ) | `maxReceiveCount` on the queue | Always — catches poison messages |
-| Partial batch failures | `ReportBatchItemFailures` | Batches with mix of good/bad messages |
-| Visibility timeout | Set to ≥ 6× function timeout | Always — prevents premature retry |
-| MaximumConcurrency | `ScalingConfig` on ESM | Protect downstream resources |
-
-### DynamoDB Streams / Kinesis
-
-| Strategy | Configuration | When to use |
-|----------|--------------|-------------|
-| BisectBatchOnFunctionError | `true` | Isolate bad records in large batches |
-| Partial batch failures | `ReportBatchItemFailures` | Avoid reprocessing successful records |
-| Maximum retry attempts | `MaximumRetryAttempts` | Limit retries to prevent shard blocking |
-| Maximum record age | `MaximumRecordAgeInSeconds` | Skip stale records |
-| On-failure destination | `DestinationConfig.OnFailure` | Capture failed records for analysis |
-| Parallelization factor | `ParallelizationFactor` | Reduce blast radius per shard |
-
-### ESM (polling) vs direct trigger (push)
-
-| Aspect | ESM (SQS, DDB, Kinesis) | Async push (SNS, S3) | Sync push (API Gateway) |
-|--------|--------------------------|----------------------|-------------------------|
-| Invocation | Synchronous (Lambda polls) | Asynchronous (service pushes) | Synchronous (service pushes) |
-| Batching | Yes (configurable) | No (single event) | No (single event) |
-| Event filtering | Lambda `FilterCriteria` | SNS filter policies (SNS-managed) | N/A |
-| Error handling | Partial batch, bisect, retry config | 2 automatic retries, DLQ/destination | Error returned directly to caller, no automatic retry |
-| Ordering | Supported (streams, FIFO) | Not guaranteed | N/A (request/response) |
+| Source | Key strategies |
+|--------|---------------|
+| SQS | Redrive policy / DLQ (`maxReceiveCount`) always; `ReportBatchItemFailures`; visibility ≥ 6× timeout; `MaximumConcurrency` to protect downstream |
+| DynamoDB/Kinesis | `BisectBatchOnFunctionError`; `ReportBatchItemFailures`; `MaximumRetryAttempts` + `MaximumRecordAgeInSeconds` (prevent shard blocking); `OnFailure` destination; `ParallelizationFactor` to reduce blast radius |
 
 ### Concurrency formulas
 
 ```
 SQS (default):     min(1250, MaximumConcurrency, ReservedConcurrency)
 SQS (provisioned):  MaximumPollers × 10
-DDB/Kinesis:        number_of_shards × ParallelizationFactor
+DynamoDB/Kinesis:   number_of_shards × ParallelizationFactor
 ```
 
 ### Idempotency
 
-All event sources deliver at least once — duplicates can occur. Use Powertools idempotency utility:
-
-```python
-from aws_lambda_powertools.utilities.batch import (
-    BatchProcessor, EventType, process_partial_response,
-)
-from aws_lambda_powertools.utilities.idempotency import (
-    IdempotencyConfig, DynamoDBPersistenceLayer, idempotent_function,
-)
-
-processor = BatchProcessor(event_type=EventType.SQS)
-persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-config = IdempotencyConfig(event_key_jmespath="messageId")
-
-@idempotent_function(config=config, persistence_store=persistence_layer, data_keyword_argument="record")
-def record_handler(record):
-    # process record...
-    pass
-
-def lambda_handler(event, context):
-    return process_partial_response(
-        event=event, record_handler=record_handler,
-        processor=processor, context=context,
-    )
-```
+All event sources deliver at-least-once — duplicates happen. Make handlers idempotent (Powertools Idempotency utility, keyed e.g. on SQS `messageId`). See [production.md](production.md#idempotency).

--- a/skills/core-skills/aws-serverless/references/lambda.md
+++ b/skills/core-skills/aws-serverless/references/lambda.md
@@ -1,16 +1,15 @@
 # AWS Lambda Reference
 
-Specific values, limits, constraints, and code that complement general Lambda knowledge.
+Quotas, constraints, and gotchas that are easy to get wrong. Assumes you already know Lambda basics (packaging, layer paths, VPC-has-no-public-IP, Graviton ≈ 34% better price-performance, Powertools APIs) — this file focuses on the values and edge cases that trip up implementations.
 
 ## Contents
 
 - [Cold Start Optimization](#cold-start-optimization)
-- [Packaging](#packaging)
 - [Memory and Timeout Tuning](#memory-and-timeout-tuning)
 - [VPC Connectivity](#vpc-connectivity)
-- [Execution Roles](#execution-roles)
 - [Runtime Lifecycle](#runtime-lifecycle)
-- [Powertools for AWS Lambda](#powertools-for-aws-lambda)
+- [Function URLs](#function-urls)
+- [Powertools and Packaging](#powertools-and-packaging)
 
 ---
 
@@ -21,28 +20,23 @@ Specific values, limits, constraints, and code that complement general Lambda kn
 Snapshots the initialized execution environment (Firecracker microVM memory + disk) and restores from cache instead of cold-booting.
 
 **Supported runtimes:** Java 11+, Python 3.12+, .NET 8+
-**NOT supported:** Node.js, Ruby, container images, OS-only runtimes
 
 **Constraints:**
 
-- Mutually exclusive with Provisioned Concurrency
+- **Mutually exclusive with Provisioned Concurrency** (cannot set both on one function)
 - Mutually exclusive with Amazon EFS
 - Ephemeral storage must be ≤ 512 MB
 - Only works on published versions (not `$LATEST`)
-- Java: no additional SnapStart overhead
-- Python/.NET: caching charge (based on memory, minimum 3 hours) + per-restore charge
+- Java: no additional SnapStart charge. Python/.NET: caching charge (by memory, min 3 hours) + per-restore charge
 
-**Restoration considerations:**
+**Restoration gotchas** (snapshot is reused across restores):
 
-- Generate unique IDs/secrets in the handler, not during init (snapshot reuse)
+- Generate unique IDs/secrets in the handler, not during init
 - Re-establish network connections in the handler (connections are stale after restore)
 - Refresh cached timestamps/credentials in the handler
 
-**CDK example (Python):**
-
 ```python
-from aws_cdk import aws_lambda as lambda_
-
+# CDK (Python)
 fn = lambda_.Function(self, "MyFunction",
     runtime=lambda_.Runtime.PYTHON_3_13,
     handler="index.handler",
@@ -57,492 +51,139 @@ version = fn.current_version
 Pre-initializes execution environments that stay warm permanently.
 
 - A single instance handles one concurrent request at a time; throughput per instance = 1 / function duration
-- Account-level RPS quota: 10 × total concurrency (applies across all invocations, not per instance)
-- Supports auto-scaling via Application Auto Scaling
+- **Account-level RPS quota: 10 × total concurrency** (applies across all invocations, not per instance)
+- Supports auto-scaling via Application Auto Scaling (target ~70% utilization)
 - Lambda can scale beyond provisioned count using on-demand instances
 - **Paid even when idle** — disable in dev/staging
-
-```typescript
-const fn = new lambda.Function(this, 'MyFunction', {
-  runtime: lambda.Runtime.NODEJS_22_X,
-  handler: 'index.handler',
-  code: lambda.Code.fromAsset('lambda'),
-});
-
-const version = fn.currentVersion;
-const alias = new lambda.Alias(this, 'ProdAlias', {
-  aliasName: 'prod',
-  version,
-  provisionedConcurrentExecutions: 10,
-});
-```
-
-### Graviton (arm64)
-
-- **Up to 34% better price-performance** compared to x86 (per AWS)
-- Supported for all Lambda managed runtimes
-- Set `architecture: lambda_.Architecture.ARM_64` in CDK
 
 ### Strategy Selection
 
 | Scenario | Strategy |
 |---|---|
 | Java/Python/.NET with heavy init | SnapStart |
-| Strict <50ms cold start | Provisioned Concurrency |
+| Strict <50ms cold start, or need EFS / >512MB ephemeral | Provisioned Concurrency |
 | Tolerant of occasional cold starts | On-demand + minimize package |
 | Predictable traffic | Provisioned Concurrency + auto-scaling |
 | General optimization | arm64 (Graviton) |
 
 ---
 
-## Packaging
-
-### Decision Tree
-
-```
-Need > 250 MB uncompressed?
-  └─ YES → Container image (up to 10 GB)
-  └─ NO
-      ├─ Sharing deps across multiple functions?
-      │   └─ YES → Lambda layers
-      └─ NO
-          ├─ Simple function, few deps → .zip
-          └─ Native binaries, complex build → Container image
-```
-
-### Size Limits
-
-| Package Type | Limit |
-|---|---|
-| .zip compressed | 50 MB |
-| .zip uncompressed (including layers) | 250 MB |
-| Container image | 10 GB |
-| Layers per function | 5 |
-
-### Layer Paths by Runtime
-
-| Runtime | Layer Path |
-|---|---|
-| Python | `python/` or `python/lib/python3.x/site-packages/` |
-| Node.js | `nodejs/node_modules/` |
-| Java | `java/lib/` |
-| Ruby | `ruby/gems/3.4.0/` or `ruby/lib/` |
-| All runtimes | `bin/` (PATH), `lib/` (LD_LIBRARY_PATH) |
-
-**Layer constraints:**
-
-- Layers count toward the 250 MB unzipped limit
-- Layers only work with .zip deployments, NOT container images
-- Not recommended for Go/Rust — bundle deps in the deployment package
-- Multiple layers with conflicting dependency versions cause subtle bugs; merge order matters
-
-### Container Image Dockerfile
-
-```dockerfile
-FROM public.ecr.aws/lambda/python:3.13
-
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-COPY app.py ${LAMBDA_TASK_ROOT}
-
-CMD ["app.handler"]
-```
-
-- Use official AWS base images from `public.ecr.aws/lambda/`
-- Container images do NOT support Lambda layers
-- SnapStart is NOT supported with container images
-
-### Python Build Tips
-
-Use `uv` for dependency installation — **10-100x faster than pip**:
-
-```bash
-uv pip install -r requirements.txt --target ./package
-```
-
-Cross-platform build flags (when building on non-Linux):
-
-```bash
-pip install -r requirements.txt \
-  --target ./package \
-  --platform manylinux2014_x86_64 \
-  --only-binary=:all:
-```
-
-Use `manylinux2014_aarch64` for arm64. Exclude `__pycache__`, `.pyc`, tests, docs.
-
----
-
 ## Memory and Timeout Tuning
 
-### Memory
+### Memory → CPU
 
 | Parameter | Value |
 |---|---|
-| Minimum | 128 MB |
-| Maximum | 10,240 MB (10 GB) |
-| Increment | 1 MB |
-| Default | 128 MB |
-| 1 vCPU at | 1,769 MB |
+| Range | 128 MB – 10,240 MB (1 MB increments), default 128 MB |
+| **1 vCPU at** | **1,769 MB** |
 | ~5.8 vCPUs at | 10,240 MB |
 
-CPU scales linearly with memory. Doubling memory doubles CPU. **Over-provisioning memory can improve performance** — faster execution = less total duration.
+CPU scales linearly with memory — doubling memory doubles CPU. **Over-provisioning memory often lowers cost** (faster execution = less billed duration). Start at 256–512 MB; tune with [AWS Lambda Power Tuning](https://github.com/alexcasalboni/aws-lambda-power-tuning) against `Max Memory Used` in REPORT lines.
 
-**Tuning process:**
+### Ephemeral storage (/tmp)
 
-1. Start at 256–512 MB (128 MB only for trivial event routers)
-2. Monitor `Max Memory Used` in CloudWatch REPORT lines
-3. Use **AWS Lambda Power Tuning** (open-source Step Functions tool):
-
-```bash
-aws stepfunctions start-execution \
-  --state-machine-arn arn:aws:states:REGION:ACCOUNT:stateMachine:powerTuningStateMachine \
-  --input '{
-    "lambdaARN": "arn:aws:lambda:REGION:ACCOUNT:function:my-function",
-    "powerValues": [128, 256, 512, 1024, 1769, 3008],
-    "num": 50,
-    "payload": "{\"test\": true}"
-  }'
-```
-
-### Ephemeral Storage (/tmp)
-
-| Parameter | Value |
-|---|---|
-| Minimum / Default | 512 MB |
-| Maximum | 10,240 MB (10 GB) |
-| Extra cost | Above 512 MB |
-
-- Content **persists across warm invocations** (use as transient cache)
-- Content is NOT cleared after invoke failures
-- SnapStart requires ≤ 512 MB ephemeral storage
+- 512 MB (default/min) – 10,240 MB; extra cost above 512 MB
+- Persists across warm invocations (transient cache); NOT cleared after invoke failures
+- SnapStart requires ≤ 512 MB
 
 ### Timeout
 
-| Parameter | Value |
-|---|---|
-| Minimum | 1 second |
-| Maximum | 900 seconds (15 minutes) |
-| Default | 3 seconds |
+- Range 1s – 900s (15 min); **default is 3s** — always set it explicitly
 
 **Critical integration limits:**
 
-- API Gateway REST API: **29s default** (adjustable for Regional/private APIs since June 2024; edge-optimized remains 29s max)
-- API Gateway HTTP API: **30-second hard limit**
-- SQS visibility timeout must be **≥ 6× function timeout** (AWS recommendation)
+- **API Gateway REST API: 29s default** — adjustable higher for Regional/private APIs; **edge-optimized remains 29s max**
+- **API Gateway HTTP API: 30s hard limit** (cannot be raised)
+- SQS visibility timeout should be **≥ 6× function timeout**
 
-### Other Limits
+### Other limits worth knowing
 
 | Resource | Limit |
 |---|---|
-| Environment variables (total) | 4 KB |
 | Sync invocation payload (request/response) | 6 MB each |
 | Async invocation payload | 1 MB |
-| Streamed response | 200 MB (first 6 MB uncapped, then 2 MBps) |
-| File descriptors | 1,024 |
-| Processes/threads | 1,024 |
-| Concurrent executions (default) | 1,000 per region (soft limit) |
-| Scaling rate | 1,000 new environments every 10s per function |
-| Function code storage (.zip) | 75 GB per region (soft limit) |
+| Streamed response | 200 MB (2 MBps after first 6 MB) |
+| Environment variables (total) | 4 KB |
+| Concurrent executions (default) | 1,000 per region (soft) |
+| Scaling rate | 1,000 new environments / 10s, per function |
 
 ---
 
 ## VPC Connectivity
 
-### Hyperplane ENI
+Lambda uses **Hyperplane ENIs** — shared across functions that use the same subnet + security group combination (NOT per-function). Each ENI supports ~65,000 connections.
 
-Lambda uses **Hyperplane Elastic Network Interfaces** (shared, not per-function):
+- First-time ENI creation can take **several minutes** (function stays `Pending`)
+- ENIs reclaimed after **14 days of inactivity** (function goes `Inactive`); removing VPC config takes up to **20 minutes**
 
-- Shared across functions using the same subnet + security group combination
-- Each ENI supports **65,000 connections/ports**
-- First-time ENI creation: **several minutes** (function stays in `Pending`)
-- ENIs reclaimed after **14 days of inactivity** (function goes `Inactive`)
-- Removing VPC config takes up to **20 minutes** for ENI cleanup
-- Default quota: **500 Hyperplane ENIs per VPC** (Lambda-specific soft limit, can be increased). The broader VPC ENI service quota is **5,000 per region** by default.
-
-### Internet Access Patterns
-
-**Lambda in a VPC NEVER gets a public IP**, even in a public subnet.
-
-**Pattern 1: Private Subnet + NAT Gateway** (most common)
-
-```
-Lambda → Private Subnet → Route Table → NAT Gateway → IGW → Internet
-```
-
-- Deploy in each AZ for HA
-
-**Pattern 2: VPC Endpoints** (for AWS services)
-
-```
-Lambda → Private Subnet → VPC Endpoint → AWS Service
-```
-
-- **Gateway endpoints:** S3, DynamoDB
-- **Interface endpoints:** STS, Secrets Manager, SQS, etc.
-- Traffic stays on AWS network — lower latency
-
-#### Pattern 3: IPv6 Egress-Only Internet Gateway
-
-```
-Lambda → Dual-Stack Subnet → Egress-Only IGW → Internet (IPv6)
-```
-
-- Eliminates NAT Gateway for IPv6 traffic
-- Requires dual-stack subnets and IPv6-capable endpoints
-- Set `Ipv6AllowedForDualStack=true` in function config
-
-### Required IAM Permissions
-
-VPC-attached functions need `AWSLambdaVPCAccessExecutionRole` managed policy or equivalent EC2 network interface permissions.
-
-### Best Practices
-
-- Reuse subnet + security group combos across functions to share ENIs
-- Use multiple subnets across AZs for HA
-- Prefer VPC endpoints over NAT Gateway for AWS service access
-- Don't attach to VPC unless accessing private resources (RDS, ElastiCache, etc.)
-
----
-
-## Execution Roles
-
-One execution role per function. Key Lambda-specific managed policies:
-
-| Policy | Grants |
-|---|---|
-| `AWSLambdaBasicExecutionRole` | CloudWatch Logs only |
-| `AWSLambdaVPCAccessExecutionRole` | VPC ENI management |
-| `AWSLambdaDynamoDBExecutionRole` | DynamoDB Streams |
-| `AWSLambdaSQSQueueExecutionRole` | SQS polling |
-| `AWSLambdaKinesisExecutionRole` | Kinesis Streams |
+Reuse subnet + SG combos to share ENIs. Prefer **VPC endpoints** (gateway: S3, DynamoDB; interface: STS, Secrets Manager, SQS, …) over NAT Gateway for AWS-service access — lower latency, traffic stays on the AWS backbone. Don't attach to a VPC unless you need private resources (RDS, ElastiCache). VPC-attached functions need `AWSLambdaVPCAccessExecutionRole`.
 
 ---
 
 ## Runtime Lifecycle
 
-### Phases
-
 ```
-┌─────────┐    ┌─────────┐    ┌──────────┐
-│  INIT   │───▶│ INVOKE  │───▶│ SHUTDOWN │
-│         │    │(repeat) │    │          │
-└─────────┘    └─────────┘    └──────────┘
+INIT ──▶ INVOKE (repeat) ──▶ SHUTDOWN          [+ RESTORE phase for SnapStart]
 ```
 
-**Init Phase** (3 sub-phases: extension init → runtime init → function init):
+**Init phase** (extension init → runtime init → function init):
 
-- On-demand timeout: **10 seconds**
-- Provisioned/SnapStart timeout: **up to 15 minutes**
-- If init exceeds 10s on-demand, Lambda retries at first invocation using the function's configured timeout
+- **On-demand init timeout: 10s.** If exceeded, Lambda retries at first invocation using the function's configured timeout.
+- **Provisioned/SnapStart init timeout: up to 15 minutes.**
 
-**Invoke Phase:**
+**Shutdown phase:** 0 ms (no extensions), 500 ms (internal only), 2,000 ms (external extensions); SIGKILL if not done in time.
 
-- Limited by function timeout (max 900s)
-- Each environment handles **one concurrent invocation** at a time
+**Restore phase (SnapStart):** 10s timeout for restore + after-restore hooks.
 
-**Shutdown Phase:**
+### Warm-start reuse
 
-- 0 ms (no extensions), 500 ms (internal only), 2,000 ms (external extensions)
-- SIGKILL if extensions don't respond in time
+Objects initialized outside the handler persist across invocations (SDK clients, DB connections, `/tmp`). Gotchas:
 
-**Restore Phase** (SnapStart only):
-
-- Resumes from cached snapshot
-- 10-second timeout for restore + after-restore hooks
-
-### Execution Environment Reuse (Warm Starts)
-
-Objects initialized outside the handler persist across invocations:
-
-- SDK clients, DB connections, cached data all survive
-- `/tmp` content persists (512 MB–10 GB)
-- Background processes resume on next invocation
-- **Workers have a maximum lease lifetime of ~14 hours** (observed behavior, not a documented SLA — do not depend on this value)
-- Environments terminated periodically for maintenance even under continuous load
-
-**Common pitfall:** Global variables persist — stale DB connections, expired credentials, and leaked state across invocations cause subtle production bugs.
-
-### Extensions
-
-- **Internal:** Run in the runtime process (APM agents)
-- **External:** Separate processes alongside the runtime
-- Use Extensions API and Telemetry API for lifecycle events, logs, metrics, traces
+- **Execution environments are recycled periodically** for maintenance even under continuous load — never assume an environment (or its warmed state) lives indefinitely.
+- **Global variables persist** — stale DB connections, expired credentials, and leaked state across invocations cause subtle production bugs. Refresh connections/credentials in the handler.
 
 ---
 
-## Powertools for AWS Lambda
+## Function URLs
 
-Official AWS toolkit for Lambda best practices. Available for Python, TypeScript, Java, .NET.
+A Function URL is a dedicated HTTPS endpoint on a single function — no API Gateway. Use for internal service-to-service (IAM auth), Lambdalith + CloudFront, response streaming, or webhook receivers. There's **no built-in rate limiting, WAF, or request validation** (front with CloudFront/API Gateway if you need those). Choose **API Gateway** instead for public APIs needing rate limiting, JWT/Cognito auth, multi-function routing, request validation, or WAF without CloudFront.
 
-**Performance note:** Powertools adds cold start overhead. Use selective imports when cold start matters:
+Invoking a Function URL **always requires `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`** — granting only `InvokeFunctionUrl` returns **HTTP 403** even with `AuthType=NONE`. The two `AuthType` options differ in *how* those permissions are supplied:
 
-```python
-# Instead of: from aws_lambda_powertools import Logger, Tracer, Metrics
-# Import only what you need if cold start is critical
-from aws_lambda_powertools import Logger
+### `AuthType=AWS_IAM` (non-public — prefer for production)
+
+Only callers with valid AWS credentials that sign requests with **SigV4** can invoke; unauthenticated requests get **403**.
+
+- **Same-account caller:** grant the two actions in the caller's **identity-based policy** *or* the function's resource-based policy — a resource-based policy is **optional** if the caller's identity policy already allows them (this is why an admin/broad identity policy invokes with no resource policy on the function).
+- **Cross-account caller:** requires **both** an identity-based policy on the caller **and** a resource-based policy on the function.
+- For CloudFront in front, use **Origin Access Control** to sign requests rather than `NONE`.
+
+### `AuthType=NONE` (public)
+
+Lambda does no auth — the resource-based policy alone gates access, so it must grant **public** access. Only use when the endpoint must be reachable by unauthenticated clients (e.g. a browser hitting the URL directly) with no CloudFront/edge auth in front; it exposes the function to anyone with the URL, so pair it with in-code auth, throttling, and monitoring. The console and SAM add both required statements automatically; with the CLI/API add each yourself (two separate `add-permission` calls):
+
+```bash
+# Statement 1: allow invoking via the Function URL (public)
+aws lambda add-permission --function-name my-function \
+  --statement-id FunctionURLAllowPublicAccess \
+  --action lambda:InvokeFunctionUrl --principal '*' \
+  --function-url-auth-type NONE
+
+# Statement 2: REQUIRED — allow the underlying invoke, scoped to URL calls
+aws lambda add-permission --function-name my-function \
+  --statement-id FunctionURLInvokeAllowPublicAccess \
+  --action lambda:InvokeFunction --principal '*' \
+  --invoked-via-function-url
 ```
 
-### Core Utilities
+The `lambda:InvokedViaFunctionUrl` condition on statement 2 (set by `--invoked-via-function-url`) restricts that grant to Function URL calls, so it does not open direct `Invoke` access. See [Lambda function URL auth](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html).
 
-| Utility | Purpose |
-|---|---|
-| Logger | Structured JSON logging with correlation IDs |
-| Tracer | X-Ray tracing with decorators/middleware |
-| Metrics | CloudWatch metrics via Embedded Metric Format (EMF) |
-| Idempotency | Make handlers idempotent using DynamoDB |
-| Batch Processing | Partial failure handling for SQS, Kinesis, DynamoDB Streams |
-| Event Handler | Routing for API Gateway, ALB, Function URLs, AppSync |
-| Parameters | Retrieve/cache SSM, Secrets Manager, AppConfig, DynamoDB values |
+## Powertools and Packaging
 
-### Environment Variables
+Use **Powertools for AWS Lambda** (Python, TypeScript, Java, .NET) for structured logging, X-Ray tracing, EMF metrics, idempotency, batch processing, event handling, and parameter caching. The APIs are well-documented at [docs.powertools.aws.dev](https://docs.powertools.aws.dev/lambda/); for a ready-to-use Python handler with Logger + Tracer + Metrics + Idempotency wired, start from [assets/powertools-handler.py](../assets/powertools-handler.py).
 
-| Variable | Purpose |
-|---|---|
-| `POWERTOOLS_SERVICE_NAME` | Service name for logs, metrics, traces |
-| `POWERTOOLS_METRICS_NAMESPACE` | CloudWatch metrics namespace |
-| `POWERTOOLS_LOG_LEVEL` | Logging level (DEBUG, INFO, WARNING, ERROR) |
-| `POWERTOOLS_TRACE_DISABLED` | Disable tracing (useful for tests) |
-| `POWERTOOLS_DEV` | Dev mode (pretty-print JSON, verbose errors) |
+Powertools adds cold-start overhead — use selective imports when cold start is critical.
 
-### Python: Logger + Tracer + Metrics
+**Useful Powertools env vars:** `POWERTOOLS_SERVICE_NAME`, `POWERTOOLS_METRICS_NAMESPACE`, `POWERTOOLS_LOG_LEVEL`, `POWERTOOLS_TRACE_DISABLED` (tests), `POWERTOOLS_DEV` (pretty-print).
 
-```python
-from aws_lambda_powertools import Logger, Tracer, Metrics
-from aws_lambda_powertools.metrics import MetricUnit
-from aws_lambda_powertools.utilities.typing import LambdaContext
-
-logger = Logger()
-tracer = Tracer()
-metrics = Metrics()
-
-@logger.inject_lambda_context(log_event=False)
-@tracer.capture_lambda_handler
-@metrics.log_metrics(capture_cold_start_metric=True)
-def handler(event: dict, context: LambdaContext) -> dict:
-    logger.info("Processing order", order_id=event.get("order_id"))
-    metrics.add_metric(name="OrdersProcessed", unit=MetricUnit.Count, value=1)
-    result = process_order(event)
-    return {"statusCode": 200, "body": result}
-
-@tracer.capture_method
-def process_order(event: dict) -> str:
-    return "processed"
-```
-
-### TypeScript: Logger + Tracer + Metrics
-
-```typescript
-import { Logger } from '@aws-lambda-powertools/logger';
-import { Tracer } from '@aws-lambda-powertools/tracer';
-import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
-import middy from '@middy/core';
-import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware';
-import { captureLambdaHandler } from '@aws-lambda-powertools/tracer/middleware';
-import { logMetrics } from '@aws-lambda-powertools/metrics/middleware';
-
-const logger = new Logger({ serviceName: 'orderService' });
-const tracer = new Tracer({ serviceName: 'orderService' });
-const metrics = new Metrics({ namespace: 'OrderApp', serviceName: 'orderService' });
-
-const lambdaHandler = async (event: any) => {
-  logger.info('Processing order', { orderId: event.orderId });
-  metrics.addMetric('OrdersProcessed', MetricUnit.Count, 1);
-  const result = await processOrder(event);
-  return { statusCode: 200, body: JSON.stringify(result) };
-};
-
-export const handler = middy(lambdaHandler)
-  .use(injectLambdaContext(logger, { logEvent: false }))
-  .use(captureLambdaHandler(tracer))
-  .use(logMetrics(metrics, { captureColdStartMetric: true }));
-```
-
-### Python: Idempotency
-
-```python
-from aws_lambda_powertools.utilities.idempotency import (
-    DynamoDBPersistenceLayer,
-    idempotent,
-)
-
-persistence_layer = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-
-@idempotent(persistence_store=persistence_layer)
-def handler(event: dict, context) -> dict:
-    payment = process_payment(event)
-    return {"payment_id": payment.id, "status": "success"}
-```
-
-### TypeScript: Idempotency
-
-```typescript
-import { makeIdempotent } from '@aws-lambda-powertools/idempotency';
-import { DynamoDBPersistenceLayer } from '@aws-lambda-powertools/idempotency/dynamodb';
-
-const persistenceStore = new DynamoDBPersistenceLayer({
-  tableName: 'IdempotencyTable',
-});
-
-const processPayment = async (event: { paymentId: string; amount: number }) => {
-  return { paymentId: event.paymentId, status: 'success' };
-};
-
-export const handler = makeIdempotent(processPayment, {
-  persistenceStore,
-});
-```
-
-### Python: Batch Processing (SQS Partial Failures)
-
-```python
-from aws_lambda_powertools.utilities.batch import (
-    BatchProcessor,
-    EventType,
-    process_partial_response,
-)
-from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
-
-processor = BatchProcessor(event_type=EventType.SQS)
-
-def record_handler(record: SQSRecord):
-    payload = record.json_body
-    process_item(payload)
-
-def handler(event, context):
-    return process_partial_response(
-        event=event,
-        record_handler=record_handler,
-        processor=processor,
-        context=context,
-    )
-```
-
-### TypeScript: Batch Processing (SQS Partial Failures)
-
-```typescript
-import {
-  BatchProcessor,
-  EventType,
-  processPartialResponse,
-} from '@aws-lambda-powertools/batch';
-import type { SQSRecord, SQSHandler } from 'aws-lambda';
-
-const processor = new BatchProcessor(EventType.SQS);
-
-const recordHandler = async (record: SQSRecord): Promise<void> => {
-  const payload = JSON.parse(record.body);
-  await processItem(payload);
-};
-
-export const handler: SQSHandler = async (event, context) => {
-  return processPartialResponse(event, recordHandler, processor, {
-    context,
-  });
-};
-```
-
-### Asset Reference
-
-For a ready-to-use Python handler with Powertools wired, read [assets/powertools-handler.py](../assets/powertools-handler.py).
+**Packaging quick facts:** 50 MB zipped / 250 MB unzipped (incl. layers) → switch to container image (10 GB) past that. Max 5 layers/function; layers don't work with container images. Use `uv pip install` (10–100× faster than pip) and `--platform manylinux2014_{x86_64,aarch64} --only-binary=:all:` for cross-platform builds, or let `sam build` handle it. See [troubleshooting.md](troubleshooting.md) for size/import errors.

--- a/skills/core-skills/aws-serverless/references/orchestration.md
+++ b/skills/core-skills/aws-serverless/references/orchestration.md
@@ -1,20 +1,18 @@
 # Orchestration Reference
 
-AWS Step Functions and Amazon EventBridge patterns and configuration.
+Step Functions and EventBridge decision matrices, error semantics, and limits. Assumes you can write Amazon States Language (Saga/Parallel/Map/Choice JSON) and EventBridge patterns — this file focuses on the choices and gotchas.
 
 ## Contents
 
-- [Step Functions Standard vs Express](#step-functions-standard-vs-express)
-- [State machine patterns](#state-machine-patterns)
+- [Standard vs Express](#standard-vs-express)
+- [State machine limits and patterns](#state-machine-limits-and-patterns)
 - [Error handling](#error-handling)
-- [EventBridge rules and patterns](#eventbridge-rules-and-patterns)
-- [EventBridge Pipes](#eventbridge-pipes)
+- [EventBridge rules, pipes, and patterns](#eventbridge-rules-pipes-and-patterns)
+- [Step Functions vs Lambda durable functions](#step-functions-vs-lambda-durable-functions)
 
 ---
 
-## Step Functions Standard vs Express
-
-### Decision Matrix
+## Standard vs Express
 
 | Dimension | Standard | Express |
 |---|---|---|
@@ -25,425 +23,108 @@ AWS Step Functions and Amazon EventBridge patterns and configuration.
 | `.waitForTaskToken` | Supported | **Not supported** |
 | Distributed Map | Supported | **Not supported** |
 | Activities | Supported | **Not supported** |
-| Idempotency | Automatic (execution name unique for 90 days) | Not managed |
+| Idempotency | Automatic (execution name unique 90 days) | Not managed |
 
-Express sub-types:
+Express sub-types: **Async** (fire-and-forget, results via CloudWatch Logs); **Sync** (blocks until completion, invokable from API Gateway/Lambda/`StartSyncExecution`, 5-min max).
 
-- **Asynchronous**: Fire-and-forget. Results via CloudWatch Logs.
-- **Synchronous**: Blocks until completion. Invokable from API Gateway, Lambda, or `StartSyncExecution`. 5-min max.
-
-| Use Case | Type |
+| Use case | Type |
 |---|---|
-| Long-running orchestration, `.sync`/callback patterns | Standard |
-| Non-idempotent operations (payments, exactly-once) | Standard |
+| Long-running, `.sync`/callback, non-idempotent (payments) | Standard |
 | Distributed Map (large-scale parallel) | Standard |
 | High-volume event processing (IoT, streaming) | Express |
 | API-backed synchronous microservice orchestration | Synchronous Express |
 
 ---
 
-## State Machine Patterns
+## State machine limits and patterns
 
-### Saga Pattern (Compensating Transactions)
+- **Payload limit: 256 KiB between states** — store large data in S3, pass S3 keys.
+- **Inline Map:** max **40 concurrent** iterations, same execution.
+- **Distributed Map:** up to **10,000 parallel child executions**, reads from S3 (JSON/CSV/inventory), supports `ItemBatcher`/`ItemReader`/`ResultWriter`. **Standard workflows only.**
+- **25,000 execution-history entries** (Standard) — split long workflows into child executions.
+- **Parallel state output is an array** (one element per branch); all branches must succeed or the state fails.
+- **Choice state:** always include a `Default` branch.
 
-Each step has a corresponding undo step invoked on failure via `Catch`. Compensations chain in reverse.
-
-```json
-{
-  "Comment": "Saga pattern — book travel",
-  "StartAt": "BookHotel",
-  "States": {
-    "BookHotel": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:book-hotel",
-      "TimeoutSeconds": 30,
-      "Catch": [{
-        "ErrorEquals": ["States.ALL"],
-        "ResultPath": "$.BookHotelError",
-        "Next": "NotifyFailure"
-      }],
-      "Next": "BookFlight"
-    },
-    "BookFlight": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:book-flight",
-      "TimeoutSeconds": 30,
-      "Catch": [{
-        "ErrorEquals": ["States.ALL"],
-        "ResultPath": "$.BookFlightError",
-        "Next": "CancelHotel"
-      }],
-      "Next": "BookCar"
-    },
-    "BookCar": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:book-car",
-      "TimeoutSeconds": 30,
-      "Catch": [{
-        "ErrorEquals": ["States.ALL"],
-        "ResultPath": "$.BookCarError",
-        "Next": "CancelFlight"
-      }],
-      "Next": "ConfirmBooking"
-    },
-    "CancelFlight": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:cancel-flight",
-      "Next": "CancelHotel"
-    },
-    "CancelHotel": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:cancel-hotel",
-      "Next": "NotifyFailure"
-    },
-    "NotifyFailure": {
-      "Type": "Fail",
-      "Error": "SagaFailed",
-      "Cause": "One or more bookings failed; compensations executed"
-    },
-    "ConfirmBooking": { "Type": "Succeed" }
-  }
-}
-```
-
-### Parallel State
-
-Executes branches concurrently. **Output is an array** with one element per branch. All branches must succeed or the entire Parallel state fails. Supports `Retry` and `Catch`.
-
-```json
-{
-  "Type": "Parallel",
-  "Branches": [
-    {
-      "StartAt": "ProcessImages",
-      "States": {
-        "ProcessImages": {
-          "Type": "Task",
-          "Resource": "arn:aws:lambda:us-east-1:123456789012:function:process-images",
-          "End": true
-        }
-      }
-    },
-    {
-      "StartAt": "ProcessMetadata",
-      "States": {
-        "ProcessMetadata": {
-          "Type": "Task",
-          "Resource": "arn:aws:lambda:us-east-1:123456789012:function:process-metadata",
-          "End": true
-        }
-      }
-    }
-  ],
-  "Next": "AggregateResults"
-}
-```
-
-### Map State
-
-**Inline Map**: Iterates over an array in the same execution. Max **40 concurrent** iterations.
-
-```json
-{
-  "Type": "Map",
-  "ItemsPath": "$.orders",
-  "MaxConcurrency": 10,
-  "ItemProcessor": {
-    "ProcessorConfig": { "Mode": "INLINE" },
-    "StartAt": "ProcessOrder",
-    "States": {
-      "ProcessOrder": {
-        "Type": "Task",
-        "Resource": "arn:aws:lambda:us-east-1:123456789012:function:process-order",
-        "End": true
-      }
-    }
-  },
-  "Next": "Done"
-}
-```
-
-**Distributed Map**: Up to **10,000 parallel child executions**. Reads from S3 (JSON, CSV, S3 inventory). Supports `ItemBatcher`, `ItemReader`, `ResultWriter`. **Standard workflows only.**
-
-### Choice State
-
-Routes execution based on input conditions. Always include a `Default` branch.
-
-Comparison operators: `StringEquals`, `StringMatches`, `NumericGreaterThan`, `NumericLessThanEquals`, `BooleanEquals`, `IsPresent`, `IsNull`, `TimestampEquals`, and `Path` variants.
-
-```json
-{
-  "Type": "Choice",
-  "Choices": [
-    { "Variable": "$.orderTotal", "NumericGreaterThan": 1000, "Next": "HighValueOrder" },
-    { "Variable": "$.isPrime", "BooleanEquals": true, "Next": "PrimeProcessing" }
-  ],
-  "Default": "StandardProcessing"
-}
-```
-
-### Agentic AI Loop Pattern (Tool Use)
-
-Model outputs a structured response indicating a tool call or final answer. Choice state routes accordingly. Tool results feed back in a loop.
-
-```json
-{
-  "Comment": "Agentic AI loop with tool use",
-  "QueryLanguage": "JSONata",
-  "StartAt": "InvokeModel",
-  "States": {
-    "InvokeModel": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::bedrock:invokeModel",
-      "Arguments": {
-        "ModelId": "global.anthropic.claude-sonnet-4-6",
-        "Body": {
-          "anthropic_version": "bedrock-2023-05-31",
-          "max_tokens": 4096,
-          "messages": "{% $states.input.messages %}"
-        },
-        "ContentType": "application/json",
-        "Accept": "application/json"
-      },
-      "Next": "CheckAction"
-    },
-    "CheckAction": {
-      "Type": "Choice",
-      "Choices": [
-        { "Condition": "{% $states.input.Body.stop_reason = 'tool_use' %}", "Next": "ExecuteTool" }
-      ],
-      "Default": "ReturnResult"
-    },
-    "ExecuteTool": {
-      "Type": "Task",
-      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:execute-tool",
-      "TimeoutSeconds": 60,
-      "Next": "InvokeModel"
-    },
-    "ReturnResult": { "Type": "Succeed" }
-  }
-}
-```
+Common patterns (write the ASL directly): **Saga** (each step has a compensating undo via `Catch`, chained in reverse); **Parallel** (concurrent branches); **Map** (iterate an array); **Agentic AI loop** (`bedrock:invokeModel` → Choice on `stop_reason = 'tool_use'` → execute tool → loop). Prefer **direct SDK integrations** (200+ services) over Lambda intermediaries to cut latency, and prefer **JSONata** for inline transforms over a Lambda task.
 
 ---
 
-## Error Handling
+## Error handling
 
-### Built-in Error Names
+### Built-in error names
 
-| Error Name | Description | Retriable? |
-|---|---|---|
-| `States.ALL` | Wildcard — matches any error | Yes |
-| `States.TaskFailed` | Wildcard for task errors (except `States.Timeout`) | Yes |
-| `States.Timeout` | Task exceeded `TimeoutSeconds` or `HeartbeatSeconds` | Yes |
-| `States.HeartbeatTimeout` | No heartbeat within `HeartbeatSeconds` | Yes |
-| `States.Permissions` | Insufficient IAM privileges | Yes |
-| `States.DataLimitExceeded` | Payload exceeds 256 KiB — **terminal** | **No** |
-| `States.Runtime` | Invalid JSONPath, null payload — **terminal** | **No** |
-| `States.ItemReaderFailed` | Map couldn't read from ItemReader source | Yes |
-| `States.ResultWriterFailed` | Map couldn't write to ResultWriter destination | Yes |
+| Error Name | Retriable? | Notes |
+|---|:---:|---|
+| `States.ALL` | Yes | Wildcard — but does **NOT** match the two terminal errors below |
+| `States.TaskFailed` | Yes | Wildcard for task errors (except `States.Timeout`) |
+| `States.Timeout` / `States.HeartbeatTimeout` | Yes | Exceeded `TimeoutSeconds` / missed `HeartbeatSeconds` |
+| `States.Permissions` | Yes | Insufficient IAM privileges |
+| `States.DataLimitExceeded` | **No** | Payload > 256 KiB — **terminal** |
+| `States.Runtime` | **No** | Invalid JSONPath, null payload — **terminal** |
+| `States.ItemReaderFailed` / `States.ResultWriterFailed` | Yes | Map source/destination errors |
 
-`States.ALL` does **not** match `States.DataLimitExceeded` or `States.Runtime`.
+> **`States.ALL` does NOT catch `States.DataLimitExceeded` or `States.Runtime`.** These are terminal and must be designed around, not retried.
 
-### Retry Configuration
-
-Available on `Task`, `Parallel`, and `Map` states. Retries are attempted before catchers.
+### Retry config
 
 ```json
 "Retry": [
-  {
-    "ErrorEquals": ["States.Timeout"],
-    "IntervalSeconds": 3,
-    "MaxAttempts": 2,
-    "BackoffRate": 2.0,
-    "MaxDelaySeconds": 30,
-    "JitterStrategy": "FULL"
-  },
-  {
-    "ErrorEquals": ["Lambda.ServiceException", "Lambda.SdkClientException"],
-    "IntervalSeconds": 1,
-    "MaxAttempts": 3,
-    "BackoffRate": 2.0
-  },
-  {
-    "ErrorEquals": ["States.ALL"],
-    "IntervalSeconds": 1,
-    "MaxAttempts": 3,
-    "BackoffRate": 2.0
-  }
+  { "ErrorEquals": ["States.Timeout"], "IntervalSeconds": 3, "MaxAttempts": 2,
+    "BackoffRate": 2.0, "MaxDelaySeconds": 30, "JitterStrategy": "FULL" },
+  { "ErrorEquals": ["Lambda.ServiceException", "Lambda.SdkClientException"],
+    "IntervalSeconds": 1, "MaxAttempts": 3, "BackoffRate": 2.0 },
+  { "ErrorEquals": ["States.ALL"], "IntervalSeconds": 1, "MaxAttempts": 3, "BackoffRate": 2.0 }
 ]
 ```
 
-| Field | Default | Description |
-|---|---|---|
-| `ErrorEquals` | (required) | Array of error names to match |
-| `IntervalSeconds` | 1 | Initial wait before first retry |
-| `MaxAttempts` | 3 | Max retries; 0 = never retry |
-| `BackoffRate` | 2.0 | Multiplier for exponential backoff |
-| `MaxDelaySeconds` | — | Cap on computed backoff interval |
-| `JitterStrategy` | `"NONE"` | `"FULL"` randomizes wait between 0 and computed interval |
+Defaults: `IntervalSeconds` 1, `MaxAttempts` 3 (0 = never), `BackoffRate` 2.0, `JitterStrategy` `"NONE"`.
 
-Rules:
+Rules and best practices:
 
-- `States.ALL` must be **last** in the Retry array
-- Retries count as state transitions (billed in Standard workflows)
-- `States.Runtime` and `States.DataLimitExceeded` **cannot be retried**
-- Use `JitterStrategy: "FULL"` to prevent thundering herd
-
-### Catch (Fallback States)
-
-```json
-"Catch": [
-  {
-    "ErrorEquals": ["CustomBusinessError"],
-    "ResultPath": "$.error-info",
-    "Next": "HandleBusinessError"
-  },
-  {
-    "ErrorEquals": ["States.ALL"],
-    "ResultPath": "$.error-info",
-    "Next": "GenericErrorHandler"
-  }
-]
-```
-
-- `ResultPath` preserves original input alongside the error (e.g., `"$.error-info"`)
-- Without `ResultPath`, error output replaces entire input
-- Retries are attempted first; catchers apply only after retries are exhausted
-
-### Error handling best practices
-
-1. **Always set `TimeoutSeconds`** on every Task state
-2. **Always retry Lambda service exceptions**: `Lambda.ServiceException`, `Lambda.SdkClientException`
-3. **Use `HeartbeatSeconds`** for long-running tasks
-4. **Combine Retry + Catch**: Retry transient, Catch permanent
-5. **Use `JitterStrategy: "FULL"`** to prevent thundering herd
-6. **Listen for execution failures via EventBridge** for top-level failures
+- `States.ALL` must be **last** in the Retry array; retries are attempted **before** catchers.
+- Retries count as state transitions (billed in Standard).
+- Always set `TimeoutSeconds` on every Task; always retry `Lambda.ServiceException` / `Lambda.SdkClientException`.
+- Use `JitterStrategy: "FULL"` to prevent thundering herd; `HeartbeatSeconds` for long tasks.
+- `Catch` with `ResultPath: "$.error-info"` preserves the original input alongside the error (without it, error output replaces the input).
+- Listen for top-level execution failures via EventBridge (`source: aws.states`, `detail-type: Step Functions Execution Status Change`, `status: [FAILED, TIMED_OUT, ABORTED]`).
 
 ---
 
-## EventBridge Rules and Patterns
+## EventBridge rules, pipes, and patterns
 
-### Event Pattern Structure
+### Event patterns
 
-All specified fields must match (AND). Values within an array are OR'd.
+All specified fields must match (AND); values within an array are OR'd. Operators: exact `["value"]`, `{"prefix"}`, `{"suffix"}`, `{"anything-but"}`, `{"numeric": [">", 0, "<=", 100]}`, `{"exists": true}`, `{"wildcard": "prod-*-east"}`.
 
-```json
-{
-  "source": ["aws.ec2"],
-  "detail-type": ["EC2 Instance State-change Notification"],
-  "detail": { "state": ["terminated", "stopped"] }
-}
-```
+### Best practices
 
-### Advanced Pattern Operators
-
-| Operator | Syntax | Description |
-|---|---|---|
-| Exact match | `["value"]` | Field equals value |
-| Prefix | `[{"prefix": "prod-"}]` | Starts with string |
-| Suffix | `[{"suffix": ".json"}]` | Ends with string |
-| Anything-but | `[{"anything-but": ["val"]}]` | Not in list |
-| Numeric range | `[{"numeric": [">", 0, "<=", 100]}]` | Numeric comparison |
-| Exists | `[{"exists": true}]` | Field must be present |
-| Wildcard | `[{"wildcard": "prod-*-east"}]` | Glob-style matching |
-
-### EventBridge best practices
-
-1. **Dedicated event bus per application domain** — default bus for AWS service events only
-2. **Be precise with patterns** — broad patterns increase risk of infinite loops
-3. **One target per rule** — simplifies debugging and IAM permissions
-4. **Use DLQs on targets** — capture failed event deliveries
-5. **Use the EventBridge Sandbox** to test patterns before deploying
-
-### Step Functions Status Change Events
-
-Step Functions emits to the default bus automatically:
-
-```json
-{
-  "source": ["aws.states"],
-  "detail-type": ["Step Functions Execution Status Change"],
-  "detail": { "status": ["FAILED", "TIMED_OUT", "ABORTED"] }
-}
-```
-
-### Integration Patterns
-
-**SFN → EventBridge** (publish events from a workflow):
-
-```json
-{
-  "Type": "Task",
-  "QueryLanguage": "JSONata",
-  "Resource": "arn:aws:states:::events:putEvents",
-  "Arguments": {
-    "Entries": [{
-      "Detail": { "orderId": "{% $states.input.orderId %}", "status": "PROCESSED" },
-      "DetailType": "OrderProcessed",
-      "EventBusName": "my-app-bus",
-      "Source": "my-app.orders"
-    }]
-  },
-  "Next": "Done"
-}
-```
-
-**EventBridge → SFN**: Rule target is the state machine ARN. Event payload becomes execution input.
-
-**Fan-out**: Single event triggers multiple workflows via multiple rules on the same bus.
-
----
-
-## EventBridge Pipes
-
-### Architecture
-
-```
-Source → [Filter] → [Enrichment] → [Transform] → Target
-```
-
-Eliminates intermediary Lambda functions for point-to-point integrations.
-
-### Supported Sources
-
-| Source | Notes |
-|---|---|
-| Amazon SQS | Standard and FIFO queues |
-| Amazon Kinesis Data Streams | Shard-level polling |
-| Amazon DynamoDB Streams | Change data capture |
-| Amazon MSK / Self-managed Kafka | Topic-level consumption |
-| Amazon MQ | ActiveMQ and RabbitMQ |
-
-### Enrichment Options
-
-Lambda, API Gateway, EventBridge API Destinations, Step Functions (Synchronous Express).
-
-### Key Features
-
-- **Filtering**: Event patterns filter at the source — pay only for matched events
-- **Ordering**: Maintains event ordering within batches
-- **Built-in retry + DLQ**: Source-level retry with dead-letter queue support
+1. **Dedicated event bus per application domain** — default bus for AWS service events only.
+2. **Be precise with patterns** — broad patterns risk infinite loops.
+3. **One target per rule** — simplifies debugging and IAM.
+4. **DLQs on all targets.**
+5. Use the EventBridge Sandbox to test patterns before deploying.
 
 ### Pipes vs Rules
 
 | Dimension | Pipes | Rules |
 |---|---|---|
 | Topology | Point-to-point (1→1) | Fan-out (1→N) |
-| Sources | SQS, Kinesis, DDB Streams, MSK, MQ | Any event on a bus |
-| Enrichment | Built-in | Not built-in |
-| Use case | Replace Lambda glue | Event routing and distribution |
+| Flow | Source → Filter → Enrichment → Transform → Target | Event routing on a bus |
+| Sources | SQS, Kinesis, DynamoDB Streams, MSK, MQ | Any event on a bus |
+| Enrichment | Built-in (Lambda, API GW, API Destinations, Sync Express SFN) | Not built-in |
+| Use case | **Replace Lambda glue** for source→target | Event routing and distribution |
+
+Pipes filtering happens **at the source** — you pay only for matched events — with built-in retry + DLQ.
 
 ---
 
-## Lambda durable functions vs Step Functions
+## Step Functions vs Lambda durable functions
 
-Lambda durable functions let you write reliable multi-step workflows as plain code (TypeScript, Python, Java) with automatic checkpointing — the SDK persists each step's result and replays from the checkpoint on interruption, enabling executions up to 1 year with zero compute during waits. Use the **aws-lambda-durable-functions** skill for full guidance.
+Lambda durable functions let you write reliable multi-step workflows as **plain code** (TS/Python/Java) with automatic checkpointing — the SDK persists each step and replays from the checkpoint on interruption, enabling executions up to 1 year with zero compute during waits. **For full guidance use the aws-lambda-durable-functions skill** (see SKILL.md routing).
 
 | Question | Lambda durable functions | Step Functions |
 |---|---|---|
-| Primary focus? | Application logic in Lambda | Orchestration across AWS services |
-| Programming model? | Standard code (TS/Python/Java) | Amazon States Language (ASL) or visual designer |
-| AWS service integrations? | Primarily Lambda | 200+ native integrations |
-| Who reads the workflow? | Developers | Non-technical stakeholders |
-| Best for? | Distributed transactions, stateful logic, AI agent loops | Business process automation, multi-service orchestration |
+| Programming model | Standard code (TS/Python/Java) | Amazon States Language / visual designer |
+| AWS service integrations | Primarily Lambda | 200+ native integrations |
+| Who reads the workflow | Developers | Non-technical stakeholders too |
+| Best for | Distributed transactions, stateful logic, AI agent loops | Business process automation, multi-service orchestration |

--- a/skills/core-skills/aws-serverless/references/production.md
+++ b/skills/core-skills/aws-serverless/references/production.md
@@ -1,15 +1,13 @@
 # Production-Ready Serverless on AWS
 
-Quick-reference for shipping Lambda workloads to production. Covers the pre-deployment checklist, architecture trade-offs, and operational patterns for production traffic.
+Pre-deployment checklist, architecture trade-offs, and operational patterns. Concise on purpose — the value here is the structured checklist and opinionated defaults, not API syntax.
 
 ## Contents
 
 - [Production readiness checklist](#production-readiness-checklist)
 - [Architecture decisions](#architecture-decisions)
 - [Observability](#observability)
-- [Security hardening](#security-hardening)
-- [Testing strategies](#testing-strategies)
-- [Idempotency patterns](#idempotency-patterns)
+- [Idempotency](#idempotency)
 - [Response streaming](#response-streaming)
 - [Anti-patterns](#anti-patterns)
 
@@ -17,365 +15,134 @@ Quick-reference for shipping Lambda workloads to production. Covers the pre-depl
 
 ## Production readiness checklist
 
-Walk through every item before the first production deployment.
-
 ### Compute
 
-- [ ] Memory right-sized (use AWS Lambda Power Tuning or load testing)
-- [ ] Timeout set explicitly (P99 + buffer, never the 3 s default)
-- [ ] Reserved concurrency configured to protect downstream systems
-- [ ] Dead-letter queue (DLQ) or on-failure destination for every async invocation
-- [ ] Environment variables for all config (bucket names, table names, endpoints)
-- [ ] Code signing enabled (if compliance requires it)
-- [ ] SDK clients initialized outside handler (reuse across warm invocations)
-- [ ] Deployment package size minimized (exclude tests, docs, unused dependencies)
+- [ ] Memory right-sized (Power Tuning / load test)
+- [ ] Timeout set explicitly (P99 + buffer — never the 3s default)
+- [ ] Reserved concurrency set to protect downstream
+- [ ] DLQ / on-failure destination on every async invocation and ESM
+- [ ] Config via env vars; SDK clients initialized outside the handler
+- [ ] Deployment package minimized (exclude tests, docs, unused deps)
 
 ### Observability
 
-- [ ] Structured JSON logging via Powertools Logger
-- [ ] X-Ray active tracing enabled
-- [ ] Custom metrics emitted via Embedded Metric Format (EMF)
-- [ ] CloudWatch Alarms on Errors, Throttles, Duration P99, IteratorAge, ConcurrentExecutions, DLQ depth
-- [ ] Log retention policy set — do not leave at unlimited
-- [ ] Correlation IDs propagated to downstream services
-- [ ] Lambda Insights enabled for system-level metrics (CPU, memory, network)
+- [ ] Structured JSON logging (Powertools Logger) + correlation IDs propagated
+- [ ] X-Ray active tracing
+- [ ] Custom metrics via EMF
+- [ ] Alarms on Errors, Throttles, Duration P99, IteratorAge, ConcurrentExecutions, DLQ depth (see below)
+- [ ] Log retention set — **not** unlimited
+- [ ] Log group encryption with customer managed KMS key when compliance requires it
+- [ ] Lambda Insights enabled
 
 ### Security
 
-- [ ] One IAM execution role per function, scoped to exact resource ARNs
-- [ ] No secrets in environment variables — use Secrets Manager / SSM with caching
-- [ ] Input validation on every event payload (JSON Schema, Zod, Pydantic)
-- [ ] VPC placement only when required (RDS, ElastiCache); VPC endpoints for AWS services
-- [ ] GuardDuty Lambda Protection enabled
-- [ ] Security Hub Lambda controls enabled
-- [ ] Dependency scanning in CI (`npm audit`, `pip-audit`, Snyk)
-- [ ] Amazon Inspector Lambda scanning enabled
+- [ ] One IAM role per function, scoped to exact resource ARNs
+- [ ] No secrets in env vars — Secrets Manager / SSM (SecureString) with Powertools caching
+- [ ] Input validation at the handler boundary (Zod / Pydantic / Powertools Validation)
+- [ ] VPC only when required (RDS, ElastiCache); VPC endpoints for AWS services
+- [ ] GuardDuty Lambda Protection, Security Hub Lambda controls, Inspector Lambda scanning, CI dependency scanning
 - [ ] Function URLs use `AWS_IAM` auth (not `NONE`) in production
+- [ ] SQS queues use SSE-KMS for encryption at rest when compliance requires customer managed keys (SSE-SQS is enabled by default)
+- [ ] DynamoDB tables use customer managed KMS keys when compliance requires key control (AWS owned encryption is enabled by default)
+- [ ] Enforce HTTPS-only access with `aws:SecureTransport` condition in resource policies (S3 buckets, SQS queues)
 
 ### Reliability
 
-- [ ] Every handler is idempotent
-- [ ] Partial batch failure reporting enabled (SQS, Kinesis, DynamoDB Streams)
-- [ ] `BisectBatchOnFunctionError` enabled for stream sources (isolates poison records)
-- [ ] Retry config tuned — `MaximumRetryAttempts`, `MaximumEventAgeInSeconds`
-- [ ] Circuit breakers on downstream HTTP calls
-- [ ] Reserved concurrency = 0 documented as emergency kill switch
-- [ ] Graceful error handling — catch, log, and return meaningful errors (no unhandled exceptions)
+- [ ] Every handler idempotent
+- [ ] Partial batch failure reporting (SQS, Kinesis, DynamoDB Streams)
+- [ ] `BisectBatchOnFunctionError` for stream sources
+- [ ] Retry config tuned (`MaximumRetryAttempts`, `MaximumEventAgeInSeconds`)
+- [ ] Reserved concurrency = 0 documented as the emergency kill switch
+- [ ] No unhandled exceptions — catch, log, return meaningful errors
 
 ### Deployment
 
-- [ ] Aliases + weighted traffic shifting (or CodeDeploy canary/linear)
-- [ ] Rollback alarms wired into the deployment pipeline
-- [ ] All infrastructure defined in code (CDK, SAM, or CloudFormation)
-- [ ] Separate AWS accounts for dev, staging, production
-- [ ] Automated smoke tests run post-deployment before full traffic shift
-- [ ] Pre-traffic hooks (BeforeAllowTraffic) validate function health before shifting
+- [ ] Aliases + weighted shifting (or CodeDeploy canary/linear) with rollback alarms
+- [ ] All infra in code (CDK/SAM/CloudFormation)
+- [ ] Separate accounts for dev/staging/prod
+- [ ] Post-deploy smoke tests + pre-traffic hooks before full shift
 
 ---
 
 ## Architecture decisions
 
-### Monolith Lambda vs micro-Lambda
+### Lambdalith vs micro-Lambda
 
-| Aspect | Lambdalith (single function) | Micro-Lambda (function per route) |
-|---|---|---|
-| Cold starts | One function to warm; larger package | Many functions; smaller, faster init |
-| IAM granularity | Single broad role | Per-function least-privilege |
-| Deployment | Everything together; simpler CI/CD | Independent; more pipeline complexity |
-| Observability | One log group; harder per-route metrics | Per-function metrics, alarms, logs |
-| Scaling | Single concurrency pool | Independent scaling + reserved concurrency per function |
-| DX | Familiar Express/FastAPI style | More AWS-native; requires IaC discipline |
-
-**Guidance**: Prefer micro-Lambda for greenfield (least privilege, independent scaling, granular observability). Use Lambdalith when migrating existing Express/FastAPI apps or when team size makes deployment simplicity more valuable than granularity.
-
-### Function URLs vs API Gateway
-
-| Feature | Function URLs | API Gateway (HTTP API) | API Gateway (REST API) |
-|---|---|---|---|
-| Auth | IAM only (or in-code) | IAM, JWT, Lambda authorizers | IAM, Cognito, Lambda authorizers, API keys |
-| Rate limiting | None built-in | Built-in throttling | Throttling + usage plans |
-| Response streaming | Yes (native) | No | Yes (proxy integration) |
-| Custom domains | Via CloudFront | Built-in | Built-in |
-| WAF | No (use CloudFront) | No (use CloudFront) | Yes |
-| Request validation | None | None | JSON Schema |
-| Caching | Via CloudFront | None | Built-in |
-| WebSocket | No | No | No (separate WebSocket API required) |
-
-**Use Function URLs** for: internal service-to-service (IAM auth), Lambdalith + CloudFront, streaming, webhook receivers.
-
-**Use API Gateway** for: public APIs needing rate limiting, JWT/Cognito auth, multi-function path routing, WAF without CloudFront.
+Prefer **micro-Lambda** (function per route) for greenfield: per-function least-privilege IAM, independent scaling + reserved concurrency, granular observability, smaller/faster cold starts. Use a **Lambdalith** when migrating an existing Express/FastAPI app or when a small team values deployment simplicity over granularity.
 
 ### Reserved vs Provisioned Concurrency
 
-| Aspect | Reserved Concurrency | Provisioned Concurrency |
-|---|---|---|
-| Purpose | Guarantee capacity + protect downstream | Eliminate cold starts |
-| Cold starts | Still possible | Eliminated (pre-warmed) |
-| Throttling | Throttles at the limit | Spills to on-demand beyond provisioned |
-| Use case | Protect a database; guarantee capacity | Latency-sensitive APIs; payment processing |
-
-Decision flow:
-
-1. **Need to limit scaling** → Reserved concurrency
-2. **Need to eliminate cold starts** → Provisioned concurrency (try SnapStart first — no additional cost for Java; caching + restore charges for Python/.NET)
-3. **Need both** → Set provisioned ≤ reserved; reserved acts as the ceiling
+Reserved = guarantee capacity + protect downstream (cold starts still possible, throttles at the limit). Provisioned = eliminate cold starts (spills to on-demand beyond the count). Need both → provisioned ≤ reserved. Try **SnapStart** before Provisioned for Java/Python 3.12+/.NET 8+ (no cost for Java). See [concurrency.md](concurrency.md).
 
 ---
 
 ## Observability
 
-### Powertools setup (Python / TypeScript / Java / .NET)
+Use Powertools **Logger** (structured JSON, auto correlation IDs), **Tracer** (wraps X-Ray, auto-captures SDK/HTTP calls; annotate traces with business keys), **Metrics** (EMF — zero latency, writes to stdout vs ~5–20ms for synchronous `PutMetricData`; avoid `PutMetricData` in hot paths).
 
-**Logger** — structured JSON, correlation IDs injected automatically, log level via env var.
+### Minimum alarm set (every production function)
 
-**Tracer** — wraps X-Ray SDK; auto-captures AWS SDK calls, HTTP requests, handler. Add custom subsegments for critical paths. Annotate traces with business keys (customer ID, order ID) for filtering.
+| Alarm | Metric | Threshold | Why |
+|---|---|---|---|
+| Error rate | `Errors / Invocations` | > 1% | Bugs / upstream failures |
+| Throttles | `Throttles` | > 0 | Concurrency limit hit |
+| Duration P99 | `Duration` P99 | > 80% of timeout | Catch slow functions before timeout |
+| Iterator age | `IteratorAge` | > 60s | Stream processing falling behind |
+| Concurrent executions | `ConcurrentExecutions` | > 80% of reserved | Approaching throttle threshold |
+| DLQ depth | SQS `ApproximateNumberOfMessagesVisible` | > 0 | Failed messages accumulating |
 
-**Metrics** — emits via Embedded Metric Format. Zero latency impact.
+Set **log retention** when creating log groups — the default is "never expire."
 
-### EMF vs PutMetricData
+### Testing
 
-| | EMF (Powertools Metrics) | `PutMetricData` API |
-|---|---|---|
-| Latency impact | Zero — writes to stdout | Synchronous API call (~5–20 ms) |
-| Complexity | One-liner with Powertools | Manual batching, error handling |
-| Recommendation | **Use this** | Avoid in hot paths |
-
-### Minimum alarm set
-
-Set these six alarms on every production function:
-
-| Alarm | Metric | Threshold | Period | Why |
-|---|---|---|---|---|
-| Error rate | `Errors / Invocations` | > 1 % | 5 min | Catch bugs and upstream failures |
-| Throttles | `Throttles` | > 0 | 5 min | Concurrency limit hit |
-| Duration P99 | `Duration` P99 | > 80 % of timeout | 5 min | Catch slow functions before timeout |
-| Iterator age | `IteratorAge` | > 60 s | 5 min | Stream processing falling behind |
-| Concurrent executions | `ConcurrentExecutions` | > 80 % of reserved | 5 min | Approaching throttle threshold |
-| DLQ depth | SQS `ApproximateNumberOfMessagesVisible` | > 0 | 5 min | Failed messages accumulating |
-
-### Log retention
-
-Set retention when creating log groups. Defaults to "never expire" — storage accumulates continuously. Choose a retention period based on your compliance and debugging needs.
+Serverless apps are mostly about **service integrations**, not complex business logic — so the **integration layer (tested in the cloud) is the most valuable**, with few unit tests (pure logic) and few E2E. Structure handlers as thin adapters calling pure functions. Don't rely on LocalStack/DynamoDB Local as primary testing (they diverge on IAM, quotas, error codes); don't mock AWS SDK calls for integration tests. Iterate fast with `sam sync` / `cdk watch`; give each developer an isolated stack.
 
 ---
 
-## Security hardening
+## Idempotency
 
-### One role per function
+Lambda guarantees **at-least-once** — duplicates come from async retries, SQS visibility expiry, stream replays, client retries, Step Functions task retries. Use the **Powertools Idempotency** utility (Python/TS/Java/.NET), backed by a DynamoDB table with TTL.
 
-Never share IAM roles across functions. Scope every policy to specific resource ARNs:
+Table: `id` (hash of idempotency key) + `status` (INPROGRESS/COMPLETED/EXPIRED), `data` (cached response), `expiration` (TTL).
 
-```yaml
-# Good
-Effect: Allow
-Action: dynamodb:PutItem
-Resource: arn:aws:dynamodb:us-east-1:123456789012:table/OrdersTable
+Idempotency key by source:
 
-# Bad
-Effect: Allow
-Action: dynamodb:*
-Resource: "*"
-```
-
-Use IAM Access Analyzer to identify unused permissions and generate least-privilege policies.
-
-### Secrets management
-
-- Store in **Secrets Manager** or **SSM Parameter Store** (SecureString)
-- Cache in the execution environment with **Powertools Parameters** (avoids API call per invocation)
-- Rotate automatically via Secrets Manager rotation Lambdas
-- Environment variables are visible in the Lambda console and API — never put secrets there
-
-### Input validation
-
-Validate at the handler boundary before business logic runs:
-
-| Language | Library |
-|---|---|
-| TypeScript | Zod, io-ts, JSON Schema |
-| Python | Pydantic, Powertools Validation (JSON Schema) |
-| Java | Bean Validation (JSR 380), JSON Schema |
-
-Powertools Validation supports envelope extraction for API Gateway, SQS, EventBridge, etc.
-
-### VPC: endpoints over NAT Gateway
-
-If your function must be in a VPC, use **VPC endpoints** for AWS service access instead of NAT Gateway:
-
-| | VPC Endpoint | NAT Gateway |
-|---|---|---|
-| Latency | Lower (stays on AWS backbone) | Higher (extra hop) |
-
-Create endpoints for: DynamoDB (gateway), S3 (gateway), SQS, Secrets Manager, SSM, KMS.
-
----
-
-## Testing strategies
-
-### The serverless testing pyramid (inverted)
-
-```
-        ┌─────────────┐
-        │   E2E Tests  │  Few — full workflow verification
-        ├─────────────┤
-        │ Integration  │  Many — THIS IS THE MOST VALUABLE LAYER
-        │  (in cloud)  │  Test real service interactions
-        ├─────────────┤
-        │  Unit Tests  │  Fast — pure business logic only
-        └─────────────┘
-```
-
-Serverless apps are primarily about service integrations, not complex business logic. Integration tests in the cloud detect the most impactful defects.
-
-### Structure code for testability
-
-```
-handler (thin adapter)
-  → extract + validate event
-  → call business logic (pure functions — unit test these)
-  → call AWS services (integration test these in the cloud)
-```
-
-### What to test where
-
-| Layer | What | How |
-|---|---|---|
-| Unit | Business logic (calculations, transforms, validation) | Local, fast, mocked dependencies |
-| Integration | Service contracts (DynamoDB reads/writes, SQS send/receive, IAM permissions) | Deploy to AWS, test against real services |
-| E2E | Full workflows (API → Lambda → DynamoDB → Stream → Lambda → SQS) | Dedicated staging environment; poll for async side effects |
-
-### Fast iteration
-
-- **`sam sync`** — hot-deploys code changes to AWS in seconds
-- **`cdk watch`** — watches for file changes and auto-deploys
-- Each developer gets an isolated test stack (separate account or prefixed stack name)
-
-### What NOT to do
-
-- Don't rely on LocalStack / DynamoDB Local as primary testing — they diverge from real AWS (IAM, quotas, error codes)
-- Don't mock AWS SDK calls for integration tests — you'll miss permission and config issues
-- Don't skip cloud testing because "it's slow" — use `sam sync` / `cdk watch`
-
----
-
-## Idempotency patterns
-
-Lambda guarantees **at-least-once** execution. Duplicates happen from: async retries, SQS visibility timeout expiry, stream shard replays, client retries on timeout, Step Functions task retries.
-
-### Powertools Idempotency utility
-
-Uses DynamoDB to track processed events. Available for Python, TypeScript, Java, .NET.
-
-**Python:**
-
-```python
-from aws_lambda_powertools.utilities.idempotency import (
-    DynamoDBPersistenceLayer, idempotent
-)
-
-persistence = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-
-@idempotent(persistence_store=persistence)
-def handler(event, context):
-    payment = process_payment(event)
-    return {"statusCode": 200, "body": payment}
-```
-
-**TypeScript:**
-
-```typescript
-import { makeIdempotent } from "@aws-lambda-powertools/idempotency";
-import { DynamoDBPersistenceLayer } from "@aws-lambda-powertools/idempotency/dynamodb";
-
-const persistence = new DynamoDBPersistenceLayer({ tableName: "IdempotencyTable" });
-
-export const handler = makeIdempotent(async (event) => {
-  const payment = await processPayment(event);
-  return { statusCode: 200, body: JSON.stringify(payment) };
-}, { persistenceStore: persistence });
-```
-
-### DynamoDB table design
-
-```
-Table: IdempotencyTable
-  PK: id (String)          — hash of the idempotency key
-  Attributes:
-    status:     INPROGRESS | COMPLETED | EXPIRED
-    data:       cached response payload
-    expiration: TTL epoch timestamp
-  TTL attribute: expiration
-```
-
-### Choosing the idempotency key
-
-| Event source | Key |
+| Source | Key |
 |---|---|
 | SQS | `messageId` |
-| EventBridge | `detail.id` or composite of event fields |
+| EventBridge | `detail.id` or composite |
 | DynamoDB Streams | `eventID` |
-| API Gateway / Function URL | `Idempotency-Key` header or request body hash |
+| API Gateway / Function URL | `Idempotency-Key` header or body hash |
 | Step Functions | Execution ID + task token |
 
-### TTL for cleanup
-
-Set TTL based on how long duplicates can arrive. Typical values:
-
-- API retries: 1 hour
-- SQS retries: match the queue's `maxReceiveCount` × visibility timeout
-- Stream replays: 24 hours (Kinesis retention default)
-
-DynamoDB automatically deletes expired items (typically within a few days of TTL expiry).
+TTL ≈ how long duplicates can arrive (API retries ~1h; SQS ≈ `maxReceiveCount` × visibility; stream replays ~24h).
 
 ---
 
 ## Response streaming
 
-### When to use
+Use for payloads > 6 MB (buffered limit), TTFB-sensitive responses, SSE, LLM token streaming, or large file generation.
 
-| Use case | Why streaming helps |
-|---|---|
-| Large payloads (> 6 MB) | Buffered limit is 6 MB; streaming supports up to 200 MB |
-| TTFB-sensitive responses | Client sees partial data immediately (HTML shell, then content) |
-| Server-sent events (SSE) | Real-time updates to browser clients |
-| LLM / AI token streaming | Stream tokens as generated (conversational AI-style) |
-| Large file generation | CSV/PDF rows streamed as produced |
+- **Function URLs** are simplest; REST API also supports streaming (proxy, STREAM mode); **HTTP API does not**.
+- **200 MB** response limit; **2 MBps** cap after the first 6 MB.
+- Billed for full duration even if the client disconnects.
+- Node.js has native support (`awslambda.streamifyResponse` + `awslambda.HttpResponseStream.from`); other runtimes need a custom runtime or Lambda Web Adapter.
+- **Not supported for VPC-attached functions via Function URL** — use the `InvokeWithResponseStream` API instead.
 
-### Constraints
+Don't stream small JSON (< 6 MB) — buffered is simpler.
 
-- **Function URLs** are simplest for streaming. REST API also supports streaming via proxy integration with STREAM transfer mode. HTTP API does **not** support streaming.
-- **200 MB** response limit
-- **2 MBps** bandwidth cap after the first 6 MB
-- Billed for full function duration even if client disconnects
-- Node.js has native support; other runtimes use custom runtime or Lambda Web Adapter
-- **Function URL streaming is NOT supported for VPC-attached functions.** Use the `InvokeWithResponseStream` API as an alternative.
+---
 
-### Node.js example
+## Anti-patterns
 
-```javascript
-export const handler = awslambda.streamifyResponse(
-  async (event, responseStream, context) => {
-    const metadata = {
-      statusCode: 200,
-      headers: { "Content-Type": "text/html" },
-    };
-    responseStream = awslambda.HttpResponseStream.from(responseStream, metadata);
-
-    responseStream.write("<html><body>");
-    for (const chunk of generateContent()) {
-      responseStream.write(chunk);
-    }
-    responseStream.write("</body></html>");
-    responseStream.end();
-  }
-);
-```
-
-### When NOT to use
-
-- Small JSON responses (< 6 MB) — buffered is simpler
-- When you need API Gateway features (rate limiting, caching, WAF) without CloudFront
-- VPC-based functions needing Function URL streaming (use `InvokeWithResponseStream` API instead)
+- **Lambda calling Lambda synchronously** — doubles latency, tight coupling, fragile error handling. Decouple via SQS, or use Step Functions when you need the result.
+- **Unintentional monolithic handler** — routing stuffed into one function without weighing trade-offs prevents independent scaling and broadens IAM blast radius. Choose Lambdalith vs micro-Lambda deliberately (see above).
+- **Secrets in env vars** — visible in console/API, 4 KB total cap. Use Secrets Manager with Powertools caching.
+- **Skipping idempotency** — at-least-once delivery causes duplicate records.
+- **VPC when not needed** — adds cold-start latency. Only for private resources; use VPC endpoints for AWS services.
+- **Default 3s timeout** — legitimate requests fail silently. Set SDK/HTTP client timeouts shorter than the Lambda timeout for meaningful errors.
+- **Missing DLQ** — failed async invocations / ESM messages are discarded silently.
+- **Log retention = forever** — storage accumulates continuously.
 
 ---
 
@@ -384,110 +151,6 @@ export const handler = awslambda.streamifyResponse(
 - [AWS Lambda Best Practices](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html)
 - [Lambda Concurrency and Scaling](https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html)
 - [Response Streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html)
-- [How to Test Serverless Functions](https://docs.aws.amazon.com/lambda/latest/dg/testing-guide.html)
+- [Testing serverless functions](https://docs.aws.amazon.com/lambda/latest/dg/testing-guide.html)
 - [Serverless Applications Lens — Well-Architected](https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/welcome.html)
 - [Powertools for AWS Lambda](https://docs.powertools.aws.dev/lambda/)
-
----
-
-## Anti-patterns
-
-Common mistakes that cause production issues in serverless applications. Each pairs the problem with the correct alternative.
-
-### Avoid: Lambda calling Lambda synchronously
-
-Synchronous Lambda-to-Lambda invocation doubles latency, creates tight coupling, and makes error handling fragile.
-
-```python
-# BAD: Direct synchronous invocation
-lambda_client.invoke(FunctionName='downstream', InvocationType='RequestResponse', Payload=json.dumps(event))
-```
-
-### Instead: Use Step Functions or SQS
-
-```python
-# GOOD: Decouple via SQS
-sqs.send_message(QueueUrl=QUEUE_URL, MessageBody=json.dumps(event))
-```
-
-Or use Step Functions for orchestration when you need the result.
-
----
-
-### Avoid: Monolithic handler without intentional design
-
-Routing logic stuffed into a single handler without considering trade-offs prevents independent scaling, broadens IAM blast radius, and increases cold start times.
-
-```python
-# BAD: One function handling all routes without considering trade-offs
-def handler(event, context):
-    path = event['path']
-    if path == '/users': return handle_users(event)
-    elif path == '/orders': return handle_orders(event)
-    elif path == '/products': return handle_products(event)
-```
-
-### Instead: Choose deliberately
-
-For greenfield projects, prefer one function per route (least privilege, independent scaling, granular observability). For migrations from Express/FastAPI or small teams prioritizing deployment simplicity, a Lambdalith is a valid choice — see [Architecture decisions](#architecture-decisions) for trade-offs.
-
----
-
-### Avoid: Secrets in environment variables
-
-Visible in console and API, 4 KB total limit for all environment variables combined.
-
-```python
-# BAD: Secret in env var
-db_password = os.environ['DB_PASSWORD']
-```
-
-### Instead: Use Secrets Manager with Powertools caching
-
-```python
-# GOOD: Cached secret retrieval
-from aws_lambda_powertools.utilities import parameters
-db_password = parameters.get_secret("my-db-secret", max_age=300)
-```
-
----
-
-### Avoid: Skipping idempotency
-
-Lambda delivers at-least-once; duplicates cause duplicate records.
-
-### Instead: Use Powertools Idempotency
-
-```python
-from aws_lambda_powertools.utilities.idempotency import idempotent, DynamoDBPersistenceLayer
-
-persistence = DynamoDBPersistenceLayer(table_name="IdempotencyTable")
-
-@idempotent(persistence_store=persistence)
-def handler(event, context):
-    return process_payment(event)
-```
-
----
-
-### Avoid: VPC when not needed
-
-Adds cold start latency. Only attach Lambda to a VPC for private resources (RDS, ElastiCache, Elasticsearch). Use VPC endpoints for AWS service access instead.
-
----
-
-### Avoid: Default 3s timeout
-
-Legitimate requests fail silently. Set timeout based on load-test P99 + buffer. Set SDK/HTTP client timeouts shorter than Lambda timeout to get meaningful errors instead of generic timeouts.
-
----
-
-### Avoid: Missing DLQ
-
-Failed async invocations and event source messages are discarded without notification. Configure dead-letter queues on all async invocations and event source mappings.
-
----
-
-### Avoid: CloudWatch Logs retention = forever
-
-Storage accumulates continuously. Set a retention period — do not leave at unlimited.

--- a/skills/core-skills/aws-serverless/references/troubleshooting.md
+++ b/skills/core-skills/aws-serverless/references/troubleshooting.md
@@ -1,711 +1,164 @@
 # Serverless Troubleshooting Reference
 
-Actionable error lookup tables: exact error string → cause → fix with CLI commands.
-
-## Contents
-
-- [Quick fixes](#quick-fixes)
-- [Lambda Error Lookup](#lambda-error-lookup)
-- [API Gateway Error Lookup](#api-gateway-error-lookup)
-- [Step Functions Error Lookup](#step-functions-error-lookup)
-- [SAM/CDK Error Lookup](#samcdk-error-lookup)
-- [Timeout Debugging](#timeout-debugging)
-- [OOM Debugging](#out-of-memory-oom-debugging)
-- [Throttling Diagnosis](#throttling-diagnosis)
-- [CloudWatch Logs Insights Queries](#cloudwatch-logs-insights-queries)
-- [X-Ray Tracing](#x-ray-tracing)
-
----
+Error → cause → fix, focused on non-obvious gotchas and exact CLI commands. The five most common fixes are first.
 
 ## Quick fixes
 
-### 502 Bad Gateway from API Gateway
-Lambda proxy integration requires `{ statusCode: int, headers: {}, body: "string" }`.
-The `body` must be a string (`JSON.stringify()`), not an object. API Gateway returns 502 when it cannot parse the Lambda response — the function ran successfully but the response shape was wrong. Note: string statusCode (e.g., "200") is silently coerced to integer, and missing statusCode defaults to 200.
-
-### CORS errors
-With Lambda proxy integration, Lambda must return CORS headers — the API Gateway console "Enable CORS" button does not work for Lambda proxy integration. Add `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers` to every Lambda response including errors. For HTTP API, use the built-in `CorsConfiguration` instead. CORS is enforced by the browser, not the server — missing headers cause the browser to block the response even though the API call succeeded.
-
-### Lambda timeout + API Gateway 504
-API Gateway has a hard integration timeout: REST API default 29s (configurable 50ms–29s; Regional/private APIs can request higher), HTTP API max 30s (can be lowered, cannot be raised). This is independent of Lambda's 15-min limit. The 504 means API Gateway gave up waiting, not that Lambda failed. For long operations, return 202 immediately, process via SQS or Step Functions, poll or use WebSocket for results.
-
-### VPC Lambda cannot reach internet
-Lambda in a VPC needs a **private** subnet + NAT Gateway in a **public** subnet. Placing Lambda in a public subnet does NOT give it a public IP — Lambda never gets a public IP regardless of subnet type because Lambda's network interface is managed by the service and doesn't support public IP assignment. For AWS services only, use VPC endpoints (free for S3 and DynamoDB gateway endpoints).
-
-### ImportModuleError / MODULE_NOT_FOUND
-Handler path doesn't match file structure, or dependencies weren't bundled. Lambda extracts code to `/var/task` and layers to `/opt` — if the handler path doesn't match the file's location relative to `/var/task`, the runtime can't find it. Python: `pip install -r requirements.txt -t ./package --platform manylinux2014_x86_64 --only-binary=:all:`. Node: verify `exports.handler` exists and `node_modules` is included. Use `sam build` to handle cross-platform packaging automatically.
+- **502 Bad Gateway (proxy):** Lambda response must be `{ statusCode: int, headers: {}, body: "string" }`. `body` must be a `JSON.stringify`'d **string**, not an object. The function ran fine — only the response shape was wrong. (String statusCode is coerced. Under **HTTP API** payload format 2.0 a missing statusCode defaults to 200, but under **REST** proxy a missing statusCode is itself a malformed response and triggers the 502.)
+- **CORS errors:** under proxy integration the **Lambda** returns CORS headers on **every** response including errors; the console "Enable CORS" button doesn't apply. HTTP API: use `CorsConfiguration`. CORS is browser-enforced — the API call itself succeeded. **Never use `AllowOrigin: '*'` in production** — wildcard CORS is a security risk (CWE-942); specify your exact domain (e.g. `https://app.example.com`).
+- **504 from API Gateway:** integration timeout (REST 29s default; HTTP 30s max), independent of Lambda's 15-min limit. For long ops: return 202 immediately, process via SQS/Step Functions, poll or use WebSocket.
+- **VPC Lambda can't reach internet:** needs **private** subnet + NAT Gateway in a **public** subnet. A public subnet does NOT give Lambda a public IP. For AWS services use VPC endpoints (free for S3/DynamoDB gateway endpoints).
+- **ImportModuleError / MODULE_NOT_FOUND:** handler path doesn't match file structure, or deps weren't bundled for the right platform. Python: `pip install -r requirements.txt -t ./package --platform manylinux2014_x86_64 --only-binary=:all:`. Use `sam build` for cross-platform packaging.
 
 ---
 
-## Lambda Error Lookup
-
-### Runtime.ImportModuleError
-
-**Error:** `Runtime.ImportModuleError: Unable to import module 'lambda_function': No module named 'lambda_function'`
-**Cause:** Handler references a module missing from the deployment package.
-
-```bash
-pip install -r requirements.txt -t ./package
-cd package && zip -r ../deployment.zip . && cd .. && zip deployment.zip lambda_function.py
-# Or: sam build && sam deploy
-```
-
-### Runtime.HandlerNotFound
-
-**Error:** `Runtime.HandlerNotFound: Handler 'handler' missing on module 'function'`
-**Cause:** File exists but function/method name doesn't match handler setting.
-
-```bash
-aws lambda update-function-configuration --function-name my-func --handler app.lambda_handler
-# Python: file.function  Node: file.export  Java: package.Class::method
-```
-
-### Task timed out
-
-**Error:** `Task timed out after 3.00 seconds`
-**Cause:** Execution exceeded configured timeout. Slow downstream calls, low memory/CPU, or VPC delays.
-
-```bash
-aws lambda update-function-configuration --function-name my-func --timeout 30
-aws lambda update-function-configuration --function-name my-func --memory-size 512
-# Set SDK/HTTP timeouts shorter than Lambda timeout for meaningful errors
-```
-
-### Runtime.OutOfMemory (OOM)
-
-**Error:** `Runtime.OutOfMemory: ... signal: killed` or `Runtime exited without providing a reason`
-**Cause:** Function exceeded allocated memory — kernel sent SIGKILL.
-
-```bash
-# Check REPORT lines: Max Memory Used vs Memory Size
-aws lambda update-function-configuration --function-name my-func --memory-size 1024
-# Stream large files instead of loading into memory; bound global caches
-```
-
-### AccessDeniedException
-
-**Error:** `AccessDeniedException: ... not authorized to perform: lambda:InvokeFunction`
-**Cause:** Calling IAM principal lacks `lambda:InvokeFunction` permission.
-
-```bash
-aws lambda add-permission --function-name my-func \
-  --statement-id AllowInvoke --action lambda:InvokeFunction \
-  --principal s3.amazonaws.com --source-arn arn:aws:s3:::my-bucket
-```
-
-### TooManyRequestsException
-
-**Error:** `TooManyRequestsException: Rate Exceeded.`
-**Cause:** Function exceeded account concurrency limit (default 1,000).
-
-```bash
-aws lambda get-account-settings
-aws service-quotas request-service-quota-increase \
-  --service-code lambda --quota-code L-B99A9384 --desired-value 3000
-aws lambda put-function-concurrency --function-name my-func --reserved-concurrent-executions 100
-```
-
-### InvalidParameterValueException (size)
-
-**Error:** `Unzipped size must be smaller than 262144000 bytes`
-**Cause:** Package exceeds 50 MB zipped / 250 MB unzipped.
-
-```bash
-find ./package -name "*.pyc" -delete && find ./package -name "*.dist-info" -type d -exec rm -rf {} +
-aws lambda publish-layer-version --layer-name my-deps --zip-file fileb://layer.zip --compatible-runtimes python3.13
-# Or upload via S3, or switch to container image packaging (10 GB limit)
-```
-
-### ETIMEDOUT (VPC)
-
-**Error:** `Error: connect ETIMEDOUT 176.32.98.189:443`
-**Cause:** VPC Lambda can't reach internet — missing NAT Gateway or VPC Endpoint.
-
-```bash
-aws ec2 describe-route-tables --filters "Name=association.subnet-id,Values=subnet-xxx"
-aws ec2 create-route --route-table-id rtb-xxx --destination-cidr-block 0.0.0.0/0 --nat-gateway-id nat-xxx
-# Or use VPC Endpoints for AWS services:
-aws ec2 create-vpc-endpoint --vpc-id vpc-xxx --service-name com.amazonaws.us-east-1.s3 --route-table-ids rtb-xxx
-```
-
-### MODULE_NOT_FOUND
-
-**Error:** `Error: Cannot find module 'my-module'`
-**Cause:** Node.js dependency missing — not bundled or built on incompatible platform.
-
-```bash
-npm install --production
-sam build --use-container  # for native modules
-unzip -l deployment.zip | grep my-module  # verify inclusion
-```
+## Lambda errors (gotchas)
 
 ### RecursiveInvocationException
 
-**Error:** `RecursiveInvocationException: Recursive invocation detected`
-**Cause:** Function writes to a resource that triggers itself again (~16 invocations before halt).
+A function writes to a resource that re-triggers it (Lambda halts after ~16 loops).
 
 ```bash
-# Emergency stop
+# Emergency stop:
 aws lambda put-function-concurrency --function-name my-func --reserved-concurrent-executions 0
-# Fix: use separate input/output buckets or prefix filters in trigger config
+# Fix: separate input/output buckets, or prefix filters in the trigger config
 ```
 
-### SnapStart Errors
+### SnapStart errors
 
-**Error:** `SnapStartException` / `SnapStartNotReadyException` / `SnapStartTimeoutException`
-**Cause:** SnapStart failed during snapshot — init threw exception or uses non-snapshottable resources (e.g., open network connections).
+`SnapStartException` / `SnapStartNotReadyException` / `SnapStartTimeoutException` — init threw, or it uses non-snapshottable resources (open network connections).
 
 ```bash
 aws lambda get-function --function-name my-func --query 'Configuration.SnapStart'
-# Java: Use CRaC hooks — beforeCheckpoint() to close connections, afterRestore() to reopen
-# Python: Use snapshot_restore runtime hooks to re-establish connections after restore
-# .NET: Use SnapshotRestore register hooks for before-snapshot and after-restore actions
+# Java:   CRaC hooks — beforeCheckpoint() closes connections, afterRestore() reopens
+# Python: snapshot_restore runtime hooks to re-establish connections after restore
+# .NET:   SnapshotRestore.Register hooks for before-snapshot / after-restore
 ```
 
 ### Sandbox.Timedout
 
-**Error:** `Sandbox.Timedout`
-**Cause:** Function exceeded its timeout. In newer runtimes, this covers both init-phase and invoke-phase timeouts. A suppressed init failure consumes the invoke timeout.
-
-```bash
-aws lambda update-function-configuration --function-name my-func --timeout 60 --memory-size 1024
-# Move heavy initialization to lazy loading inside the handler
-```
+Exceeded the timeout. In newer runtimes this covers **both** init-phase and invoke-phase timeouts — a suppressed init failure consumes the invoke timeout. Move heavy init to lazy loading inside the handler; raise `--timeout`/`--memory-size`.
 
 ### ENILimitReachedException
 
-**Error:** `ENILimitReachedException`
-**Cause:** VPC reached network interface quota. Lambda Hyperplane ENIs have a default quota of 500 per VPC (see lambda.md); the overall VPC ENI quota is 5,000 per region. Check which limit applies.
+VPC hit its network-interface quota. Two limits can apply — the Lambda-specific Hyperplane ENI-per-VPC quota and the broader VPC ENI-per-Region quota — so check which one was reached (Service Quotas / `describe-account-attributes`).
 
 ```bash
 aws service-quotas request-service-quota-increase --service-code vpc --quota-code L-DF5E4CA3 --desired-value 10000
-# Consolidate functions to use same subnet + security group combinations
+# Consolidate functions onto the same subnet + security group combinations
 ```
 
-### InvalidZipFileException
-
-**Error:** `InvalidZipFileException: Could not unzip uploaded file.`
-**Cause:** Invalid ZIP or handler nested in subdirectory instead of at root.
+### TooManyRequestsException / throttling
 
 ```bash
-unzip -t deployment.zip  # verify integrity
-cd my-folder && zip -r ../deployment.zip . && cd ..  # files at root, not nested
+aws lambda get-account-settings
+aws service-quotas request-service-quota-increase --service-code lambda --quota-code L-B99A9384 --desired-value 3000
+aws lambda put-function-concurrency --function-name my-func --reserved-concurrent-executions 100
 ```
+
+Throttle behavior by invocation type: **Sync (API GW)** → 429 (may surface as 500); **Async (S3, SNS)** → auto-retries up to 6h; **SQS** → returns to queue, backs off; **Kinesis/DynamoDB Streams** → retries batch, blocks shard.
 
 ### CodeStorageExceededException
 
-**Error:** `CodeStorageExceededException: Code storage limit exceeded.`
-**Cause:** Account exceeded 75 GB code storage per region (all versions + layers).
-
-```bash
-aws lambda list-versions-by-function --function-name my-func
-aws lambda delete-function --function-name my-func --qualifier 1
-aws lambda list-layers  # delete unused layers too
-```
+Account exceeded its per-Region code storage quota (unzipped; all versions + layers). Check the current limit with `aws service-quotas get-service-quota --service-code lambda --quota-code L-2ACBD22F` (it is adjustable and has changed over time). Delete old versions and unused layers (`aws lambda list-versions-by-function`, `delete-function --qualifier`).
 
 ---
 
-## API Gateway Error Lookup
+## API Gateway errors (gotchas)
 
-### Malformed Lambda Proxy Response (502)
-
-**Error:** `Malformed Lambda proxy response` → 502
-**Cause:** Lambda response missing required format — `body` must be a string, response must be a JSON object (not a plain string or array).
-
-```python
-return {"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": json.dumps({"msg": "ok"})}
-```
-
-```javascript
-return { statusCode: 200, headers: { "Content-Type": "application/json" }, body: JSON.stringify({ msg: "ok" }) };
-```
-
-### Missing Authentication Token (403)
-
-**Error:** `403 Forbidden: Missing Authentication Token`
-**Cause:** URL doesn't match any resource/method, or API not deployed to stage. Usually routing, not auth.
-
-```bash
-aws apigateway create-deployment --rest-api-id abc123 --stage-name prod
-# Verify: https://{api-id}.execute-api.{region}.amazonaws.com/{stage}/{resource}
-```
-
-### Invalid Permissions on Lambda (500)
-
-**Error:** `Invalid permissions on Lambda function`
-**Cause:** API Gateway lacks `lambda:InvokeFunction` permission on the target function.
-
-```bash
-aws lambda add-permission --function-name my-func --statement-id apigw-invoke \
-  --action lambda:InvokeFunction --principal apigateway.amazonaws.com \
-  --source-arn "arn:aws:execute-api:us-east-1:123456789012:api-id/*/GET/resource"
-```
-
-### Endpoint Request Timed Out (504)
-
-**Error:** `Endpoint request timed out` → 504
-**Cause:** Lambda didn't respond within 29s (REST) / 30s (HTTP) integration timeout.
-
-```bash
-aws lambda update-function-configuration --function-name my-func --memory-size 1024
-# For long operations: return 202 immediately, process async, poll for results
-```
-
-### Authorizer Unauthorized (401)
-
-**Error:** `Unauthorized` (401)
-**Cause:** Lambda authorizer returned deny, threw error, or timed out.
-
-```bash
-aws logs tail /aws/lambda/my-authorizer --since 1h --filter-pattern ERROR
-# Verify authorizer returns: { principalId, policyDocument: { Statement: [{ Effect: "Allow" }] } }
-```
-
-### WAF Access Denied (403)
-
-**Error:** `403 Forbidden` with `x-amzn-errortype: ForbiddenException`
-**Cause:** AWS WAF rule matched — IP denylist, rate limit, or injection detection.
-
-```bash
-# Check WAF sampled requests in console to identify blocking rule
-# Test rules in Count mode before switching to Block
-```
-
-### CORS Errors
-
-**Error:** `blocked by CORS policy: No 'Access-Control-Allow-Origin' header`
-**Cause:** Lambda proxy integration must return CORS headers; HTTP APIs can configure at API level.
-
-```yaml
-# SAM Globals
-Globals:
-  Api:
-    Cors:
-      AllowOrigin: "'*'"
-      AllowMethods: "'GET,POST,OPTIONS'"
-      AllowHeaders: "'Content-Type,Authorization'"
-```
-
-```bash
-# HTTP API
-aws apigatewayv2 update-api --api-id abc123 \
-  --cors-configuration AllowOrigins="*",AllowMethods="GET,POST",AllowHeaders="Content-Type"
-```
-
-### Internal Server Error — Lambda Throttled (500)
-
-**Error:** 500 with CloudWatch log `Lambda invocation failed with status 429`
-**Cause:** Lambda throttled but API Gateway surfaces as 500.
-
-```bash
-# Increase Lambda concurrency (see TooManyRequestsException above)
-aws apigateway update-stage --rest-api-id abc123 --stage-name prod \
-  --patch-operations op=replace,path=/*/*/throttling/rateLimit,value=1000
-```
+| Error | Cause | Fix |
+|---|---|---|
+| `403 Missing Authentication Token` | URL doesn't match a resource/method, or API not deployed | Usually routing, not auth — verify path and `create-deployment` to the stage |
+| `Invalid permissions on Lambda function` (500) | API GW lacks `lambda:InvokeFunction` | `aws lambda add-permission --principal apigateway.amazonaws.com --source-arn "arn:aws:execute-api:...:api-id/*/GET/resource"` (add `--source-account <account-id>` to scope cross-service triggers like S3 to your account) |
+| `Unauthorized` (401) | Lambda authorizer denied/errored/timed out | Check authorizer logs; verify it returns a valid Allow policy |
+| `403` + `x-amzn-errortype: ForbiddenException` | WAF rule matched | Check WAF sampled requests; test rules in Count mode first |
+| 500 with log `status 429` | Lambda throttled, surfaced as 500 | Increase Lambda concurrency |
 
 ---
 
-## Step Functions Error Lookup
+## Step Functions errors
 
-### States.TaskFailed
-
-**Error:** `States.TaskFailed`
-**Cause:** Task failed — unhandled Lambda exception, service error, or missing permissions.
-
-```json
-"Retry": [{"ErrorEquals": ["States.TaskFailed","Lambda.ServiceException","Lambda.SdkClientException"], "IntervalSeconds": 2, "MaxAttempts": 3, "BackoffRate": 2.0}],
-"Catch": [{"ErrorEquals": ["States.TaskFailed"], "Next": "HandleError", "ResultPath": "$.error"}]
-```
-
-### States.Timeout
-
-**Error:** `States.Timeout`
-**Cause:** Task exceeded `TimeoutSeconds` or missed `HeartbeatSeconds` deadline.
-
-```json
-{"Type": "Task", "Resource": "arn:aws:lambda:...", "TimeoutSeconds": 300, "HeartbeatSeconds": 60, "Next": "NextState"}
-```
-
-### States.DataLimitExceeded
-
-**Error:** `States.DataLimitExceeded`
-**Cause:** State input/output exceeded 256 KB. Cannot be caught by `States.ALL`.
-
-**Fix:** Store large data in S3, pass only S3 keys between states. Use `InputPath`/`OutputPath` to filter.
-
-### ExecutionAlreadyExists
-
-**Error:** `ExecutionAlreadyExists`
-**Cause:** Execution name must be unique per state machine for 90 days.
-
-```bash
-aws stepfunctions start-execution --state-machine-arn arn:aws:states:... \
-  --name "exec-$(date +%s)" --input '{}'
-# Or omit --name for auto-generated names
-```
-
-### States.Permissions
-
-**Error:** `States.Permissions: insufficient privileges`
-**Cause:** Execution role lacks permission to invoke target service.
-
-```bash
-aws iam list-attached-role-policies --role-name StepFunctionsRole
-# Add lambda:InvokeFunction, dynamodb:PutItem, etc. to the execution role
-```
+| Error | Cause / Fix |
+|---|---|
+| `States.TaskFailed` | Add `Retry` for `States.TaskFailed`/`Lambda.ServiceException`/`Lambda.SdkClientException`; `Catch` to a handler |
+| `States.Timeout` | Set `TimeoutSeconds` (and `HeartbeatSeconds` for long tasks) |
+| `States.DataLimitExceeded` | Input/output > 256 KiB — **cannot be caught by `States.ALL`**. Store in S3, pass keys |
+| `ExecutionAlreadyExists` | Names unique per state machine for 90 days — use `--name "exec-$(date +%s)"` or omit `--name` |
+| `States.Permissions` | Execution role lacks target-service permission |
 
 ---
 
-## SAM/CDK Error Lookup
+## SAM/CDK errors
 
-### Stale Build Cache
-
-**Error:** `sam build` uses old dependencies after updating requirements.txt, or `--clear-cache` flag unrecognized.
-**Cause:** SAM caches build artifacts. There is no `--clear-cache` flag.
+### Stale build cache
 
 ```bash
-sam build --no-cached              # Force clean build (correct flag)
-rm -rf .aws-sam/cache              # Or manually delete cache directory
+sam build --no-cached        # correct flag — there is NO --clear-cache
+rm -rf .aws-sam/cache        # or delete the cache directory
 ```
 
 ### PythonPipBuilder:ResolveDependencies
 
-**Error:** `PythonPipBuilder:ResolveDependencies - pip install returned a non-zero exit code`
-**Cause:** Dependency version conflicts or missing native libraries.
+Version conflicts or missing native libs: `sam build --use-container --no-cached`; use binary wheels (`psycopg2-binary`).
 
-```bash
-sam build --use-container --no-cached
-# Use binary wheels: psycopg2-binary instead of psycopg2
-```
+### CDK NodejsFunction: `Cannot find module 'esbuild'`
 
-### DockerBuildFailed
+`npm install --save-dev esbuild`.
 
-**Error:** `DockerBuildFailed: Docker build failed.`
-**Cause:** Docker not running or Dockerfile errors.
-
-```bash
-docker info  # verify running
-sudo systemctl start docker  # start if needed
-```
-
-### Cannot find module 'esbuild'
-
-**Error:** `Cannot find module 'esbuild'`
-**Cause:** CDK `NodejsFunction` needs esbuild for bundling.
-
-```bash
-npm install --save-dev esbuild
-```
-
-### CREATE_FAILED
-
-**Error:** `CREATE_FAILED: AWS::Lambda::Function`
-**Cause:** Invalid runtime, missing S3 code, role not ready, or package too large.
+### CREATE_FAILED / UPDATE_ROLLBACK_FAILED
 
 ```bash
 aws cloudformation describe-stack-events --stack-name my-stack \
   --query "StackEvents[?ResourceStatus=='CREATE_FAILED'].[LogicalResourceId,ResourceStatusReason]" --output table
-```
-
-### UPDATE_ROLLBACK_FAILED
-
-**Error:** `UPDATE_ROLLBACK_FAILED`
-**Cause:** Update failed and rollback also failed — resource manually deleted or permissions changed.
-
-```bash
-aws cloudformation continue-update-rollback --stack-name my-stack
+# Rollback also failed (resource manually deleted / perms changed):
 aws cloudformation continue-update-rollback --stack-name my-stack --resources-to-skip MyFunction
 ```
 
-### Security Constraints Not Satisfied
+### Circular dependency
 
-**Error:** `Security Constraints Not Satisfied`
-**Cause:** SAM template missing required properties (Handler, Runtime, CodeUri).
+`Circular dependency between resources: [MyFunction, MyRole, ...]` — break the cycle by giving the function an explicit `FunctionName` and referencing the hardcoded ARN (`!Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:my-function-name"`) instead of `!Ref`/`!GetAtt`, or extract the IAM role/policy into a separate resource.
 
-```bash
-sam validate --lint
-```
+### Other quick ones
 
-### CDK Bootstrap Required
-
-**Error:** `This stack uses assets, so the toolkit stack must be deployed`
-**Cause:** Target account/region not bootstrapped.
-
-```bash
-cdk bootstrap aws://123456789012/us-east-1
-```
-
-### Circular Dependency
-
-**Error:** `Circular dependency between resources: [MyFunction, MyRole, ...]`
-**Cause:** Resources reference each other in a cycle.
-
-```yaml
-# Break cycle: give the function an explicit name and hardcode the ARN
-MyFunction:
-  Type: AWS::Lambda::Function
-  Properties:
-    FunctionName: my-function-name  # explicit name
-
-MyRole:
-  Type: AWS::IAM::Role
-  Properties:
-    Policies:
-      - PolicyDocument:
-          Statement:
-            - Effect: Allow
-              Action: lambda:InvokeFunction
-              # No ${MyFunction} reference — no implicit dependency
-              Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:my-function-name"
-# Or restructure to eliminate the cycle (extract IAM role/policy into a separate resource)
-```
+- `DockerBuildFailed` → `docker info` / start Docker.
+- `Security Constraints Not Satisfied` (missing Handler/Runtime/CodeUri) → `sam validate --lint`.
+- `This stack uses assets, so the toolkit stack must be deployed` → `cdk bootstrap aws://ACCOUNT/REGION`.
 
 ---
 
-## Timeout Debugging
+## Diagnostics
+
+For systematic timeout investigation (config → logs → metrics → VPC → cold start → memory → downstream), use the **debugging-lambda-timeouts** skill (see SKILL.md routing).
+
+CloudWatch Logs Insights run against `/aws/lambda/FUNCTION_NAME` (API Gateway uses the access log group). Useful fields on `@type = "REPORT"` lines: `@initDuration` (cold start), `@duration`, `@billedDuration`, `@maxMemoryUsed`, `@memorySize`. Examples:
 
 ```
-Function times out
-├── INIT phase? (Sandbox.Timedout)
-│   ├── YES → Increase timeout + memory, lazy-load heavy deps
-│   └── NO → INVOKE phase
-│       ├── Timeout ≈ avg duration? → Set to 2-3x average
-│       ├── Calling external services? → Set SDK timeouts < Lambda timeout
-│       ├── CPU-bound? → Increase memory (1,769 MB = 1 vCPU)
-│       └── VPC? → Check NAT Gateway / security group / VPC Endpoints
-```
+# Cold start rate + init latency
+filter @type="REPORT" | stats count() as total, sum(ispresent(@initDuration)) as coldStarts,
+  avg(@initDuration) as avgInitMs, pct(@initDuration,99) as p99InitMs by bin(1h)
 
-```bash
-aws lambda get-function-configuration --function-name my-func --query '[Timeout,MemorySize]'
-aws cloudwatch get-metric-statistics --namespace AWS/Lambda --metric-name Duration \
-  --dimensions Name=FunctionName,Value=my-func --period 300 --statistics Average Maximum \
-  --start-time $(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%S) --end-time $(date -u +%Y-%m-%dT%H:%M:%S)
-# For percentiles, use a separate call:
-aws cloudwatch get-metric-statistics --namespace AWS/Lambda --metric-name Duration \
-  --dimensions Name=FunctionName,Value=my-func --period 300 --extended-statistics p99 \
-  --start-time $(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%S) --end-time $(date -u +%Y-%m-%dT%H:%M:%S)
-```
+# Out-of-memory (>90% used)
+filter @type="REPORT" | filter @maxMemoryUsed/@memorySize > 0.9
+  | fields @timestamp, @requestId, @maxMemoryUsed/1e6 as usedMB | sort @timestamp desc
 
----
+# Latency percentiles
+filter @type="REPORT" | stats pct(@duration,50) as p50, pct(@duration,90) as p90,
+  pct(@duration,99) as p99, max(@duration) as max by bin(1h)
 
-## Out-of-Memory (OOM) Debugging
-
-```
-Runtime.OutOfMemory / signal: killed
-├── Check REPORT: Max Memory Used ≈ Memory Size? → OOM confirmed
-├── Immediate? → Payload/dependency too large → increase memory
-├── Gradual? → Memory leak → check global vars accumulating across warm invocations
-└── Fix: increase memory, stream large files, bound caches
-```
-
-| Memory (MB) | vCPUs | Use Case |
-|-------------|-------|----------|
-| 128 | ~0.08 | Simple transforms |
-| 512 | ~0.3 | Moderate processing |
-| 1,769 | 1.0 | CPU-intensive single-threaded |
-| 3,538 | 2.0 | Multi-threaded |
-| 10,240 | ~5.8 | Heavy compute, ML inference |
-
----
-
-## Throttling Diagnosis
-
-| Concept | Default | Notes |
-|---------|---------|-------|
-| Account concurrency | 1,000/region | Request increase via Service Quotas |
-| Reserved concurrency | None | Guarantees AND caps function concurrency |
-| Concurrency scaling rate | 1,000 envs/10s | Per function, uniform across regions |
-
-| Invocation Type | Throttle Behavior |
-|-----------------|-------------------|
-| Synchronous (API GW) | Returns 429 (API GW may show 500) |
-| Async (S3, SNS) | Auto-retries up to 6 hours |
-| SQS trigger | Returns to queue, backs off |
-| Kinesis/DDB Streams | Retries batch, blocks shard |
-
-```bash
-aws lambda get-account-settings
-aws cloudwatch get-metric-statistics --namespace AWS/Lambda --metric-name Throttles \
-  --dimensions Name=FunctionName,Value=my-func --period 60 --statistics Sum \
-  --start-time $(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%S) --end-time $(date -u +%Y-%m-%dT%H:%M:%S)
-```
-
----
-
-## CloudWatch Logs Insights Queries
-
-Run against `/aws/lambda/FUNCTION_NAME`. For API Gateway, use the access log group.
-
-### Cold Starts
-
-```
-filter @type = "REPORT" | filter ispresent(@initDuration)
-| stats count() as coldStarts, avg(@initDuration) as avgInitMs, max(@initDuration) as maxInitMs, pct(@initDuration, 99) as p99InitMs by bin(1h)
-```
-
-### Cold Start Percentage
-
-```
-filter @type = "REPORT"
-| stats count() as total, sum(ispresent(@initDuration)) as coldStarts, sum(ispresent(@initDuration)) * 100.0 / count() as pct by bin(1h)
-```
-
-### Errors by Type
-
-```
-filter @message like /(?i)error|exception/
-| parse @message /(?<errorType>[A-Za-z]+Error|[A-Za-z]+Exception)/
-| stats count() as cnt by errorType | sort cnt desc
-```
-
-### Timeouts
-
-```
-filter @message like /Task timed out/ | stats count() as timeouts by bin(1h) | sort bin desc
-```
-
-### Memory Utilization
-
-```
-filter @type = "REPORT"
-| stats max(@memorySize/1e6) as provisionedMB, avg(@maxMemoryUsed/1e6) as avgUsedMB, max(@maxMemoryUsed/1e6) as maxUsedMB, pct(@maxMemoryUsed/1e6, 99) as p99UsedMB
-```
-
-### Out-of-Memory Detection (>90% memory)
-
-```
-filter @type = "REPORT" | filter @maxMemoryUsed / @memorySize > 0.9
-| fields @timestamp, @requestId, @maxMemoryUsed/1e6 as usedMB, @memorySize/1e6 as allocatedMB | sort @timestamp desc | limit 50
-```
-
-### Overprovisioned Memory (<50% used)
-
-```
-filter @type = "REPORT"
-| stats max(@memorySize/1e6) as provMB, max(@maxMemoryUsed/1e6) as peakMB, max(@maxMemoryUsed)*100.0/max(@memorySize) as pct
-| filter pct < 50
-```
-
-### Memory Growth (Leak Detection)
-
-```
-filter @type = "REPORT" | stats avg(@maxMemoryUsed/1e6) as avgMemMB by bin(5m) | sort bin asc
-```
-
-### Latency Percentiles
-
-```
-filter @type = "REPORT"
-| stats avg(@duration) as avg, pct(@duration,50) as p50, pct(@duration,90) as p90, pct(@duration,95) as p95, pct(@duration,99) as p99, max(@duration) as max by bin(1h)
-```
-
-### Slowest Invocations
-
-```
-filter @type = "REPORT"
-| fields @timestamp, @requestId, @duration, @maxMemoryUsed/1000000 as memMB, ispresent(@initDuration) as coldStart
-| sort @duration desc | limit 20
-```
-
-### API Gateway 5xx
-
-```
+# API Gateway 5xx (access log group)
 filter status >= 500 | stats count() as errors by status, path, httpMethod | sort errors desc
 ```
 
-### API Gateway 5xx Over Time
+### Memory ↔ vCPU (for OOM / CPU tuning)
 
-```
-filter status >= 500 | stats count() by bin(5m) | sort bin desc
-```
+| Memory | vCPUs | Use case |
+|---|---|---|
+| 128 MB | ~0.08 | Simple transforms |
+| 512 MB | ~0.3 | Moderate processing |
+| 1,769 MB | 1.0 | CPU-intensive single-threaded |
+| 3,538 MB | 2.0 | Multi-threaded |
+| 10,240 MB | ~5.8 (up to 6 vCPU) | Heavy compute / ML inference |
 
-### Throttle Events
+### X-Ray
 
-```
-filter @message like /Rate Exceeded|TooManyRequestsException|Throttl/
-| fields @timestamp, @requestId, @message | sort @timestamp desc | limit 50
-```
-
-### Billed Duration
-
-```
-filter @type = "REPORT"
-| stats count() as invocations, sum(@billedDuration)/1000 as totalBilledSec, avg(@billedDuration) as avgBilledMs by bin(1d)
-```
-
-### Error Messages with Request IDs
-
-```
-filter @message like /(?i)error|exception|fail/
-| fields @timestamp, @requestId, @message | sort @timestamp desc | limit 50
-```
-
----
-
-## X-Ray Tracing
-
-### Enable in SAM
-
-```yaml
-Globals:
-  Function:
-    Tracing: Active
-```
-
-### Enable in CDK
-
-```typescript
-new lambda.Function(this, 'Fn', {
-  tracing: lambda.Tracing.ACTIVE,  // adds AWSXRayDaemonWriteAccess automatically
-});
-```
-
-### Required IAM
-`AWSXRayDaemonWriteAccess` managed policy on the execution role. SAM/CDK add this automatically.
-
-### Default Sampling
-1 request/second (reservoir) + 5% of additional requests.
-
-### Instrument SDK Calls
-
-```python
-from aws_xray_sdk.core import patch_all
-patch_all()
-```
-
-```javascript
-// SDK v3 (Node.js 18+)
-const { captureAWSv3Client } = require('aws-xray-sdk-core');
-const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
-const ddb = captureAWSv3Client(new DynamoDBClient({}));
-```
-
-### Query Traces
-
-```bash
-aws xray get-trace-summaries --start-time $(date -u -d '1 hour ago' +%s) --end-time $(date -u +%s) \
-  --filter-expression 'service("my-func") AND fault'
-aws xray batch-get-traces --trace-ids "1-xxx-yyy"
-```
-
-### Enable for API Gateway
-
-```yaml
-Resources:
-  MyApi:
-    Type: AWS::Serverless::Api
-    Properties:
-      StageName: prod
-      TracingEnabled: true
-```
-
-### Enable for Step Functions
-
-```yaml
-Resources:
-  MyStateMachine:
-    Type: AWS::Serverless::StateMachine
-    Properties:
-      Tracing:
-        Enabled: true
-```
+Enable via SAM `Tracing: Active` (Function) / `TracingEnabled: true` (Api) or CDK `tracing: lambda.Tracing.ACTIVE` (adds `AWSXRayDaemonWriteAccess` automatically). Default sampling: 1 req/s reservoir + 5%. Instrument SDK calls with `patch_all()` (Python) / `captureAWSv3Client` (Node).


### PR DESCRIPTION
## Description

Streamlines the `aws-serverless` skill to focus on values, quotas, and edge cases that trip up implementations rather than restating basics that current frontier models already know.

- Reduces the skill body substantially (~6,200 lines removed, ~1,100 added across the mirrored copies) while preserving the exact runtime versions, quota values, and feature matrices.
- Adds a **"Specialized skills — check these first"** routing section that points to the dedicated Lambda/API Gateway/Step Functions skills (`aws-lambda-microvms`, `aws-lambda-durable-functions`, `aws-lambda-managed-instances`, `connecting-lambda-to-api-gateway`, `connecting-lambda-to-dynamodb`, `creating-api-gateway-stage`, `deploying-custom-domain-rest-api`, `debugging-lambda-timeouts`, `processing-s3-uploads-with-step-functions`) before falling back to the general references.
- Applied to both the `skills/core-skills/` tree and the `plugins/aws-core/` copy to keep them in sync.

The streamlined content was evaluated with the AWSMCPSkillsEval harness across three models (Sonnet 5, Opus 4.8, GPT 5.4) and two harnesses (Claude Code, Kiro): all three models reached 100% task completion with the skill loaded vs. 53.8–66.7% at baseline.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation update
- [x] Other <!-- Streamline / improve an existing skill -->

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
