### PR TITLE
feat(amazon-bedrock): bedrock agents to agentcore harness migration and bedrock agents maintenance mode announcement

### DIFF
--- a/plugins/aws-core/skills/amazon-bedrock/SKILL.md
+++ b/plugins/aws-core/skills/amazon-bedrock/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amazon-bedrock
-description: Builds generative AI applications on Amazon Bedrock. Covers model invocation (Converse API, InvokeModel), RAG with Knowledge Bases, Bedrock Agents, Guardrails, and AgentCore. Use when invoking models, setting up Knowledge Bases, creating agents, applying guardrails, deploying to AgentCore, troubleshooting Bedrock errors (ThrottlingException, AccessDeniedException), or choosing models (Claude, Llama, Nova, Titan). ALSO USE for prompt caching setup and debugging, quota health checks and throttling diagnosis, cost attribution and tracking, migrating between Claude model generations (4.5 to 4.6 to 4.7), chunking strategies, API selection (Converse vs InvokeModel), guardrail capabilities, and model selection. Also covers AgentCore Payments setup (x402, microtransactions, Payment Manager, Connector, Instrument, Coinbase CDP, Stripe Privy, 402 Payment Required, pay for content, paid endpoint, agent payments). NOT for custom model training, Rekognition, or Comprehend.
+description: Builds generative AI applications on Amazon Bedrock. Covers model invocation (Converse API, InvokeModel), RAG with Knowledge Bases, Bedrock Agents, Guardrails, and AgentCore. Use when invoking models, setting up Knowledge Bases, creating agents, applying guardrails, deploying to AgentCore, migrating/porting/converting a Bedrock Agent (including inline agents) to an AgentCore Harness, troubleshooting Bedrock errors (ThrottlingException, AccessDeniedException), or choosing models (Claude, Llama, Nova, Titan). ALSO USE for prompt caching setup and debugging, quota health checks and throttling diagnosis, cost attribution and tracking, migrating between Claude model generations (4.5 to 4.6 to 4.7), chunking strategies, API selection (Converse vs InvokeModel), guardrail capabilities, and model selection. Also covers AgentCore Payments setup (x402, microtransactions, Payment Manager, Connector, Instrument, Coinbase CDP, Stripe Privy, 402 Payment Required, pay for content, paid endpoint, agent payments). NOT for custom model training, Rekognition, or Comprehend.
 version: 1
 ---
 
