### PR TITLE
fix: use folded block scalars for SKILL.md descriptions containing colons

### DIFF
--- a/plugins/aws-agents/skills/agents-build/SKILL.md
+++ b/plugins/aws-agents/skills/agents-build/SKILL.md
@@ -6,14 +6,12 @@ description: >
   code interpreter, or resource removal. Triggers on: "add memory",
   "remember across sessions", "call agent from app", "invoke agent from
   code", "auth to call agent", "streaming responses", "VPC", "VPC
-  connectivity", "VPC error", "can't reach from VPC", "multi-agent",
-  "A2A", "A2A auth", "orchestrator not delegating", "specialist not
-  called", "migrate Bedrock Agent", "after import", "migration issue",
-  "framework for migration", "change model", "browser tool", "code
-  interpreter", "delete agent", "tear down", "agentcore remove",
-  "cross-account memory", "resource-based policy on memory", "pay for
-  x402 content", "402 Payment Required", "microtransactions", "paid API
-  or tool".
+  connectivity", "VPC error", "multi-agent", "A2A", "A2A auth",
+  "orchestrator not delegating", "specialist not called", "migrate
+  Bedrock Agent", "after import", "migration issue", "change model",
+  "browser tool", "code interpreter", "delete agent", "tear down",
+  "agentcore remove", "cross-account memory", "pay for x402 content",
+  "402 Payment Required", "paid API or tool".
   Not for connecting to external APIs via Gateway — use agents-connect.
   Not for scaffolding a new project — use agents-get-started.
   Not for CLI/dev server errors — use agents-debug.

--- a/plugins/aws-agents/skills/agents-build/SKILL.md
+++ b/plugins/aws-agents/skills/agents-build/SKILL.md
@@ -6,12 +6,14 @@ description: >
   code interpreter, or resource removal. Triggers on: "add memory",
   "remember across sessions", "call agent from app", "invoke agent from
   code", "auth to call agent", "streaming responses", "VPC", "VPC
-  connectivity", "VPC error", "multi-agent", "A2A", "A2A auth",
-  "orchestrator not delegating", "specialist not called", "migrate
-  Bedrock Agent", "after import", "migration issue", "change model",
-  "browser tool", "code interpreter", "delete agent", "tear down",
-  "agentcore remove", "cross-account memory", "pay for x402 content",
-  "402 Payment Required", "paid API or tool".
+  connectivity", "VPC error", "can't reach from VPC", "multi-agent",
+  "A2A", "A2A auth", "orchestrator not delegating", "specialist not
+  called", "migrate Bedrock Agent", "after import", "migration issue",
+  "framework for migration", "change model", "browser tool", "code
+  interpreter", "delete agent", "tear down", "agentcore remove",
+  "cross-account memory", "resource-based policy on memory", "pay for
+  x402 content", "402 Payment Required", "microtransactions", "paid API
+  or tool".
   Not for connecting to external APIs via Gateway — use agents-connect.
   Not for scaffolding a new project — use agents-get-started.
   Not for CLI/dev server errors — use agents-debug.

--- a/skills/specialized-skills/networking-and-content-delivery-skills/directconnect/SKILL.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/directconnect/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: directconnect
-description: Configures AWS Direct Connect: choosing a connection model (dedicated, hosted, or a link aggregation group) and completing the cross connect; creating private, public, and transit virtual interfaces and bringing up BGP; reaching many VPCs through a Direct Connect gateway including cross-account transit gateway associations; encrypting traffic with MACsec or a private IP Site-to-Site VPN; making the connection resilient and tuning failover; managing link aggregation groups; SiteLink; and migrating from a virtual private gateway to a transit gateway. Use when the user wants a private, consistent network link between a data center and AWS, or operates an existing Direct Connect setup and needs to extend, encrypt, or harden it. Routes to the right per-task procedure in references. Do NOT use for transit gateway route tables and attachments (transitgateway skill), Site-to-Site VPN without Direct Connect (sitetositevpn skill), or Route 53 DNS routing (route53 skill).
+description: >-
+  Configures AWS Direct Connect: choosing a connection model (dedicated, hosted, or a link
+  aggregation group) and completing the cross connect; creating private, public, and transit virtual
+  interfaces and bringing up BGP; reaching many VPCs through a Direct Connect gateway including
+  cross-account transit gateway associations; encrypting traffic with MACsec or a private IP
+  Site-to-Site VPN; making the connection resilient and tuning failover; managing link aggregation
+  groups; SiteLink; and migrating from a virtual private gateway to a transit gateway. Use when the
+  user wants a private, consistent network link between a data center and AWS, or operates an
+  existing Direct Connect setup and needs to extend, encrypt, or harden it. Routes to the right
+  per-task procedure in references. Do NOT use for transit gateway route tables and attachments
+  (transitgateway skill), Site-to-Site VPN without Direct Connect (sitetositevpn skill), or Route 53
+  DNS routing (route53 skill).
 version: 1
 ---
 

