### PR TITLE
feat: add aws-compute core skill

### DIFF
--- a/plugins/aws-core/skills/aws-compute/SKILL.md
+++ b/plugins/aws-core/skills/aws-compute/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: aws-compute
+description: "Provisions, scales, and operates Amazon EC2 virtual-machine workloads: instance-type selection (Graviton/Arm64, burstable T credits, GPU, instance store vs EBS), launch templates, Auto Scaling groups (scaling policies, instance refresh, mixed instances, Spot, warm pools, lifecycle hooks), IMDSv2, placement groups, Elastic IPs, AMI lifecycle, and Systems Manager fleet operations (Session Manager, Run Command, Patch Manager). Applies to EC2 instance and fleet questions, InsufficientInstanceCapacity, CPU-credit/surplus charges, IMDSv2 401s, instances stuck in Pending:Wait, ASG not replacing unhealthy instances, status-check failures, SSH refused/timed out, or instances missing as SSM managed nodes. For a single secure instance launch, the launching-ec2-instance-with-best-practices skill is more appropriate; for instance profiles, see setting-up-ec2-instance-profiles; for Image Builder, see creating-ec2-image-builder-pipeline. Does NOT cover Lambda, ECS/Fargate, EKS, VPC/ALB/NLB design, or IAM policy authoring."
+version: 1
+---
+
+# Amazon EC2 Compute
+
+Best experience with the AWS MCP server; also works with the AWS CLI alone — no hard dependency on either.
+
+## Critical Warnings
+
+**Launch configurations are deprecated** and do not support current EC2 instance types; new accounts cannot create them. Use launch templates for every new Auto Scaling group. See [auto-scaling.md](references/auto-scaling.md).
+
+**ASGs ignore ELB health checks by default**: An Auto Scaling group only uses EC2 status checks unless you set `--health-check-type ELB`. Without it, instances failing the load balancer's health check stay in service forever. See [auto-scaling.md](references/auto-scaling.md).
+
+**IMDSv2 hop limit breaks containers**: the default `HttpPutResponseHopLimit` of 1 makes the IMDSv2 token PUT response fail to reach a containerized process (the extra hop exceeds the response TTL), so the token request times out. Set `HttpPutResponseHopLimit=2` for bridge/awsvpc container workloads. (If IMDSv2 is *required*, a subsequent tokenless GET returns `401`; if optional, it silently falls back to IMDSv1.) See [provisioning.md](references/provisioning.md).
+
+**T3/T3a/T4g default to unlimited mode**: Unlike T2 (standard), these burst without throttling but bill surplus CPU credits when 24h-average CPU exceeds baseline — a silent cost leak. See [instance-selection.md](references/instance-selection.md).
+
+**Instance store is ephemeral**: Data on instance store volumes is lost on stop, hibernate, terminate, instance-type change, and host failure — it survives only a reboot. Put anything durable on EBS/EFS/S3. See [instance-selection.md](references/instance-selection.md).
+
+## Which do you need?
+
+| If you're deciding... | Guidance |
+|-----------------------|----------|
+| Instance family / size / Graviton / GPU / burstable | [instance-selection.md](references/instance-selection.md) — start with the workload→family table |
+| How to define instances once and reuse (launch template) | [provisioning.md](references/provisioning.md) |
+| How to run many instances that scale automatically | [auto-scaling.md](references/auto-scaling.md) |
+| How to access/patch/manage instances without SSH keys | [systems-manager.md](references/systems-manager.md) |
+
+## Quick Navigation
+
+| You want to... | Go to |
+|----------------|-------|
+| Pick an instance type, Graviton vs x86, burstable credits, GPU, instance store vs EBS | [instance-selection.md](references/instance-selection.md) |
+| Create a launch template, user data, key pairs, IMDSv2, placement groups, Elastic IPs | [provisioning.md](references/provisioning.md) |
+| Set up or fix an Auto Scaling group, scaling policies, instance refresh, Spot, lifecycle hooks | [auto-scaling.md](references/auto-scaling.md) |
+| Get SSH-less access, patch a fleet, or fix an instance not showing as a managed node | [systems-manager.md](references/systems-manager.md) |
+| Create, share, or retire (deprecate/disable/deregister) an AMI | [ami-management.md](references/ami-management.md) |
+| Fix something broken (can't connect, status-check fail, capacity error, stuck instances) | [troubleshooting.md](references/troubleshooting.md) |
+
+## Common Workflows
+
+**"Stand up an autoscaling web fleet"** → Create a launch template (AMI, type, IMDSv2), then an ASG referencing it with `--health-check-type ELB` and a target-tracking policy, see [auto-scaling.md](references/auto-scaling.md). For the public entry point, secure the load balancer (TLS/ACM, WAF, security response headers) per the Security Considerations below and the load-balancer notes in [auto-scaling.md](references/auto-scaling.md) — the load-balancer build itself belongs to `aws-networking`.
+
+**"Roll out a new AMI to my fleet"** → New launch template version → instance refresh; pin a numeric launch-template version so rollback works, see [auto-scaling.md](references/auto-scaling.md).
+
+**"Connect to a private instance without a bastion"** → Give the instance SSM permissions (an instance profile with `AmazonSSMManagedInstanceCore`, or account-level DHMC) plus a network path, then use Session Manager, see [systems-manager.md](references/systems-manager.md).
+
+**"Cut EC2 cost"** → Right-size (burstable vs fixed-performance), Graviton where the app supports Arm64, Spot with `price-capacity-optimized` for fault-tolerant fleets, release idle Elastic IPs, see [instance-selection.md](references/instance-selection.md).
+
+## Troubleshooting
+
+| Symptom | Likely cause | Quick fix |
+|---------|-------------|-----------|
+| SSH "Connection timed out" | Network path (SG/NACL/route/no public IP) | Open TCP 22 from your IP; check route to IGW; verify public IP — see [troubleshooting.md](references/troubleshooting.md) |
+| SSH "Connection refused" | Host: sshd down or still booting | Wait for boot; check sshd/port via Session Manager or serial console |
+| `InsufficientInstanceCapacity` | AWS lacks capacity of that type in the AZ (NOT a quota) | Try another AZ / instance type / retry; don't request a quota increase |
+| `InstanceLimitExceeded` | vCPU quota reached (this IS a quota) | Request a Service Quotas increase for the instance family |
+| ASG never replaces LB-unhealthy instances | Health check type still EC2 | Set `--health-check-type ELB` |
+| Instances stuck in `Pending:Wait`, terminated after ~1h | Lifecycle hook never completed (heartbeat 3600s, default ABANDON) | Call `complete-lifecycle-action` CONTINUE, or set DefaultResult CONTINUE |
+| System status check failed | AWS host/hardware | Stop/start to migrate to new hardware (reboot won't) |
+| Instance status check failed | Instance OS/network config | Reboot or fix the OS/network config |
+
+Full tables and more errors in [troubleshooting.md](references/troubleshooting.md).
+
+## Security Considerations
+
+- **Enforce IMDSv2** (`HttpTokens=required`) on launch templates to block SSRF-based credential theft; set the account-level default per Region (applies to new launches only).
+- **Prefer Session Manager over inbound SSH** — no open port 22, no key management, and a CloudTrail record of session API calls; enable Session Manager session logging to CloudWatch Logs/S3 (off by default) to capture the in-session commands themselves — see [systems-manager.md](references/systems-manager.md).
+- **Use instance profiles, never embedded credentials**; scope the role to least privilege.
+- **Encrypt EBS/AMIs**; to share an encrypted AMI cross-account, re-encrypt under a customer-managed KMS key (the default `aws/ebs` key can't be shared).
+- **Enable CloudTrail** in all Regions to audit EC2/ASG/SSM API activity, and alarm on sensitive actions (security-group changes, `RunInstances`/`TerminateInstances` from unexpected principals) so unauthorized changes surface.
+- **For public-facing web fleets**, encrypt traffic in transit with an ACM certificate on the load balancer's HTTPS listener and add AWS WAF for defense in depth against common web exploits — the load-balancer/WAF setup itself lives in `aws-networking`.
+- For hardening beyond this guidance, see [AWS EC2 security best practices](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security.html) and CIS Benchmarks for the guest OS.
+
+## Not Covered By This Skill
+
+- **Launching a single hardened instance with best-practice defaults** → use the `launching-ec2-instance-with-best-practices` skill
+- **Creating IAM roles / instance profiles for EC2** → use the `setting-up-ec2-instance-profiles` skill
+- **Building AMIs with an Image Builder pipeline** → use the `creating-ec2-image-builder-pipeline` skill
+- **Lambda / serverless** → `aws-serverless`; **ECS/Fargate** → `aws-containers`; **EKS/Kubernetes** → `kubernetes`
+- **VPC, subnets, ALB/NLB, endpoints** → `aws-networking` or built-in knowledge
+- **IAM policy logic and CloudWatch dashboards/agent setup** → `aws-iam`, `aws-observability`

--- a/plugins/aws-core/skills/aws-compute/references/ami-management.md
+++ b/plugins/aws-core/skills/aws-compute/references/ami-management.md
@@ -1,0 +1,58 @@
+# AMI Management
+
+## Overview
+Creating, sharing, and retiring Amazon Machine Images. For building AMIs with an automated pipeline (recipes, components, distribution), use the `creating-ec2-image-builder-pipeline` skill — this reference covers the AMI lifecycle and sharing that a domain skill owns.
+
+## Create a custom AMI
+
+```bash
+aws ec2 create-image --instance-id <id> --name "my-app-v1" --description "..."
+```
+
+`NoReboot` defaults to `false`, so EC2 reboots the instance to guarantee a consistent file system. **Setting `--no-reboot` skips that, and AWS cannot guarantee file-system integrity** — only use it if you've quiesced/flushed the disk yourself.
+
+The AMI's snapshots inherit the source volumes' encryption. Image from encrypted EBS volumes so the AMI is encrypted at rest; if the source is unencrypted, `copy-image --encrypted --kms-key-id <customer-managed-key>` produces an encrypted copy (also the prerequisite for cross-account sharing — see below).
+
+## Retire an AMI: deprecate vs disable vs deregister
+These are three distinct actions with different reversibility — choosing the wrong one either fails to block launches or destroys the image.
+
+| Action | Effect | Still launchable? | Reversible? |
+|--------|--------|-------------------|-------------|
+| **Deprecate** (`enable-image-deprecation`) | Hides the AMI from `describe-images` listings and the console wizard for other accounts after a date | **Yes** — anyone with the AMI ID can still launch; ASGs/launch templates keep using it | Yes (`disable-image-deprecation`) |
+| **Disable** (`disable-image`) | Sets state to `disabled`, **blocks all new launches**, and revokes launch permissions/sharing | No | **Partially** — `enable-image` restores launchability, visibility, and shareability, but accounts/orgs/OUs that lost access when the AMI was disabled do NOT regain it automatically; you must re-grant launch permissions (re-share) via `modify-image-attribute`. (AMI tags are unaffected by disable/enable.) |
+| **Deregister** (`deregister-image`) | Permanently removes the AMI | No | Only if a Recycle Bin retention rule was set beforehand |
+
+**To block new launches while keeping the ability to restore, use `disable-image`** — deprecate does not actually stop launch-by-ID, and deregister is effectively permanent.
+
+## Share an AMI cross-account / cross-region
+Grant launch permission with `modify-image-attribute` (specific account IDs, an Organization/OU, or public).
+
+**Encrypted AMIs have a KMS catch:** an AMI whose snapshots are encrypted with the **default AWS-managed EBS key (`aws/ebs`) cannot be shared across accounts** — the default service key is usable only within the owning account, so grantees can't decrypt the snapshots even with launch permission. To share an encrypted AMI:
+
+1. Re-encrypt the snapshots under a **customer-managed KMS key** (e.g., copy the AMI/snapshot specifying that key).
+2. Grant the target account permission on that customer-managed KMS key via the key policy: `kms:DescribeKey`, `kms:Decrypt`, `kms:CreateGrant`, `kms:ReEncrypt*`, `kms:GenerateDataKey*`.
+3. Add the account to the AMI's launch permissions.
+
+KMS keys are Region-scoped, so copying/sharing an encrypted AMI to a different Region or account needs a customer-managed KMS key in each Region. To prevent accidental public exposure, enable **AMI block public access** at the account level (per Region; it doesn't retroactively unshare existing public AMIs).
+
+## Common Errors
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| Target account can't launch a shared encrypted AMI | Snapshots use the default `aws/ebs` key | Re-encrypt under a customer-managed key and grant the account key access |
+| Users still launch an AMI you "removed" | Deprecation only hides; still launchable by ID | Use `disable-image` to block launches (or deregister to delete) |
+| Deregistered AMI can't be recovered | Deregister is permanent without Recycle Bin | Prefer `disable-image` to block reversibly; set Recycle Bin rules for critical AMIs |
+| New AMI has a corrupt filesystem | `--no-reboot` skipped the consistency reboot | Recreate without `--no-reboot`, or flush/quiesce before imaging |
+
+## Security Considerations
+
+- **Cross-account sharing requires a customer-managed KMS key** — snapshots under the default `aws/ebs` key can't be shared. Re-encrypt under a customer-managed key and grant the target account access to it in the key policy. See the "Share an AMI cross-account" section above for the full set of required KMS actions (`kms:DescribeKey`, `kms:Decrypt`, `kms:CreateGrant`, `kms:ReEncrypt*`, `kms:GenerateDataKey*`).
+- **Enable AMI block public access** at the account/Region level to prevent accidental public exposure of an image.
+- **Scrub secrets before imaging** — an AMI captures the source instance's disk, so remove anything sensitive first: shell history (`~/.bash_history`), long-lived credentials/API keys, SSH host keys and `authorized_keys`, and any secrets injected via user data or configuration management. Otherwise they are baked into every instance launched from the AMI (and into anyone you share it with).
+- **Prefer reversible retirement** — `disable-image` blocks launches and revokes sharing but is reversible; `deregister-image` is effectively permanent (only recoverable via a pre-set Recycle Bin rule). Reversible retirement matters for security investigations: if an image is later implicated in a discovered security event, a disabled AMI can be retained and restored for forensic analysis, whereas a deregistered one may be gone.
+- **Audit AMI operations with CloudTrail** — enable CloudTrail in all Regions and alarm on sensitive AMI actions (`ModifyImageAttribute` for sharing changes, `DeregisterImage`, `DisableImage`) to detect unauthorized cross-account sharing or destructive deregistration.
+
+## Related
+
+- The `creating-ec2-image-builder-pipeline` skill for automated AMI build pipelines
+- [provisioning.md](provisioning.md) to reference the AMI in a launch template

--- a/plugins/aws-core/skills/aws-compute/references/auto-scaling.md
+++ b/plugins/aws-core/skills/aws-compute/references/auto-scaling.md
@@ -1,0 +1,118 @@
+# EC2 Auto Scaling
+
+## Overview
+Running a self-healing, elastic fleet with Auto Scaling groups (ASGs): health checks, scaling policies, rolling updates via instance refresh, mixed instances/Spot, warm pools, lifecycle hooks, and load-balancer attachment.
+
+## Create an ASG
+Creating an ASG requires only a name, `MinSize`, and `MaxSize`, plus a launch source (a **launch template** — recommended, see [provisioning.md](provisioning.md) — or a MixedInstancesPolicy). `DesiredCapacity` is optional (defaults to `MinSize`). Specifying subnets (`VPCZoneIdentifier`) across multiple AZs is optional at the API level but a strongly recommended resilience practice.
+
+```bash
+aws autoscaling create-auto-scaling-group \
+  --auto-scaling-group-name my-asg \
+  --launch-template LaunchTemplateName=my-app,Version='3' \
+  --min-size 2 --max-size 6 --desired-capacity 2 \
+  --vpc-zone-identifier "subnet-aaa,subnet-bbb" \
+  --health-check-type ELB --health-check-grace-period 300
+```
+
+## Health checks (the #1 gotcha)
+EC2 status checks are always on. **ELB health checks are ignored unless you set `--health-check-type ELB`** — otherwise an instance that fails the target group's health check but passes EC2 checks stays in service and is never replaced. Fix an existing group:
+
+```bash
+aws autoscaling update-auto-scaling-group --auto-scaling-group-name my-asg \
+  --health-check-type ELB --health-check-grace-period 300
+```
+
+**Grace period:** console default 300s, CLI/SDK default 0 (off). Too short → new instances are killed before they finish booting (symptom: ASG "keeps replacing instances"). If an instance leaves the `running` state, it's replaced immediately regardless of grace period.
+
+## Scaling policies
+
+| Policy | When |
+|--------|------|
+| **Target tracking** (recommended default) | Keep a metric at a target (e.g., `ASGAverageCPUUtilization` 50%, or `ALBRequestCountPerTarget`) |
+| Step scaling | Different-sized responses based on alarm breach magnitude |
+| Simple scaling (legacy) | Avoid for new work |
+| Predictive scaling | ML forecast that provisions ahead of predictable cycles — **complements**, not replaces, dynamic scaling |
+
+Target tracking uses **instance warmup** (`DefaultInstanceWarmup`), not the ASG cooldown (cooldown applies to simple scaling). Set warmup so not-yet-ready instances don't skew metrics.
+
+```bash
+aws autoscaling put-scaling-policy --auto-scaling-group-name my-asg \
+  --policy-name cpu50 --policy-type TargetTrackingScaling \
+  --target-tracking-configuration '{"PredefinedMetricSpecification":{"PredefinedMetricType":"ASGAverageCPUUtilization"},"TargetValue":50.0}'
+```
+
+## Instance refresh (rolling updates)
+Roll out a launch-template change (new AMI, user data) by replacing instances in batches:
+
+```bash
+aws autoscaling start-instance-refresh --auto-scaling-group-name my-asg \
+  --preferences '{"MinHealthyPercentage":90,"InstanceWarmup":300}'
+```
+
+- **Skip matching is enabled by default in the console** — the refresh skips instances already matching the target config. If nothing gets replaced, the ASG probably isn't pointing at a new, specific launch-template version (e.g., it uses `$Latest`/`$Default` or an SSM-parameter AMI that resolved unchanged). Point the ASG at the new numeric version or disable skip matching.
+- `MinHealthyPercentage` default 90; `MaxHealthyPercentage` 100–200 (requires Min set, spread ≤100). Setting `MinHealthyPercentage=100` (with `MaxHealthyPercentage>100`) launches replacements before terminating old ones (faster, extra cost).
+- Checkpoints replace in stages (ascending %, last = 100). Monitor with `describe-instance-refreshes`; cancel with `cancel-instance-refresh`; mid-flight `rollback-instance-refresh`.
+- **Auto-rollback is unsupported** when the launch template version is `$Latest`/`$Default` or the AMI is an SSM parameter — pin a numeric version to enable it.
+
+## Mixed instances and Spot
+A mixed instances policy combines a launch template with instance-type overrides and an on-demand/Spot distribution for cost and resilience.
+
+- **Spot allocation strategy: use `price-capacity-optimized`** (low price + available capacity → fewer interruptions). `capacity-optimized` is a fine alternative; `lowest-price` is legacy and interrupts more.
+- **Enable Capacity Rebalancing** (`--capacity-rebalance`) so the ASG proactively replaces at-risk Spot instances on the rebalance recommendation, before the 2-minute interruption notice.
+- Diversify across many instance types and AZs. `OnDemandBaseCapacity` guarantees a floor of On-Demand; `OnDemandPercentageAboveBaseCapacity` splits the rest.
+
+## Warm pools
+A warm pool keeps pre-initialized (Stopped by default, or Running/Hibernated) instances ready, cutting scale-out latency for long-booting apps (e.g., 30s vs 4min). Default size = max − desired; cap with `MaxGroupPreparedCapacity`. Warm-pool instances don't contribute to scaling metrics until they enter service.
+
+## Lifecycle hooks
+Hooks pause instances at `Pending:Wait` (launch) or `Terminating:Wait` (terminate) so you can run setup/teardown.
+
+- **Heartbeat timeout defaults to 3600s (1h); `DefaultResult` defaults to `ABANDON`** — a launch hook that times out terminates the instance. This is the classic "stuck in Pending:Wait for an hour then killed."
+- Signal completion: `aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE …`, or extend with `record-lifecycle-action-heartbeat`. If the hook doesn't need to block, set `DefaultResult=CONTINUE`. Verify the notification target (SNS/SQS/EventBridge) and its IAM permissions. Since payloads carry instance metadata, enable SSE-KMS on the SNS topic/SQS queue and restrict its access policy so only authorized AWS accounts and principals can subscribe or poll — verify each SNS subscriber and SQS consumer is expected, and rely on SNS subscription confirmation to keep unauthorized endpoints from receiving instance metadata.
+
+## Attaching a load balancer target group
+Attach the **target group** to the ASG (not the instances) — the ASG auto-registers/deregisters:
+
+```bash
+aws autoscaling attach-traffic-sources --auto-scaling-group-name my-asg \
+  --traffic-sources Identifier=<target-group-arn>
+```
+
+- Target group **target type must be `instance`** (not `ip`) for an ASG. LB, target group, and ASG must share account/VPC/Region.
+- Don't manually register instances — the ASG owns registration.
+- Deregistration delay (connection draining) defaults to 300s; premature termination during draining causes client 5xx.
+- The launch template's security group must allow inbound from the load balancer; apply launch-template changes to existing instances via instance refresh.
+- For a public web fleet, terminate TLS on the load balancer with an ACM certificate (HTTPS listener, redirect HTTP→HTTPS) so client traffic is encrypted in transit; the listener/ALB configuration itself belongs to `aws-networking`.
+- For a public web fleet, also set security response headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options) via an ALB response header policy or application middleware; the detailed ALB setup belongs to `aws-networking`.
+- For a public web fleet, front the ALB with AWS WAF for defense in depth against common web exploits (SQL injection, XSS, bot traffic); the detailed WAF rule configuration belongs to `aws-networking`.
+
+## Monitoring
+Enable ASG group metrics (`enable-metrics-collection`) plus detailed instance monitoring in the launch template, and alarm on key metrics (`GroupInServiceInstances`, unhealthy host count) and ASG activity notifications (to a KMS-encrypted SNS topic) so scaling failures surface early.
+
+For a security audit trail (not just operational metrics), ensure CloudTrail is enabled in all Regions and alarm on sensitive Auto Scaling / EC2 API actions — e.g. `UpdateAutoScalingGroup`, `DeleteAutoScalingGroup`, and unexpected scaling activity — so unauthorized configuration changes are detected.
+
+## Common Errors
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| ASG never replaces LB-unhealthy instances | Health check type still EC2 | `--health-check-type ELB` |
+| ASG keeps replacing booting instances | Grace period too short | Raise grace period or use a launch lifecycle hook |
+| Instances stuck in `Pending:Wait`, killed after ~1h | Hook not completed (3600s, ABANDON) | `complete-lifecycle-action` CONTINUE, or `DefaultResult=CONTINUE` |
+| Instance refresh replaced nothing | Skip matching + config unchanged | Point ASG at new numeric launch-template version, or disable skip matching |
+| Instance refresh won't roll back | Launch template uses `$Latest`/`$Default`/SSM AMI | Pin a numeric version + specify desired config |
+| Frequent Spot interruptions | `lowest-price` strategy, few types | `price-capacity-optimized` + Capacity Rebalancing + diversify |
+| Can't attach target group | Target type is `ip` | Recreate target group with target type `instance` |
+| `MaxHealthyPercentage` rejected | Out of 100–200 or Min unset or spread >100 | Set both, keep spread ≤100 |
+
+## Security Considerations
+
+- **Lifecycle-hook notifications carry instance metadata** — prevent confused-deputy on the notification role by adding `aws:SourceArn` (the ASG ARN) / `aws:SourceAccount` condition keys to the **IAM service role's trust policy** (the statement trusting `autoscaling.amazonaws.com`), not to the SNS/SQS policy. Separately harden the topic/queue: enable SSE-KMS, restrict the access policy to authorized accounts/principals and restrict publish to that role, verify each subscriber/consumer is expected, and require SNS subscription confirmation so unauthorized endpoints can't receive it.
+- **Audit ASG configuration changes** — ensure CloudTrail is on and alarm on sensitive actions (`UpdateAutoScalingGroup`, `DeleteAutoScalingGroup`, unexpected scaling activity) to catch unauthorized changes.
+- **Inherit least-privilege from the launch template** — the template's IMDSv2/security-group/instance-profile settings propagate to every launched instance, so harden it (see [provisioning.md](provisioning.md)).
+
+## Related
+
+- [provisioning.md](provisioning.md) — launch templates
+- [instance-selection.md](instance-selection.md) — instance types and Spot suitability
+- [troubleshooting.md](troubleshooting.md) — capacity and connectivity errors

--- a/plugins/aws-core/skills/aws-compute/references/instance-selection.md
+++ b/plugins/aws-core/skills/aws-compute/references/instance-selection.md
@@ -1,0 +1,66 @@
+# EC2 Instance Selection
+
+## Overview
+Choosing the right instance type, CPU architecture, burstable mode, and storage.
+
+## Pick a family by workload
+
+| Workload | Family | Notes |
+|----------|--------|-------|
+| Balanced web/app servers, dev | General purpose: M (steady), T (bursty) | T is cheapest for spiky/idle workloads |
+| CPU-bound: batch, transcoding, HPC, game servers, ML inference | Compute optimized: C | Highest vCPU:memory ratio among the general/compute/memory (M/C/R) families |
+| In-memory DBs, caches, big-data analytics | Memory optimized: R (X = extreme) | High memory:vCPU |
+| High random IOPS: NoSQL, OLTP, disk-based caches | Storage optimized: I | Local NVMe SSD; see instance-store caveat below |
+| Dense sequential throughput: data warehouses, HDFS, log processing | Storage optimized: D | Local HDD; see instance-store caveat below |
+| Training / graphics | Accelerated: P, G (GPU) | P for training, G for graphics/inference |
+| ML inference / training on AWS silicon | Inf (Inferentia), Trn (Trainium) | Lower cost per inference/training |
+| Tightly coupled HPC | Hpc | Best price-performance at scale |
+
+Within a family, size (`.large`, `.xlarge`, …) scales vCPU and memory together. Prefer current generation over previous. New families and generations ship regularly, so confirm the current roster with `aws ec2 describe-instance-types --filters Name=current-generation,Values=true` or the EC2 instance-types documentation rather than treating this table as exhaustive.
+
+## Graviton (Arm64) vs x86
+AWS Graviton instances — the `g` suffix denotes Graviton/Arm64 (e.g. `m7g`, `c7g`, `t4g`; additional generations ship over time, so discover current ones with `aws ec2 describe-instance-types --filters Name=processor-info.supported-architecture,Values=arm64 Name=current-generation,Values=true`) — run the Arm64 architecture and generally deliver better price-performance than comparable x86 instances, with each generation improving on the last. Check the current Graviton generation and its published price-performance figures in the AWS documentation before sizing.
+
+**Decision:** Use Graviton when your language/runtime and all dependencies support Arm64 (Go, Java, Python, Node, .NET, most containers do). Stay on x86 (Intel/AMD) for software with x86-only binaries or drivers.
+
+**Gotcha:** Graviton requires an **Arm64/aarch64 AMI** and Arm64-compiled binaries. An x86 AMI won't launch on a `*g` type (the type appears disabled at launch). You can't change architecture in place — rebuild.
+
+## Burstable T instances and CPU credits
+T instances provide a **baseline** CPU percentage and earn **CPU credits** while below baseline, spending them to burst above it (1 credit = 1 vCPU running at 100% for 1 minute).
+
+| Mode | Behavior when credits run out | Default on |
+|------|-------------------------------|-----------|
+| `standard` | Throttled down to baseline | T2 |
+| `unlimited` | Keeps bursting; bills **surplus credits** if 24h-avg CPU > baseline | **T3, T3a, T4g** (also T2 opt-in) |
+
+Defaults can differ on newer burstable generations — confirm a given type with `aws ec2 describe-instance-types --instance-types <type>` (and the credit-specification default) rather than assuming from this table.
+
+- **Cost trap:** T3/T3a/T4g default to unlimited, so a sustained-high-CPU workload silently accrues surplus charges (watch `CPUSurplusCreditsCharged`). For steady high CPU, move to a fixed-performance family (M/C/R) or set `standard`.
+- Set mode at launch or with `aws ec2 modify-instance-credit-specification --instance-credit-specification InstanceId=<id>,CpuCredits=standard`.
+- Credit persistence on stop: T2 Standard loses all accrued credits (balance reset to zero, fresh launch credits on restart); T3, T3a, and T4g keep their CPU credit balance for 7 days after stop, after which the credits are lost. Restart within 7 days and no credits are lost.
+- T3 on a Dedicated Host is standard-only.
+
+## Instance store vs EBS
+Instance store = physically attached ephemeral disk (families with the `d` suffix and I/D families).
+
+**Instance store data is lost on stop, hibernate, terminate, instance-type change, and underlying host failure; it survives only a reboot.** It's also attach-at-launch-only. Use it for scratch/cache/replicated data. For anything durable, use EBS (persists independently), EFS, or S3. Encrypt EBS volumes by default.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Instance type disabled/greyed out at launch | AMI architecture ≠ instance architecture (x86 AMI on Graviton) | Use an Arm64 AMI for `*g` types; rebuild app for Arm64 |
+| Unexpected CPU surplus charges on T3/T4g | Unlimited mode + sustained CPU above baseline | Switch to `standard`, or right-size to M/C/R |
+| Scratch data gone after resize/stop | Instance store wiped on stop/type-change | Store durable data on EBS/EFS/S3 |
+| Sudden throttling to baseline (standard T2) | CPU credit balance depleted | Enable unlimited (mind cost) or use fixed-performance family |
+
+## Security Considerations
+
+- **Graviton (Arm64) needs Arm64 builds** — before migrating, confirm all security-critical software (TLS libraries, IDS/endpoint agents, compliance tooling) ships Arm64 binaries, not just your app.
+- **Instance store is ephemeral** — never place cryptographic keys, certificates, or secrets on it; they're lost on stop/terminate and can't be reliably wiped. Keep secrets in Secrets Manager / SSM Parameter Store and durable data on encrypted EBS.
+- **Choose EBS-capable, encryptable types for production** — enable EBS encryption by default and detailed monitoring on the chosen family.
+
+## Related
+
+- [provisioning.md](provisioning.md) to bake the choice into a launch template
+- [auto-scaling.md](auto-scaling.md) for mixed instance types and Spot

--- a/plugins/aws-core/skills/aws-compute/references/provisioning.md
+++ b/plugins/aws-core/skills/aws-compute/references/provisioning.md
@@ -1,0 +1,91 @@
+# EC2 Provisioning
+
+## Overview
+Defining reusable instance configuration with launch templates, plus user data, key pairs/SSH access, IMDSv2, placement groups, and Elastic IPs.
+
+## Launch templates (use these, not launch configurations)
+A launch template captures AMI, instance type, network interfaces, user data, security groups, instance profile, block device mappings, metadata options, and tags — versioned and reusable by Auto Scaling groups, Spot fleets, and one-off launches.
+
+**Launch configurations are deprecated:** they do not support current EC2 instance types, and new accounts cannot create them — see the [AWS launch-configurations docs](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html). Always use launch templates.
+
+```bash
+aws ec2 create-launch-template \
+  --launch-template-name my-app \
+  --version-description v1 \
+  --launch-template-data '{
+    "ImageId": "ami-xxxxxxxx",
+    "InstanceType": "m7g.large",
+    "IamInstanceProfile": {"Name": "my-app-instance-profile"},
+    "MetadataOptions": {"HttpTokens": "required", "HttpPutResponseHopLimit": 2},
+    "BlockDeviceMappings": [{"DeviceName": "/dev/xvda", "Ebs": {"Encrypted": true}}],
+    "Monitoring": {"Enabled": true},
+    "TagSpecifications": [{"ResourceType":"instance","Tags":[{"Key":"managed_by","Value":"aws-skills"},{"Key":"skill","Value":"aws-compute"}]}]
+  }'
+```
+
+Before hardcoding an instance type like `m7g.large` in production, verify it is current-generation for the target Region: `aws ec2 describe-instance-types --filters Name=current-generation,Values=true --query 'InstanceTypes[].InstanceType'`. The `current-generation` filter (values `true`|`false`) returns whether a type is the latest generation of its instance family, and filter names/values are case-sensitive. Note the command is Region-scoped, so a type may be current-generation but not offered in every Region — cross-check availability with `aws ec2 describe-instance-type-offerings --location-type region --filters Name=instance-type,Values=m7g.large`.
+
+`"Monitoring": {"Enabled": true}` turns on detailed (1-minute) CloudWatch metrics — a production-ready default that also improves ASG scaling responsiveness (omit it only to save cost on non-critical fleets, which falls back to 5-minute metrics).
+
+When the template sets `SecurityGroupIds`, scope those rules to least privilege — reference another security group for internal/tier-to-tier access, or a specific CIDR for known callers, rather than `0.0.0.0/0` (justify any open ingress). Instances inherit these rules at launch, so an over-permissive template propagates to the whole fleet.
+
+**Versioning:** reference a version by number, `$Latest`, or `$Default` (the unspecified default is `$Default`). For instance refresh and rollback, **pin a numeric version** — rollback is unsupported when the ASG uses `$Latest`/`$Default` or an SSM-parameter AMI. Create a new version with `create-launch-template-version`; changing a template does not touch running instances (do an instance refresh — see [auto-scaling.md](auto-scaling.md)).
+
+## IMDSv2
+IMDSv2 requires a session token (PUT to `/latest/api/token`, then the token in each metadata GET), defeating SSRF credential theft. Enforce it:
+
+- **`HttpTokens=required` is what enforces IMDSv2** — it blocks IMDSv1 (a tokenless/invalid-token GET then returns `401 Unauthorized`); also set `HttpEndpoint=enabled`.
+- **`HttpPutResponseHopLimit` defaults to 1 (range 1–64) and does NOT enforce IMDSv2. Set it to 2 for containers on EC2** — the default hop limit of 1 makes the IMDSv2 token PUT response fail to reach a containerized process (the extra hop exceeds the response TTL), so the token request times out; the extra hop covers container → bridge → IMDS. (If IMDSv2 is *required*, a subsequent tokenless GET returns 401; if optional, it silently falls back to IMDSv1. Host-networked containers are unaffected.)
+- Account-level (per Region) default: `aws ec2 modify-instance-metadata-defaults --http-tokens required --http-put-response-hop-limit 2` (org-wide enforcement is a separate Organizations declarative policy). **Applies only to new launches** — existing instances are unchanged; fix each with `modify-instance-metadata-options`. Launch-time settings override the account default.
+
+## User data
+Bootstrap scripts run by cloud-init (Linux) / EC2Launch (Windows). **Runs once at first boot by default.** On Linux, cloud-init runs user data as root; for every-boot, use a cloud-init `#cloud-config` with `[scripts-user, always]` (these are Linux-specific — Windows uses EC2Launch v2, which runs as Local System and re-runs with `frequency: always`). Shell scripts start with `#!`; 16 KB limit before base64 (gzip to fit). Output goes to `/var/log/cloud-init-output.log` — check it when bootstrap "didn't run."
+
+**Never put secrets in user data.** It is stored unencrypted, is readable via IMDS by any process on the instance (`http://169.254.169.254/latest/user-data`), is echoed to `/var/log/cloud-init-output.log`, and appears in the `requestParameters` of the `RunInstances` CloudTrail event. Fetch secrets at boot from AWS Secrets Manager or SSM Parameter Store (SecureString) using the instance-profile role.
+
+## Key pairs and SSH access
+
+- Types: RSA (Linux + Windows) or ED25519 (**Linux only**). `chmod 400 key.pem`.
+- Default users by AMI: `ec2-user` (Amazon Linux/RHEL/SUSE), `ubuntu` (Ubuntu), `admin` (Debian), `centos` (CentOS), `bitnami` (Bitnami); RHEL/SUSE also accept `root`. For other AMIs the default is typically `ec2-user` — confirm with the AMI provider rather than assuming `root`.
+- **EC2 Instance Connect** pushes a temporary key valid **60 seconds** (`aws ec2-instance-connect send-ssh-public-key …`) — connect immediately or you get `Permission denied (publickey)`.
+- Prefer **Session Manager** (no keys, no open port 22) — see [systems-manager.md](systems-manager.md).
+- Lost key: create a new key pair and reattach the public key via Instance Connect, Session Manager, or by editing `authorized_keys` on the detached root volume.
+
+## Placement groups
+
+| Strategy | Placement | Limit | Use for |
+|----------|-----------|-------|---------|
+| Cluster | Packed in one AZ, high bandwidth | Capacity risk if grown incrementally | Tightly coupled HPC/low-latency |
+| Spread | Distinct hardware (one instance per rack) | **Max 7 running instances per AZ per group** | Small set of critical instances |
+| Partition | Isolated racks per partition | **Max 7 partitions per AZ** (instances per partition limited only by account limits) | HDFS/HBase/Cassandra/Kafka |
+
+Cluster: launch all instances of the **same type in one request**; on `InsufficientInstanceCapacity`, stop/start all group members to re-place them. Reference a shared placement group by ID (not name) in the CLI. The spread and partition per-AZ maximums above are firm documented hard limits (not raisable Service Quota defaults) and apply even for shared placement groups.
+
+## Elastic IPs
+
+- **All public IPv4 is billed per hour** — including idle Elastic IPs and EIPs on stopped instances (check current rates on the EC2 pricing page or via `aws pricing get-products`). Release unused ones: `aws ec2 release-address --allocation-id <id>` (EIPs keep billing after the instance is terminated until released). The per-Region EIP quota is low by default (check the current value with `aws service-quotas get-service-quota --service-code ec2 --quota-code L-0263D0A3`).
+- An auto-assigned public IP **changes on stop/start**; attach an Elastic IP for a stable address (common cause of "SSH broke after restart").
+- Remap on failover by disassociating/reassociating the EIP (no release needed).
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Container gets `401` from IMDS, host works | Hop limit 1 | Set `HttpPutResponseHopLimit=2` |
+| Account IMDSv2 default didn't affect existing instances | Default is new-launch + per-Region only | `modify-instance-metadata-options` per instance |
+| `Permission denied (publickey)` | Wrong user/key/permissions, or Instance Connect key expired (60s) | Correct username, `chmod 400`, re-run send-ssh-public-key |
+| SSH broke after stop/start | Public IP changed | Attach an Elastic IP or use the new IP / DNS name |
+| Charged for an unattached Elastic IP | Public IPv4 billed even when idle | Release it |
+
+## Security Considerations
+
+- **Enforce IMDSv2** in the launch template (`HttpTokens=required`, and hop limit 2 for containers) to block SSRF-based credential theft.
+- **Never embed secrets in user data** — it's stored unencrypted, readable via IMDS, logged to cloud-init output, and recorded in the `requestParameters` of the `RunInstances` CloudTrail event; fetch them at boot from Secrets Manager / SSM Parameter Store (SecureString) via the instance profile.
+- **Scope security groups to least privilege** — reference another security group or a specific CIDR rather than `0.0.0.0/0`; the template's rules propagate to every launched instance.
+- **Encrypt EBS volumes** in the block device mappings, and **prefer Session Manager over SSH** (no open port 22, no key sprawl).
+
+## Related
+
+- [instance-selection.md](instance-selection.md) — what to put in the template
+- [auto-scaling.md](auto-scaling.md) — use the template in an ASG
+- [systems-manager.md](systems-manager.md) — keyless access

--- a/plugins/aws-core/skills/aws-compute/references/systems-manager.md
+++ b/plugins/aws-core/skills/aws-compute/references/systems-manager.md
@@ -1,0 +1,66 @@
+# EC2 Operations with Systems Manager
+
+## Overview
+Operating EC2 fleets without SSH keys or open ports: registering managed nodes, Session Manager access, Run Command, Patch Manager, and State Manager.
+
+## Make an instance a managed node
+An EC2 instance becomes a Systems Manager managed node when the SSM Agent (running, with a network path to the service) has SSM credentials, via **either**:
+
+1. An attached IAM instance profile with the `AmazonSSMManagedInstanceCore` managed policy (or an equivalent custom policy). A missing instance profile is the single most common reason an instance is "not managed."
+2. Account + Region-level **Default Host Management Configuration (DHMC)**, which needs **no per-instance profile** — it uses the `AWSSystemsManagerDefaultEC2InstanceManagementRole` role with the `AmazonSSMManagedEC2InstanceDefaultPolicy` policy, and requires IMDSv2 and a current SSM Agent version (see the [DHMC prerequisites](https://docs.aws.amazon.com/systems-manager/latest/userguide/fleet-manager-default-host-management-configuration.html)). Note: if an instance profile is already attached, SSM Agent uses it before DHMC — remove any `ssm:UpdateInstanceInformation` permission from the profile for DHMC to take over.
+
+The SSM Agent is preinstalled on many current AWS-provided AMIs — Amazon Linux 2/2023, Ubuntu, Windows Server among them; check the [SSM Agent preinstalled-AMI list](https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html) or confirm the `amazon-ssm-agent` package is present.
+
+Check Fleet Manager for node status (`PingStatus` is `Online`, `ConnectionLost`, or `Inactive`). An Organizations SCP that denies SSM actions also blocks managed status.
+
+## Session Manager (keyless shell access)
+Session Manager gives a browser/CLI shell with **no inbound ports, no bastion, and no SSH keys** — the agent connects outbound to the service.
+
+```bash
+aws ssm start-session --target <instance-id>
+```
+
+**Encrypt session logging.** Session output can contain sensitive command results. Encrypt the destination yourself first: KMS on the CloudWatch Logs log group (`aws logs associate-kms-key --log-group-name <name> --kms-key-id <arn>`) or SSE-KMS on the S3 bucket. Then set `cloudWatchEncryptionEnabled` / `s3EncryptionEnabled` = true — these flags do **not** enable encryption; when true they require the destination to already be encrypted and SSM refuses to stream logs to an unencrypted destination (an enforcement gate). Separately, `kmsKeyId` encrypts the data channel between the client and the managed node (on top of default TLS).
+
+**Audit SSM API usage with CloudTrail.** Session logging captures *what* ran inside a session; CloudTrail records *who* called SSM and from where — enable it in all Regions to log `StartSession`, `SendCommand`, and `GetParameter`, and alarm on unexpected callers or principals. It is the API-level audit trail for fleet operations.
+
+For an instance in a **private subnet with no NAT/internet gateway**, the agent can't reach the service, so create the following VPC endpoints (interface endpoints with private DNS enabled, except S3 which uses a free gateway endpoint) — `ssm` and `ssmmessages` are always required:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `com.amazonaws.<region>.ssm` | Core Systems Manager API |
+| `com.amazonaws.<region>.ssmmessages` | **Session Manager data channel**; also carries Run Command with current agents |
+| `com.amazonaws.<region>.ec2messages` | Legacy — superseded by `ssmmessages`; not required with a current SSM Agent |
+| `com.amazonaws.<region>.s3` | Patch downloads, Run Command document content, and S3 output capture — use a **gateway endpoint** (free, no per-hour charge). Required for Patch Manager / `AWS-RunPatchBaseline` and S3 output in a no-NAT subnet |
+| `com.amazonaws.<region>.kms` | Session encryption — required only when `kmsKeyId` (above) is configured; without it the encrypted channel can't be established |
+
+Alternatively allow HTTPS (443) egress to those service endpoints (add `kms.<region>.amazonaws.com` when session encryption is enabled). `TargetNotConnected` means prerequisites are unmet, the node isn't managed, or you're in the wrong Region.
+
+## Fleet operations
+
+- **Run Command** — one-off fleet execution; `aws ssm send-command --document-name AWS-RunShellScript --targets "Key=tag:Role,Values=web-tier" --parameters 'commands=[...]'`. Target by instance IDs or tags. Command output can contain sensitive data — when capturing it to S3 (`--output-s3-bucket-name`) or CloudWatch Logs (`--cloud-watch-output-config`), enable KMS encryption (SSE-KMS bucket / KMS-encrypted log group) on the destination. Secure the S3 output bucket by granting `s3:PutObject` (and `s3:GetObject`, `s3:PutObjectAcl` as needed) to the managed node's **instance-profile IAM role** as the bucket-policy `Principal` (`arn:aws:iam::<account>:role/<InstanceProfileRole>`), scoped to the key prefix via `Resource`. Run Command output is written by the instance role directly, not by the SSM service principal — so do **not** use `aws:SourceArn`/`aws:SourceAccount` here (those apply only when a service principal writes on your behalf). When you build `--targets` tag values or `--parameters` commands from external or user-supplied input, validate and escape them first — unsanitized values flow into shell execution on the fleet and are a command-injection path.
+- **Patch Manager** — patch at scale with patch baselines + maintenance windows + tag-based patch groups; core document `AWS-RunPatchBaseline` (`Scan`/`Install`).
+- **State Manager** — associations that re-apply desired state on a schedule (vs Run Command's one-shot).
+
+## Common Errors
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| Instance not a managed node | No instance profile with `AmazonSSMManagedInstanceCore` | Attach a role with that policy via an instance profile |
+| `TargetNotConnected` on start-session | No network path (private subnet, no endpoints) or node not Online | Add ssm/ssmmessages/ec2messages endpoints or NAT egress; confirm Online |
+| Managed but Session Manager fails | `ssmmessages` endpoint missing | Add the ssmmessages interface endpoint |
+| Node managed but SCP blocks actions | Org SCP denies SSM permissions | Update the SCP to allow required SSM actions |
+| Maintenance window runs nothing | Target tag mismatch or nodes not managed | Fix the tag match; ensure nodes are managed and running in the window |
+
+## Security Considerations
+
+- **Sanitize any external input** built into `--targets` tag values or `--parameters` commands before calling Run Command or State Manager — unsanitized values flow into shell execution on the fleet and are a command-injection vector.
+- **Encrypt session and command output** (KMS on the Session Manager S3/CloudWatch sinks, SSE-KMS on Run Command output destinations) — it can contain sensitive results.
+- **Audit with CloudTrail** in all Regions (`StartSession`, `SendCommand`, `GetParameter`) and alarm on unexpected callers; prefer Session Manager over inbound SSH for its keyless, fully-audited access.
+- **Scope SSM access with IAM** — the instance profile needs only `AmazonSSMManagedInstanceCore`; grant human operators least-privilege session/command permissions.
+
+## Related
+
+- [provisioning.md](provisioning.md) for key pairs (when you do need SSH)
+- The `setting-up-ec2-instance-profiles` skill for creating the instance profile itself
+- [troubleshooting.md](troubleshooting.md) for connectivity issues

--- a/plugins/aws-core/skills/aws-compute/references/troubleshooting.md
+++ b/plugins/aws-core/skills/aws-compute/references/troubleshooting.md
@@ -1,0 +1,59 @@
+# EC2 Troubleshooting
+
+## Overview
+Diagnosing the common EC2 failures: connectivity, status checks, capacity/quota errors, Spot interruptions, credit exhaustion, and instances that die on launch. Match the exact error string first — several look similar but have opposite fixes.
+
+## Can't SSH in: read the exact error
+The error string tells you the layer.
+
+| Error | Layer | Causes | Fix |
+|-------|-------|--------|-----|
+| **Connection timed out** | Network — packets never arrive | Security group missing inbound TCP 22 from your IP; NACL blocking; no route to internet gateway; instance has no/changed public IP; local firewall | Open 22 from your IP; verify route + public IP; note public IP changes on stop/start unless an Elastic IP is attached |
+| **Connection refused** | Host — reachable, nothing on the port | sshd not running/listening on that port; instance still booting; sshd misconfigured | Wait for boot; check sshd via Session Manager or EC2 serial console |
+| **Permission denied (publickey)** | Auth | Wrong username for the AMI; wrong key; key file perms; EC2 Instance Connect key expired (60s) | Use the AMI's default user (ec2-user/ubuntu/admin/root); `chmod 400 key.pem`; re-run send-ssh-public-key |
+
+Keyless fallbacks: Session Manager, EC2 Instance Connect, or the serial console (Nitro instances). The serial console is **not on by default** — it needs account-level enablement plus IAM permissions, and on Linux requires a preconfigured password-based user (only the browser client itself is truly keyless). The `AWSSupport-TroubleshootSSH` runbook automates checks. Debug with `ssh -vvv -i key.pem user@host`. For "Connection timed out", enable VPC Flow Logs to confirm whether packets reach the ENI (ACCEPT/REJECT) — KMS-encrypt the flow-log destination (S3 bucket via SSE-KMS or CloudWatch Logs log group); add the CloudWatch agent for OS-level visibility.
+
+## Status check failed: system vs instance
+
+| Check | Monitors | Remedy |
+|-------|----------|--------|
+| **System** (`StatusCheckFailed_System`) | AWS host/hardware/power/network | **Stop/start** an EBS-backed instance to migrate to new hardware (a reboot stays on the same host); or set a CloudWatch instance-recovery action; or wait for AWS |
+| **Instance** (`StatusCheckFailed_Instance`) | The instance's OS/network config | Reboot or fix the OS/network config yourself |
+| Attached EBS | Attached EBS volumes | Investigate the volume; ASG replacement isn't automatic for this check — by default. Enabling the opt-in EBS health check on the ASG (Nitro instances) makes it detect attached-EBS impairment and replace the instance automatically |
+
+## Capacity vs quota errors (opposite fixes)
+
+| Error | Meaning | Fix |
+|-------|---------|-----|
+| **InsufficientInstanceCapacity** | AWS lacks spare capacity for that type in that AZ — NOT a quota | Try another AZ, another instance type/size, retry later, or request fewer per call. In a cluster placement group, stop/start all group instances to re-place them |
+| **InstanceLimitExceeded** | You hit an On-Demand vCPU-based quota (grouped, e.g. the Standard family group A/C/D/H/I/M/R/T/Z; the vCPU-phrased variant is `VcpuLimitExceeded`) — this IS a quota | Raise it via Service Quotas for that quota and Region |
+
+A quota increase does nothing for `InsufficientInstanceCapacity`.
+
+## Spot interruptions
+Spot instances get a **2-minute interruption notice** (via instance metadata `instance-action` and the EventBridge event `EC2 Spot Instance Interruption Warning`). An earlier, softer signal — the **rebalance recommendation** (`EC2 Instance Rebalance Recommendation`) — usually arrives earlier than (but is best-effort and can arrive together with) the two-minute interruption notice, giving more time to drain. In an ASG, enable Capacity Rebalancing to act on it automatically (see [auto-scaling.md](auto-scaling.md)). Test interruption handling with AWS Fault Injection Service.
+
+## High CPU / sudden slowdown on burstable (T) instances
+A T instance that suddenly and persistently drops to sluggish performance under sustained load has likely exhausted its CPU credits: in `standard` mode it throttles to baseline. Switch to `unlimited` (watch surplus charges) or move to a fixed-performance family. In `unlimited` mode the reverse symptom — a surprise bill — comes from `CPUSurplusCreditsCharged`. See [instance-selection.md](instance-selection.md).
+
+## Instance immediately stops or terminates after launch
+
+- **Encrypted root EBS volume the launch role can't decrypt** — the principal/role lacks KMS key permissions; grant key access. Check the system log to confirm the OS never booted.
+- Hitting EBS volume quotas can block/impair launches.
+- Remember instance store data is gone after any stop.
+
+## Instance status check fails after changing to a Nitro type
+Migrating to a Nitro-based instance type without the ENA and NVMe drivers installed causes instance status check failures — install the drivers before switching.
+
+## Security Considerations
+
+- **Prefer Session Manager over SSH for diagnosis** — keyless, IAM-scoped, and fully audited via CloudTrail (no key sprawl or open port 22).
+- **Treat repeated connection failures as possible reconnaissance** — enable CloudTrail and VPC Flow Logs so failed access attempts are visible.
+- **A status-check failure can be a security event, not just hardware** — before reflexively rebooting a suspect instance, review system logs and consider isolation/forensics (a reboot can destroy volatile evidence and instance-store data).
+
+## Related
+
+- [auto-scaling.md](auto-scaling.md) — ASG health, Spot, lifecycle hooks
+- [provisioning.md](provisioning.md) — Elastic IPs, key pairs, IMDS
+- [systems-manager.md](systems-manager.md) — keyless access as an SSH fallback

--- a/skills/core-skills/aws-compute/SKILL.md
+++ b/skills/core-skills/aws-compute/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: aws-compute
+description: "Provisions, scales, and operates Amazon EC2 virtual-machine workloads: instance-type selection (Graviton/Arm64, burstable T credits, GPU, instance store vs EBS), launch templates, Auto Scaling groups (scaling policies, instance refresh, mixed instances, Spot, warm pools, lifecycle hooks), IMDSv2, placement groups, Elastic IPs, AMI lifecycle, and Systems Manager fleet operations (Session Manager, Run Command, Patch Manager). Applies to EC2 instance and fleet questions, InsufficientInstanceCapacity, CPU-credit/surplus charges, IMDSv2 401s, instances stuck in Pending:Wait, ASG not replacing unhealthy instances, status-check failures, SSH refused/timed out, or instances missing as SSM managed nodes. For a single secure instance launch, the launching-ec2-instance-with-best-practices skill is more appropriate; for instance profiles, see setting-up-ec2-instance-profiles; for Image Builder, see creating-ec2-image-builder-pipeline. Does NOT cover Lambda, ECS/Fargate, EKS, VPC/ALB/NLB design, or IAM policy authoring."
+version: 1
+---
+
+# Amazon EC2 Compute
+
+Best experience with the AWS MCP server; also works with the AWS CLI alone — no hard dependency on either.
+
+## Critical Warnings
+
+**Launch configurations are deprecated** and do not support current EC2 instance types; new accounts cannot create them. Use launch templates for every new Auto Scaling group. See [auto-scaling.md](references/auto-scaling.md).
+
+**ASGs ignore ELB health checks by default**: An Auto Scaling group only uses EC2 status checks unless you set `--health-check-type ELB`. Without it, instances failing the load balancer's health check stay in service forever. See [auto-scaling.md](references/auto-scaling.md).
+
+**IMDSv2 hop limit breaks containers**: the default `HttpPutResponseHopLimit` of 1 makes the IMDSv2 token PUT response fail to reach a containerized process (the extra hop exceeds the response TTL), so the token request times out. Set `HttpPutResponseHopLimit=2` for bridge/awsvpc container workloads. (If IMDSv2 is *required*, a subsequent tokenless GET returns `401`; if optional, it silently falls back to IMDSv1.) See [provisioning.md](references/provisioning.md).
+
+**T3/T3a/T4g default to unlimited mode**: Unlike T2 (standard), these burst without throttling but bill surplus CPU credits when 24h-average CPU exceeds baseline — a silent cost leak. See [instance-selection.md](references/instance-selection.md).
+
+**Instance store is ephemeral**: Data on instance store volumes is lost on stop, hibernate, terminate, instance-type change, and host failure — it survives only a reboot. Put anything durable on EBS/EFS/S3. See [instance-selection.md](references/instance-selection.md).
+
+## Which do you need?
+
+| If you're deciding... | Guidance |
+|-----------------------|----------|
+| Instance family / size / Graviton / GPU / burstable | [instance-selection.md](references/instance-selection.md) — start with the workload→family table |
+| How to define instances once and reuse (launch template) | [provisioning.md](references/provisioning.md) |
+| How to run many instances that scale automatically | [auto-scaling.md](references/auto-scaling.md) |
+| How to access/patch/manage instances without SSH keys | [systems-manager.md](references/systems-manager.md) |
+
+## Quick Navigation
+
+| You want to... | Go to |
+|----------------|-------|
+| Pick an instance type, Graviton vs x86, burstable credits, GPU, instance store vs EBS | [instance-selection.md](references/instance-selection.md) |
+| Create a launch template, user data, key pairs, IMDSv2, placement groups, Elastic IPs | [provisioning.md](references/provisioning.md) |
+| Set up or fix an Auto Scaling group, scaling policies, instance refresh, Spot, lifecycle hooks | [auto-scaling.md](references/auto-scaling.md) |
+| Get SSH-less access, patch a fleet, or fix an instance not showing as a managed node | [systems-manager.md](references/systems-manager.md) |
+| Create, share, or retire (deprecate/disable/deregister) an AMI | [ami-management.md](references/ami-management.md) |
+| Fix something broken (can't connect, status-check fail, capacity error, stuck instances) | [troubleshooting.md](references/troubleshooting.md) |
+
+## Common Workflows
+
+**"Stand up an autoscaling web fleet"** → Create a launch template (AMI, type, IMDSv2), then an ASG referencing it with `--health-check-type ELB` and a target-tracking policy, see [auto-scaling.md](references/auto-scaling.md). For the public entry point, secure the load balancer (TLS/ACM, WAF, security response headers) per the Security Considerations below and the load-balancer notes in [auto-scaling.md](references/auto-scaling.md) — the load-balancer build itself belongs to `aws-networking`.
+
+**"Roll out a new AMI to my fleet"** → New launch template version → instance refresh; pin a numeric launch-template version so rollback works, see [auto-scaling.md](references/auto-scaling.md).
+
+**"Connect to a private instance without a bastion"** → Give the instance SSM permissions (an instance profile with `AmazonSSMManagedInstanceCore`, or account-level DHMC) plus a network path, then use Session Manager, see [systems-manager.md](references/systems-manager.md).
+
+**"Cut EC2 cost"** → Right-size (burstable vs fixed-performance), Graviton where the app supports Arm64, Spot with `price-capacity-optimized` for fault-tolerant fleets, release idle Elastic IPs, see [instance-selection.md](references/instance-selection.md).
+
+## Troubleshooting
+
+| Symptom | Likely cause | Quick fix |
+|---------|-------------|-----------|
+| SSH "Connection timed out" | Network path (SG/NACL/route/no public IP) | Open TCP 22 from your IP; check route to IGW; verify public IP — see [troubleshooting.md](references/troubleshooting.md) |
+| SSH "Connection refused" | Host: sshd down or still booting | Wait for boot; check sshd/port via Session Manager or serial console |
+| `InsufficientInstanceCapacity` | AWS lacks capacity of that type in the AZ (NOT a quota) | Try another AZ / instance type / retry; don't request a quota increase |
+| `InstanceLimitExceeded` | vCPU quota reached (this IS a quota) | Request a Service Quotas increase for the instance family |
+| ASG never replaces LB-unhealthy instances | Health check type still EC2 | Set `--health-check-type ELB` |
+| Instances stuck in `Pending:Wait`, terminated after ~1h | Lifecycle hook never completed (heartbeat 3600s, default ABANDON) | Call `complete-lifecycle-action` CONTINUE, or set DefaultResult CONTINUE |
+| System status check failed | AWS host/hardware | Stop/start to migrate to new hardware (reboot won't) |
+| Instance status check failed | Instance OS/network config | Reboot or fix the OS/network config |
+
+Full tables and more errors in [troubleshooting.md](references/troubleshooting.md).
+
+## Security Considerations
+
+- **Enforce IMDSv2** (`HttpTokens=required`) on launch templates to block SSRF-based credential theft; set the account-level default per Region (applies to new launches only).
+- **Prefer Session Manager over inbound SSH** — no open port 22, no key management, and a CloudTrail record of session API calls; enable Session Manager session logging to CloudWatch Logs/S3 (off by default) to capture the in-session commands themselves — see [systems-manager.md](references/systems-manager.md).
+- **Use instance profiles, never embedded credentials**; scope the role to least privilege.
+- **Encrypt EBS/AMIs**; to share an encrypted AMI cross-account, re-encrypt under a customer-managed KMS key (the default `aws/ebs` key can't be shared).
+- **Enable CloudTrail** in all Regions to audit EC2/ASG/SSM API activity, and alarm on sensitive actions (security-group changes, `RunInstances`/`TerminateInstances` from unexpected principals) so unauthorized changes surface.
+- **For public-facing web fleets**, encrypt traffic in transit with an ACM certificate on the load balancer's HTTPS listener and add AWS WAF for defense in depth against common web exploits — the load-balancer/WAF setup itself lives in `aws-networking`.
+- For hardening beyond this guidance, see [AWS EC2 security best practices](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security.html) and CIS Benchmarks for the guest OS.
+
+## Not Covered By This Skill
+
+- **Launching a single hardened instance with best-practice defaults** → use the `launching-ec2-instance-with-best-practices` skill
+- **Creating IAM roles / instance profiles for EC2** → use the `setting-up-ec2-instance-profiles` skill
+- **Building AMIs with an Image Builder pipeline** → use the `creating-ec2-image-builder-pipeline` skill
+- **Lambda / serverless** → `aws-serverless`; **ECS/Fargate** → `aws-containers`; **EKS/Kubernetes** → `kubernetes`
+- **VPC, subnets, ALB/NLB, endpoints** → `aws-networking` or built-in knowledge
+- **IAM policy logic and CloudWatch dashboards/agent setup** → `aws-iam`, `aws-observability`

--- a/skills/core-skills/aws-compute/references/ami-management.md
+++ b/skills/core-skills/aws-compute/references/ami-management.md
@@ -1,0 +1,58 @@
+# AMI Management
+
+## Overview
+Creating, sharing, and retiring Amazon Machine Images. For building AMIs with an automated pipeline (recipes, components, distribution), use the `creating-ec2-image-builder-pipeline` skill — this reference covers the AMI lifecycle and sharing that a domain skill owns.
+
+## Create a custom AMI
+
+```bash
+aws ec2 create-image --instance-id <id> --name "my-app-v1" --description "..."
+```
+
+`NoReboot` defaults to `false`, so EC2 reboots the instance to guarantee a consistent file system. **Setting `--no-reboot` skips that, and AWS cannot guarantee file-system integrity** — only use it if you've quiesced/flushed the disk yourself.
+
+The AMI's snapshots inherit the source volumes' encryption. Image from encrypted EBS volumes so the AMI is encrypted at rest; if the source is unencrypted, `copy-image --encrypted --kms-key-id <customer-managed-key>` produces an encrypted copy (also the prerequisite for cross-account sharing — see below).
+
+## Retire an AMI: deprecate vs disable vs deregister
+These are three distinct actions with different reversibility — choosing the wrong one either fails to block launches or destroys the image.
+
+| Action | Effect | Still launchable? | Reversible? |
+|--------|--------|-------------------|-------------|
+| **Deprecate** (`enable-image-deprecation`) | Hides the AMI from `describe-images` listings and the console wizard for other accounts after a date | **Yes** — anyone with the AMI ID can still launch; ASGs/launch templates keep using it | Yes (`disable-image-deprecation`) |
+| **Disable** (`disable-image`) | Sets state to `disabled`, **blocks all new launches**, and revokes launch permissions/sharing | No | **Partially** — `enable-image` restores launchability, visibility, and shareability, but accounts/orgs/OUs that lost access when the AMI was disabled do NOT regain it automatically; you must re-grant launch permissions (re-share) via `modify-image-attribute`. (AMI tags are unaffected by disable/enable.) |
+| **Deregister** (`deregister-image`) | Permanently removes the AMI | No | Only if a Recycle Bin retention rule was set beforehand |
+
+**To block new launches while keeping the ability to restore, use `disable-image`** — deprecate does not actually stop launch-by-ID, and deregister is effectively permanent.
+
+## Share an AMI cross-account / cross-region
+Grant launch permission with `modify-image-attribute` (specific account IDs, an Organization/OU, or public).
+
+**Encrypted AMIs have a KMS catch:** an AMI whose snapshots are encrypted with the **default AWS-managed EBS key (`aws/ebs`) cannot be shared across accounts** — the default service key is usable only within the owning account, so grantees can't decrypt the snapshots even with launch permission. To share an encrypted AMI:
+
+1. Re-encrypt the snapshots under a **customer-managed KMS key** (e.g., copy the AMI/snapshot specifying that key).
+2. Grant the target account permission on that customer-managed KMS key via the key policy: `kms:DescribeKey`, `kms:Decrypt`, `kms:CreateGrant`, `kms:ReEncrypt*`, `kms:GenerateDataKey*`.
+3. Add the account to the AMI's launch permissions.
+
+KMS keys are Region-scoped, so copying/sharing an encrypted AMI to a different Region or account needs a customer-managed KMS key in each Region. To prevent accidental public exposure, enable **AMI block public access** at the account level (per Region; it doesn't retroactively unshare existing public AMIs).
+
+## Common Errors
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| Target account can't launch a shared encrypted AMI | Snapshots use the default `aws/ebs` key | Re-encrypt under a customer-managed key and grant the account key access |
+| Users still launch an AMI you "removed" | Deprecation only hides; still launchable by ID | Use `disable-image` to block launches (or deregister to delete) |
+| Deregistered AMI can't be recovered | Deregister is permanent without Recycle Bin | Prefer `disable-image` to block reversibly; set Recycle Bin rules for critical AMIs |
+| New AMI has a corrupt filesystem | `--no-reboot` skipped the consistency reboot | Recreate without `--no-reboot`, or flush/quiesce before imaging |
+
+## Security Considerations
+
+- **Cross-account sharing requires a customer-managed KMS key** — snapshots under the default `aws/ebs` key can't be shared. Re-encrypt under a customer-managed key and grant the target account access to it in the key policy. See the "Share an AMI cross-account" section above for the full set of required KMS actions (`kms:DescribeKey`, `kms:Decrypt`, `kms:CreateGrant`, `kms:ReEncrypt*`, `kms:GenerateDataKey*`).
+- **Enable AMI block public access** at the account/Region level to prevent accidental public exposure of an image.
+- **Scrub secrets before imaging** — an AMI captures the source instance's disk, so remove anything sensitive first: shell history (`~/.bash_history`), long-lived credentials/API keys, SSH host keys and `authorized_keys`, and any secrets injected via user data or configuration management. Otherwise they are baked into every instance launched from the AMI (and into anyone you share it with).
+- **Prefer reversible retirement** — `disable-image` blocks launches and revokes sharing but is reversible; `deregister-image` is effectively permanent (only recoverable via a pre-set Recycle Bin rule). Reversible retirement matters for security investigations: if an image is later implicated in a discovered security event, a disabled AMI can be retained and restored for forensic analysis, whereas a deregistered one may be gone.
+- **Audit AMI operations with CloudTrail** — enable CloudTrail in all Regions and alarm on sensitive AMI actions (`ModifyImageAttribute` for sharing changes, `DeregisterImage`, `DisableImage`) to detect unauthorized cross-account sharing or destructive deregistration.
+
+## Related
+
+- The `creating-ec2-image-builder-pipeline` skill for automated AMI build pipelines
+- [provisioning.md](provisioning.md) to reference the AMI in a launch template

--- a/skills/core-skills/aws-compute/references/auto-scaling.md
+++ b/skills/core-skills/aws-compute/references/auto-scaling.md
@@ -1,0 +1,118 @@
+# EC2 Auto Scaling
+
+## Overview
+Running a self-healing, elastic fleet with Auto Scaling groups (ASGs): health checks, scaling policies, rolling updates via instance refresh, mixed instances/Spot, warm pools, lifecycle hooks, and load-balancer attachment.
+
+## Create an ASG
+Creating an ASG requires only a name, `MinSize`, and `MaxSize`, plus a launch source (a **launch template** — recommended, see [provisioning.md](provisioning.md) — or a MixedInstancesPolicy). `DesiredCapacity` is optional (defaults to `MinSize`). Specifying subnets (`VPCZoneIdentifier`) across multiple AZs is optional at the API level but a strongly recommended resilience practice.
+
+```bash
+aws autoscaling create-auto-scaling-group \
+  --auto-scaling-group-name my-asg \
+  --launch-template LaunchTemplateName=my-app,Version='3' \
+  --min-size 2 --max-size 6 --desired-capacity 2 \
+  --vpc-zone-identifier "subnet-aaa,subnet-bbb" \
+  --health-check-type ELB --health-check-grace-period 300
+```
+
+## Health checks (the #1 gotcha)
+EC2 status checks are always on. **ELB health checks are ignored unless you set `--health-check-type ELB`** — otherwise an instance that fails the target group's health check but passes EC2 checks stays in service and is never replaced. Fix an existing group:
+
+```bash
+aws autoscaling update-auto-scaling-group --auto-scaling-group-name my-asg \
+  --health-check-type ELB --health-check-grace-period 300
+```
+
+**Grace period:** console default 300s, CLI/SDK default 0 (off). Too short → new instances are killed before they finish booting (symptom: ASG "keeps replacing instances"). If an instance leaves the `running` state, it's replaced immediately regardless of grace period.
+
+## Scaling policies
+
+| Policy | When |
+|--------|------|
+| **Target tracking** (recommended default) | Keep a metric at a target (e.g., `ASGAverageCPUUtilization` 50%, or `ALBRequestCountPerTarget`) |
+| Step scaling | Different-sized responses based on alarm breach magnitude |
+| Simple scaling (legacy) | Avoid for new work |
+| Predictive scaling | ML forecast that provisions ahead of predictable cycles — **complements**, not replaces, dynamic scaling |
+
+Target tracking uses **instance warmup** (`DefaultInstanceWarmup`), not the ASG cooldown (cooldown applies to simple scaling). Set warmup so not-yet-ready instances don't skew metrics.
+
+```bash
+aws autoscaling put-scaling-policy --auto-scaling-group-name my-asg \
+  --policy-name cpu50 --policy-type TargetTrackingScaling \
+  --target-tracking-configuration '{"PredefinedMetricSpecification":{"PredefinedMetricType":"ASGAverageCPUUtilization"},"TargetValue":50.0}'
+```
+
+## Instance refresh (rolling updates)
+Roll out a launch-template change (new AMI, user data) by replacing instances in batches:
+
+```bash
+aws autoscaling start-instance-refresh --auto-scaling-group-name my-asg \
+  --preferences '{"MinHealthyPercentage":90,"InstanceWarmup":300}'
+```
+
+- **Skip matching is enabled by default in the console** — the refresh skips instances already matching the target config. If nothing gets replaced, the ASG probably isn't pointing at a new, specific launch-template version (e.g., it uses `$Latest`/`$Default` or an SSM-parameter AMI that resolved unchanged). Point the ASG at the new numeric version or disable skip matching.
+- `MinHealthyPercentage` default 90; `MaxHealthyPercentage` 100–200 (requires Min set, spread ≤100). Setting `MinHealthyPercentage=100` (with `MaxHealthyPercentage>100`) launches replacements before terminating old ones (faster, extra cost).
+- Checkpoints replace in stages (ascending %, last = 100). Monitor with `describe-instance-refreshes`; cancel with `cancel-instance-refresh`; mid-flight `rollback-instance-refresh`.
+- **Auto-rollback is unsupported** when the launch template version is `$Latest`/`$Default` or the AMI is an SSM parameter — pin a numeric version to enable it.
+
+## Mixed instances and Spot
+A mixed instances policy combines a launch template with instance-type overrides and an on-demand/Spot distribution for cost and resilience.
+
+- **Spot allocation strategy: use `price-capacity-optimized`** (low price + available capacity → fewer interruptions). `capacity-optimized` is a fine alternative; `lowest-price` is legacy and interrupts more.
+- **Enable Capacity Rebalancing** (`--capacity-rebalance`) so the ASG proactively replaces at-risk Spot instances on the rebalance recommendation, before the 2-minute interruption notice.
+- Diversify across many instance types and AZs. `OnDemandBaseCapacity` guarantees a floor of On-Demand; `OnDemandPercentageAboveBaseCapacity` splits the rest.
+
+## Warm pools
+A warm pool keeps pre-initialized (Stopped by default, or Running/Hibernated) instances ready, cutting scale-out latency for long-booting apps (e.g., 30s vs 4min). Default size = max − desired; cap with `MaxGroupPreparedCapacity`. Warm-pool instances don't contribute to scaling metrics until they enter service.
+
+## Lifecycle hooks
+Hooks pause instances at `Pending:Wait` (launch) or `Terminating:Wait` (terminate) so you can run setup/teardown.
+
+- **Heartbeat timeout defaults to 3600s (1h); `DefaultResult` defaults to `ABANDON`** — a launch hook that times out terminates the instance. This is the classic "stuck in Pending:Wait for an hour then killed."
+- Signal completion: `aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE …`, or extend with `record-lifecycle-action-heartbeat`. If the hook doesn't need to block, set `DefaultResult=CONTINUE`. Verify the notification target (SNS/SQS/EventBridge) and its IAM permissions. Since payloads carry instance metadata, enable SSE-KMS on the SNS topic/SQS queue and restrict its access policy so only authorized AWS accounts and principals can subscribe or poll — verify each SNS subscriber and SQS consumer is expected, and rely on SNS subscription confirmation to keep unauthorized endpoints from receiving instance metadata.
+
+## Attaching a load balancer target group
+Attach the **target group** to the ASG (not the instances) — the ASG auto-registers/deregisters:
+
+```bash
+aws autoscaling attach-traffic-sources --auto-scaling-group-name my-asg \
+  --traffic-sources Identifier=<target-group-arn>
+```
+
+- Target group **target type must be `instance`** (not `ip`) for an ASG. LB, target group, and ASG must share account/VPC/Region.
+- Don't manually register instances — the ASG owns registration.
+- Deregistration delay (connection draining) defaults to 300s; premature termination during draining causes client 5xx.
+- The launch template's security group must allow inbound from the load balancer; apply launch-template changes to existing instances via instance refresh.
+- For a public web fleet, terminate TLS on the load balancer with an ACM certificate (HTTPS listener, redirect HTTP→HTTPS) so client traffic is encrypted in transit; the listener/ALB configuration itself belongs to `aws-networking`.
+- For a public web fleet, also set security response headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options) via an ALB response header policy or application middleware; the detailed ALB setup belongs to `aws-networking`.
+- For a public web fleet, front the ALB with AWS WAF for defense in depth against common web exploits (SQL injection, XSS, bot traffic); the detailed WAF rule configuration belongs to `aws-networking`.
+
+## Monitoring
+Enable ASG group metrics (`enable-metrics-collection`) plus detailed instance monitoring in the launch template, and alarm on key metrics (`GroupInServiceInstances`, unhealthy host count) and ASG activity notifications (to a KMS-encrypted SNS topic) so scaling failures surface early.
+
+For a security audit trail (not just operational metrics), ensure CloudTrail is enabled in all Regions and alarm on sensitive Auto Scaling / EC2 API actions — e.g. `UpdateAutoScalingGroup`, `DeleteAutoScalingGroup`, and unexpected scaling activity — so unauthorized configuration changes are detected.
+
+## Common Errors
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| ASG never replaces LB-unhealthy instances | Health check type still EC2 | `--health-check-type ELB` |
+| ASG keeps replacing booting instances | Grace period too short | Raise grace period or use a launch lifecycle hook |
+| Instances stuck in `Pending:Wait`, killed after ~1h | Hook not completed (3600s, ABANDON) | `complete-lifecycle-action` CONTINUE, or `DefaultResult=CONTINUE` |
+| Instance refresh replaced nothing | Skip matching + config unchanged | Point ASG at new numeric launch-template version, or disable skip matching |
+| Instance refresh won't roll back | Launch template uses `$Latest`/`$Default`/SSM AMI | Pin a numeric version + specify desired config |
+| Frequent Spot interruptions | `lowest-price` strategy, few types | `price-capacity-optimized` + Capacity Rebalancing + diversify |
+| Can't attach target group | Target type is `ip` | Recreate target group with target type `instance` |
+| `MaxHealthyPercentage` rejected | Out of 100–200 or Min unset or spread >100 | Set both, keep spread ≤100 |
+
+## Security Considerations
+
+- **Lifecycle-hook notifications carry instance metadata** — prevent confused-deputy on the notification role by adding `aws:SourceArn` (the ASG ARN) / `aws:SourceAccount` condition keys to the **IAM service role's trust policy** (the statement trusting `autoscaling.amazonaws.com`), not to the SNS/SQS policy. Separately harden the topic/queue: enable SSE-KMS, restrict the access policy to authorized accounts/principals and restrict publish to that role, verify each subscriber/consumer is expected, and require SNS subscription confirmation so unauthorized endpoints can't receive it.
+- **Audit ASG configuration changes** — ensure CloudTrail is on and alarm on sensitive actions (`UpdateAutoScalingGroup`, `DeleteAutoScalingGroup`, unexpected scaling activity) to catch unauthorized changes.
+- **Inherit least-privilege from the launch template** — the template's IMDSv2/security-group/instance-profile settings propagate to every launched instance, so harden it (see [provisioning.md](provisioning.md)).
+
+## Related
+
+- [provisioning.md](provisioning.md) — launch templates
+- [instance-selection.md](instance-selection.md) — instance types and Spot suitability
+- [troubleshooting.md](troubleshooting.md) — capacity and connectivity errors

--- a/skills/core-skills/aws-compute/references/instance-selection.md
+++ b/skills/core-skills/aws-compute/references/instance-selection.md
@@ -1,0 +1,66 @@
+# EC2 Instance Selection
+
+## Overview
+Choosing the right instance type, CPU architecture, burstable mode, and storage.
+
+## Pick a family by workload
+
+| Workload | Family | Notes |
+|----------|--------|-------|
+| Balanced web/app servers, dev | General purpose: M (steady), T (bursty) | T is cheapest for spiky/idle workloads |
+| CPU-bound: batch, transcoding, HPC, game servers, ML inference | Compute optimized: C | Highest vCPU:memory ratio among the general/compute/memory (M/C/R) families |
+| In-memory DBs, caches, big-data analytics | Memory optimized: R (X = extreme) | High memory:vCPU |
+| High random IOPS: NoSQL, OLTP, disk-based caches | Storage optimized: I | Local NVMe SSD; see instance-store caveat below |
+| Dense sequential throughput: data warehouses, HDFS, log processing | Storage optimized: D | Local HDD; see instance-store caveat below |
+| Training / graphics | Accelerated: P, G (GPU) | P for training, G for graphics/inference |
+| ML inference / training on AWS silicon | Inf (Inferentia), Trn (Trainium) | Lower cost per inference/training |
+| Tightly coupled HPC | Hpc | Best price-performance at scale |
+
+Within a family, size (`.large`, `.xlarge`, …) scales vCPU and memory together. Prefer current generation over previous. New families and generations ship regularly, so confirm the current roster with `aws ec2 describe-instance-types --filters Name=current-generation,Values=true` or the EC2 instance-types documentation rather than treating this table as exhaustive.
+
+## Graviton (Arm64) vs x86
+AWS Graviton instances — the `g` suffix denotes Graviton/Arm64 (e.g. `m7g`, `c7g`, `t4g`; additional generations ship over time, so discover current ones with `aws ec2 describe-instance-types --filters Name=processor-info.supported-architecture,Values=arm64 Name=current-generation,Values=true`) — run the Arm64 architecture and generally deliver better price-performance than comparable x86 instances, with each generation improving on the last. Check the current Graviton generation and its published price-performance figures in the AWS documentation before sizing.
+
+**Decision:** Use Graviton when your language/runtime and all dependencies support Arm64 (Go, Java, Python, Node, .NET, most containers do). Stay on x86 (Intel/AMD) for software with x86-only binaries or drivers.
+
+**Gotcha:** Graviton requires an **Arm64/aarch64 AMI** and Arm64-compiled binaries. An x86 AMI won't launch on a `*g` type (the type appears disabled at launch). You can't change architecture in place — rebuild.
+
+## Burstable T instances and CPU credits
+T instances provide a **baseline** CPU percentage and earn **CPU credits** while below baseline, spending them to burst above it (1 credit = 1 vCPU running at 100% for 1 minute).
+
+| Mode | Behavior when credits run out | Default on |
+|------|-------------------------------|-----------|
+| `standard` | Throttled down to baseline | T2 |
+| `unlimited` | Keeps bursting; bills **surplus credits** if 24h-avg CPU > baseline | **T3, T3a, T4g** (also T2 opt-in) |
+
+Defaults can differ on newer burstable generations — confirm a given type with `aws ec2 describe-instance-types --instance-types <type>` (and the credit-specification default) rather than assuming from this table.
+
+- **Cost trap:** T3/T3a/T4g default to unlimited, so a sustained-high-CPU workload silently accrues surplus charges (watch `CPUSurplusCreditsCharged`). For steady high CPU, move to a fixed-performance family (M/C/R) or set `standard`.
+- Set mode at launch or with `aws ec2 modify-instance-credit-specification --instance-credit-specification InstanceId=<id>,CpuCredits=standard`.
+- Credit persistence on stop: T2 Standard loses all accrued credits (balance reset to zero, fresh launch credits on restart); T3, T3a, and T4g keep their CPU credit balance for 7 days after stop, after which the credits are lost. Restart within 7 days and no credits are lost.
+- T3 on a Dedicated Host is standard-only.
+
+## Instance store vs EBS
+Instance store = physically attached ephemeral disk (families with the `d` suffix and I/D families).
+
+**Instance store data is lost on stop, hibernate, terminate, instance-type change, and underlying host failure; it survives only a reboot.** It's also attach-at-launch-only. Use it for scratch/cache/replicated data. For anything durable, use EBS (persists independently), EFS, or S3. Encrypt EBS volumes by default.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Instance type disabled/greyed out at launch | AMI architecture ≠ instance architecture (x86 AMI on Graviton) | Use an Arm64 AMI for `*g` types; rebuild app for Arm64 |
+| Unexpected CPU surplus charges on T3/T4g | Unlimited mode + sustained CPU above baseline | Switch to `standard`, or right-size to M/C/R |
+| Scratch data gone after resize/stop | Instance store wiped on stop/type-change | Store durable data on EBS/EFS/S3 |
+| Sudden throttling to baseline (standard T2) | CPU credit balance depleted | Enable unlimited (mind cost) or use fixed-performance family |
+
+## Security Considerations
+
+- **Graviton (Arm64) needs Arm64 builds** — before migrating, confirm all security-critical software (TLS libraries, IDS/endpoint agents, compliance tooling) ships Arm64 binaries, not just your app.
+- **Instance store is ephemeral** — never place cryptographic keys, certificates, or secrets on it; they're lost on stop/terminate and can't be reliably wiped. Keep secrets in Secrets Manager / SSM Parameter Store and durable data on encrypted EBS.
+- **Choose EBS-capable, encryptable types for production** — enable EBS encryption by default and detailed monitoring on the chosen family.
+
+## Related
+
+- [provisioning.md](provisioning.md) to bake the choice into a launch template
+- [auto-scaling.md](auto-scaling.md) for mixed instance types and Spot

--- a/skills/core-skills/aws-compute/references/provisioning.md
+++ b/skills/core-skills/aws-compute/references/provisioning.md
@@ -1,0 +1,91 @@
+# EC2 Provisioning
+
+## Overview
+Defining reusable instance configuration with launch templates, plus user data, key pairs/SSH access, IMDSv2, placement groups, and Elastic IPs.
+
+## Launch templates (use these, not launch configurations)
+A launch template captures AMI, instance type, network interfaces, user data, security groups, instance profile, block device mappings, metadata options, and tags — versioned and reusable by Auto Scaling groups, Spot fleets, and one-off launches.
+
+**Launch configurations are deprecated:** they do not support current EC2 instance types, and new accounts cannot create them — see the [AWS launch-configurations docs](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html). Always use launch templates.
+
+```bash
+aws ec2 create-launch-template \
+  --launch-template-name my-app \
+  --version-description v1 \
+  --launch-template-data '{
+    "ImageId": "ami-xxxxxxxx",
+    "InstanceType": "m7g.large",
+    "IamInstanceProfile": {"Name": "my-app-instance-profile"},
+    "MetadataOptions": {"HttpTokens": "required", "HttpPutResponseHopLimit": 2},
+    "BlockDeviceMappings": [{"DeviceName": "/dev/xvda", "Ebs": {"Encrypted": true}}],
+    "Monitoring": {"Enabled": true},
+    "TagSpecifications": [{"ResourceType":"instance","Tags":[{"Key":"managed_by","Value":"aws-skills"},{"Key":"skill","Value":"aws-compute"}]}]
+  }'
+```
+
+Before hardcoding an instance type like `m7g.large` in production, verify it is current-generation for the target Region: `aws ec2 describe-instance-types --filters Name=current-generation,Values=true --query 'InstanceTypes[].InstanceType'`. The `current-generation` filter (values `true`|`false`) returns whether a type is the latest generation of its instance family, and filter names/values are case-sensitive. Note the command is Region-scoped, so a type may be current-generation but not offered in every Region — cross-check availability with `aws ec2 describe-instance-type-offerings --location-type region --filters Name=instance-type,Values=m7g.large`.
+
+`"Monitoring": {"Enabled": true}` turns on detailed (1-minute) CloudWatch metrics — a production-ready default that also improves ASG scaling responsiveness (omit it only to save cost on non-critical fleets, which falls back to 5-minute metrics).
+
+When the template sets `SecurityGroupIds`, scope those rules to least privilege — reference another security group for internal/tier-to-tier access, or a specific CIDR for known callers, rather than `0.0.0.0/0` (justify any open ingress). Instances inherit these rules at launch, so an over-permissive template propagates to the whole fleet.
+
+**Versioning:** reference a version by number, `$Latest`, or `$Default` (the unspecified default is `$Default`). For instance refresh and rollback, **pin a numeric version** — rollback is unsupported when the ASG uses `$Latest`/`$Default` or an SSM-parameter AMI. Create a new version with `create-launch-template-version`; changing a template does not touch running instances (do an instance refresh — see [auto-scaling.md](auto-scaling.md)).
+
+## IMDSv2
+IMDSv2 requires a session token (PUT to `/latest/api/token`, then the token in each metadata GET), defeating SSRF credential theft. Enforce it:
+
+- **`HttpTokens=required` is what enforces IMDSv2** — it blocks IMDSv1 (a tokenless/invalid-token GET then returns `401 Unauthorized`); also set `HttpEndpoint=enabled`.
+- **`HttpPutResponseHopLimit` defaults to 1 (range 1–64) and does NOT enforce IMDSv2. Set it to 2 for containers on EC2** — the default hop limit of 1 makes the IMDSv2 token PUT response fail to reach a containerized process (the extra hop exceeds the response TTL), so the token request times out; the extra hop covers container → bridge → IMDS. (If IMDSv2 is *required*, a subsequent tokenless GET returns 401; if optional, it silently falls back to IMDSv1. Host-networked containers are unaffected.)
+- Account-level (per Region) default: `aws ec2 modify-instance-metadata-defaults --http-tokens required --http-put-response-hop-limit 2` (org-wide enforcement is a separate Organizations declarative policy). **Applies only to new launches** — existing instances are unchanged; fix each with `modify-instance-metadata-options`. Launch-time settings override the account default.
+
+## User data
+Bootstrap scripts run by cloud-init (Linux) / EC2Launch (Windows). **Runs once at first boot by default.** On Linux, cloud-init runs user data as root; for every-boot, use a cloud-init `#cloud-config` with `[scripts-user, always]` (these are Linux-specific — Windows uses EC2Launch v2, which runs as Local System and re-runs with `frequency: always`). Shell scripts start with `#!`; 16 KB limit before base64 (gzip to fit). Output goes to `/var/log/cloud-init-output.log` — check it when bootstrap "didn't run."
+
+**Never put secrets in user data.** It is stored unencrypted, is readable via IMDS by any process on the instance (`http://169.254.169.254/latest/user-data`), is echoed to `/var/log/cloud-init-output.log`, and appears in the `requestParameters` of the `RunInstances` CloudTrail event. Fetch secrets at boot from AWS Secrets Manager or SSM Parameter Store (SecureString) using the instance-profile role.
+
+## Key pairs and SSH access
+
+- Types: RSA (Linux + Windows) or ED25519 (**Linux only**). `chmod 400 key.pem`.
+- Default users by AMI: `ec2-user` (Amazon Linux/RHEL/SUSE), `ubuntu` (Ubuntu), `admin` (Debian), `centos` (CentOS), `bitnami` (Bitnami); RHEL/SUSE also accept `root`. For other AMIs the default is typically `ec2-user` — confirm with the AMI provider rather than assuming `root`.
+- **EC2 Instance Connect** pushes a temporary key valid **60 seconds** (`aws ec2-instance-connect send-ssh-public-key …`) — connect immediately or you get `Permission denied (publickey)`.
+- Prefer **Session Manager** (no keys, no open port 22) — see [systems-manager.md](systems-manager.md).
+- Lost key: create a new key pair and reattach the public key via Instance Connect, Session Manager, or by editing `authorized_keys` on the detached root volume.
+
+## Placement groups
+
+| Strategy | Placement | Limit | Use for |
+|----------|-----------|-------|---------|
+| Cluster | Packed in one AZ, high bandwidth | Capacity risk if grown incrementally | Tightly coupled HPC/low-latency |
+| Spread | Distinct hardware (one instance per rack) | **Max 7 running instances per AZ per group** | Small set of critical instances |
+| Partition | Isolated racks per partition | **Max 7 partitions per AZ** (instances per partition limited only by account limits) | HDFS/HBase/Cassandra/Kafka |
+
+Cluster: launch all instances of the **same type in one request**; on `InsufficientInstanceCapacity`, stop/start all group members to re-place them. Reference a shared placement group by ID (not name) in the CLI. The spread and partition per-AZ maximums above are firm documented hard limits (not raisable Service Quota defaults) and apply even for shared placement groups.
+
+## Elastic IPs
+
+- **All public IPv4 is billed per hour** — including idle Elastic IPs and EIPs on stopped instances (check current rates on the EC2 pricing page or via `aws pricing get-products`). Release unused ones: `aws ec2 release-address --allocation-id <id>` (EIPs keep billing after the instance is terminated until released). The per-Region EIP quota is low by default (check the current value with `aws service-quotas get-service-quota --service-code ec2 --quota-code L-0263D0A3`).
+- An auto-assigned public IP **changes on stop/start**; attach an Elastic IP for a stable address (common cause of "SSH broke after restart").
+- Remap on failover by disassociating/reassociating the EIP (no release needed).
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Container gets `401` from IMDS, host works | Hop limit 1 | Set `HttpPutResponseHopLimit=2` |
+| Account IMDSv2 default didn't affect existing instances | Default is new-launch + per-Region only | `modify-instance-metadata-options` per instance |
+| `Permission denied (publickey)` | Wrong user/key/permissions, or Instance Connect key expired (60s) | Correct username, `chmod 400`, re-run send-ssh-public-key |
+| SSH broke after stop/start | Public IP changed | Attach an Elastic IP or use the new IP / DNS name |
+| Charged for an unattached Elastic IP | Public IPv4 billed even when idle | Release it |
+
+## Security Considerations
+
+- **Enforce IMDSv2** in the launch template (`HttpTokens=required`, and hop limit 2 for containers) to block SSRF-based credential theft.
+- **Never embed secrets in user data** — it's stored unencrypted, readable via IMDS, logged to cloud-init output, and recorded in the `requestParameters` of the `RunInstances` CloudTrail event; fetch them at boot from Secrets Manager / SSM Parameter Store (SecureString) via the instance profile.
+- **Scope security groups to least privilege** — reference another security group or a specific CIDR rather than `0.0.0.0/0`; the template's rules propagate to every launched instance.
+- **Encrypt EBS volumes** in the block device mappings, and **prefer Session Manager over SSH** (no open port 22, no key sprawl).
+
+## Related
+
+- [instance-selection.md](instance-selection.md) — what to put in the template
+- [auto-scaling.md](auto-scaling.md) — use the template in an ASG
+- [systems-manager.md](systems-manager.md) — keyless access

--- a/skills/core-skills/aws-compute/references/systems-manager.md
+++ b/skills/core-skills/aws-compute/references/systems-manager.md
@@ -1,0 +1,66 @@
+# EC2 Operations with Systems Manager
+
+## Overview
+Operating EC2 fleets without SSH keys or open ports: registering managed nodes, Session Manager access, Run Command, Patch Manager, and State Manager.
+
+## Make an instance a managed node
+An EC2 instance becomes a Systems Manager managed node when the SSM Agent (running, with a network path to the service) has SSM credentials, via **either**:
+
+1. An attached IAM instance profile with the `AmazonSSMManagedInstanceCore` managed policy (or an equivalent custom policy). A missing instance profile is the single most common reason an instance is "not managed."
+2. Account + Region-level **Default Host Management Configuration (DHMC)**, which needs **no per-instance profile** — it uses the `AWSSystemsManagerDefaultEC2InstanceManagementRole` role with the `AmazonSSMManagedEC2InstanceDefaultPolicy` policy, and requires IMDSv2 and a current SSM Agent version (see the [DHMC prerequisites](https://docs.aws.amazon.com/systems-manager/latest/userguide/fleet-manager-default-host-management-configuration.html)). Note: if an instance profile is already attached, SSM Agent uses it before DHMC — remove any `ssm:UpdateInstanceInformation` permission from the profile for DHMC to take over.
+
+The SSM Agent is preinstalled on many current AWS-provided AMIs — Amazon Linux 2/2023, Ubuntu, Windows Server among them; check the [SSM Agent preinstalled-AMI list](https://docs.aws.amazon.com/systems-manager/latest/userguide/ami-preinstalled-agent.html) or confirm the `amazon-ssm-agent` package is present.
+
+Check Fleet Manager for node status (`PingStatus` is `Online`, `ConnectionLost`, or `Inactive`). An Organizations SCP that denies SSM actions also blocks managed status.
+
+## Session Manager (keyless shell access)
+Session Manager gives a browser/CLI shell with **no inbound ports, no bastion, and no SSH keys** — the agent connects outbound to the service.
+
+```bash
+aws ssm start-session --target <instance-id>
+```
+
+**Encrypt session logging.** Session output can contain sensitive command results. Encrypt the destination yourself first: KMS on the CloudWatch Logs log group (`aws logs associate-kms-key --log-group-name <name> --kms-key-id <arn>`) or SSE-KMS on the S3 bucket. Then set `cloudWatchEncryptionEnabled` / `s3EncryptionEnabled` = true — these flags do **not** enable encryption; when true they require the destination to already be encrypted and SSM refuses to stream logs to an unencrypted destination (an enforcement gate). Separately, `kmsKeyId` encrypts the data channel between the client and the managed node (on top of default TLS).
+
+**Audit SSM API usage with CloudTrail.** Session logging captures *what* ran inside a session; CloudTrail records *who* called SSM and from where — enable it in all Regions to log `StartSession`, `SendCommand`, and `GetParameter`, and alarm on unexpected callers or principals. It is the API-level audit trail for fleet operations.
+
+For an instance in a **private subnet with no NAT/internet gateway**, the agent can't reach the service, so create the following VPC endpoints (interface endpoints with private DNS enabled, except S3 which uses a free gateway endpoint) — `ssm` and `ssmmessages` are always required:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `com.amazonaws.<region>.ssm` | Core Systems Manager API |
+| `com.amazonaws.<region>.ssmmessages` | **Session Manager data channel**; also carries Run Command with current agents |
+| `com.amazonaws.<region>.ec2messages` | Legacy — superseded by `ssmmessages`; not required with a current SSM Agent |
+| `com.amazonaws.<region>.s3` | Patch downloads, Run Command document content, and S3 output capture — use a **gateway endpoint** (free, no per-hour charge). Required for Patch Manager / `AWS-RunPatchBaseline` and S3 output in a no-NAT subnet |
+| `com.amazonaws.<region>.kms` | Session encryption — required only when `kmsKeyId` (above) is configured; without it the encrypted channel can't be established |
+
+Alternatively allow HTTPS (443) egress to those service endpoints (add `kms.<region>.amazonaws.com` when session encryption is enabled). `TargetNotConnected` means prerequisites are unmet, the node isn't managed, or you're in the wrong Region.
+
+## Fleet operations
+
+- **Run Command** — one-off fleet execution; `aws ssm send-command --document-name AWS-RunShellScript --targets "Key=tag:Role,Values=web-tier" --parameters 'commands=[...]'`. Target by instance IDs or tags. Command output can contain sensitive data — when capturing it to S3 (`--output-s3-bucket-name`) or CloudWatch Logs (`--cloud-watch-output-config`), enable KMS encryption (SSE-KMS bucket / KMS-encrypted log group) on the destination. Secure the S3 output bucket by granting `s3:PutObject` (and `s3:GetObject`, `s3:PutObjectAcl` as needed) to the managed node's **instance-profile IAM role** as the bucket-policy `Principal` (`arn:aws:iam::<account>:role/<InstanceProfileRole>`), scoped to the key prefix via `Resource`. Run Command output is written by the instance role directly, not by the SSM service principal — so do **not** use `aws:SourceArn`/`aws:SourceAccount` here (those apply only when a service principal writes on your behalf). When you build `--targets` tag values or `--parameters` commands from external or user-supplied input, validate and escape them first — unsanitized values flow into shell execution on the fleet and are a command-injection path.
+- **Patch Manager** — patch at scale with patch baselines + maintenance windows + tag-based patch groups; core document `AWS-RunPatchBaseline` (`Scan`/`Install`).
+- **State Manager** — associations that re-apply desired state on a schedule (vs Run Command's one-shot).
+
+## Common Errors
+
+| Error/Symptom | Cause | Fix |
+|---------------|-------|-----|
+| Instance not a managed node | No instance profile with `AmazonSSMManagedInstanceCore` | Attach a role with that policy via an instance profile |
+| `TargetNotConnected` on start-session | No network path (private subnet, no endpoints) or node not Online | Add ssm/ssmmessages/ec2messages endpoints or NAT egress; confirm Online |
+| Managed but Session Manager fails | `ssmmessages` endpoint missing | Add the ssmmessages interface endpoint |
+| Node managed but SCP blocks actions | Org SCP denies SSM permissions | Update the SCP to allow required SSM actions |
+| Maintenance window runs nothing | Target tag mismatch or nodes not managed | Fix the tag match; ensure nodes are managed and running in the window |
+
+## Security Considerations
+
+- **Sanitize any external input** built into `--targets` tag values or `--parameters` commands before calling Run Command or State Manager — unsanitized values flow into shell execution on the fleet and are a command-injection vector.
+- **Encrypt session and command output** (KMS on the Session Manager S3/CloudWatch sinks, SSE-KMS on Run Command output destinations) — it can contain sensitive results.
+- **Audit with CloudTrail** in all Regions (`StartSession`, `SendCommand`, `GetParameter`) and alarm on unexpected callers; prefer Session Manager over inbound SSH for its keyless, fully-audited access.
+- **Scope SSM access with IAM** — the instance profile needs only `AmazonSSMManagedInstanceCore`; grant human operators least-privilege session/command permissions.
+
+## Related
+
+- [provisioning.md](provisioning.md) for key pairs (when you do need SSH)
+- The `setting-up-ec2-instance-profiles` skill for creating the instance profile itself
+- [troubleshooting.md](troubleshooting.md) for connectivity issues

--- a/skills/core-skills/aws-compute/references/troubleshooting.md
+++ b/skills/core-skills/aws-compute/references/troubleshooting.md
@@ -1,0 +1,59 @@
+# EC2 Troubleshooting
+
+## Overview
+Diagnosing the common EC2 failures: connectivity, status checks, capacity/quota errors, Spot interruptions, credit exhaustion, and instances that die on launch. Match the exact error string first — several look similar but have opposite fixes.
+
+## Can't SSH in: read the exact error
+The error string tells you the layer.
+
+| Error | Layer | Causes | Fix |
+|-------|-------|--------|-----|
+| **Connection timed out** | Network — packets never arrive | Security group missing inbound TCP 22 from your IP; NACL blocking; no route to internet gateway; instance has no/changed public IP; local firewall | Open 22 from your IP; verify route + public IP; note public IP changes on stop/start unless an Elastic IP is attached |
+| **Connection refused** | Host — reachable, nothing on the port | sshd not running/listening on that port; instance still booting; sshd misconfigured | Wait for boot; check sshd via Session Manager or EC2 serial console |
+| **Permission denied (publickey)** | Auth | Wrong username for the AMI; wrong key; key file perms; EC2 Instance Connect key expired (60s) | Use the AMI's default user (ec2-user/ubuntu/admin/root); `chmod 400 key.pem`; re-run send-ssh-public-key |
+
+Keyless fallbacks: Session Manager, EC2 Instance Connect, or the serial console (Nitro instances). The serial console is **not on by default** — it needs account-level enablement plus IAM permissions, and on Linux requires a preconfigured password-based user (only the browser client itself is truly keyless). The `AWSSupport-TroubleshootSSH` runbook automates checks. Debug with `ssh -vvv -i key.pem user@host`. For "Connection timed out", enable VPC Flow Logs to confirm whether packets reach the ENI (ACCEPT/REJECT) — KMS-encrypt the flow-log destination (S3 bucket via SSE-KMS or CloudWatch Logs log group); add the CloudWatch agent for OS-level visibility.
+
+## Status check failed: system vs instance
+
+| Check | Monitors | Remedy |
+|-------|----------|--------|
+| **System** (`StatusCheckFailed_System`) | AWS host/hardware/power/network | **Stop/start** an EBS-backed instance to migrate to new hardware (a reboot stays on the same host); or set a CloudWatch instance-recovery action; or wait for AWS |
+| **Instance** (`StatusCheckFailed_Instance`) | The instance's OS/network config | Reboot or fix the OS/network config yourself |
+| Attached EBS | Attached EBS volumes | Investigate the volume; ASG replacement isn't automatic for this check — by default. Enabling the opt-in EBS health check on the ASG (Nitro instances) makes it detect attached-EBS impairment and replace the instance automatically |
+
+## Capacity vs quota errors (opposite fixes)
+
+| Error | Meaning | Fix |
+|-------|---------|-----|
+| **InsufficientInstanceCapacity** | AWS lacks spare capacity for that type in that AZ — NOT a quota | Try another AZ, another instance type/size, retry later, or request fewer per call. In a cluster placement group, stop/start all group instances to re-place them |
+| **InstanceLimitExceeded** | You hit an On-Demand vCPU-based quota (grouped, e.g. the Standard family group A/C/D/H/I/M/R/T/Z; the vCPU-phrased variant is `VcpuLimitExceeded`) — this IS a quota | Raise it via Service Quotas for that quota and Region |
+
+A quota increase does nothing for `InsufficientInstanceCapacity`.
+
+## Spot interruptions
+Spot instances get a **2-minute interruption notice** (via instance metadata `instance-action` and the EventBridge event `EC2 Spot Instance Interruption Warning`). An earlier, softer signal — the **rebalance recommendation** (`EC2 Instance Rebalance Recommendation`) — usually arrives earlier than (but is best-effort and can arrive together with) the two-minute interruption notice, giving more time to drain. In an ASG, enable Capacity Rebalancing to act on it automatically (see [auto-scaling.md](auto-scaling.md)). Test interruption handling with AWS Fault Injection Service.
+
+## High CPU / sudden slowdown on burstable (T) instances
+A T instance that suddenly and persistently drops to sluggish performance under sustained load has likely exhausted its CPU credits: in `standard` mode it throttles to baseline. Switch to `unlimited` (watch surplus charges) or move to a fixed-performance family. In `unlimited` mode the reverse symptom — a surprise bill — comes from `CPUSurplusCreditsCharged`. See [instance-selection.md](instance-selection.md).
+
+## Instance immediately stops or terminates after launch
+
+- **Encrypted root EBS volume the launch role can't decrypt** — the principal/role lacks KMS key permissions; grant key access. Check the system log to confirm the OS never booted.
+- Hitting EBS volume quotas can block/impair launches.
+- Remember instance store data is gone after any stop.
+
+## Instance status check fails after changing to a Nitro type
+Migrating to a Nitro-based instance type without the ENA and NVMe drivers installed causes instance status check failures — install the drivers before switching.
+
+## Security Considerations
+
+- **Prefer Session Manager over SSH for diagnosis** — keyless, IAM-scoped, and fully audited via CloudTrail (no key sprawl or open port 22).
+- **Treat repeated connection failures as possible reconnaissance** — enable CloudTrail and VPC Flow Logs so failed access attempts are visible.
+- **A status-check failure can be a security event, not just hardware** — before reflexively rebooting a suspect instance, review system logs and consider isolation/forensics (a reboot can destroy volatile evidence and instance-store data).
+
+## Related
+
+- [auto-scaling.md](auto-scaling.md) — ASG health, Spot, lifecycle hooks
+- [provisioning.md](provisioning.md) — Elastic IPs, key pairs, IMDS
+- [systems-manager.md](systems-manager.md) — keyless access as an SSH fallback


### PR DESCRIPTION
## Description

Adds the `aws-compute` core skill — the VM-compute domain skill for Amazon EC2. Covers instance-type selection (Graviton/Arm64, burstable T credits, GPU, instance store vs EBS), launch templates, Auto Scaling groups (scaling policies, instance refresh, mixed instances, Spot, warm pools, lifecycle hooks), IMDSv2, placement groups, Elastic IPs, AMI lifecycle, and Systems Manager fleet operations (Session Manager, Run Command, Patch Manager). Routes to the sibling EC2 skills rather than duplicating them.

Added in both locations, per the core-skill layout:
- `skills/core-skills/aws-compute/`
- `plugins/aws-core/skills/aws-compute/`

Text-only skill (no executable code).

## Type of Change

- [x] New skill

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My changes pass `python3 tools/validate.py`
- [ ] I have updated relevant documentation