@@ -61,6 +61,8 @@ AgentCore is a separate service with its own endpoints. Refer to [AgentCore endp
 
 **SDK versions**: Requires recent versions of boto3 (≥ 1.34.x) and AWS CLI v2. Older versions are missing Converse API, Agents, and AgentCore support. Run `aws --version` and `pip show boto3` to check.
 
+**Bedrock Agents classic is in maintenance mode**: classic Bedrock Agents (`bedrock-agent`) is in maintenance mode and closed to new customers ([announcement](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html)). For new agent workloads use AgentCore (the Harness managed loop); for existing agents, recommend migrating to an AgentCore Harness — see the [migration guide](references/migrate-bedrock-agents-to-agentcore-harness.md).
+
 ## Security Considerations
 
 - Use **IAM roles** (not IAM users) for all Bedrock service access
@@ -97,6 +99,7 @@ For full API details and provider-specific body formats, read [model invocation 
 | Create an agent that takes actions | Bedrock Agents | [agent creation](references/agents-and-action-groups.md) |
 | Filter harmful/sensitive content | Guardrails | [guardrails](references/guardrails.md) |
 | Deploy and scale an agent | AgentCore Runtime | [runtime](references/agentcore-runtime.md) |
+| Migrate an existing Bedrock Agent (classic) to an AgentCore Harness | Bedrock Agents to AgentCore harness Migration | [migration guide](references/migrate-bedrock-agents-to-agentcore-harness.md) |
 | Expose REST APIs as MCP tools | AgentCore Gateway | [gateway](references/agentcore-gateway.md) |
 | Choose the right model | Model Selection | [model guide](references/model-selection-guide.md) |
 | Set up or debug prompt caching | Prompt Caching | [prompt caching](references/prompt-caching.md) |
@@ -354,6 +357,7 @@ For model ID formats (4 patterns), access provisioning, and selection criteria, 
 - [Amazon Bedrock User Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
 - [Amazon Bedrock API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/welcome.html)
 - [Amazon Bedrock AgentCore User Guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html)
+- [Bedrock Agents Classic Maintenance mode Announcement](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html)
 - [Bedrock Pricing](https://aws.amazon.com/bedrock/pricing/)
 - [Bedrock Quotas and Limits](https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html)
 - [Bedrock Supported Regions](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html)

--- a/plugins/aws-core/skills/amazon-bedrock/assets/kb_shim.py.tmpl
+++ b/plugins/aws-core/skills/amazon-bedrock/assets/kb_shim.py.tmpl
@@ -1,0 +1,80 @@
+"""
+Knowledge Base shim Lambda — AgentCore Gateway target.
+
+WHY: the native Gateway KB connector only takes a MANAGED Bedrock KB and a fixed
+retrieval contract. For VECTOR / KENDRA / SQL KBs, or to preserve a managed KB's
+non-default retrieval config (reranker, metadata filter, hybrid override, top-k),
+expose retrieval as this Lambda: it presents one MCP tool, calls
+`bedrock-agent-runtime:Retrieve` against the source KB, and returns MCP-shaped
+passages.
+
+Gateway invokes a Lambda target with the tool arguments flat in `event` and the
+tool name in context.client_context.custom['bedrockAgentCoreToolName']
+("<target>___<tool>"). The handler also tolerates a direct {"query": ...} for local
+testing.
+"""
+# <<< RENDER: delete this whole block after substituting the tokens below.
+#   {{KB_ID}}        - the source knowledge base id
+#   {{TOP_K}}        - numberOfResults from the source KB association (default 5)
+#   {{SEARCH_TYPE}}  - "HYBRID" | "SEMANTIC" | "" (empty means KB default)
+# <<< /RENDER
+import boto3
+
+# Rendered at migration time — the Gateway lambda code target has no
+# environment-variable support, so all config is baked in as literals.
+_KB_ID = "{{KB_ID}}"
+_TOP_K = int("{{TOP_K}}")
+_SEARCH_TYPE = "{{SEARCH_TYPE}}".strip().upper()
+_MAX_QUERY_LEN = 1000  # reject oversized queries — abuse / runaway retrieval cost
+
+_runtime = boto3.client("bedrock-agent-runtime")
+
+
+def _vector_search_config():
+    cfg = {"numberOfResults": _TOP_K}
+    if _SEARCH_TYPE in ("HYBRID", "SEMANTIC"):
+        cfg["overrideSearchType"] = _SEARCH_TYPE
+    # <<< OPTIONAL: metadata_filter
+    # Render the source KB association's `filter` here when present.
+    # cfg["filter"] = {{METADATA_FILTER_JSON}}
+    # <<< /OPTIONAL: metadata_filter
+    # <<< OPTIONAL: reranking
+    # Render the source KB association's `rerankingConfiguration` here when present.
+    # (Set on retrievalConfiguration, not vectorSearchConfiguration — see the
+    #  bedrock-agent-runtime Retrieve API shape.)
+    # <<< /OPTIONAL: reranking
+    return cfg
+
+
+def lambda_handler(event, context):
+    # single-tool target: Gateway passes the tool args flat in `event`
+    args = event if isinstance(event, dict) else {}
+    query = args.get("query") or args.get("text") or ""
+    if not isinstance(query, str) or not query:
+        return {"error": "Missing required argument 'query'."}
+    if len(query) > _MAX_QUERY_LEN:
+        return {"error": f"Query exceeds {_MAX_QUERY_LEN} chars."}
+
+    vector_cfg = _vector_search_config()
+    max_results = args.get("max_results")
+    if isinstance(max_results, int) and max_results > 0:
+        vector_cfg["numberOfResults"] = max_results
+
+    resp = _runtime.retrieve(
+        knowledgeBaseId=_KB_ID,
+        retrievalQuery={"text": query},
+        retrievalConfiguration={"vectorSearchConfiguration": vector_cfg},
+    )
+    # Returns KB passage text + source location verbatim. If the KB holds
+    # sensitive data (PII, financial records), review what it returns and redact
+    # or filter fields here before returning, and keep this Lambda's CloudWatch
+    # log group KMS-encrypted (see references/deploy.md) — do not log full passages.
+    results = [
+        {
+            "text": r.get("content", {}).get("text", ""),
+            "source": r.get("location", {}),
+            "score": r.get("score"),
+        }
+        for r in resp.get("retrievalResults", [])
+    ]
+    return {"results": results, "count": len(results)}

--- a/plugins/aws-core/skills/amazon-bedrock/assets/lambda_shim.py.tmpl
+++ b/plugins/aws-core/skills/amazon-bedrock/assets/lambda_shim.py.tmpl
@@ -1,0 +1,158 @@
+"""
+Action-Group shim Lambda — AgentCore Gateway target (proxy-by-ARN).
+
+WHY: a Bedrock action-group Lambda is invoked with the Bedrock envelope and returns
+a wrapped response. AgentCore Gateway sends the tool arguments flat in `event` with
+the tool name in context.client_context.custom['bedrockAgentCoreToolName']
+("<target>___<tool>") and expects plain JSON. This shim is a NEW Lambda deployed in
+front of the original: it translates the Gateway event into the Bedrock event,
+invokes the original by ARN, and unwraps the response. The original is left
+untouched, so the source agent keeps working.
+
+Do NOT zip or `create-function` this yourself. Place this handler at
+tools/<shim>/handler.py, hand-add a `targetType:"lambda"` code target to
+agentcore.json pointing at it, and let `agentcore deploy` build the Lambda. All
+config ({{TOKEN}}s below) is baked in at render time — the code target has no
+environment-variable support. See references/deploy.md "How shims are deployed".
+"""
+# <<< RENDER: delete this whole block after substituting the tokens below.
+#   {{ORIGINAL_LAMBDA_ARN}}  - the source action-group Lambda ARN
+#   {{SCHEMA_STYLE}}         - "function" (functionSchema) | "openapi" (apiSchema)
+#   {{OP_ROUTES}}            - (openapi only) JSON object mapping each operationId to
+#                             its {"method","apiPath"} from the SOURCE OpenAPI schema.
+#                             apiPath MUST be the literal route TEMPLATE, e.g.
+#                             "/customer/{customer_id}" — NOT a value-substituted path.
+# <<< /RENDER
+import json
+import re
+
+import boto3
+
+# Rendered at migration time — the Gateway lambda code target has no
+# environment-variable support, so all config is baked in as literals.
+_ORIGINAL_ARN = "{{ORIGINAL_LAMBDA_ARN}}"
+_SCHEMA_STYLE = "{{SCHEMA_STYLE}}"  # function | openapi
+_MAX_ARG_BYTES = 256 * 1024  # cap forwarded payload — reject oversized/abusive input
+
+# operationId -> {"method": <HTTP method>, "apiPath": <route TEMPLATE>}.
+# Rendered from the source OpenAPI schema. The apiPath is the template with
+# placeholders intact (e.g. "/customer/{customer_id}") because the original Bedrock
+# Lambda dispatches by matching that exact template; path-param VALUES stay in the
+# parameters array, never substituted into the path.
+_OP_ROUTES = {{OP_ROUTES}}
+_lambda = boto3.client("lambda")
+
+
+def _resolve_tool_and_args(event, context):
+    cc = getattr(context, "client_context", None)
+    custom = getattr(cc, "custom", None) if cc else None
+    raw = (custom or {}).get("bedrockAgentCoreToolName", "") if custom else ""
+    tool = raw.split("___", 1)[1] if "___" in raw else raw
+    args = event if isinstance(event, dict) else {}
+    return tool, args
+
+
+def _validate_args(args):
+    """Reject unexpected shapes before forwarding to the original Lambda: keys must
+    be strings and the whole payload must stay under a sane size cap. This keeps the
+    shim from injecting oversized or malformed input into the original's envelope."""
+    if not all(isinstance(k, str) for k in args):
+        raise ValueError("All argument keys must be strings.")
+    if len(json.dumps(args, default=str).encode("utf-8")) > _MAX_ARG_BYTES:
+        raise ValueError(f"Arguments exceed {_MAX_ARG_BYTES} bytes.")
+
+
+def _to_bedrock_event(tool, args):
+    """Build the Bedrock-Agents envelope the original handler expects."""
+    _validate_args(args)
+    if _SCHEMA_STYLE == "openapi":
+        # Look up the route TEMPLATE for this operationId and pass it verbatim.
+        route = _OP_ROUTES.get(tool)
+        if route is None:
+            raise ValueError(
+                f"No OpenAPI route for operationId {tool!r}; _OP_ROUTES must be "
+                "rendered from the source schema."
+            )
+        # In the real Bedrock envelope, path/query params live in `parameters` and
+        # body params in `requestBody` — don't put every arg in both, or a Lambda
+        # that reads both sees duplicated/misplaced values. Path params are the
+        # `{placeholder}` names in the route template. For methods with no request
+        # body (GET/DELETE/HEAD) the remaining args are query params and also belong
+        # in `parameters`; only body-bearing methods route the rest to `requestBody`.
+        path_names = set(re.findall(r"\{(\w+)\}", route["apiPath"]))
+        non_path = {k: v for k, v in args.items() if k not in path_names}
+        base = {
+            "messageVersion": "1.0", "actionGroup": "migrated",
+            "apiPath": route["apiPath"],       # literal template — never substitute values
+            "httpMethod": route["method"],
+        }
+        # `parameters` entries declare type "string", so values must be strings —
+        # Gateway may hand us typed JSON (int/bool). `requestBody` keeps native types.
+        if route["method"].upper() in ("GET", "DELETE", "HEAD"):
+            params = [{"name": k, "value": str(v), "type": "string"}
+                      for k, v in args.items()]  # path + query, all in parameters
+            base["parameters"] = params
+        else:
+            base["parameters"] = [{"name": k, "value": str(v), "type": "string"}
+                                  for k in path_names for v in [args[k]]]
+            base["requestBody"] = {"content": {"application/json": {
+                "properties": [{"name": k, "value": v} for k, v in non_path.items()]}}}
+        return base
+    # functionSchema style: all args are flat parameters.
+    params = [{"name": k, "value": str(v), "type": "string"} for k, v in args.items()]
+    return {"messageVersion": "1.0", "actionGroup": "migrated",
+            "parameters": params, "function": tool}
+
+
+def _unwrap(resp):
+    """Pull the tool output out of the Bedrock-Agents response envelope."""
+    if not isinstance(resp, dict):
+        return {"body": resp}
+    r = resp.get("response", {})
+    fr = r.get("functionResponse", {})
+    if fr:
+        body = fr.get("responseBody", {}).get("TEXT", {}).get("body")
+        if body is not None:
+            return {"body": body}
+    api = r.get("apiResponse", {})
+    if api:
+        body = api.get("responseBody", {}).get("application/json", {}).get("body")
+        if body is not None:
+            return {"body": body}
+    return resp  # some Lambdas already return plain JSON
+
+
+def lambda_handler(event, context):
+    # This shim forwards user-provided tool arguments, which may hold PII, financial
+    # data, or other sensitive values. Do NOT log the full event/args/response, and
+    # keep this Lambda's CloudWatch log group KMS-encrypted (see references/deploy.md).
+    tool, args = _resolve_tool_and_args(event, context)
+    bedrock_event = _to_bedrock_event(tool, dict(args))
+    try:
+        out = _lambda.invoke(
+            FunctionName=_ORIGINAL_ARN,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(bedrock_event).encode("utf-8"),
+        )
+    except _lambda.exceptions.ClientError as e:
+        # AccessDenied here means the SOURCE Lambda's resource policy does not yet
+        # allow this shim role to invoke it. This is a source-side grant the builder
+        # must add (see references/deploy.md "Source-side prerequisites") — the
+        # migration must NOT add-permission on the source itself.
+        if e.response.get("Error", {}).get("Code") in ("AccessDeniedException", "AccessDenied"):
+            raise RuntimeError(
+                f"Denied invoking original Lambda {_ORIGINAL_ARN}. The builder must grant "
+                "this shim's role lambda:InvokeFunction on the source (do not modify the "
+                "source from the migration)."
+            ) from e
+        raise
+    payload = json.loads(out["Payload"].read() or b"{}")
+    # A failed original Lambda returns 200 with FunctionError set and the error in
+    # the payload — surface it as a real failure so the Gateway/Harness sees the
+    # tool errored, instead of passing the error dict off as a successful result.
+    if "FunctionError" in out:
+        raise RuntimeError(
+            f"Original Lambda failed ({out['FunctionError']}): "
+            f"{payload.get('errorMessage', 'unknown error')}"
+        )
+    return _unwrap(payload)

--- a/plugins/aws-core/skills/amazon-bedrock/assets/tool_schema.json.tmpl
+++ b/plugins/aws-core/skills/amazon-bedrock/assets/tool_schema.json.tmpl
@@ -1,0 +1,12 @@
+[
+  {
+    "_comment": "ToolDefinition[]: one entry per source tool/operation, mirroring the source schema exactly — see references/mapping.md.",
+    "name": "{{TOOL_NAME}}",
+    "description": "{{TOOL_DESCRIPTION_FROM_SOURCE}}",
+    "inputSchema": {
+      "type": "object",
+      "properties": {{TOOL_PROPERTIES_FROM_SOURCE}},
+      "required": {{TOOL_REQUIRED_FROM_SOURCE}}
+    }
+  }
+]

--- a/plugins/aws-core/skills/amazon-bedrock/references/agents-and-action-groups.md
+++ b/plugins/aws-core/skills/amazon-bedrock/references/agents-and-action-groups.md
@@ -1,5 +1,12 @@
 # Create a Bedrock Agent with Action Groups
 
+## Notice
+
+**IMPORTANT**
+Bedrock Agents has been renamed to Bedrock Agents classic and is now in maintenance mode, and is no longer open to new customers ([Maintenance Mode Announcement](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html) for dates and specifics). For new workloads, it is recommended to use Bedrock AgentCore, use the reference files to learn how to get started with AgentCore. For existing Agents, it is recommended to migrate your Amazon Bedrock Agents Classic workloads to Amazon Bedrock AgentCore. AgentCore is the platform to build, connect, and optimize AI agents. The managed harness in AgentCore provides a config-based starting point where developers can declare the agent's model, tools, and instructions. AgentCore handles the environment, compute, memory, identity, and observability. When a user is asking you for help with Bedrock Agents, bring up the maintenance mode announcement, recommend Bedrock AgentCore and that you can help with the migration.
+
+The migration guide is available in [bedrock-agents-to-agentcore-harness-migration-guide](./migrate-bedrock-agents-to-agentcore-harness.md). If the user is asking questions about what to do about the maintenance mode announcement, if they need help with the migration refer to the guide.
+
 ## Table of Contents
 
 - Overview

--- a/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/cli.md
+++ b/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/cli.md
@@ -1,0 +1,36 @@
+# AgentCore CLI
+
+The migration tool is the AgentCore CLI, package **`@aws/agentcore`** — use the **latest** version. Its command/flag surface shifts between releases, so **verify it live** rather than trusting a hardcoded flag table.
+
+The AgentCore CLI (`@aws/agentcore`) is **not** the same as the `bedrock-agentcore-starter-toolkit`. The starter toolkit is deprecated and not recommended — do not use it or its commands for this migration. Everything here uses `@aws/agentcore`.
+
+## Authoritative, always-current sources
+
+- Installed surface: `agentcore --help`, then `agentcore <command> --help` for each command about to be used.
+- Per-project schema the CLI ships: `https://schema.agentcore.aws.dev/v1/agentcore.json` inside any scaffolded project (authoritative shape for `agentcore.json`, harness, gateway, target, tool-schema). Read before hand-editing config.
+- Published / latest version: `npm view @aws/agentcore version`.
+- Package page: https://www.npmjs.com/package/@aws/agentcore
+
+## Phase 0 checks
+
+```bash
+agentcore --version
+npm view @aws/agentcore version      # newer release available?
+python3 -c "import boto3; print(boto3.__version__)"   # discovery path probe (see discovery.md)
+```
+
+Then probe the commands the migration actually calls and confirm the flags/values each needs are present:
+
+```bash
+agentcore create --help
+agentcore add gateway --help
+agentcore add gateway-target --help
+agentcore add harness --help
+agentcore add tool --help
+agentcore deploy --help
+```
+
+If a required flag is **absent**, stop — don't generate commands against a surface that no longer exists. Update the CLI (`npm install -g @aws/agentcore@latest`) and re-probe, or update this skill if the references assume a flag the CLI renamed.
+
+## Never reverse-engineer the CLI bundle
+Do **not** read the CLI's minified source (`node_modules/@aws/agentcore/dist/**`) — internal names and wizard-only code paths produce confident-but-wrong conclusions. If `--help`, `.llm-context`, the hosted schema, and these references don't answer it, stop and ask the user.

--- a/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/deploy.md
+++ b/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/deploy.md
@@ -1,0 +1,116 @@
+# Deploy
+
+Deploy into the **source agent's region** (mirror). If any step fails, surface the error and stop — **fail loudly**, never silently work around a failure.
+
+## CRITICAL: set the deploy-target region right after scaffold (region trap)
+`agentcore create` with no resolved region **silently writes a default region** into `agentcore/aws-targets.json` that is usually not the source agent's. Immediately after scaffold, before any `add`/`deploy`: **edit `agentcore/aws-targets.json` so the deploy-target region is the source agent's region**, and verify it before the first deploy. A wrong region is wrong on two counts: the shims invoke the **source** Lambdas / KB **by ARN**, so a harness elsewhere can't reach them; and a deploy can hit region-specific Harness CFN-type issues that surface as a stack rollback (read the CloudFormation failure; if region-specific, redeploy in the source region).
+
+If a deploy already landed in the wrong region: `aws cloudformation delete-stack` the wrong-region stack, reset `agentcore/.cli/deployed-state.json` to `{"targets":{}}`, fix `aws-targets.json`, then redeploy.
+
+## Source-side prerequisites — the builder grants these, never the migration (INV-1)
+
+The AG shim invokes the **original** source Lambda by ARN, so the source Lambda's resource policy must allow the shim's execution role to call it. **This is the builder's job, not the migration's** — the skill must never mutate source-side infrastructure to unblock itself.
+
+Expect the **first shim invocation to fail with `AccessDeniedException`** until the permission exists. When it does: **stop and hand the builder this command; do NOT run `aws lambda add-permission` on the source yourself** (that mutates the source and breaks INV-1):
+
+```bash
+aws lambda add-permission --function-name <original-fn> \
+  --statement-id agentcore-shim-invoke --action lambda:InvokeFunction \
+  --principal <shim-role-arn> --source-arn <shim-lambda-arn>
+```
+
+(`bedrock-agent-runtime:Retrieve` for the KB shim is granted on the shim role via its `iamPolicy`, so the KB path needs no source-side change — only the AG-shim → original-Lambda invoke does.)
+
+## Two-phase deploy
+
+A gateway tool can only attach once the gateway and its targets are *deployed* (`add tool --type agentcore_gateway` reads the gateway's deployed tool list). So deploy twice:
+
+1. **Scaffold:** `agentcore create` (plain — not the `--type import`/`agentcore import` path, which builds a *code* project, not a Harness). Then `cd` in and run **every** later `add`/`deploy`/`status` from that one directory — those commands resolve the project from the cwd, so a second project or a different dir yields "No agentcore project found".
+2. **Add** infra that doesn't need a deployed gateway:
+   - `agentcore add gateway`, then hand-add one **`targetType: "lambda"` code target** to `agentcore.json` per action group / KB shim (see "How shims are deployed").
+   - `agentcore add harness` (one command, all flags): `--model-id` (= source `foundationModel`), `--temperature`/`--top-p`/`--model-max-tokens` (only one of temperature/top-p when the model rejects both), `--system-prompt` (folded instruction + non-DEFAULT override intent, per [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)). Managed memory stays on. `--additional-params` is `lite_llm`-provider only, so a bedrock harness rejects it — which is why the source guardrail is classified **cannot migrate** (verify the current CLI surface per [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)'s guardrail section before relying on this).
+   - if the source had CodeInterpreter: `agentcore add tool --harness <name> --type agentcore_code_interpreter --name <tool-name>`.
+3. **First deploy:** `agentcore deploy` — creates gateway, targets, harness, memory.
+4. **Attach the gateway tool** (gateway now deployed): `agentcore add tool --harness <name> --type agentcore_gateway --name <tool-name> --gateway <gateway-project-name> --outbound-auth awsIam`. `--gateway <project-name>` resolves the deployed ARN automatically. **Add it exactly once** — check `harness.json`/`agentcore status` first; a duplicate `agentcore_gateway` tool deploys fine but breaks at runtime (`Tool name '…' already exists`), silently disabling every gateway-backed tool. If already doubled, remove the extra from `harness.json` and redeploy.
+5. **Second deploy:** `agentcore deploy` — applies the gateway tool. The migration isn't complete until this succeeds and `agentcore status` shows the harness at a new version with the tool.
+
+## Inbound auth — match the source's invocation posture, never loosen it (INV-2/INV-3)
+
+`--outbound-auth awsIam` above governs how the **harness calls the gateway**. It says nothing about **who may invoke the migrated harness/gateway** — that is *inbound* auth, and it is a separate, mandatory decision. The source Bedrock Agent is IAM-gated: only principals with `bedrock-agent-runtime:InvokeAgent` on that agent's ARN can invoke it. The migrated harness must be **no more reachable than that**.
+
+- **Discover the source posture** (Phase 2): which principals hold `bedrock-agent-runtime:InvokeAgent` on the source, and any resource-based policy on the agent. This is the bar to match.
+- **Configure inbound auth explicitly** on `add harness`/`add gateway` — check `agentcore add harness --help` and `add gateway --help` for the inbound-auth flag (SigV4 with an allowed-role list, JWT with a verified issuer, etc.) and set it to match the discovered posture. Do **not** rely on the CLI default.
+- **If the CLI's inbound default is unauthenticated or broader than the source** (or you cannot determine it), **hard-stop** and have the builder confirm the intended posture before deploying — a migrated agent invokable by parties who couldn't reach the source violates both secure-by-default and preserve-posture.
+
+## How shims are deployed — hand-author the code target, CLI builds it at deploy
+
+`agentcore add gateway-target` **cannot create a code target non-interactively** (`--type lambda` is rejected). So this is one of the guide's explicitly sanctioned hand-edits (see "Config edits — the rule"): add the target to `agentcore.json` yourself, then `agentcore deploy` builds the Lambda from your source. Per shim:
+
+1. Place rendered shim at `tools/<shim>/handler.py` (from `{kb_shim,lambda_shim}.py.tmpl` in `assets/`) with a `pyproject.toml` beside it.
+2. Add one entry to `agentCoreGateways[<i>].targets[]` in `agentcore.json`:
+
+   ```json
+   {
+     "name": "<shim-name>",
+     "targetType": "lambda",
+     "toolDefinitions": [ /* one per function/operation; mirror source schema exactly */ ],
+     "compute": {
+       "host": "Lambda",
+       "implementation": { "language": "Python", "path": "tools/<shim>", "handler": "handler.lambda_handler" },
+       "pythonVersion": "<PYTHON_VERSION_ENUM>",
+       "timeout": 30,
+       "iamPolicy": { /* full policy document, least-privilege — see below */ }
+     }
+   }
+   ```
+
+3. Run `agentcore validate` (must print `Valid`), then `agentcore deploy`.
+
+**No `environment` key — all shim config is baked in at render time.** The `compute` schema is strict and has **no** environment-variable support; adding an `environment` key fails `agentcore validate`. Every `{{TOKEN}}` in the shim templates (`ORIGINAL_LAMBDA_ARN`, `SCHEMA_STYLE`, `OP_ROUTES`, `KB_ID`, …) is substituted directly into `tools/<shim>/handler.py` as a literal. An unsubstituted token causes a `SyntaxError` or wrong behavior at runtime — the post-render grep in [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md) is the gate.
+
+**Scope `iamPolicy` to a single resource ARN — never a wildcard.** It is a full policy document (`Version` + `Statement` array are required), granting exactly one action on exactly one resource:
+
+- AG shim — invoke only the original Lambda:
+
+  ```json
+  { "Version": "2012-10-17", "Statement": [
+    { "Effect": "Allow", "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:<region>:<account>:function:<original-name>" } ] }
+  ```
+
+- KB shim — retrieve only from the source KB:
+
+  ```json
+  { "Version": "2012-10-17", "Statement": [
+    { "Effect": "Allow", "Action": "bedrock-agent-runtime:Retrieve",
+      "Resource": "arn:aws:bedrock:<region>:<account>:knowledge-base/<kb-id>" } ] }
+  ```
+
+**Logging & monitoring.** Give the execution role `logs:CreateLogGroup`, `logs:CreateLogStream`, `logs:PutLogEvents` scoped to the function's log group (`arn:aws:logs:<region>:<account>:log-group:/aws/lambda/<fn>:*`); recommend a CloudWatch alarm on the shim's `Errors`/`Throttles` metrics; and confirm CloudTrail captures `lambda:Invoke` for audit. The shims handle tool arguments (AG shim) and retrieval text (KB shim), which may be sensitive: **encrypt the log group with a KMS key** (`aws logs associate-kms-key --log-group-name /aws/lambda/<fn> --kms-key-id <key-arn>`) and do **not** log full request/response payloads.
+
+**Throttling & blast radius.** Set **reserved concurrency** on each shim Lambda (`aws lambda put-function-concurrency`) so a runaway caller can't exhaust account-wide Lambda concurrency, and enable request throttling on the Gateway if the CLI/service exposes it.
+
+**Non-negotiable details (these fail `agentcore validate` if wrong):**
+
+- The `compute` block is **strict** — unknown keys (e.g. `environment`) are rejected, and a Python Lambda **must** set `pythonVersion`.
+- `pythonVersion` is an enum (e.g. `PYTHON_3_12`), **not** a bare `"3.12"` — check the project's `agentcore.json` schema (or `agentcore validate` feedback) for the currently valid values. Prefer the source Lambda's runtime.
+- `implementation` requires all three of `language`, `path`, `handler` and nothing else.
+- `targetType` is the literal string `"lambda"` here (valid in the JSON schema, even though `--type lambda` is rejected on the CLI).
+- `path` is relative to the project root (parent of `agentcore/`).
+- `handler` is `<file>.<function>` = `handler.lambda_handler`.
+
+Do **not** use `--type lambda-function-arn` — that wires a *pre-existing* Lambda by ARN, not a shim this skill builds.
+
+## Config edits — the rule
+Hand-edit a config file **only where this guide explicitly says to** — the region correction in `aws-targets.json`, the `targetType: "lambda"` code target in `agentcore.json`, the documented recovery edits (removing a duplicate `agentcore_gateway` tool from `harness.json`; resetting `deployed-state.json` for a wrong-region redeploy). Everything else goes through `agentcore` commands — harness and tools via `add harness`/`add tool`, gateways and other targets via `add gateway`/`add gateway-target`. Do not invent new hand-edits: when an `add` command fails, fix its flags (missing `--name`, wrong `--type`) rather than editing `harness.json`/`agentcore.json` to route around the failure.
+
+## One action group = one target, with all its functions
+A Bedrock action group can expose several functions/operations (up to three), each with its own schema. The tool-schema file is a **`ToolDefinition[]` array**, so a single Lambda target carries every function in that action group — one array entry per function/operationId. Do not split an action group into multiple targets. [tool_schema.json.tmpl](assets/tool_schema.json.tmpl) is already an array; add one entry per function, mirroring the source schema exactly ([mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).
+
+## Verification
+The migration is done when `agentcore deploy` reports success. Before treating it as complete, **prompt the user** to confirm the deploy succeeded and they're satisfied — surface the deployed harness/gateway ARNs from `agentcore status`. Deeper parity (invoking the harness, comparing against the source) is out of scope unless the user asks.
+
+## Rendering templates into CLI inputs
+
+- KB shim / AG shim Lambda code: adapt the `*.py.tmpl` files in `assets/` (rendering rules in [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)) and place the rendered handler at `tools/<shim>/handler.py` — see "How shims are deployed" above.
+- Tool-schema files: one array per target, one entry per source function/operation, mirroring the source schema exactly ([mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).

--- a/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/discovery.md
+++ b/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/discovery.md
@@ -1,0 +1,36 @@
+# Discovery & source resolution (Phases 1–2)
+
+## Resolving the source agent
+Inputs the user may give: agent **id**, **name**, **ARN**, or nothing.
+
+- **Name only:** list agents in the confirmed region (`bedrock-agent:ListAgents`) and disambiguate with the user.
+- **Nothing:** list agents and present candidates.
+- **ARN:** the agent id is the last `/` segment.
+
+Default to the **production alias's** numbered version, not DRAFT: list aliases (`ListAgentAliases`), have the user identify the production alias, read its `routingConfiguration[0].agentVersion`. **DRAFT-only** (only the auto `TSTALIASID` alias pointing at DRAFT, with no numbered version) is a valid, eligible source — confirm and proceed. Honor an explicit "migrate DRAFT" request.
+
+Confirm the full `(account, region, agentId, agentVersion, aliasId)` tuple before discovery.
+
+## Two discovery paths — prefer the script, fall back to the AWS CLI
+Goal: one JSON manifest, `./out/source-agent.json`, that later phases read.
+
+**Inline agents take neither path.** An inline agent (invoked via `InvokeInlineAgent`) has no persisted `agentId`, so both Path A (the fetch script, which needs `--agent-id`) and Path B (the `aws bedrock-agent get-agent` reads) are inapplicable. Its `InvokeInlineAgent` request payload already contains the configuration — map the payload's fields into the same manifest keys (below): `instruction`, `foundationModel`, `actionGroups`, `knowledgeBases`, `guardrailConfiguration`, and prompt overrides. Fields the payload doesn't carry (execution-role policies, aliases/versions) simply don't exist for an inline agent; omit them. Then proceed to eligibility exactly as for a stored agent.
+
+**The manifest is sensitive.** It captures account ids, IAM role ARNs, attached and inline policy documents, Lambda ARNs, and KB configuration. Do not commit it (add `out/` to `.gitignore`); store it **encrypted at rest** — an encrypted volume or a KMS-backed location, not filesystem permissions alone — readable only by the running user; and delete it after a successful migration unless it is being kept for audit.
+
+### Path A (preferred): bundled fetcher
+`fetch_bedrock_agent.py` snapshots the agent in one command (inlines S3 OpenAPI schemas with `--inline-s3-schemas`; tolerates per-call permission errors). **Requires `python3` + `boto3`** — probe in Phase 0 (`python3 -c "import boto3"`). The script exits with code **3** and prints `FALLBACK_REQUIRED` if boto3 is missing, so a failed run is a clean signal to switch to Path B. Do **not** `pip install` into the user's environment.
+
+```bash
+python3 scripts/fetch_bedrock_agent.py \
+  --agent-id <id> --agent-version <resolved> --region <region> \
+  --inline-s3-schemas --out ./out/source-agent.json
+```
+
+### Path B (fallback): AWS CLI read commands
+The `aws` CLI is a self-contained binary already required for the migration, so it works where a bare python3 may not. Run the equivalent read sequence (`aws bedrock-agent get-agent`, `list/get-agent-action-group`, `list/get-agent-knowledge-base`, `get-knowledge-base`, `list-agent-aliases`, `list-agent-versions`, `list-agent-collaborators` when collaboration is on; `aws s3 cp` to inline S3 schemas; `aws iam get-role` for the execution role) and assemble the same manifest shape yourself. Tolerate `AccessDenied`/`NotFound`/`Validation` on individual calls; abort only on outright failure.
+
+If discovery fails outright, stop and report. Do not partially migrate from an incomplete manifest.
+
+## Manifest schema — the script is the source of truth
+`fetch_bedrock_agent.py` defines the manifest shape; don't duplicate a schema spec here (it would drift). Top-level keys it writes: `discovery` (account/region/caller/version/warnings), `agent`, `agentCollaborationMode`, `orchestrationType`, `executionRole`, `actionGroups`, `knowledgeBases`, `collaborators`, `aliasesAndVersions`. The **Path B (AWS CLI) fallback must assemble the same keys** so downstream phases read one shape regardless of path.

--- a/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/eligibility.md
+++ b/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/eligibility.md
@@ -1,0 +1,35 @@
+# Eligibility rubric
+
+Check each condition against the discovery manifest. A **hard-stop** means the agent has a feature with no validated AgentCore Harness path — stop the migration, name the failing condition, and suggest the manual alternative. Do not migrate the eligible parts of an ineligible agent: a half-migrated agent is worse than a clear "not yet."
+
+State the result of *every* condition to the user, not just the first failure — they need the full picture to decide what to fix.
+
+For an **inline agent**, evaluate these same conditions against the fields of the `InvokeInlineAgent` payload (the manifest built from it) rather than a stored agent — e.g. multimodal input from the payload's model/inputs, collaboration/orchestration from its config. The rubric is identical; only the source of the fields differs.
+
+## Hard-stop conditions
+
+### 1. Multimodal input
+**Signal:** the agent processes images or audio (vision model for image input, or documented image/audio handling). The validated harness path is text-only.
+**Alternative:** keep on Bedrock until a multimodal path is validated. (This is a true hard-stop — don't offer a degraded "migrate anyway with image/audio dropped" path, which would contradict the hard-stop rule above.)
+
+### 2. Multi-agent collaboration
+**Signal:** `agentCollaborationMode` is `SUPERVISOR` or `SUPERVISOR_ROUTER`. The supervisor is out of scope — do **not** flatten collaborators into its prompt, wire them as sub-agents, or migrate it alone (dangling references).
+**Alternative:** each collaborator is an ordinary Bedrock agent; any that doesn't itself collaborate can be migrated on its own (run this skill once per collaborator). Only the supervisor layer is excluded.
+
+### 3. Unreachable knowledge base
+**Signal:** an associated KB is in an account/region the credentials cannot reach — so `bedrock-agent-runtime:Retrieve` can't reproduce its retrieval.
+**Alternative:** grant cross-account/region access, then re-run.
+**Not the KB *type*:** every type (`VECTOR`/`MANAGED`/`KENDRA`/`SQL`) is reachable via `Retrieve` and eligible; type only picks the wiring (see [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).
+
+### 4. Custom orchestration
+**Signal:** `orchestrationType` is `CUSTOM_ORCHESTRATION` (custom orchestration Lambda). The harness runs its own loop; that control flow has no equivalent and would be silently dropped.
+**Alternative:** re-express the logic as harness tools/prompt as a fresh design, or keep on Bedrock.
+
+## Eligible — do not mistake these for blockers
+
+- **DRAFT-only agent** (no published version) — common; treat DRAFT as the source (see [discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md)).
+- **Mixed action-group schema styles** (`functionSchema` and OpenAPI in one agent).
+- **Managed KB with non-default retrieval config, code interpreter, session memory** — all have harness targets (see [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).
+- **An agent with a guardrail** — eligible overall; the guardrail capability just can't be carried.
+
+(Eligible to migrate, but whose *capability* the harness can't reproduce — classify **cannot** and surface to the user: **Return-of-Control action groups** and the **guardrail**. See [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md).)

--- a/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/mapping.md
+++ b/plugins/aws-core/skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/mapping.md
@@ -1,0 +1,62 @@
+# Component mapping
+
+Map each source component to its harness target. **Mirror** behavior, not Bedrock structure. Adapt the `.tmpl` templates in the skill's `assets/` directory: substitute every `{{TOKEN}}`, and delete every marker block — `# <<< RENDER … # <<< /RENDER` (token docs) and `# <<< OPTIONAL: … # <<< /OPTIONAL` (features that don't apply). After rendering, no `{{`, `}}`, or `<<<` may remain — that grep is the verification gate, and it must come back clean.
+
+The `.tmpl` files are not for any template engine; they are guidance for you (the LLM) on how to fill them in.
+
+## Mapping action groups to Gateway targets
+
+A Bedrock action-group Lambda speaks the Bedrock event envelope; AgentCore Gateway invokes Lambda targets with a different shape, so the original won't work behind Gateway unchanged.
+
+**Default: proxy-by-ARN.** Create a *new* shim Lambda ([lambda_shim.py.tmpl](assets/lambda_shim.py.tmpl) — its docstring documents both envelopes) that translates the Gateway event into the Bedrock event, invokes the original by ARN, and unwraps the response. This leaves the original **untouched** — editing it in place can change its response shape and break the source agent. The original's ARN is rendered into the shim source as a literal (no env vars — see [deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md)).
+
+**OpenAPI action groups: pass the route TEMPLATE verbatim.** The original Lambda dispatches by matching `apiPath` against the literal route template (`/customer/{customer_id}`), with path-param values delivered separately in `parameters`. Substituting a value into the path (`/customer/tkashina`) matches no template, so the original falls through to its unhandled-op branch. Render the shim's `_OP_ROUTES` table (mapping each operationId to its `{method, apiPath-template}`) from the source OpenAPI schema with placeholders intact, and keep values in `parameters`.
+
+Each action group becomes one Gateway **`targetType: "lambda"` code target**, hand-added to `agentcore.json` (the CLI can't create it non-interactively), with `toolDefinitions` holding **one entry per function/operation**. `agentcore deploy` then builds the shim Lambda. Exact block + gotchas in [deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md); follow it.
+
+### Tool schemas — mirror exactly
+Reproduce the source action group's schema faithfully into the tool-schema file ([tool_schema.json.tmpl](assets/tool_schema.json.tmpl)): same tool names, parameter names, types, and descriptions. Do **not** rewrite or "improve" them — fidelity to the source agent's behavior is the goal, and a renamed tool or tightened type changes how the model selects it.
+
+## Mapping the knowledge base (connector or KB shim, by type)
+
+**Decide by `knowledgeBaseConfiguration.type` FIRST — the native Gateway connector accepts ONLY a `MANAGED` Bedrock KB.**
+
+- **Any non-`MANAGED` type (`VECTOR`, `KENDRA`, `SQL`)** → **always the KB shim.** The connector cannot accept these at all, so type alone decides and retrieval config is irrelevant. Use the **KB shim** ([kb_shim.py.tmpl](assets/kb_shim.py.tmpl)): a hand-added **`targetType: "lambda"` code target** (see [deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md)) that calls `bedrock-agent-runtime:Retrieve` and returns MCP-shaped passages.
+- **`MANAGED`** → then (and only then) check the **retrieval config on the KB association** (`knowledgeBaseConfigurations[].retrievalConfiguration`: reranker, metadata filter, hybrid/search-type override, top-k):
+  - **default** retrieval config → native Gateway connector: `add gateway-target --type connector --connector bedrock-knowledge-bases --knowledge-base-id <id>`.
+  - **non-default** retrieval config → the **KB shim** (the connector uses a fixed retrieval contract and would silently drop the custom config), reproducing that config from the manifest's KB association.
+
+Both paths reproduce the source agent's retrieval — the choice is wiring, not fidelity, so every reachable KB is still **clean**. (An *unreachable* KB is a hard-stop — see [eligibility.md](references/bedrock-agents-to-agentcore-harness/eligibility.md). Type picks the wiring; it is never itself the blocker.)
+
+### Return-of-Control action groups — cannot migrate
+A `customControl: RETURN_CONTROL` action group has no Lambda; the original application handled execution outside Bedrock. There is no automatic harness equivalent. **Do not silently drop it.** Classify it **cannot** in the migration assessment and confirm with the user before continuing — the migrated agent will lack that capability unless the user supplies a backend for it.
+
+## Built-in action groups
+
+- **`AMAZON.UserInput`**: no tool. Add a clarification instruction to the system prompt; the harness asks clarifying questions naturally.
+- **`AMAZON.CodeInterpreter`**: use the built-in tool, `agentcore add tool --harness <harness-name> --type agentcore_code_interpreter --name <tool-name>` (`--harness` and `--name` required — see [deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md)).
+
+## Mapping memory to managed memory (default)
+
+Use the harness's **managed memory**, which is on by default — the harness auto-provisions an AgentCore Memory instance (semantic + summarization strategies, with the service's default expiry) and loads/saves session history automatically. Check the [harness memory devguide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-memory.html) or `DescribeHarness` for the current defaults rather than assuming a fixed retention. Do not pass `--no-harness-memory`. This covers the common source case (`SESSION_SUMMARY`) via the built-in `SUMMARIZATION` strategy; customize strategies via `UpdateHarness` only if the source clearly needs more.
+
+**Leave truncation at its default (`sliding_window`).** Do not set truncation to `summarization` — it runs mid-conversation and errors on short sessions (`Cannot summarize: insufficient messages`). The default is already safe.
+
+Reference: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-memory.html
+
+## Mapping model parameters to the harness model config
+Set model params via `agentcore add harness` flags: `--model-id`, `--model-max-tokens`, `--temperature`, `--top-p`, `--api-format`. Some models reject setting temperature and top-p together — check the target model's inference-parameter constraints (e.g. `aws bedrock get-foundation-model`, or a probe call) and set **only one** if so.
+
+## Mapping idle session TTL (preserve the source's session-lifetime bound)
+The source's `idleSessionTTLInSeconds` bounds how long an idle session is retained — a security control (it caps the credential/context leakage and replay window). Read its actual value from the discovery manifest (the source agent's own setting, whatever it is) and preserve it: if `agentcore add harness` exposes an equivalent session-TTL flag, set it to the source value. If the CLI has no equivalent, **classify it degraded in Phase 4** with the concrete delta (e.g. "source set 300s; migrated defaults to Ns") so the builder decides — never silently extend the window.
+
+## Guardrail — cannot migrate; surface to the user
+Check whether the installed CLI can attach a guardrail to a **bedrock** harness before classifying: look in `agentcore add harness --help` for a guardrail field, and note that `--additional-params` (the pass-through) is `lite_llm`-provider only, so a bedrock harness rejects it. If no guardrail path exists in the CLI surface you're running, classify the guardrail **cannot** in the assessment and tell the user the migrated harness will **not** enforce it, recording the source `guardrailIdentifier` + version. Do **not** fake it with a system-prompt mention (that enforces nothing). Enforcing it means applying `ApplyGuardrail` outside the harness — out of scope. If the CLI surface you're running exposes a guardrail field, use it and reclassify as clean.
+
+## Mapping the prompt to the system prompt
+Fold the agent instruction into the harness `--system-prompt`. If `AMAZON.UserInput` was present, include the clarification instruction.
+
+Prompt overrides in **DEFAULT** mode carry nothing custom — skip them. But a **non-DEFAULT override** (especially `ORCHESTRATION` or `PRE_PROCESSING`) may hold real business logic — routing rules like "use tool X for billing questions, tool Y for refunds," or input-classification the app relied on. Don't discard that as boilerplate. Read each non-DEFAULT override, separate the Bedrock-Agents scaffolding (the orchestration loop mechanics the harness now owns) from the business intent, and fold the intent into the system prompt — a modern model handles tool-routing guidance cleanly in the prompt. When unsure whether an override is boilerplate or load-bearing, surface it to the user rather than dropping it.
+
+## Mapping the model (mirror the source)
+Default `--model-id` to the source agent's `foundationModel`. If the CLI's harness default differs, set it explicitly to match the source (parity).

--- a/plugins/aws-core/skills/amazon-bedrock/references/migrate-bedrock-agents-to-agentcore-harness.md
+++ b/plugins/aws-core/skills/amazon-bedrock/references/migrate-bedrock-agents-to-agentcore-harness.md
@@ -1,0 +1,98 @@
+# Bedrock Agents to AgentCore Harness
+
+Migrate a Bedrock Agent into an AgentCore **Harness** (the managed agent loop) using the **AgentCore CLI**. The skill drives the CLI to scaffold and deploy; it never hand-rolls boto3 infrastructure the CLI owns. Remeber that this skill can be used for performing the migration AND helping the user answer any migration related questions even if they don't want to perform the migration.
+
+Reference files, scripts and templates are available in [references](references/bedrock-agents-to-agentcore-harness/)
+
+**Inline agents.** This guidance also migrates a Bedrock **inline** agent (one invoked via `InvokeInlineAgent` with its configuration supplied per-request rather than persisted as a stored agent). An inline agent has no `agentId`, so it takes a modified entry path: **its `InvokeInlineAgent` request payload *is* the source manifest.** Concretely — **skip Phase 0's agent-region confirm and all of Phase 1 (identity resolution) and Phase 2's fetch (`fetch_bedrock_agent.py` needs an `--agent-id` an inline agent doesn't have)**; instead, take the user-supplied `InvokeInlineAgent` payload, extract its components (`foundationModel`, `instruction`, `actionGroups`, `knowledgeBases`, `guardrailConfiguration`, prompt overrides), write them into `./out/source-agent.json` in the manifest shape ([bedrock-agents-to-agentcore-harness/discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md)), then **enter at Phase 3**. Every phase from Phase 3 on — eligibility gates, component mapping, deploy — applies unchanged, since they operate on the manifest, not on how it was obtained.
+
+Two ideas run through every phase:
+
+- **gate** — a hard checkpoint the migration must pass before continuing. Some gates are eligibility (a source feature with no validated harness path); others are user approval (account, region, cost). A failed gate stops the migration and is reported, never worked around silently.
+- **mirror** — preserve user-visible *behavior*, not Bedrock-Agents *structure*: keep what the agent does, drop only what the harness now does for you (see [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).
+
+This skill makes AWS API calls throughout (STS, Bedrock Agent reads, deploys). The **AWS MCP server is recommended** for streamlined access, but is not required — every step also works with the AWS CLI and boto3 as described here.
+
+## Capture the request first
+
+The triggering request *is* the input. Extract whatever the user gave — agent **id/name/ARN**, **region**, **profile/account** — and **confirm** it in the phases below rather than re-asking. Identity resolution (Phase 1) runs *after* preflight, since listing agents to disambiguate a name needs a confirmed account + region first.
+
+**Fail fast.** If the request *already* names a hard-stop disqualifier (multi-agent, custom orchestration, multimodal), say so and stop before preflight — always with that condition's specific alternative from [bedrock-agents-to-agentcore-harness/eligibility.md](references/bedrock-agents-to-agentcore-harness/eligibility.md), never a bare "not supported." Phase 3 still runs the full gate for everything that clears this.
+
+## Phases
+
+Finish each phase and summarize before the next.
+
+### Phase 0 — Preflight (environment gates)
+
+Establish the migration runs against the account, region, and CLI the user intends — before touching the source agent.
+
+1. Confirm the **CLI** is present and current per [bedrock-agents-to-agentcore-harness/cli.md](references/bedrock-agents-to-agentcore-harness/cli.md). Stop if it is missing or a required command/flag is absent.
+2. Resolve AWS credentials and run `aws sts get-caller-identity`. **Echo the account id, caller ARN, and resolved region back to the user and ask them to confirm or correct** before proceeding. Never assume the default profile is the right one.
+3. Confirm the **source agent's region** here (if the user supplied one, confirm rather than re-ask). The harness must deploy there — but the CLI defaults elsewhere, so you set it explicitly before the first deploy (Phase 6; see deploy.md's region trap).
+
+Completion criterion: the user has confirmed `(account, region)` and the CLI passed its checks.
+
+### Phase 1 — Identify the source agent
+
+**Inline agents skip this phase** (they have no `agentId`; see "Inline agents" above — take the payload and enter at Phase 3).
+
+Resolve a concrete `(agentId, agentVersion, aliasId)` from whatever the user gave (id, name, ARN, or nothing). If the user gave a name fragment, gave nothing, or **asks to see what's available**, list the agents in the confirmed region (`bedrock-agent:ListAgents`) and present them for the user to pick from. Default to the **production alias's** numbered version, not DRAFT — unless the user has only DRAFT or asks for it explicitly. See [bedrock-agents-to-agentcore-harness/discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md) for resolution rules and the DRAFT-only case.
+
+Completion criterion: the user has confirmed the exact `(account, region, agentId, agentVersion, aliasId)` tuple.
+
+### Phase 2 — Discovery
+
+Snapshot the agent into one manifest (`./out/source-agent.json`) — via the bundled `scripts/fetch_bedrock_agent.py` (needs python3 + boto3), or the `aws bedrock-agent` fallback when boto3 is absent. Both paths and the manifest shape are in [bedrock-agents-to-agentcore-harness/discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md). **For an inline agent** the fetch script does not apply (no `agentId`) — build the manifest from the `InvokeInlineAgent` payload instead, per "Inline agents" above and discovery.md's inline note.
+
+Read the manifest and present a **concise, human-readable inventory** — a scannable list or small table (model; action groups by name + type; KBs + type; guardrail; memory; collaboration), not a prose paragraph.
+
+Also capture the source's **security posture** so the migration can preserve it (see [bedrock-agents-to-agentcore-harness/deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md)): its **inbound invocation posture** (which principals hold `bedrock-agent-runtime:InvokeAgent`, plus any resource-based policy on the agent) and its `idleSessionTTLInSeconds`. These set the bar Phase 6 must match, not loosen.
+
+Completion criterion: manifest written and inventory presented.
+
+### Phase 3 — Eligibility gate
+
+Check the manifest against the eligibility rubric in [bedrock-agents-to-agentcore-harness/eligibility.md](references/bedrock-agents-to-agentcore-harness/eligibility.md). Any **hard-stop** condition (multimodal input, multi-agent collaboration, unreachable KB, custom orchestration) ends the migration here.
+
+If a gate fails: **stop**, tell the user exactly which condition failed and why, and suggest manual alternatives.
+
+Completion criterion: every hard-stop condition checked and explicitly cleared, or the migration stopped with a reported reason.
+
+### Phase 4 — Migration assessment (gate)
+
+The agent is eligible, but not every component migrates with full fidelity. Before planning, show the user a **per-component ledger** classifying each discovered component three ways:
+
+- **clean** — behavior preserved. Most components land here: action groups via shim, *any* KB (MANAGED-with-default-config via connector, everything else via KB shim — both reproduce retrieval, see [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)), CodeInterpreter built-in, model + inference params, and managed memory (the standard harness memory, not a downgrade).
+- **degraded** — a genuine fidelity change the user should weigh, e.g. a non-DEFAULT orchestration/pre-processing prompt whose business logic can't be cleanly folded into the system prompt, or any behavior the migration can only approximate.
+- **cannot** — no harness equivalent, capability lost: Return-of-Control action groups and the **guardrail** (see [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)). Surface both to the user.
+
+Use the mapping in [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md) to classify. Present the ledger and **pause for explicit acknowledgement** — the user must accept the *degraded* and *cannot* items before planning. Nothing irreversible has happened yet; this is informed consent on fidelity loss.
+
+Completion criterion: user has seen the full ledger and acknowledged the degraded/cannot items.
+
+### Phase 5 — Plan
+
+Map each acknowledged component to its harness target using [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md). Produce a written **migration plan** and **pause for approval** (gate). Surface costs and that the source agent is never modified.
+
+Completion criterion: user approved the written plan.
+
+### Phase 6 — Implement & deploy
+
+Drive the CLI per the approved plan, following [bedrock-agents-to-agentcore-harness/deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md) end to end: scaffold with plain `agentcore create`, deploy the shim Lambdas, `add gateway`/`gateway-target`/`harness`, then the **two-phase deploy**. On scaffolding specifically: use `agentcore create` with no flags. Do **not** use `agentcore create --import` (or `agentcore import`) — that flag *does exist*, but it imports the Bedrock Agent into a **code project**, not a Harness, so it is the wrong route for this migration. There is **no** `agentcore init` command. Set the deploy region before the first deploy (deploy.md's region trap). Generate shim code and tool schemas by **adapting** the `.tmpl` templates in `assets/` per [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md). Configure the harness/gateway **inbound auth** to match the source's invocation posture discovered in Phase 2 (deploy.md "Inbound auth") — do not accept the CLI default if it is broader. If deploy fails, surface the error — **fail loudly**, never silently work around it. In particular, if a shim invocation fails with `AccessDenied`, **do not** run `aws lambda add-permission` on the source — that mutates source-side infra; stop and hand the builder the command (deploy.md "Source-side prerequisites").
+
+Completion criterion: `agentcore deploy` reports success. Verification is deploy-success-only; deeper parity is out of scope.
+
+## Security considerations
+
+- **Least-privilege shim roles** — one action on one resource ARN, no wildcards; exact policies in [bedrock-agents-to-agentcore-harness/deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md).
+- **The manifest holds sensitive data** — handling rules in [bedrock-agents-to-agentcore-harness/discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md).
+- **Use ephemeral credentials** (IAM roles, SSO, `assume-role`) for both discovery and deploy — never long-lived IAM user access keys.
+
+## What this migration can not do
+
+- Modify or delete the source Bedrock Agent.
+- Modify the source Lambda's resource policy. If a shim invocation fails with `AccessDenied`, stop and ask the builder to grant the shim role `lambda:InvokeFunction` on the source (deploy.md "Source-side prerequisites") — never run `add-permission` on the source itself.
+- Migrate KB vector stores / data sources — the new agent calls into the existing KB.
+- Migrate conversation history or end-user authentication.
+- Bypass the AgentCore CLI for infrastructure the CLI owns.

--- a/plugins/aws-core/skills/amazon-bedrock/scripts/fetch_bedrock_agent.py
+++ b/plugins/aws-core/skills/amazon-bedrock/scripts/fetch_bedrock_agent.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+Fetch a complete manifest of a Bedrock Agent (Phase 1: Discovery).
+
+Pulls every component the migration cares about into a single JSON document so the
+rest of the skill can reason over a static snapshot instead of repeatedly calling
+the Bedrock control plane.
+
+Usage:
+    python fetch_bedrock_agent.py --agent-id ABC123 --region us-east-1 --out manifest.json
+
+By default fetches the DRAFT version. The skill should resolve a numbered version
+via the production alias in Phase 0 and pass --agent-version <n>. If this script
+sees DRAFT, it prints a WARNING summarizing that the production alias may point
+elsewhere.
+
+Pass --inline-s3-schemas to fetch action-group OpenAPI schemas stored in S3 and
+inline them into the manifest under each action group's `apiSchema._inlinedPayload`.
+
+Requires: boto3 with read-only credentials. Prefer ephemeral, role-based
+credentials (an assumed IAM role, SSO session, or instance profile) over
+long-lived IAM user access keys — `--profile` may otherwise resolve to static
+keys in ~/.aws/credentials.
+
+Minimum IAM permissions (all read-only; scope Resource as noted):
+    sts:GetCallerIdentity
+    bedrock-agent:GetAgent, ListAgentActionGroups,
+        GetAgentActionGroup, ListAgentKnowledgeBases, GetAgentKnowledgeBase,
+        GetKnowledgeBase, ListDataSources, GetDataSource, ListAgentAliases,
+        GetAgentAlias, ListAgentVersions, ListAgentCollaborators (optional),
+        GetAgentCollaborator (optional)
+        -> scope to the specific agent/KB ARNs where possible
+    iam:GetRole, ListAttachedRolePolicies, ListRolePolicies, GetRolePolicy
+        -> scope to the agent's execution-role ARN
+    s3:GetObject (only with --inline-s3-schemas)
+        -> scope to the OpenAPI schema object(s)
+No write/mutating permissions are needed; grant none.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    # boto3 is not in the stdlib. Exit with a distinct code so the caller can
+    # cleanly fall back to the `aws bedrock-agent` CLI path (see
+    # references/discovery.md "Fallback") instead of treating this as a crash.
+    sys.stderr.write(
+        "FALLBACK_REQUIRED: boto3 not available. Use the aws-CLI discovery path "
+        "documented in references/discovery.md.\n"
+    )
+    sys.exit(3)
+
+# Errors we tolerate per-call (record but don't crash). All other ClientErrors propagate.
+TOLERATED_ERROR_CODES = {
+    "AccessDeniedException",
+    "ResourceNotFoundException",
+    "ValidationException",
+}
+
+
+def _safe(call, *args, **kwargs):
+    """Run a boto3 call, returning {'_error': code, '_message': str} on tolerated errors."""
+    try:
+        return call(*args, **kwargs)
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code in TOLERATED_ERROR_CODES:
+            return {"_error": code, "_message": str(e)}
+        raise
+
+
+def _strip_response_metadata(d: Any) -> Any:
+    if isinstance(d, dict):
+        return {k: _strip_response_metadata(v) for k, v in d.items() if k != "ResponseMetadata"}
+    if isinstance(d, list):
+        return [_strip_response_metadata(x) for x in d]
+    return d
+
+
+def _maybe_inline_s3_schema(
+    s3_client, api_schema: Optional[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """If apiSchema points to S3, fetch it and inline under _inlinedPayload."""
+    if not api_schema or "s3" not in api_schema:
+        return api_schema
+    s3_ref = api_schema["s3"]
+    bucket = s3_ref.get("s3BucketName")
+    key = s3_ref.get("s3ObjectKey")
+    if not (bucket and key):
+        return api_schema
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=key)
+        body = obj["Body"].read().decode("utf-8")
+        return {**api_schema, "_inlinedPayload": body, "_inlinedSource": f"s3://{bucket}/{key}"}
+    except ClientError as e:
+        return {**api_schema, "_inlineError": str(e)}
+
+
+def fetch_action_groups(
+    bedrock_agent, s3_client, agent_id: str, version: str, inline_s3: bool
+) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    paginator = bedrock_agent.get_paginator("list_agent_action_groups")
+    for page in paginator.paginate(agentId=agent_id, agentVersion=version):
+        for summary in page.get("actionGroupSummaries", []):
+            detail = _safe(
+                bedrock_agent.get_agent_action_group,
+                agentId=agent_id,
+                agentVersion=version,
+                actionGroupId=summary["actionGroupId"],
+            )
+            ag = _strip_response_metadata(detail).get("agentActionGroup", detail)
+            if inline_s3 and isinstance(ag, dict) and "apiSchema" in ag:
+                ag["apiSchema"] = _maybe_inline_s3_schema(s3_client, ag.get("apiSchema"))
+            out.append(ag)
+    return out
+
+
+def fetch_knowledge_bases(bedrock_agent, agent_id: str, version: str) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    paginator = bedrock_agent.get_paginator("list_agent_knowledge_bases")
+    for page in paginator.paginate(agentId=agent_id, agentVersion=version):
+        for summary in page.get("agentKnowledgeBaseSummaries", []):
+            assoc = _safe(
+                bedrock_agent.get_agent_knowledge_base,
+                agentId=agent_id,
+                agentVersion=version,
+                knowledgeBaseId=summary["knowledgeBaseId"],
+            )
+            kb_detail = _safe(
+                bedrock_agent.get_knowledge_base, knowledgeBaseId=summary["knowledgeBaseId"]
+            )
+            ds_list: List[Dict[str, Any]] = []
+            ds_paginator = bedrock_agent.get_paginator("list_data_sources")
+            try:
+                for ds_page in ds_paginator.paginate(knowledgeBaseId=summary["knowledgeBaseId"]):
+                    for ds_summary in ds_page.get("dataSourceSummaries", []):
+                        ds = _safe(
+                            bedrock_agent.get_data_source,
+                            knowledgeBaseId=summary["knowledgeBaseId"],
+                            dataSourceId=ds_summary["dataSourceId"],
+                        )
+                        ds_list.append(_strip_response_metadata(ds))
+            except ClientError as e:
+                ds_list.append({"_error": str(e)})
+            out.append(
+                {
+                    "association": _strip_response_metadata(assoc).get("agentKnowledgeBase", assoc),
+                    "knowledgeBase": _strip_response_metadata(kb_detail).get(
+                        "knowledgeBase", kb_detail
+                    ),
+                    "dataSources": ds_list,
+                }
+            )
+    return out
+
+
+def fetch_aliases_and_versions(bedrock_agent, agent_id: str) -> Dict[str, Any]:
+    aliases: List[Dict[str, Any]] = []
+    versions: List[Dict[str, Any]] = []
+    try:
+        for page in bedrock_agent.get_paginator("list_agent_aliases").paginate(agentId=agent_id):
+            for s in page.get("agentAliasSummaries", []):
+                detail = _safe(
+                    bedrock_agent.get_agent_alias, agentId=agent_id, agentAliasId=s["agentAliasId"]
+                )
+                aliases.append(_strip_response_metadata(detail).get("agentAlias", detail))
+    except ClientError as e:
+        aliases.append({"_error": str(e)})
+    try:
+        for page in bedrock_agent.get_paginator("list_agent_versions").paginate(agentId=agent_id):
+            for s in page.get("agentVersionSummaries", []):
+                versions.append(s)
+    except ClientError as e:
+        versions.append({"_error": str(e)})
+    return {"aliases": aliases, "versions": versions}
+
+
+def fetch_collaborators(bedrock_agent, agent_id: str, version: str) -> List[Dict[str, Any]]:
+    """Multi-agent collaborator agents (if collaboration is enabled on the source)."""
+    out: List[Dict[str, Any]] = []
+    if not hasattr(bedrock_agent, "list_agent_collaborators"):
+        return out  # SDK too old; collaboration won't be in the manifest
+    try:
+        for page in bedrock_agent.get_paginator("list_agent_collaborators").paginate(
+            agentId=agent_id, agentVersion=version
+        ):
+            for s in page.get("agentCollaboratorSummaries", []):
+                detail = _safe(
+                    bedrock_agent.get_agent_collaborator,
+                    agentId=agent_id,
+                    agentVersion=version,
+                    collaboratorId=s["collaboratorId"],
+                )
+                out.append(_strip_response_metadata(detail).get("agentCollaborator", detail))
+    except (ClientError, AttributeError) as e:
+        out.append({"_error": str(e)})
+    return out
+
+
+def fetch_iam_role(iam, role_arn: Optional[str]) -> Dict[str, Any]:
+    if not role_arn:
+        return {}
+    role_name = role_arn.split("/")[-1]
+    role = _safe(iam.get_role, RoleName=role_name)
+    attached = _safe(iam.list_attached_role_policies, RoleName=role_name)
+    inline_names = _safe(iam.list_role_policies, RoleName=role_name)
+    inline_policies: List[Dict[str, Any]] = []
+    if isinstance(inline_names, dict) and "_error" not in inline_names:
+        for name in inline_names.get("PolicyNames", []):
+            doc = _safe(iam.get_role_policy, RoleName=role_name, PolicyName=name)
+            inline_policies.append(_strip_response_metadata(doc))
+    return {
+        "role": _strip_response_metadata(role).get("Role", role),
+        "attachedPolicies": _strip_response_metadata(attached).get("AttachedPolicies", attached),
+        "inlinePolicies": inline_policies,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch a complete Bedrock Agent manifest for migration."
+    )
+    # id only — Phase 1 resolves name/ARN to a confirmed agentId before this runs
+    parser.add_argument("--agent-id", required=True)
+    parser.add_argument(
+        "--agent-version",
+        default="DRAFT",
+        help="Agent version to inspect. Default DRAFT, but the skill should resolve a numbered "
+        "version from the production alias before calling this.",
+    )
+    parser.add_argument(
+        "--agent-alias-id", help="Optional alias id, included in manifest for reference"
+    )
+    parser.add_argument(
+        "--region", required=False, help="AWS region (defaults to credential default)"
+    )
+    parser.add_argument("--profile", required=False, help="AWS profile")
+    parser.add_argument(
+        "--inline-s3-schemas",
+        action="store_true",
+        help="Fetch action-group OpenAPI schemas stored in S3 and inline them into the manifest.",
+    )
+    parser.add_argument("--out", required=True, help="Path to write the JSON manifest")
+    args = parser.parse_args()
+
+    session = boto3.Session(profile_name=args.profile, region_name=args.region)
+    bedrock_agent = session.client("bedrock-agent")
+    iam = session.client("iam")
+    sts = session.client("sts")
+    s3_client = session.client("s3") if args.inline_s3_schemas else None
+
+    identity = sts.get_caller_identity()
+    region = session.region_name
+    if not region:
+        print(
+            "ERROR: no region resolved from credentials. Pass --region or set AWS_DEFAULT_REGION.",
+            file=sys.stderr,
+        )
+        return 2
+
+    agent_id = args.agent_id
+    # get_agent is fundamental to discovery — a tolerated error here (e.g.
+    # ResourceNotFoundException) would write a broken manifest whose downstream
+    # field lookups silently produce wrong defaults. So fail hard, not via _safe.
+    try:
+        agent = bedrock_agent.get_agent(agentId=agent_id)
+    except ClientError as e:
+        print(f"ERROR: failed to fetch agent {agent_id}: {e}", file=sys.stderr)
+        return 1
+    agent_doc = _strip_response_metadata(agent).get("agent", agent)
+    role_info = fetch_iam_role(iam, agent_doc.get("agentResourceRoleArn"))
+
+    aliases_and_versions = fetch_aliases_and_versions(bedrock_agent, agent_id)
+
+    manifest: Dict[str, Any] = {
+        "discovery": {
+            "account": identity.get("Account"),
+            "region": region,
+            "callerArn": identity.get("Arn"),
+            "fetchedAgentVersion": args.agent_version,
+            "fetchedAgentAliasId": args.agent_alias_id,
+            "warnings": [],
+        },
+        "agent": agent_doc,
+        "agentCollaborationMode": agent_doc.get("agentCollaboration") or "DISABLED",
+        "orchestrationType": agent_doc.get("orchestrationType") or "DEFAULT",
+        "executionRole": role_info,
+        "actionGroups": fetch_action_groups(
+            bedrock_agent, s3_client, agent_id, args.agent_version, args.inline_s3_schemas
+        ),
+        "knowledgeBases": fetch_knowledge_bases(bedrock_agent, agent_id, args.agent_version),
+        "collaborators": fetch_collaborators(bedrock_agent, agent_id, args.agent_version),
+        "aliasesAndVersions": aliases_and_versions,
+    }
+
+    if args.agent_version == "DRAFT":
+        prod_aliases = [
+            a
+            for a in aliases_and_versions["aliases"]
+            if isinstance(a, dict) and a.get("agentAliasId") not in (None, "TSTALIASID")
+        ]
+        if prod_aliases:
+            tag = ", ".join(
+                f"{a.get('agentAliasName', '?')}->v{(a.get('routingConfiguration') or [{}])[0].get('agentVersion', '?')}"
+                for a in prod_aliases
+            )
+            manifest["discovery"]["warnings"].append(
+                f"Fetched DRAFT but non-DRAFT aliases exist ({tag}). DRAFT may diverge from production."
+            )
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(manifest, f, indent=2, default=str)
+    # Manifest holds sensitive data (account ids, role ARNs, inline IAM policies).
+    # Restrict to owner read/write; prefer writing it to an encrypted volume.
+    try:
+        os.chmod(args.out, 0o600)
+    except OSError as e:
+        print(
+            f"WARNING: could not restrict permissions on {args.out} ({e}). It holds "
+            "sensitive data (account ids, role ARNs, IAM policies) and may be readable "
+            "by others — secure or delete it manually.",
+            file=sys.stderr,
+        )
+
+    print(f"Wrote {args.out}")
+    for w in manifest["discovery"]["warnings"]:
+        print(f"  WARNING: {w}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/core-skills/amazon-bedrock/SKILL.md
+++ b/skills/core-skills/amazon-bedrock/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amazon-bedrock
-description: Builds generative AI applications on Amazon Bedrock. Covers model invocation (Converse API, InvokeModel), RAG with Knowledge Bases, Bedrock Agents, Guardrails, and AgentCore (including the Harness managed agent loop). Use when invoking models, setting up Knowledge Bases, creating agents, applying guardrails, deploying to AgentCore, troubleshooting Bedrock errors (ThrottlingException, AccessDeniedException), or choosing models (Claude, Llama, Nova, Titan). ALSO USE for prompt caching setup and debugging, quota health checks and throttling diagnosis, cost attribution and tracking, migrating between Claude model generations (4.5 to 4.6 to 4.7), chunking strategies, API selection (Converse vs InvokeModel), guardrail capabilities, and model selection. Also covers AgentCore Payments setup (x402, microtransactions, Payment Manager, Connector, Instrument, Coinbase CDP, Stripe Privy, 402 Payment Required, pay for content, paid endpoint, agent payments). NOT for custom model training, Rekognition, or Comprehend.
+description: Builds generative AI applications on Amazon Bedrock. Covers model invocation (Converse API, InvokeModel), RAG with Knowledge Bases, Bedrock Agents, Guardrails, and AgentCore (including the Harness managed agent loop). Use when invoking models, setting up Knowledge Bases, creating agents, applying guardrails, deploying to AgentCore, migrating/porting/converting a Bedrock Agent (including inline agents) to an AgentCore Harness, troubleshooting Bedrock errors (ThrottlingException, AccessDeniedException), or choosing models (Claude, Llama, Nova, Titan). ALSO USE for prompt caching setup and debugging, quota health checks and throttling diagnosis, cost attribution and tracking, migrating between Claude model generations (4.5 to 4.6 to 4.7), chunking strategies, API selection (Converse vs InvokeModel), guardrail capabilities, and model selection. Also covers AgentCore Payments setup (x402, microtransactions, Payment Manager, Connector, Instrument, Coinbase CDP, Stripe Privy, 402 Payment Required, pay for content, paid endpoint, agent payments). NOT for custom model training, Rekognition, or Comprehend.
 version: 2
 ---
 
@@ -61,6 +61,8 @@ AgentCore is a separate service with its own endpoints. Refer to [AgentCore endp
 
 **SDK versions**: Requires recent versions of boto3 (≥ 1.34.x) and AWS CLI v2. Older versions are missing Converse API, Agents, and AgentCore support. Run `aws --version` and `pip show boto3` to check.
 
+**Bedrock Agents classic is in maintenance mode**: classic Bedrock Agents (`bedrock-agent`) is in maintenance mode and closed to new customers ([announcement](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html)). For new agent workloads use AgentCore (the Harness managed loop); for existing agents, recommend migrating to an AgentCore Harness — see the [migration guide](references/migrate-bedrock-agents-to-agentcore-harness.md).
+
 ## Security Considerations
 
 - Use **IAM roles** (not IAM users) for all Bedrock service access
@@ -98,6 +100,7 @@ For full API details and provider-specific body formats, read [model invocation 
 | Filter harmful/sensitive content | Guardrails | [guardrails](references/guardrails.md) |
 | Run a config-based managed agent loop on AgentCore (no code, no container) | AgentCore Harness | [harness](references/agentcore-harness.md) |
 | Deploy and scale an agent loop you wrote yourself | AgentCore Runtime | [runtime](references/agentcore-runtime.md) |
+| Migrate an existing Bedrock Agent (classic) to an AgentCore Harness | Bedrock Agents to AgentCore harness Migration | [migration guide](references/migrate-bedrock-agents-to-agentcore-harness.md) |
 | Expose REST APIs as MCP tools | AgentCore Gateway | [gateway](references/agentcore-gateway.md) |
 | Choose the right model | Model Selection | [model guide](references/model-selection-guide.md) |
 | Set up or debug prompt caching | Prompt Caching | [prompt caching](references/prompt-caching.md) |
@@ -358,6 +361,7 @@ For model ID formats (4 patterns), access provisioning, and selection criteria, 
 - [Amazon Bedrock User Guide](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html)
 - [Amazon Bedrock API Reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/welcome.html)
 - [Amazon Bedrock AgentCore User Guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html)
+- [Bedrock Agents Classic Maintenance mode Announcement](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html)
 - [Bedrock Pricing](https://aws.amazon.com/bedrock/pricing/)
 - [Bedrock Quotas and Limits](https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html)
 - [Bedrock Supported Regions](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html)

--- a/skills/core-skills/amazon-bedrock/assets/kb_shim.py.tmpl
+++ b/skills/core-skills/amazon-bedrock/assets/kb_shim.py.tmpl
@@ -1,0 +1,80 @@
+"""
+Knowledge Base shim Lambda — AgentCore Gateway target.
+
+WHY: the native Gateway KB connector only takes a MANAGED Bedrock KB and a fixed
+retrieval contract. For VECTOR / KENDRA / SQL KBs, or to preserve a managed KB's
+non-default retrieval config (reranker, metadata filter, hybrid override, top-k),
+expose retrieval as this Lambda: it presents one MCP tool, calls
+`bedrock-agent-runtime:Retrieve` against the source KB, and returns MCP-shaped
+passages.
+
+Gateway invokes a Lambda target with the tool arguments flat in `event` and the
+tool name in context.client_context.custom['bedrockAgentCoreToolName']
+("<target>___<tool>"). The handler also tolerates a direct {"query": ...} for local
+testing.
+"""
+# <<< RENDER: delete this whole block after substituting the tokens below.
+#   {{KB_ID}}        - the source knowledge base id
+#   {{TOP_K}}        - numberOfResults from the source KB association (default 5)
+#   {{SEARCH_TYPE}}  - "HYBRID" | "SEMANTIC" | "" (empty means KB default)
+# <<< /RENDER
+import boto3
+
+# Rendered at migration time — the Gateway lambda code target has no
+# environment-variable support, so all config is baked in as literals.
+_KB_ID = "{{KB_ID}}"
+_TOP_K = int("{{TOP_K}}")
+_SEARCH_TYPE = "{{SEARCH_TYPE}}".strip().upper()
+_MAX_QUERY_LEN = 1000  # reject oversized queries — abuse / runaway retrieval cost
+
+_runtime = boto3.client("bedrock-agent-runtime")
+
+
+def _vector_search_config():
+    cfg = {"numberOfResults": _TOP_K}
+    if _SEARCH_TYPE in ("HYBRID", "SEMANTIC"):
+        cfg["overrideSearchType"] = _SEARCH_TYPE
+    # <<< OPTIONAL: metadata_filter
+    # Render the source KB association's `filter` here when present.
+    # cfg["filter"] = {{METADATA_FILTER_JSON}}
+    # <<< /OPTIONAL: metadata_filter
+    # <<< OPTIONAL: reranking
+    # Render the source KB association's `rerankingConfiguration` here when present.
+    # (Set on retrievalConfiguration, not vectorSearchConfiguration — see the
+    #  bedrock-agent-runtime Retrieve API shape.)
+    # <<< /OPTIONAL: reranking
+    return cfg
+
+
+def lambda_handler(event, context):
+    # single-tool target: Gateway passes the tool args flat in `event`
+    args = event if isinstance(event, dict) else {}
+    query = args.get("query") or args.get("text") or ""
+    if not isinstance(query, str) or not query:
+        return {"error": "Missing required argument 'query'."}
+    if len(query) > _MAX_QUERY_LEN:
+        return {"error": f"Query exceeds {_MAX_QUERY_LEN} chars."}
+
+    vector_cfg = _vector_search_config()
+    max_results = args.get("max_results")
+    if isinstance(max_results, int) and max_results > 0:
+        vector_cfg["numberOfResults"] = max_results
+
+    resp = _runtime.retrieve(
+        knowledgeBaseId=_KB_ID,
+        retrievalQuery={"text": query},
+        retrievalConfiguration={"vectorSearchConfiguration": vector_cfg},
+    )
+    # Returns KB passage text + source location verbatim. If the KB holds
+    # sensitive data (PII, financial records), review what it returns and redact
+    # or filter fields here before returning, and keep this Lambda's CloudWatch
+    # log group KMS-encrypted (see references/deploy.md) — do not log full passages.
+    results = [
+        {
+            "text": r.get("content", {}).get("text", ""),
+            "source": r.get("location", {}),
+            "score": r.get("score"),
+        }
+        for r in resp.get("retrievalResults", [])
+    ]
+    return {"results": results, "count": len(results)}

--- a/skills/core-skills/amazon-bedrock/assets/lambda_shim.py.tmpl
+++ b/skills/core-skills/amazon-bedrock/assets/lambda_shim.py.tmpl
@@ -1,0 +1,158 @@
+"""
+Action-Group shim Lambda — AgentCore Gateway target (proxy-by-ARN).
+
+WHY: a Bedrock action-group Lambda is invoked with the Bedrock envelope and returns
+a wrapped response. AgentCore Gateway sends the tool arguments flat in `event` with
+the tool name in context.client_context.custom['bedrockAgentCoreToolName']
+("<target>___<tool>") and expects plain JSON. This shim is a NEW Lambda deployed in
+front of the original: it translates the Gateway event into the Bedrock event,
+invokes the original by ARN, and unwraps the response. The original is left
+untouched, so the source agent keeps working.
+
+Do NOT zip or `create-function` this yourself. Place this handler at
+tools/<shim>/handler.py, hand-add a `targetType:"lambda"` code target to
+agentcore.json pointing at it, and let `agentcore deploy` build the Lambda. All
+config ({{TOKEN}}s below) is baked in at render time — the code target has no
+environment-variable support. See references/deploy.md "How shims are deployed".
+"""
+# <<< RENDER: delete this whole block after substituting the tokens below.
+#   {{ORIGINAL_LAMBDA_ARN}}  - the source action-group Lambda ARN
+#   {{SCHEMA_STYLE}}         - "function" (functionSchema) | "openapi" (apiSchema)
+#   {{OP_ROUTES}}            - (openapi only) JSON object mapping each operationId to
+#                             its {"method","apiPath"} from the SOURCE OpenAPI schema.
+#                             apiPath MUST be the literal route TEMPLATE, e.g.
+#                             "/customer/{customer_id}" — NOT a value-substituted path.
+# <<< /RENDER
+import json
+import re
+
+import boto3
+
+# Rendered at migration time — the Gateway lambda code target has no
+# environment-variable support, so all config is baked in as literals.
+_ORIGINAL_ARN = "{{ORIGINAL_LAMBDA_ARN}}"
+_SCHEMA_STYLE = "{{SCHEMA_STYLE}}"  # function | openapi
+_MAX_ARG_BYTES = 256 * 1024  # cap forwarded payload — reject oversized/abusive input
+
+# operationId -> {"method": <HTTP method>, "apiPath": <route TEMPLATE>}.
+# Rendered from the source OpenAPI schema. The apiPath is the template with
+# placeholders intact (e.g. "/customer/{customer_id}") because the original Bedrock
+# Lambda dispatches by matching that exact template; path-param VALUES stay in the
+# parameters array, never substituted into the path.
+_OP_ROUTES = {{OP_ROUTES}}
+_lambda = boto3.client("lambda")
+
+
+def _resolve_tool_and_args(event, context):
+    cc = getattr(context, "client_context", None)
+    custom = getattr(cc, "custom", None) if cc else None
+    raw = (custom or {}).get("bedrockAgentCoreToolName", "") if custom else ""
+    tool = raw.split("___", 1)[1] if "___" in raw else raw
+    args = event if isinstance(event, dict) else {}
+    return tool, args
+
+
+def _validate_args(args):
+    """Reject unexpected shapes before forwarding to the original Lambda: keys must
+    be strings and the whole payload must stay under a sane size cap. This keeps the
+    shim from injecting oversized or malformed input into the original's envelope."""
+    if not all(isinstance(k, str) for k in args):
+        raise ValueError("All argument keys must be strings.")
+    if len(json.dumps(args, default=str).encode("utf-8")) > _MAX_ARG_BYTES:
+        raise ValueError(f"Arguments exceed {_MAX_ARG_BYTES} bytes.")
+
+
+def _to_bedrock_event(tool, args):
+    """Build the Bedrock-Agents envelope the original handler expects."""
+    _validate_args(args)
+    if _SCHEMA_STYLE == "openapi":
+        # Look up the route TEMPLATE for this operationId and pass it verbatim.
+        route = _OP_ROUTES.get(tool)
+        if route is None:
+            raise ValueError(
+                f"No OpenAPI route for operationId {tool!r}; _OP_ROUTES must be "
+                "rendered from the source schema."
+            )
+        # In the real Bedrock envelope, path/query params live in `parameters` and
+        # body params in `requestBody` — don't put every arg in both, or a Lambda
+        # that reads both sees duplicated/misplaced values. Path params are the
+        # `{placeholder}` names in the route template. For methods with no request
+        # body (GET/DELETE/HEAD) the remaining args are query params and also belong
+        # in `parameters`; only body-bearing methods route the rest to `requestBody`.
+        path_names = set(re.findall(r"\{(\w+)\}", route["apiPath"]))
+        non_path = {k: v for k, v in args.items() if k not in path_names}
+        base = {
+            "messageVersion": "1.0", "actionGroup": "migrated",
+            "apiPath": route["apiPath"],       # literal template — never substitute values
+            "httpMethod": route["method"],
+        }
+        # `parameters` entries declare type "string", so values must be strings —
+        # Gateway may hand us typed JSON (int/bool). `requestBody` keeps native types.
+        if route["method"].upper() in ("GET", "DELETE", "HEAD"):
+            params = [{"name": k, "value": str(v), "type": "string"}
+                      for k, v in args.items()]  # path + query, all in parameters
+            base["parameters"] = params
+        else:
+            base["parameters"] = [{"name": k, "value": str(v), "type": "string"}
+                                  for k in path_names for v in [args[k]]]
+            base["requestBody"] = {"content": {"application/json": {
+                "properties": [{"name": k, "value": v} for k, v in non_path.items()]}}}
+        return base
+    # functionSchema style: all args are flat parameters.
+    params = [{"name": k, "value": str(v), "type": "string"} for k, v in args.items()]
+    return {"messageVersion": "1.0", "actionGroup": "migrated",
+            "parameters": params, "function": tool}
+
+
+def _unwrap(resp):
+    """Pull the tool output out of the Bedrock-Agents response envelope."""
+    if not isinstance(resp, dict):
+        return {"body": resp}
+    r = resp.get("response", {})
+    fr = r.get("functionResponse", {})
+    if fr:
+        body = fr.get("responseBody", {}).get("TEXT", {}).get("body")
+        if body is not None:
+            return {"body": body}
+    api = r.get("apiResponse", {})
+    if api:
+        body = api.get("responseBody", {}).get("application/json", {}).get("body")
+        if body is not None:
+            return {"body": body}
+    return resp  # some Lambdas already return plain JSON
+
+
+def lambda_handler(event, context):
+    # This shim forwards user-provided tool arguments, which may hold PII, financial
+    # data, or other sensitive values. Do NOT log the full event/args/response, and
+    # keep this Lambda's CloudWatch log group KMS-encrypted (see references/deploy.md).
+    tool, args = _resolve_tool_and_args(event, context)
+    bedrock_event = _to_bedrock_event(tool, dict(args))
+    try:
+        out = _lambda.invoke(
+            FunctionName=_ORIGINAL_ARN,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(bedrock_event).encode("utf-8"),
+        )
+    except _lambda.exceptions.ClientError as e:
+        # AccessDenied here means the SOURCE Lambda's resource policy does not yet
+        # allow this shim role to invoke it. This is a source-side grant the builder
+        # must add (see references/deploy.md "Source-side prerequisites") — the
+        # migration must NOT add-permission on the source itself.
+        if e.response.get("Error", {}).get("Code") in ("AccessDeniedException", "AccessDenied"):
+            raise RuntimeError(
+                f"Denied invoking original Lambda {_ORIGINAL_ARN}. The builder must grant "
+                "this shim's role lambda:InvokeFunction on the source (do not modify the "
+                "source from the migration)."
+            ) from e
+        raise
+    payload = json.loads(out["Payload"].read() or b"{}")
+    # A failed original Lambda returns 200 with FunctionError set and the error in
+    # the payload — surface it as a real failure so the Gateway/Harness sees the
+    # tool errored, instead of passing the error dict off as a successful result.
+    if "FunctionError" in out:
+        raise RuntimeError(
+            f"Original Lambda failed ({out['FunctionError']}): "
+            f"{payload.get('errorMessage', 'unknown error')}"
+        )
+    return _unwrap(payload)

--- a/skills/core-skills/amazon-bedrock/assets/tool_schema.json.tmpl
+++ b/skills/core-skills/amazon-bedrock/assets/tool_schema.json.tmpl
@@ -1,0 +1,12 @@
+[
+  {
+    "_comment": "ToolDefinition[]: one entry per source tool/operation, mirroring the source schema exactly — see references/mapping.md.",
+    "name": "{{TOOL_NAME}}",
+    "description": "{{TOOL_DESCRIPTION_FROM_SOURCE}}",
+    "inputSchema": {
+      "type": "object",
+      "properties": {{TOOL_PROPERTIES_FROM_SOURCE}},
+      "required": {{TOOL_REQUIRED_FROM_SOURCE}}
+    }
+  }
+]

--- a/skills/core-skills/amazon-bedrock/references/agents-and-action-groups.md
+++ b/skills/core-skills/amazon-bedrock/references/agents-and-action-groups.md
@@ -1,5 +1,12 @@
 # Create a Bedrock Agent with Action Groups
 
+## Notice
+
+**IMPORTANT**
+Bedrock Agents has been renamed to Bedrock Agents classic and is now in maintenance mode, and is no longer open to new customers ([Maintenance Mode Announcement](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html) for dates and specifics). For new workloads, it is recommended to use Bedrock AgentCore, use the reference files to learn how to get started with AgentCore. For existing Agents, it is recommended to migrate your Amazon Bedrock Agents Classic workloads to Amazon Bedrock AgentCore. AgentCore is the platform to build, connect, and optimize AI agents. The managed harness in AgentCore provides a config-based starting point where developers can declare the agent's model, tools, and instructions. AgentCore handles the environment, compute, memory, identity, and observability. When a user is asking you for help with Bedrock Agents, bring up the maintenance mode announcement, recommend Bedrock AgentCore and that you can help with the migration.
+
+The migration guide is available in [bedrock-agents-to-agentcore-harness-migration-guide](./migrate-bedrock-agents-to-agentcore-harness.md). If the user is asking questions about what to do about the maintenance mode announcement, if they need help with the migration refer to the guide.
+
 ## Table of Contents
 
 - Overview

--- a/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/cli.md
+++ b/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/cli.md
@@ -1,0 +1,36 @@
+# AgentCore CLI
+
+The migration tool is the AgentCore CLI, package **`@aws/agentcore`** — use the **latest** version. Its command/flag surface shifts between releases, so **verify it live** rather than trusting a hardcoded flag table.
+
+The AgentCore CLI (`@aws/agentcore`) is **not** the same as the `bedrock-agentcore-starter-toolkit`. The starter toolkit is deprecated and not recommended — do not use it or its commands for this migration. Everything here uses `@aws/agentcore`.
+
+## Authoritative, always-current sources
+
+- Installed surface: `agentcore --help`, then `agentcore <command> --help` for each command about to be used.
+- Per-project schema the CLI ships: `https://schema.agentcore.aws.dev/v1/agentcore.json` inside any scaffolded project (authoritative shape for `agentcore.json`, harness, gateway, target, tool-schema). Read before hand-editing config.
+- Published / latest version: `npm view @aws/agentcore version`.
+- Package page: https://www.npmjs.com/package/@aws/agentcore
+
+## Phase 0 checks
+
+```bash
+agentcore --version
+npm view @aws/agentcore version      # newer release available?
+python3 -c "import boto3; print(boto3.__version__)"   # discovery path probe (see discovery.md)
+```
+
+Then probe the commands the migration actually calls and confirm the flags/values each needs are present:
+
+```bash
+agentcore create --help
+agentcore add gateway --help
+agentcore add gateway-target --help
+agentcore add harness --help
+agentcore add tool --help
+agentcore deploy --help
+```
+
+If a required flag is **absent**, stop — don't generate commands against a surface that no longer exists. Update the CLI (`npm install -g @aws/agentcore@latest`) and re-probe, or update this skill if the references assume a flag the CLI renamed.
+
+## Never reverse-engineer the CLI bundle
+Do **not** read the CLI's minified source (`node_modules/@aws/agentcore/dist/**`) — internal names and wizard-only code paths produce confident-but-wrong conclusions. If `--help`, `.llm-context`, the hosted schema, and these references don't answer it, stop and ask the user.

--- a/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/deploy.md
+++ b/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/deploy.md
@@ -1,0 +1,116 @@
+# Deploy
+
+Deploy into the **source agent's region** (mirror). If any step fails, surface the error and stop — **fail loudly**, never silently work around a failure.
+
+## CRITICAL: set the deploy-target region right after scaffold (region trap)
+`agentcore create` with no resolved region **silently writes a default region** into `agentcore/aws-targets.json` that is usually not the source agent's. Immediately after scaffold, before any `add`/`deploy`: **edit `agentcore/aws-targets.json` so the deploy-target region is the source agent's region**, and verify it before the first deploy. A wrong region is wrong on two counts: the shims invoke the **source** Lambdas / KB **by ARN**, so a harness elsewhere can't reach them; and a deploy can hit region-specific Harness CFN-type issues that surface as a stack rollback (read the CloudFormation failure; if region-specific, redeploy in the source region).
+
+If a deploy already landed in the wrong region: `aws cloudformation delete-stack` the wrong-region stack, reset `agentcore/.cli/deployed-state.json` to `{"targets":{}}`, fix `aws-targets.json`, then redeploy.
+
+## Source-side prerequisites — the builder grants these, never the migration (INV-1)
+
+The AG shim invokes the **original** source Lambda by ARN, so the source Lambda's resource policy must allow the shim's execution role to call it. **This is the builder's job, not the migration's** — the skill must never mutate source-side infrastructure to unblock itself.
+
+Expect the **first shim invocation to fail with `AccessDeniedException`** until the permission exists. When it does: **stop and hand the builder this command; do NOT run `aws lambda add-permission` on the source yourself** (that mutates the source and breaks INV-1):
+
+```bash
+aws lambda add-permission --function-name <original-fn> \
+  --statement-id agentcore-shim-invoke --action lambda:InvokeFunction \
+  --principal <shim-role-arn> --source-arn <shim-lambda-arn>
+```
+
+(`bedrock-agent-runtime:Retrieve` for the KB shim is granted on the shim role via its `iamPolicy`, so the KB path needs no source-side change — only the AG-shim → original-Lambda invoke does.)
+
+## Two-phase deploy
+
+A gateway tool can only attach once the gateway and its targets are *deployed* (`add tool --type agentcore_gateway` reads the gateway's deployed tool list). So deploy twice:
+
+1. **Scaffold:** `agentcore create` (plain — not the `--type import`/`agentcore import` path, which builds a *code* project, not a Harness). Then `cd` in and run **every** later `add`/`deploy`/`status` from that one directory — those commands resolve the project from the cwd, so a second project or a different dir yields "No agentcore project found".
+2. **Add** infra that doesn't need a deployed gateway:
+   - `agentcore add gateway`, then hand-add one **`targetType: "lambda"` code target** to `agentcore.json` per action group / KB shim (see "How shims are deployed").
+   - `agentcore add harness` (one command, all flags): `--model-id` (= source `foundationModel`), `--temperature`/`--top-p`/`--model-max-tokens` (only one of temperature/top-p when the model rejects both), `--system-prompt` (folded instruction + non-DEFAULT override intent, per [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)). Managed memory stays on. `--additional-params` is `lite_llm`-provider only, so a bedrock harness rejects it — which is why the source guardrail is classified **cannot migrate** (verify the current CLI surface per [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)'s guardrail section before relying on this).
+   - if the source had CodeInterpreter: `agentcore add tool --harness <name> --type agentcore_code_interpreter --name <tool-name>`.
+3. **First deploy:** `agentcore deploy` — creates gateway, targets, harness, memory.
+4. **Attach the gateway tool** (gateway now deployed): `agentcore add tool --harness <name> --type agentcore_gateway --name <tool-name> --gateway <gateway-project-name> --outbound-auth awsIam`. `--gateway <project-name>` resolves the deployed ARN automatically. **Add it exactly once** — check `harness.json`/`agentcore status` first; a duplicate `agentcore_gateway` tool deploys fine but breaks at runtime (`Tool name '…' already exists`), silently disabling every gateway-backed tool. If already doubled, remove the extra from `harness.json` and redeploy.
+5. **Second deploy:** `agentcore deploy` — applies the gateway tool. The migration isn't complete until this succeeds and `agentcore status` shows the harness at a new version with the tool.
+
+## Inbound auth — match the source's invocation posture, never loosen it (INV-2/INV-3)
+
+`--outbound-auth awsIam` above governs how the **harness calls the gateway**. It says nothing about **who may invoke the migrated harness/gateway** — that is *inbound* auth, and it is a separate, mandatory decision. The source Bedrock Agent is IAM-gated: only principals with `bedrock-agent-runtime:InvokeAgent` on that agent's ARN can invoke it. The migrated harness must be **no more reachable than that**.
+
+- **Discover the source posture** (Phase 2): which principals hold `bedrock-agent-runtime:InvokeAgent` on the source, and any resource-based policy on the agent. This is the bar to match.
+- **Configure inbound auth explicitly** on `add harness`/`add gateway` — check `agentcore add harness --help` and `add gateway --help` for the inbound-auth flag (SigV4 with an allowed-role list, JWT with a verified issuer, etc.) and set it to match the discovered posture. Do **not** rely on the CLI default.
+- **If the CLI's inbound default is unauthenticated or broader than the source** (or you cannot determine it), **hard-stop** and have the builder confirm the intended posture before deploying — a migrated agent invokable by parties who couldn't reach the source violates both secure-by-default and preserve-posture.
+
+## How shims are deployed — hand-author the code target, CLI builds it at deploy
+
+`agentcore add gateway-target` **cannot create a code target non-interactively** (`--type lambda` is rejected). So this is one of the guide's explicitly sanctioned hand-edits (see "Config edits — the rule"): add the target to `agentcore.json` yourself, then `agentcore deploy` builds the Lambda from your source. Per shim:
+
+1. Place rendered shim at `tools/<shim>/handler.py` (from `{kb_shim,lambda_shim}.py.tmpl` in `assets/`) with a `pyproject.toml` beside it.
+2. Add one entry to `agentCoreGateways[<i>].targets[]` in `agentcore.json`:
+
+   ```json
+   {
+     "name": "<shim-name>",
+     "targetType": "lambda",
+     "toolDefinitions": [ /* one per function/operation; mirror source schema exactly */ ],
+     "compute": {
+       "host": "Lambda",
+       "implementation": { "language": "Python", "path": "tools/<shim>", "handler": "handler.lambda_handler" },
+       "pythonVersion": "<PYTHON_VERSION_ENUM>",
+       "timeout": 30,
+       "iamPolicy": { /* full policy document, least-privilege — see below */ }
+     }
+   }
+   ```
+
+3. Run `agentcore validate` (must print `Valid`), then `agentcore deploy`.
+
+**No `environment` key — all shim config is baked in at render time.** The `compute` schema is strict and has **no** environment-variable support; adding an `environment` key fails `agentcore validate`. Every `{{TOKEN}}` in the shim templates (`ORIGINAL_LAMBDA_ARN`, `SCHEMA_STYLE`, `OP_ROUTES`, `KB_ID`, …) is substituted directly into `tools/<shim>/handler.py` as a literal. An unsubstituted token causes a `SyntaxError` or wrong behavior at runtime — the post-render grep in [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md) is the gate.
+
+**Scope `iamPolicy` to a single resource ARN — never a wildcard.** It is a full policy document (`Version` + `Statement` array are required), granting exactly one action on exactly one resource:
+
+- AG shim — invoke only the original Lambda:
+
+  ```json
+  { "Version": "2012-10-17", "Statement": [
+    { "Effect": "Allow", "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:<region>:<account>:function:<original-name>" } ] }
+  ```
+
+- KB shim — retrieve only from the source KB:
+
+  ```json
+  { "Version": "2012-10-17", "Statement": [
+    { "Effect": "Allow", "Action": "bedrock-agent-runtime:Retrieve",
+      "Resource": "arn:aws:bedrock:<region>:<account>:knowledge-base/<kb-id>" } ] }
+  ```
+
+**Logging & monitoring.** Give the execution role `logs:CreateLogGroup`, `logs:CreateLogStream`, `logs:PutLogEvents` scoped to the function's log group (`arn:aws:logs:<region>:<account>:log-group:/aws/lambda/<fn>:*`); recommend a CloudWatch alarm on the shim's `Errors`/`Throttles` metrics; and confirm CloudTrail captures `lambda:Invoke` for audit. The shims handle tool arguments (AG shim) and retrieval text (KB shim), which may be sensitive: **encrypt the log group with a KMS key** (`aws logs associate-kms-key --log-group-name /aws/lambda/<fn> --kms-key-id <key-arn>`) and do **not** log full request/response payloads.
+
+**Throttling & blast radius.** Set **reserved concurrency** on each shim Lambda (`aws lambda put-function-concurrency`) so a runaway caller can't exhaust account-wide Lambda concurrency, and enable request throttling on the Gateway if the CLI/service exposes it.
+
+**Non-negotiable details (these fail `agentcore validate` if wrong):**
+
+- The `compute` block is **strict** — unknown keys (e.g. `environment`) are rejected, and a Python Lambda **must** set `pythonVersion`.
+- `pythonVersion` is an enum (e.g. `PYTHON_3_12`), **not** a bare `"3.12"` — check the project's `agentcore.json` schema (or `agentcore validate` feedback) for the currently valid values. Prefer the source Lambda's runtime.
+- `implementation` requires all three of `language`, `path`, `handler` and nothing else.
+- `targetType` is the literal string `"lambda"` here (valid in the JSON schema, even though `--type lambda` is rejected on the CLI).
+- `path` is relative to the project root (parent of `agentcore/`).
+- `handler` is `<file>.<function>` = `handler.lambda_handler`.
+
+Do **not** use `--type lambda-function-arn` — that wires a *pre-existing* Lambda by ARN, not a shim this skill builds.
+
+## Config edits — the rule
+Hand-edit a config file **only where this guide explicitly says to** — the region correction in `aws-targets.json`, the `targetType: "lambda"` code target in `agentcore.json`, the documented recovery edits (removing a duplicate `agentcore_gateway` tool from `harness.json`; resetting `deployed-state.json` for a wrong-region redeploy). Everything else goes through `agentcore` commands — harness and tools via `add harness`/`add tool`, gateways and other targets via `add gateway`/`add gateway-target`. Do not invent new hand-edits: when an `add` command fails, fix its flags (missing `--name`, wrong `--type`) rather than editing `harness.json`/`agentcore.json` to route around the failure.
+
+## One action group = one target, with all its functions
+A Bedrock action group can expose several functions/operations (up to three), each with its own schema. The tool-schema file is a **`ToolDefinition[]` array**, so a single Lambda target carries every function in that action group — one array entry per function/operationId. Do not split an action group into multiple targets. [tool_schema.json.tmpl](assets/tool_schema.json.tmpl) is already an array; add one entry per function, mirroring the source schema exactly ([mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).
+
+## Verification
+The migration is done when `agentcore deploy` reports success. Before treating it as complete, **prompt the user** to confirm the deploy succeeded and they're satisfied — surface the deployed harness/gateway ARNs from `agentcore status`. Deeper parity (invoking the harness, comparing against the source) is out of scope unless the user asks.
+
+## Rendering templates into CLI inputs
+
+- KB shim / AG shim Lambda code: adapt the `*.py.tmpl` files in `assets/` (rendering rules in [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)) and place the rendered handler at `tools/<shim>/handler.py` — see "How shims are deployed" above.
+- Tool-schema files: one array per target, one entry per source function/operation, mirroring the source schema exactly ([mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).

--- a/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/discovery.md
+++ b/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/discovery.md
@@ -1,0 +1,36 @@
+# Discovery & source resolution (Phases 1–2)
+
+## Resolving the source agent
+Inputs the user may give: agent **id**, **name**, **ARN**, or nothing.
+
+- **Name only:** list agents in the confirmed region (`bedrock-agent:ListAgents`) and disambiguate with the user.
+- **Nothing:** list agents and present candidates.
+- **ARN:** the agent id is the last `/` segment.
+
+Default to the **production alias's** numbered version, not DRAFT: list aliases (`ListAgentAliases`), have the user identify the production alias, read its `routingConfiguration[0].agentVersion`. **DRAFT-only** (only the auto `TSTALIASID` alias pointing at DRAFT, with no numbered version) is a valid, eligible source — confirm and proceed. Honor an explicit "migrate DRAFT" request.
+
+Confirm the full `(account, region, agentId, agentVersion, aliasId)` tuple before discovery.
+
+## Two discovery paths — prefer the script, fall back to the AWS CLI
+Goal: one JSON manifest, `./out/source-agent.json`, that later phases read.
+
+**Inline agents take neither path.** An inline agent (invoked via `InvokeInlineAgent`) has no persisted `agentId`, so both Path A (the fetch script, which needs `--agent-id`) and Path B (the `aws bedrock-agent get-agent` reads) are inapplicable. Its `InvokeInlineAgent` request payload already contains the configuration — map the payload's fields into the same manifest keys (below): `instruction`, `foundationModel`, `actionGroups`, `knowledgeBases`, `guardrailConfiguration`, and prompt overrides. Fields the payload doesn't carry (execution-role policies, aliases/versions) simply don't exist for an inline agent; omit them. Then proceed to eligibility exactly as for a stored agent.
+
+**The manifest is sensitive.** It captures account ids, IAM role ARNs, attached and inline policy documents, Lambda ARNs, and KB configuration. Do not commit it (add `out/` to `.gitignore`); store it **encrypted at rest** — an encrypted volume or a KMS-backed location, not filesystem permissions alone — readable only by the running user; and delete it after a successful migration unless it is being kept for audit.
+
+### Path A (preferred): bundled fetcher
+`fetch_bedrock_agent.py` snapshots the agent in one command (inlines S3 OpenAPI schemas with `--inline-s3-schemas`; tolerates per-call permission errors). **Requires `python3` + `boto3`** — probe in Phase 0 (`python3 -c "import boto3"`). The script exits with code **3** and prints `FALLBACK_REQUIRED` if boto3 is missing, so a failed run is a clean signal to switch to Path B. Do **not** `pip install` into the user's environment.
+
+```bash
+python3 scripts/fetch_bedrock_agent.py \
+  --agent-id <id> --agent-version <resolved> --region <region> \
+  --inline-s3-schemas --out ./out/source-agent.json
+```
+
+### Path B (fallback): AWS CLI read commands
+The `aws` CLI is a self-contained binary already required for the migration, so it works where a bare python3 may not. Run the equivalent read sequence (`aws bedrock-agent get-agent`, `list/get-agent-action-group`, `list/get-agent-knowledge-base`, `get-knowledge-base`, `list-agent-aliases`, `list-agent-versions`, `list-agent-collaborators` when collaboration is on; `aws s3 cp` to inline S3 schemas; `aws iam get-role` for the execution role) and assemble the same manifest shape yourself. Tolerate `AccessDenied`/`NotFound`/`Validation` on individual calls; abort only on outright failure.
+
+If discovery fails outright, stop and report. Do not partially migrate from an incomplete manifest.
+
+## Manifest schema — the script is the source of truth
+`fetch_bedrock_agent.py` defines the manifest shape; don't duplicate a schema spec here (it would drift). Top-level keys it writes: `discovery` (account/region/caller/version/warnings), `agent`, `agentCollaborationMode`, `orchestrationType`, `executionRole`, `actionGroups`, `knowledgeBases`, `collaborators`, `aliasesAndVersions`. The **Path B (AWS CLI) fallback must assemble the same keys** so downstream phases read one shape regardless of path.

--- a/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/eligibility.md
+++ b/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/eligibility.md
@@ -1,0 +1,35 @@
+# Eligibility rubric
+
+Check each condition against the discovery manifest. A **hard-stop** means the agent has a feature with no validated AgentCore Harness path — stop the migration, name the failing condition, and suggest the manual alternative. Do not migrate the eligible parts of an ineligible agent: a half-migrated agent is worse than a clear "not yet."
+
+State the result of *every* condition to the user, not just the first failure — they need the full picture to decide what to fix.
+
+For an **inline agent**, evaluate these same conditions against the fields of the `InvokeInlineAgent` payload (the manifest built from it) rather than a stored agent — e.g. multimodal input from the payload's model/inputs, collaboration/orchestration from its config. The rubric is identical; only the source of the fields differs.
+
+## Hard-stop conditions
+
+### 1. Multimodal input
+**Signal:** the agent processes images or audio (vision model for image input, or documented image/audio handling). The validated harness path is text-only.
+**Alternative:** keep on Bedrock until a multimodal path is validated. (This is a true hard-stop — don't offer a degraded "migrate anyway with image/audio dropped" path, which would contradict the hard-stop rule above.)
+
+### 2. Multi-agent collaboration
+**Signal:** `agentCollaborationMode` is `SUPERVISOR` or `SUPERVISOR_ROUTER`. The supervisor is out of scope — do **not** flatten collaborators into its prompt, wire them as sub-agents, or migrate it alone (dangling references).
+**Alternative:** each collaborator is an ordinary Bedrock agent; any that doesn't itself collaborate can be migrated on its own (run this skill once per collaborator). Only the supervisor layer is excluded.
+
+### 3. Unreachable knowledge base
+**Signal:** an associated KB is in an account/region the credentials cannot reach — so `bedrock-agent-runtime:Retrieve` can't reproduce its retrieval.
+**Alternative:** grant cross-account/region access, then re-run.
+**Not the KB *type*:** every type (`VECTOR`/`MANAGED`/`KENDRA`/`SQL`) is reachable via `Retrieve` and eligible; type only picks the wiring (see [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).
+
+### 4. Custom orchestration
+**Signal:** `orchestrationType` is `CUSTOM_ORCHESTRATION` (custom orchestration Lambda). The harness runs its own loop; that control flow has no equivalent and would be silently dropped.
+**Alternative:** re-express the logic as harness tools/prompt as a fresh design, or keep on Bedrock.
+
+## Eligible — do not mistake these for blockers
+
+- **DRAFT-only agent** (no published version) — common; treat DRAFT as the source (see [discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md)).
+- **Mixed action-group schema styles** (`functionSchema` and OpenAPI in one agent).
+- **Managed KB with non-default retrieval config, code interpreter, session memory** — all have harness targets (see [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).
+- **An agent with a guardrail** — eligible overall; the guardrail capability just can't be carried.
+
+(Eligible to migrate, but whose *capability* the harness can't reproduce — classify **cannot** and surface to the user: **Return-of-Control action groups** and the **guardrail**. See [mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md).)

--- a/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/mapping.md
+++ b/skills/core-skills/amazon-bedrock/references/bedrock-agents-to-agentcore-harness/mapping.md
@@ -1,0 +1,62 @@
+# Component mapping
+
+Map each source component to its harness target. **Mirror** behavior, not Bedrock structure. Adapt the `.tmpl` templates in the skill's `assets/` directory: substitute every `{{TOKEN}}`, and delete every marker block — `# <<< RENDER … # <<< /RENDER` (token docs) and `# <<< OPTIONAL: … # <<< /OPTIONAL` (features that don't apply). After rendering, no `{{`, `}}`, or `<<<` may remain — that grep is the verification gate, and it must come back clean.
+
+The `.tmpl` files are not for any template engine; they are guidance for you (the LLM) on how to fill them in.
+
+## Mapping action groups to Gateway targets
+
+A Bedrock action-group Lambda speaks the Bedrock event envelope; AgentCore Gateway invokes Lambda targets with a different shape, so the original won't work behind Gateway unchanged.
+
+**Default: proxy-by-ARN.** Create a *new* shim Lambda ([lambda_shim.py.tmpl](assets/lambda_shim.py.tmpl) — its docstring documents both envelopes) that translates the Gateway event into the Bedrock event, invokes the original by ARN, and unwraps the response. This leaves the original **untouched** — editing it in place can change its response shape and break the source agent. The original's ARN is rendered into the shim source as a literal (no env vars — see [deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md)).
+
+**OpenAPI action groups: pass the route TEMPLATE verbatim.** The original Lambda dispatches by matching `apiPath` against the literal route template (`/customer/{customer_id}`), with path-param values delivered separately in `parameters`. Substituting a value into the path (`/customer/tkashina`) matches no template, so the original falls through to its unhandled-op branch. Render the shim's `_OP_ROUTES` table (mapping each operationId to its `{method, apiPath-template}`) from the source OpenAPI schema with placeholders intact, and keep values in `parameters`.
+
+Each action group becomes one Gateway **`targetType: "lambda"` code target**, hand-added to `agentcore.json` (the CLI can't create it non-interactively), with `toolDefinitions` holding **one entry per function/operation**. `agentcore deploy` then builds the shim Lambda. Exact block + gotchas in [deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md); follow it.
+
+### Tool schemas — mirror exactly
+Reproduce the source action group's schema faithfully into the tool-schema file ([tool_schema.json.tmpl](assets/tool_schema.json.tmpl)): same tool names, parameter names, types, and descriptions. Do **not** rewrite or "improve" them — fidelity to the source agent's behavior is the goal, and a renamed tool or tightened type changes how the model selects it.
+
+## Mapping the knowledge base (connector or KB shim, by type)
+
+**Decide by `knowledgeBaseConfiguration.type` FIRST — the native Gateway connector accepts ONLY a `MANAGED` Bedrock KB.**
+
+- **Any non-`MANAGED` type (`VECTOR`, `KENDRA`, `SQL`)** → **always the KB shim.** The connector cannot accept these at all, so type alone decides and retrieval config is irrelevant. Use the **KB shim** ([kb_shim.py.tmpl](assets/kb_shim.py.tmpl)): a hand-added **`targetType: "lambda"` code target** (see [deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md)) that calls `bedrock-agent-runtime:Retrieve` and returns MCP-shaped passages.
+- **`MANAGED`** → then (and only then) check the **retrieval config on the KB association** (`knowledgeBaseConfigurations[].retrievalConfiguration`: reranker, metadata filter, hybrid/search-type override, top-k):
+  - **default** retrieval config → native Gateway connector: `add gateway-target --type connector --connector bedrock-knowledge-bases --knowledge-base-id <id>`.
+  - **non-default** retrieval config → the **KB shim** (the connector uses a fixed retrieval contract and would silently drop the custom config), reproducing that config from the manifest's KB association.
+
+Both paths reproduce the source agent's retrieval — the choice is wiring, not fidelity, so every reachable KB is still **clean**. (An *unreachable* KB is a hard-stop — see [eligibility.md](references/bedrock-agents-to-agentcore-harness/eligibility.md). Type picks the wiring; it is never itself the blocker.)
+
+### Return-of-Control action groups — cannot migrate
+A `customControl: RETURN_CONTROL` action group has no Lambda; the original application handled execution outside Bedrock. There is no automatic harness equivalent. **Do not silently drop it.** Classify it **cannot** in the migration assessment and confirm with the user before continuing — the migrated agent will lack that capability unless the user supplies a backend for it.
+
+## Built-in action groups
+
+- **`AMAZON.UserInput`**: no tool. Add a clarification instruction to the system prompt; the harness asks clarifying questions naturally.
+- **`AMAZON.CodeInterpreter`**: use the built-in tool, `agentcore add tool --harness <harness-name> --type agentcore_code_interpreter --name <tool-name>` (`--harness` and `--name` required — see [deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md)).
+
+## Mapping memory to managed memory (default)
+
+Use the harness's **managed memory**, which is on by default — the harness auto-provisions an AgentCore Memory instance (semantic + summarization strategies, with the service's default expiry) and loads/saves session history automatically. Check the [harness memory devguide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-memory.html) or `DescribeHarness` for the current defaults rather than assuming a fixed retention. Do not pass `--no-harness-memory`. This covers the common source case (`SESSION_SUMMARY`) via the built-in `SUMMARIZATION` strategy; customize strategies via `UpdateHarness` only if the source clearly needs more.
+
+**Leave truncation at its default (`sliding_window`).** Do not set truncation to `summarization` — it runs mid-conversation and errors on short sessions (`Cannot summarize: insufficient messages`). The default is already safe.
+
+Reference: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-memory.html
+
+## Mapping model parameters to the harness model config
+Set model params via `agentcore add harness` flags: `--model-id`, `--model-max-tokens`, `--temperature`, `--top-p`, `--api-format`. Some models reject setting temperature and top-p together — check the target model's inference-parameter constraints (e.g. `aws bedrock get-foundation-model`, or a probe call) and set **only one** if so.
+
+## Mapping idle session TTL (preserve the source's session-lifetime bound)
+The source's `idleSessionTTLInSeconds` bounds how long an idle session is retained — a security control (it caps the credential/context leakage and replay window). Read its actual value from the discovery manifest (the source agent's own setting, whatever it is) and preserve it: if `agentcore add harness` exposes an equivalent session-TTL flag, set it to the source value. If the CLI has no equivalent, **classify it degraded in Phase 4** with the concrete delta (e.g. "source set 300s; migrated defaults to Ns") so the builder decides — never silently extend the window.
+
+## Guardrail — cannot migrate; surface to the user
+Check whether the installed CLI can attach a guardrail to a **bedrock** harness before classifying: look in `agentcore add harness --help` for a guardrail field, and note that `--additional-params` (the pass-through) is `lite_llm`-provider only, so a bedrock harness rejects it. If no guardrail path exists in the CLI surface you're running, classify the guardrail **cannot** in the assessment and tell the user the migrated harness will **not** enforce it, recording the source `guardrailIdentifier` + version. Do **not** fake it with a system-prompt mention (that enforces nothing). Enforcing it means applying `ApplyGuardrail` outside the harness — out of scope. If the CLI surface you're running exposes a guardrail field, use it and reclassify as clean.
+
+## Mapping the prompt to the system prompt
+Fold the agent instruction into the harness `--system-prompt`. If `AMAZON.UserInput` was present, include the clarification instruction.
+
+Prompt overrides in **DEFAULT** mode carry nothing custom — skip them. But a **non-DEFAULT override** (especially `ORCHESTRATION` or `PRE_PROCESSING`) may hold real business logic — routing rules like "use tool X for billing questions, tool Y for refunds," or input-classification the app relied on. Don't discard that as boilerplate. Read each non-DEFAULT override, separate the Bedrock-Agents scaffolding (the orchestration loop mechanics the harness now owns) from the business intent, and fold the intent into the system prompt — a modern model handles tool-routing guidance cleanly in the prompt. When unsure whether an override is boilerplate or load-bearing, surface it to the user rather than dropping it.
+
+## Mapping the model (mirror the source)
+Default `--model-id` to the source agent's `foundationModel`. If the CLI's harness default differs, set it explicitly to match the source (parity).

--- a/skills/core-skills/amazon-bedrock/references/migrate-bedrock-agents-to-agentcore-harness.md
+++ b/skills/core-skills/amazon-bedrock/references/migrate-bedrock-agents-to-agentcore-harness.md
@@ -1,0 +1,98 @@
+# Bedrock Agents to AgentCore Harness
+
+Migrate a Bedrock Agent into an AgentCore **Harness** (the managed agent loop) using the **AgentCore CLI**. The skill drives the CLI to scaffold and deploy; it never hand-rolls boto3 infrastructure the CLI owns. Remeber that this skill can be used for performing the migration AND helping the user answer any migration related questions even if they don't want to perform the migration.
+
+Reference files, scripts and templates are available in [references](references/bedrock-agents-to-agentcore-harness/)
+
+**Inline agents.** This guidance also migrates a Bedrock **inline** agent (one invoked via `InvokeInlineAgent` with its configuration supplied per-request rather than persisted as a stored agent). An inline agent has no `agentId`, so it takes a modified entry path: **its `InvokeInlineAgent` request payload *is* the source manifest.** Concretely — **skip Phase 0's agent-region confirm and all of Phase 1 (identity resolution) and Phase 2's fetch (`fetch_bedrock_agent.py` needs an `--agent-id` an inline agent doesn't have)**; instead, take the user-supplied `InvokeInlineAgent` payload, extract its components (`foundationModel`, `instruction`, `actionGroups`, `knowledgeBases`, `guardrailConfiguration`, prompt overrides), write them into `./out/source-agent.json` in the manifest shape ([bedrock-agents-to-agentcore-harness/discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md)), then **enter at Phase 3**. Every phase from Phase 3 on — eligibility gates, component mapping, deploy — applies unchanged, since they operate on the manifest, not on how it was obtained.
+
+Two ideas run through every phase:
+
+- **gate** — a hard checkpoint the migration must pass before continuing. Some gates are eligibility (a source feature with no validated harness path); others are user approval (account, region, cost). A failed gate stops the migration and is reported, never worked around silently.
+- **mirror** — preserve user-visible *behavior*, not Bedrock-Agents *structure*: keep what the agent does, drop only what the harness now does for you (see [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)).
+
+This skill makes AWS API calls throughout (STS, Bedrock Agent reads, deploys). The **AWS MCP server is recommended** for streamlined access, but is not required — every step also works with the AWS CLI and boto3 as described here.
+
+## Capture the request first
+
+The triggering request *is* the input. Extract whatever the user gave — agent **id/name/ARN**, **region**, **profile/account** — and **confirm** it in the phases below rather than re-asking. Identity resolution (Phase 1) runs *after* preflight, since listing agents to disambiguate a name needs a confirmed account + region first.
+
+**Fail fast.** If the request *already* names a hard-stop disqualifier (multi-agent, custom orchestration, multimodal), say so and stop before preflight — always with that condition's specific alternative from [bedrock-agents-to-agentcore-harness/eligibility.md](references/bedrock-agents-to-agentcore-harness/eligibility.md), never a bare "not supported." Phase 3 still runs the full gate for everything that clears this.
+
+## Phases
+
+Finish each phase and summarize before the next.
+
+### Phase 0 — Preflight (environment gates)
+
+Establish the migration runs against the account, region, and CLI the user intends — before touching the source agent.
+
+1. Confirm the **CLI** is present and current per [bedrock-agents-to-agentcore-harness/cli.md](references/bedrock-agents-to-agentcore-harness/cli.md). Stop if it is missing or a required command/flag is absent.
+2. Resolve AWS credentials and run `aws sts get-caller-identity`. **Echo the account id, caller ARN, and resolved region back to the user and ask them to confirm or correct** before proceeding. Never assume the default profile is the right one.
+3. Confirm the **source agent's region** here (if the user supplied one, confirm rather than re-ask). The harness must deploy there — but the CLI defaults elsewhere, so you set it explicitly before the first deploy (Phase 6; see deploy.md's region trap).
+
+Completion criterion: the user has confirmed `(account, region)` and the CLI passed its checks.
+
+### Phase 1 — Identify the source agent
+
+**Inline agents skip this phase** (they have no `agentId`; see "Inline agents" above — take the payload and enter at Phase 3).
+
+Resolve a concrete `(agentId, agentVersion, aliasId)` from whatever the user gave (id, name, ARN, or nothing). If the user gave a name fragment, gave nothing, or **asks to see what's available**, list the agents in the confirmed region (`bedrock-agent:ListAgents`) and present them for the user to pick from. Default to the **production alias's** numbered version, not DRAFT — unless the user has only DRAFT or asks for it explicitly. See [bedrock-agents-to-agentcore-harness/discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md) for resolution rules and the DRAFT-only case.
+
+Completion criterion: the user has confirmed the exact `(account, region, agentId, agentVersion, aliasId)` tuple.
+
+### Phase 2 — Discovery
+
+Snapshot the agent into one manifest (`./out/source-agent.json`) — via the bundled `scripts/fetch_bedrock_agent.py` (needs python3 + boto3), or the `aws bedrock-agent` fallback when boto3 is absent. Both paths and the manifest shape are in [bedrock-agents-to-agentcore-harness/discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md). **For an inline agent** the fetch script does not apply (no `agentId`) — build the manifest from the `InvokeInlineAgent` payload instead, per "Inline agents" above and discovery.md's inline note.
+
+Read the manifest and present a **concise, human-readable inventory** — a scannable list or small table (model; action groups by name + type; KBs + type; guardrail; memory; collaboration), not a prose paragraph.
+
+Also capture the source's **security posture** so the migration can preserve it (see [bedrock-agents-to-agentcore-harness/deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md)): its **inbound invocation posture** (which principals hold `bedrock-agent-runtime:InvokeAgent`, plus any resource-based policy on the agent) and its `idleSessionTTLInSeconds`. These set the bar Phase 6 must match, not loosen.
+
+Completion criterion: manifest written and inventory presented.
+
+### Phase 3 — Eligibility gate
+
+Check the manifest against the eligibility rubric in [bedrock-agents-to-agentcore-harness/eligibility.md](references/bedrock-agents-to-agentcore-harness/eligibility.md). Any **hard-stop** condition (multimodal input, multi-agent collaboration, unreachable KB, custom orchestration) ends the migration here.
+
+If a gate fails: **stop**, tell the user exactly which condition failed and why, and suggest manual alternatives.
+
+Completion criterion: every hard-stop condition checked and explicitly cleared, or the migration stopped with a reported reason.
+
+### Phase 4 — Migration assessment (gate)
+
+The agent is eligible, but not every component migrates with full fidelity. Before planning, show the user a **per-component ledger** classifying each discovered component three ways:
+
+- **clean** — behavior preserved. Most components land here: action groups via shim, *any* KB (MANAGED-with-default-config via connector, everything else via KB shim — both reproduce retrieval, see [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)), CodeInterpreter built-in, model + inference params, and managed memory (the standard harness memory, not a downgrade).
+- **degraded** — a genuine fidelity change the user should weigh, e.g. a non-DEFAULT orchestration/pre-processing prompt whose business logic can't be cleanly folded into the system prompt, or any behavior the migration can only approximate.
+- **cannot** — no harness equivalent, capability lost: Return-of-Control action groups and the **guardrail** (see [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md)). Surface both to the user.
+
+Use the mapping in [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md) to classify. Present the ledger and **pause for explicit acknowledgement** — the user must accept the *degraded* and *cannot* items before planning. Nothing irreversible has happened yet; this is informed consent on fidelity loss.
+
+Completion criterion: user has seen the full ledger and acknowledged the degraded/cannot items.
+
+### Phase 5 — Plan
+
+Map each acknowledged component to its harness target using [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md). Produce a written **migration plan** and **pause for approval** (gate). Surface costs and that the source agent is never modified.
+
+Completion criterion: user approved the written plan.
+
+### Phase 6 — Implement & deploy
+
+Drive the CLI per the approved plan, following [bedrock-agents-to-agentcore-harness/deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md) end to end: scaffold with plain `agentcore create`, deploy the shim Lambdas, `add gateway`/`gateway-target`/`harness`, then the **two-phase deploy**. On scaffolding specifically: use `agentcore create` with no flags. Do **not** use `agentcore create --import` (or `agentcore import`) — that flag *does exist*, but it imports the Bedrock Agent into a **code project**, not a Harness, so it is the wrong route for this migration. There is **no** `agentcore init` command. Set the deploy region before the first deploy (deploy.md's region trap). Generate shim code and tool schemas by **adapting** the `.tmpl` templates in `assets/` per [bedrock-agents-to-agentcore-harness/mapping.md](references/bedrock-agents-to-agentcore-harness/mapping.md). Configure the harness/gateway **inbound auth** to match the source's invocation posture discovered in Phase 2 (deploy.md "Inbound auth") — do not accept the CLI default if it is broader. If deploy fails, surface the error — **fail loudly**, never silently work around it. In particular, if a shim invocation fails with `AccessDenied`, **do not** run `aws lambda add-permission` on the source — that mutates source-side infra; stop and hand the builder the command (deploy.md "Source-side prerequisites").
+
+Completion criterion: `agentcore deploy` reports success. Verification is deploy-success-only; deeper parity is out of scope.
+
+## Security considerations
+
+- **Least-privilege shim roles** — one action on one resource ARN, no wildcards; exact policies in [bedrock-agents-to-agentcore-harness/deploy.md](references/bedrock-agents-to-agentcore-harness/deploy.md).
+- **The manifest holds sensitive data** — handling rules in [bedrock-agents-to-agentcore-harness/discovery.md](references/bedrock-agents-to-agentcore-harness/discovery.md).
+- **Use ephemeral credentials** (IAM roles, SSO, `assume-role`) for both discovery and deploy — never long-lived IAM user access keys.
+
+## What this migration can not do
+
+- Modify or delete the source Bedrock Agent.
+- Modify the source Lambda's resource policy. If a shim invocation fails with `AccessDenied`, stop and ask the builder to grant the shim role `lambda:InvokeFunction` on the source (deploy.md "Source-side prerequisites") — never run `add-permission` on the source itself.
+- Migrate KB vector stores / data sources — the new agent calls into the existing KB.
+- Migrate conversation history or end-user authentication.
+- Bypass the AgentCore CLI for infrastructure the CLI owns.

--- a/skills/core-skills/amazon-bedrock/scripts/fetch_bedrock_agent.py
+++ b/skills/core-skills/amazon-bedrock/scripts/fetch_bedrock_agent.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+Fetch a complete manifest of a Bedrock Agent (Phase 1: Discovery).
+
+Pulls every component the migration cares about into a single JSON document so the
+rest of the skill can reason over a static snapshot instead of repeatedly calling
+the Bedrock control plane.
+
+Usage:
+    python fetch_bedrock_agent.py --agent-id ABC123 --region us-east-1 --out manifest.json
+
+By default fetches the DRAFT version. The skill should resolve a numbered version
+via the production alias in Phase 0 and pass --agent-version <n>. If this script
+sees DRAFT, it prints a WARNING summarizing that the production alias may point
+elsewhere.
+
+Pass --inline-s3-schemas to fetch action-group OpenAPI schemas stored in S3 and
+inline them into the manifest under each action group's `apiSchema._inlinedPayload`.
+
+Requires: boto3 with read-only credentials. Prefer ephemeral, role-based
+credentials (an assumed IAM role, SSO session, or instance profile) over
+long-lived IAM user access keys — `--profile` may otherwise resolve to static
+keys in ~/.aws/credentials.
+
+Minimum IAM permissions (all read-only; scope Resource as noted):
+    sts:GetCallerIdentity
+    bedrock-agent:GetAgent, ListAgentActionGroups,
+        GetAgentActionGroup, ListAgentKnowledgeBases, GetAgentKnowledgeBase,
+        GetKnowledgeBase, ListDataSources, GetDataSource, ListAgentAliases,
+        GetAgentAlias, ListAgentVersions, ListAgentCollaborators (optional),
+        GetAgentCollaborator (optional)
+        -> scope to the specific agent/KB ARNs where possible
+    iam:GetRole, ListAttachedRolePolicies, ListRolePolicies, GetRolePolicy
+        -> scope to the agent's execution-role ARN
+    s3:GetObject (only with --inline-s3-schemas)
+        -> scope to the OpenAPI schema object(s)
+No write/mutating permissions are needed; grant none.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    # boto3 is not in the stdlib. Exit with a distinct code so the caller can
+    # cleanly fall back to the `aws bedrock-agent` CLI path (see
+    # references/discovery.md "Fallback") instead of treating this as a crash.
+    sys.stderr.write(
+        "FALLBACK_REQUIRED: boto3 not available. Use the aws-CLI discovery path "
+        "documented in references/discovery.md.\n"
+    )
+    sys.exit(3)
+
+# Errors we tolerate per-call (record but don't crash). All other ClientErrors propagate.
+TOLERATED_ERROR_CODES = {
+    "AccessDeniedException",
+    "ResourceNotFoundException",
+    "ValidationException",
+}
+
+
+def _safe(call, *args, **kwargs):
+    """Run a boto3 call, returning {'_error': code, '_message': str} on tolerated errors."""
+    try:
+        return call(*args, **kwargs)
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code in TOLERATED_ERROR_CODES:
+            return {"_error": code, "_message": str(e)}
+        raise
+
+
+def _strip_response_metadata(d: Any) -> Any:
+    if isinstance(d, dict):
+        return {k: _strip_response_metadata(v) for k, v in d.items() if k != "ResponseMetadata"}
+    if isinstance(d, list):
+        return [_strip_response_metadata(x) for x in d]
+    return d
+
+
+def _maybe_inline_s3_schema(
+    s3_client, api_schema: Optional[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """If apiSchema points to S3, fetch it and inline under _inlinedPayload."""
+    if not api_schema or "s3" not in api_schema:
+        return api_schema
+    s3_ref = api_schema["s3"]
+    bucket = s3_ref.get("s3BucketName")
+    key = s3_ref.get("s3ObjectKey")
+    if not (bucket and key):
+        return api_schema
+    try:
+        obj = s3_client.get_object(Bucket=bucket, Key=key)
+        body = obj["Body"].read().decode("utf-8")
+        return {**api_schema, "_inlinedPayload": body, "_inlinedSource": f"s3://{bucket}/{key}"}
+    except ClientError as e:
+        return {**api_schema, "_inlineError": str(e)}
+
+
+def fetch_action_groups(
+    bedrock_agent, s3_client, agent_id: str, version: str, inline_s3: bool
+) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    paginator = bedrock_agent.get_paginator("list_agent_action_groups")
+    for page in paginator.paginate(agentId=agent_id, agentVersion=version):
+        for summary in page.get("actionGroupSummaries", []):
+            detail = _safe(
+                bedrock_agent.get_agent_action_group,
+                agentId=agent_id,
+                agentVersion=version,
+                actionGroupId=summary["actionGroupId"],
+            )
+            ag = _strip_response_metadata(detail).get("agentActionGroup", detail)
+            if inline_s3 and isinstance(ag, dict) and "apiSchema" in ag:
+                ag["apiSchema"] = _maybe_inline_s3_schema(s3_client, ag.get("apiSchema"))
+            out.append(ag)
+    return out
+
+
+def fetch_knowledge_bases(bedrock_agent, agent_id: str, version: str) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    paginator = bedrock_agent.get_paginator("list_agent_knowledge_bases")
+    for page in paginator.paginate(agentId=agent_id, agentVersion=version):
+        for summary in page.get("agentKnowledgeBaseSummaries", []):
+            assoc = _safe(
+                bedrock_agent.get_agent_knowledge_base,
+                agentId=agent_id,
+                agentVersion=version,
+                knowledgeBaseId=summary["knowledgeBaseId"],
+            )
+            kb_detail = _safe(
+                bedrock_agent.get_knowledge_base, knowledgeBaseId=summary["knowledgeBaseId"]
+            )
+            ds_list: List[Dict[str, Any]] = []
+            ds_paginator = bedrock_agent.get_paginator("list_data_sources")
+            try:
+                for ds_page in ds_paginator.paginate(knowledgeBaseId=summary["knowledgeBaseId"]):
+                    for ds_summary in ds_page.get("dataSourceSummaries", []):
+                        ds = _safe(
+                            bedrock_agent.get_data_source,
+                            knowledgeBaseId=summary["knowledgeBaseId"],
+                            dataSourceId=ds_summary["dataSourceId"],
+                        )
+                        ds_list.append(_strip_response_metadata(ds))
+            except ClientError as e:
+                ds_list.append({"_error": str(e)})
+            out.append(
+                {
+                    "association": _strip_response_metadata(assoc).get("agentKnowledgeBase", assoc),
+                    "knowledgeBase": _strip_response_metadata(kb_detail).get(
+                        "knowledgeBase", kb_detail
+                    ),
+                    "dataSources": ds_list,
+                }
+            )
+    return out
+
+
+def fetch_aliases_and_versions(bedrock_agent, agent_id: str) -> Dict[str, Any]:
+    aliases: List[Dict[str, Any]] = []
+    versions: List[Dict[str, Any]] = []
+    try:
+        for page in bedrock_agent.get_paginator("list_agent_aliases").paginate(agentId=agent_id):
+            for s in page.get("agentAliasSummaries", []):
+                detail = _safe(
+                    bedrock_agent.get_agent_alias, agentId=agent_id, agentAliasId=s["agentAliasId"]
+                )
+                aliases.append(_strip_response_metadata(detail).get("agentAlias", detail))
+    except ClientError as e:
+        aliases.append({"_error": str(e)})
+    try:
+        for page in bedrock_agent.get_paginator("list_agent_versions").paginate(agentId=agent_id):
+            for s in page.get("agentVersionSummaries", []):
+                versions.append(s)
+    except ClientError as e:
+        versions.append({"_error": str(e)})
+    return {"aliases": aliases, "versions": versions}
+
+
+def fetch_collaborators(bedrock_agent, agent_id: str, version: str) -> List[Dict[str, Any]]:
+    """Multi-agent collaborator agents (if collaboration is enabled on the source)."""
+    out: List[Dict[str, Any]] = []
+    if not hasattr(bedrock_agent, "list_agent_collaborators"):
+        return out  # SDK too old; collaboration won't be in the manifest
+    try:
+        for page in bedrock_agent.get_paginator("list_agent_collaborators").paginate(
+            agentId=agent_id, agentVersion=version
+        ):
+            for s in page.get("agentCollaboratorSummaries", []):
+                detail = _safe(
+                    bedrock_agent.get_agent_collaborator,
+                    agentId=agent_id,
+                    agentVersion=version,
+                    collaboratorId=s["collaboratorId"],
+                )
+                out.append(_strip_response_metadata(detail).get("agentCollaborator", detail))
+    except (ClientError, AttributeError) as e:
+        out.append({"_error": str(e)})
+    return out
+
+
+def fetch_iam_role(iam, role_arn: Optional[str]) -> Dict[str, Any]:
+    if not role_arn:
+        return {}
+    role_name = role_arn.split("/")[-1]
+    role = _safe(iam.get_role, RoleName=role_name)
+    attached = _safe(iam.list_attached_role_policies, RoleName=role_name)
+    inline_names = _safe(iam.list_role_policies, RoleName=role_name)
+    inline_policies: List[Dict[str, Any]] = []
+    if isinstance(inline_names, dict) and "_error" not in inline_names:
+        for name in inline_names.get("PolicyNames", []):
+            doc = _safe(iam.get_role_policy, RoleName=role_name, PolicyName=name)
+            inline_policies.append(_strip_response_metadata(doc))
+    return {
+        "role": _strip_response_metadata(role).get("Role", role),
+        "attachedPolicies": _strip_response_metadata(attached).get("AttachedPolicies", attached),
+        "inlinePolicies": inline_policies,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch a complete Bedrock Agent manifest for migration."
+    )
+    # id only — Phase 1 resolves name/ARN to a confirmed agentId before this runs
+    parser.add_argument("--agent-id", required=True)
+    parser.add_argument(
+        "--agent-version",
+        default="DRAFT",
+        help="Agent version to inspect. Default DRAFT, but the skill should resolve a numbered "
+        "version from the production alias before calling this.",
+    )
+    parser.add_argument(
+        "--agent-alias-id", help="Optional alias id, included in manifest for reference"
+    )
+    parser.add_argument(
+        "--region", required=False, help="AWS region (defaults to credential default)"
+    )
+    parser.add_argument("--profile", required=False, help="AWS profile")
+    parser.add_argument(
+        "--inline-s3-schemas",
+        action="store_true",
+        help="Fetch action-group OpenAPI schemas stored in S3 and inline them into the manifest.",
+    )
+    parser.add_argument("--out", required=True, help="Path to write the JSON manifest")
+    args = parser.parse_args()
+
+    session = boto3.Session(profile_name=args.profile, region_name=args.region)
+    bedrock_agent = session.client("bedrock-agent")
+    iam = session.client("iam")
+    sts = session.client("sts")
+    s3_client = session.client("s3") if args.inline_s3_schemas else None
+
+    identity = sts.get_caller_identity()
+    region = session.region_name
+    if not region:
+        print(
+            "ERROR: no region resolved from credentials. Pass --region or set AWS_DEFAULT_REGION.",
+            file=sys.stderr,
+        )
+        return 2
+
+    agent_id = args.agent_id
+    # get_agent is fundamental to discovery — a tolerated error here (e.g.
+    # ResourceNotFoundException) would write a broken manifest whose downstream
+    # field lookups silently produce wrong defaults. So fail hard, not via _safe.
+    try:
+        agent = bedrock_agent.get_agent(agentId=agent_id)
+    except ClientError as e:
+        print(f"ERROR: failed to fetch agent {agent_id}: {e}", file=sys.stderr)
+        return 1
+    agent_doc = _strip_response_metadata(agent).get("agent", agent)
+    role_info = fetch_iam_role(iam, agent_doc.get("agentResourceRoleArn"))
+
+    aliases_and_versions = fetch_aliases_and_versions(bedrock_agent, agent_id)
+
+    manifest: Dict[str, Any] = {
+        "discovery": {
+            "account": identity.get("Account"),
+            "region": region,
+            "callerArn": identity.get("Arn"),
+            "fetchedAgentVersion": args.agent_version,
+            "fetchedAgentAliasId": args.agent_alias_id,
+            "warnings": [],
+        },
+        "agent": agent_doc,
+        "agentCollaborationMode": agent_doc.get("agentCollaboration") or "DISABLED",
+        "orchestrationType": agent_doc.get("orchestrationType") or "DEFAULT",
+        "executionRole": role_info,
+        "actionGroups": fetch_action_groups(
+            bedrock_agent, s3_client, agent_id, args.agent_version, args.inline_s3_schemas
+        ),
+        "knowledgeBases": fetch_knowledge_bases(bedrock_agent, agent_id, args.agent_version),
+        "collaborators": fetch_collaborators(bedrock_agent, agent_id, args.agent_version),
+        "aliasesAndVersions": aliases_and_versions,
+    }
+
+    if args.agent_version == "DRAFT":
+        prod_aliases = [
+            a
+            for a in aliases_and_versions["aliases"]
+            if isinstance(a, dict) and a.get("agentAliasId") not in (None, "TSTALIASID")
+        ]
+        if prod_aliases:
+            tag = ", ".join(
+                f"{a.get('agentAliasName', '?')}->v{(a.get('routingConfiguration') or [{}])[0].get('agentVersion', '?')}"
+                for a in prod_aliases
+            )
+            manifest["discovery"]["warnings"].append(
+                f"Fetched DRAFT but non-DRAFT aliases exist ({tag}). DRAFT may diverge from production."
+            )
+
+    out_dir = os.path.dirname(os.path.abspath(args.out))
+    os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(manifest, f, indent=2, default=str)
+    # Manifest holds sensitive data (account ids, role ARNs, inline IAM policies).
+    # Restrict to owner read/write; prefer writing it to an encrypted volume.
+    try:
+        os.chmod(args.out, 0o600)
+    except OSError as e:
+        print(
+            f"WARNING: could not restrict permissions on {args.out} ({e}). It holds "
+            "sensitive data (account ids, role ARNs, IAM policies) and may be readable "
+            "by others — secure or delete it manually.",
+            file=sys.stderr,
+        )
+
+    print(f"Wrote {args.out}")
+    for w in manifest["discovery"]["warnings"]:
+        print(f"  WARNING: {w}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION


## Description

Amazon Bedrock Agents [announced](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html) that it will enter maintenance mode on 06/30/2026 and new customers will be unable to create Bedrock Agents starting 7/30/2026. 

This PR updates the `amazon-bedrock` skill with guidance about the maintenance mode announcement and a comprehensive guide that Agents can use to migrate existing Bedrock Agents to Bedrock AgentCore harness using the [agentcore cli](https://github.com/aws/agentcore-cli)

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [x] Other - Skill update

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