--- a/skills/specialized-skills/networking-and-content-delivery-skills/route53/SKILL.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/route53/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: route53
-description: Configures Amazon Route 53 DNS: public and private records, traffic-steering routing policies, health checks, DNS Firewall, Route 53 Profiles, VPC Resolver (also known as Route 53 Resolver) for hybrid and Outposts networks, and Global Resolver. Applicable when the customer wants to point a hostname at a target, split or fail over traffic across endpoints, monitor an endpoint, block malicious domains, centralize DNS across accounts, or resolve private DNS across a hybrid network. Routes to the right per-task procedure in references. Does not cover CloudFront-specific setup (see the route53-cloudfront skill) or non-DNS networking.
+description: >-
+  Configures Amazon Route 53 DNS: public and private records, traffic-steering routing policies,
+  health checks, DNS Firewall, Route 53 Profiles, VPC Resolver (also known as Route 53 Resolver) for
+  hybrid and Outposts networks, and Global Resolver. Applicable when the customer wants to point a
+  hostname at a target, split or fail over traffic across endpoints, monitor an endpoint, block
+  malicious domains, centralize DNS across accounts, or resolve private DNS across a hybrid network.
+  Routes to the right per-task procedure in references. Does not cover CloudFront-specific setup (see
+  the route53-cloudfront skill) or non-DNS networking.
 version: 1
 ---
 

--- a/skills/specialized-skills/networking-and-content-delivery-skills/shieldadvanced/SKILL.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/shieldadvanced/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: shieldadvanced
-description: Configures AWS Shield Advanced for enhanced Distributed Denial of Service (DDoS) protection: subscribing accounts and adding resource protections, enabling automatic application layer (layer 7) mitigation through AWS WAF, configuring health-based detection with Route 53 health checks, setting up Shield Response Team (SRT) access and proactive engagement, reviewing DDoS events and requesting cost protection credits, and aggregating resources into protection groups. Applicable when the user wants stronger DDoS protection for internet-facing resources (CloudFront, Application or Network Load Balancers, Elastic IP addresses, Global Accelerator, or Route 53 hosted zones), wants expert help during an attack, or wants to recover attack-driven scaling charges. Routes to the right per-task procedure in references. Not applicable for authoring AWS WAF rules (waf skill), creating Route 53 health checks (route53 skill), or org-wide Shield Advanced rollout with Firewall Manager (firewallmanager skill).
+description: >-
+  Configures AWS Shield Advanced for enhanced Distributed Denial of Service (DDoS) protection:
+  subscribing accounts and adding resource protections, enabling automatic application layer (layer 7)
+  mitigation through AWS WAF, configuring health-based detection with Route 53 health checks, setting
+  up Shield Response Team (SRT) access and proactive engagement, reviewing DDoS events and requesting
+  cost protection credits, and aggregating resources into protection groups. Applicable when the user
+  wants stronger DDoS protection for internet-facing resources (CloudFront, Application or Network
+  Load Balancers, Elastic IP addresses, Global Accelerator, or Route 53 hosted zones), wants expert
+  help during an attack, or wants to recover attack-driven scaling charges. Routes to the right
+  per-task procedure in references. Not applicable for authoring AWS WAF rules (waf skill), creating
+  Route 53 health checks (route53 skill), or org-wide Shield Advanced rollout with Firewall Manager
+  (firewallmanager skill).
 version: 1
 ---
 

--- a/skills/specialized-skills/networking-and-content-delivery-skills/transitgateway/SKILL.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/transitgateway/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: transitgateway
-description: Configures AWS Transit Gateway: creating a hub and attaching VPCs, segmenting traffic with route tables, centralizing egress and inspection through a hub (appliances or a Gateway Load Balancer endpoint), forcing east-west traffic between VPCs through AWS Network Firewall, connecting on-premises networks over the transit-gateway side of a Site-to-Site VPN or Direct Connect attachment (including ECMP to aggregate bandwidth across multiple VPN tunnels), peering transit gateways across Regions, migrating from a VPC peering mesh, and routing IP multicast. Applicable when connecting many VPCs through one router, isolating environments, forcing VPC-to-VPC traffic through a central Network Firewall, reaching on-premises over the hub, linking Regions, or moving off a peering mesh. Not applicable for single-VPC routing, VPC peering between two VPCs (vpcpeering skill), Direct Connect gateway or virtual interface setup (directconnect skill), or Route 53 DNS work.
+description: >-
+  Configures AWS Transit Gateway: creating a hub and attaching VPCs, segmenting traffic with route
+  tables, centralizing egress and inspection through a hub (appliances or a Gateway Load Balancer
+  endpoint), forcing east-west traffic between VPCs through AWS Network Firewall, connecting
+  on-premises networks over the transit-gateway side of a Site-to-Site VPN or Direct Connect
+  attachment (including ECMP to aggregate bandwidth across multiple VPN tunnels), peering transit
+  gateways across Regions, migrating from a VPC peering mesh, and routing IP multicast. Applicable
+  when connecting many VPCs through one router, isolating environments, forcing VPC-to-VPC traffic
+  through a central Network Firewall, reaching on-premises over the hub, linking Regions, or moving
+  off a peering mesh. Not applicable for single-VPC routing, VPC peering between two VPCs (vpcpeering
+  skill), Direct Connect gateway or virtual interface setup (directconnect skill), or Route 53 DNS
+  work.
 version: 1
 ---
 

--- a/skills/specialized-skills/networking-and-content-delivery-skills/waf/SKILL.md
+++ b/skills/specialized-skills/networking-and-content-delivery-skills/waf/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: waf
-description: Configures AWS WAF to filter web traffic: creating web access control lists (web ACLs) on CloudFront, Application Load Balancers, API Gateway, and AppSync; AWS Managed Rules tuned in Count mode; rate-based rules for HTTP floods; IP set and geographic match rules; Bot Control (Common and Targeted); turning bot labels into a confidence signal; stripping spoofed inbound x-amzn-waf-* headers; recovering the real client IP behind a CDN; Fraud Control (account takeover and account creation fraud prevention); and logging and request sampling. Use when the user wants to protect a web application or API from common exploits, bots, credential stuffing, fake-account creation, or HTTP floods at the application layer (layer 7). Routes to the right per-task procedure in references. Do NOT use for L3/L4 DDoS protection (shieldadvanced skill), multi-account WAF rollout (firewallmanager skill), CloudFront configuration (cloudfront skill), or Route 53 health checks or records (route53 skill).
+description: >-
+  Configures AWS WAF to filter web traffic: creating web access control lists (web ACLs) on
+  CloudFront, Application Load Balancers, API Gateway, and AppSync; AWS Managed Rules tuned in Count
+  mode; rate-based rules for HTTP floods; IP set and geographic match rules; Bot Control (Common and
+  Targeted); turning bot labels into a confidence signal; stripping spoofed inbound x-amzn-waf-*
+  headers; recovering the real client IP behind a CDN; Fraud Control (account takeover and account
+  creation fraud prevention); and logging and request sampling. Use when the user wants to protect a
+  web application or API from common exploits, bots, credential stuffing, fake-account creation, or
+  HTTP floods at the application layer (layer 7). Routes to the right per-task procedure in
+  references. Do NOT use for L3/L4 DDoS protection (shieldadvanced skill), multi-account WAF rollout
+  (firewallmanager skill), CloudFront configuration (cloudfront skill), or Route 53 health checks or
+  records (route53 skill).
 version: 1
 ---
 


### PR DESCRIPTION
## Description

Five SKILL.md files under `skills/specialized-skills/networking-and-content-delivery-skills/` have
`description:` written as an unquoted single-line YAML scalar containing `: ` (colon-space). Strict
YAML parsers reject this with `mapping values are not allowed here`. This PR rewrites each as a
folded block scalar (`description: >-`), which treats internal colons as literal characters.

Content of each description is preserved; only the YAML style changes.

## Type of Change

- [x] Bug fix

## Files changed

- `skills/specialized-skills/networking-and-content-delivery-skills/directconnect/SKILL.md`
- `skills/specialized-skills/networking-and-content-delivery-skills/waf/SKILL.md`
- `skills/specialized-skills/networking-and-content-delivery-skills/route53/SKILL.md`
- `skills/specialized-skills/networking-and-content-delivery-skills/transitgateway/SKILL.md`
- `skills/specialized-skills/networking-and-content-delivery-skills/shieldadvanced/SKILL.md`

## Verification

```bash
python3 -c "import yaml, pathlib; [yaml.safe_load(p.read_text().split('---')[1]) for p in pathlib.Path('skills/specialized-skills/networking-and-content-delivery-skills').rglob('SKILL.md')]" && echo OK
```

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

Fixes the strict-parse half of #176.