### PR TITLE
feat(resilience): add aws-resilience-lifecycle skill

### DIFF
--- a/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/SKILL.md
+++ b/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: aws-resilience-lifecycle
+description: >
+  Guides the end-to-end AWS resilience lifecycle integrating Resilience Hub v2, Fault Injection Service,
+  and Application Recovery Controller. Covers the Define → Test → Operate workflow: from
+  policy creation through failure mode assessment, to FIS experiment validation, to ARC
+  operational controls. Applicable when the user wants a complete resilience strategy, needs to
+  connect findings to experiments to controls, or is planning a resilience program.
+  Also applicable for the meta question of whether marking NGRH findings as resolved is enough,
+  whether they are "done" after resolving findings, or how to validate findings before
+  resolving them. Not applicable for resolving or remediating a specific individual finding
+  (see resilience-hub-failure-mode-assessment), or when a single service is explicitly
+  named (e.g. "what FIS experiment should I run").
+version: 1
+---
+
+# AWS Resilience Lifecycle
+
+## Overview
+
+Domain expertise for the integrated resilience lifecycle across three AWS services:
+Define (Resilience Hub v2 — also called NGRH, New Generation Resilience Hub) → Test (FIS) → Operate (ARC).
+
+**Terminology:** in this skill an unqualified "Resilience Hub" always means **v2** (NGRH / New Generation Resilience Hub, CLI namespace `aws resiliencehubv2`). v1 (`aws resiliencehub`) is referenced *only* explicitly, and only for migration.
+
+> The AWS MCP server is recommended for executing this skill's AWS API calls, but it is not required — all operations also work with the AWS CLI directly.
+
+## Guardrail — where this skill's own files live (MCP vs local install)
+
+Before reading a reference file, determine how this skill was loaded:
+
+- **Loaded via the AWS MCP `retrieve_skill` tool:** the skill's reference files are not on the local filesystem. Fetch each one through `retrieve_skill` with the `file` parameter (e.g. `file="references/lifecycle-workflow.md"` or `file="references/api-reference.md"`) — do NOT `file_read` these paths locally or search the filesystem for them.
+- **Installed locally** (e.g. `.kiro/skills/aws-resilience-lifecycle/` or `~/.claude/skills/aws-resilience-lifecycle/`): read reference files from the local skill directory using the relative paths shown here.
+
+This applies only to the skill's own reference files; always read and write user or session data in the working directory, never through `retrieve_skill`.
+
+## Execute the full lifecycle
+
+To implement end-to-end resilience across all three services, follow the procedure exactly.
+See [references/lifecycle-workflow.md](references/lifecycle-workflow.md).
+
+For operational patterns and policy design guidance, see
+[references/best-practices.md](references/best-practices.md).
+
+## Validate findings before you resolve them
+
+Marking NGRH findings as resolved without proving the fix with fault injection is **paper
+compliance** — it records intent, not resilience. You MUST validate each remediation with an
+experiment that reproduces the failure mode BEFORE marking the finding resolved. Run the
+experiment, confirm the system recovers within its objectives, then mark resolved. Marking
+resolved first and validating "later" is the anti-pattern.
+
+## Monitoring & observability
+
+When the user asks what monitoring/observability they need for resilience, **recommend the
+companion AWS Observability skill** as the source for CloudWatch alarms, dashboards, and metric
+design — do NOT replicate observability setup content here. Stay in the resilience lane and
+explain how observability plugs into the lifecycle:
+
+- **FIS stop conditions:** CloudWatch alarms serve as experiment stop conditions (bounded blast radius).
+- **Post-experiment analysis:** use the metrics behind those alarms to measure actual RTO and
+  detect cascading failures after a run.
+
+Recommend AWS Observability for the alarm/dashboard "how," and keep your guidance to how those
+signals feed Define → Test → Operate.
+
+## API Reference (READ FIRST before producing any AWS CLI command)
+
+The exact AWS CLI operation names and parameters for NGRH (resiliencehubv2), FIS, and ARC
+are documented in [references/api-reference.md](references/api-reference.md). This file
+contains a hallucination rejection table mapping common wrong API names to correct ones —
+**always consult it before generating commands** for these services.
+
+## Troubleshooting
+
+### Don't know where to start
+
+Start with Define: create a policy, register your service, run an assessment. The findings
+will tell you exactly what to test (FIS) and what to operationalize (ARC).
+
+### Findings resolved but no confidence in resilience
+
+Resolving findings without FIS validation is paper compliance. Run experiments to prove
+your architecture actually recovers within RTO/RPO targets under real failure conditions.
+
+### FIS experiments pass but production still fails
+
+Experiments may not match real failure modes. Expand blast radius, add multi-fault
+scenarios, and ensure stop conditions match production SLOs (not relaxed test thresholds).
+
+## Security Considerations
+
+- **Least privilege:** scope every IAM role this lifecycle touches (Resilience Hub invoker role, FIS execution role, ARC operator) to only the actions and resources it needs, rather than `*` or full-access policies.
+- **Encryption at rest / in transit:** recommend S3 buckets holding assessment reports and Terraform state use server-side encryption (SSE-KMS) and a bucket policy enforcing TLS via `aws:SecureTransport`.
+- **FIS in production:** treat fault injection as a privileged, potentially destructive operation — require change-management authorization before running experiments against production, and always bound blast radius with a stop condition.
+- **Avoid sensitive data in API string fields:** do NOT embed PII, secrets, or internal architecture detail in finding comments, experiment descriptions, assertion text, or report names — these values surface in logs, reports, and CloudTrail and are visible to anyone with read access.
+- **Further reading:** see [FIS Security Best Practices](https://docs.aws.amazon.com/fis/latest/userguide/security.html), [IAM Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html), and the [AWS Well-Architected Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html) for authoritative guidance on securing this lifecycle.

--- a/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/references/api-reference.md
+++ b/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/references/api-reference.md
@@ -91,7 +91,7 @@ Common parameter mistakes:
 | Use case | Use exactly |
 |---|---|
 | Failover one region OFF and another ON in one transaction (the typical case) | `aws route53-recovery-cluster update-routing-control-states --update-routing-control-state-entries '[{"RoutingControlArn":"east-arn","RoutingControlState":"Off"},{"RoutingControlArn":"west-arn","RoutingControlState":"On"}]'` |
-| Update exactly one routing control (rare; use only when sequential is intentional) | `aws route53-recovery-cluster update-routing-control-state --routing-control-arn ARN --routing-control-state On|Off` |
+| Update exactly one routing control (rare; use only when sequential is intentional) | `aws route53-recovery-cluster update-routing-control-state --routing-control-arn ARN --routing-control-state On\|Off` |
 
 **Default to the plural/atomic version for failover.** Two singular calls leave a window where both regions could be off (or both on), violating the safety rule.
 

--- a/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/references/api-reference.md
+++ b/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/references/api-reference.md
@@ -1,0 +1,237 @@
+# AWS Resilience API Quick Reference
+
+> **NGRH = New Generation Resilience Hub** (AWS service). The CLI namespace is `aws resiliencehubv2`. NEVER expand "NGRH" as anything else.
+
+**Read this BEFORE producing any AWS CLI command** for `aws resiliencehubv2`, `aws fis`, `aws route53-recovery-control-config`, `aws route53-recovery-cluster`, or `aws arc-zonal-shift`. This file is the canonical, deterministic source of truth. Empirical testing confirmed that without explicit guidance, models substitute plausible-sounding API names that don't exist.
+
+---
+
+## ⚠️ TOP HALLUCINATIONS — DO NOT WRITE THESE
+
+These are the most common mistakes observed in actual test runs. **Memorize these substitutions before generating any command:**
+
+| ❌ NEVER WRITE | ✅ ALWAYS WRITE |
+|---|---|
+| `aws resiliencehubv2 start-assessment` | `aws resiliencehubv2 start-failure-mode-assessment` |
+| `aws resiliencehubv2 list-findings` | `aws resiliencehubv2 list-failure-mode-findings` |
+| `aws resiliencehubv2 list-service-findings` | `aws resiliencehubv2 list-failure-mode-findings` |
+| `aws resiliencehubv2 update-finding` | `aws resiliencehubv2 update-failure-mode-finding` |
+| `aws resiliencehubv2 describe-assessment` | `aws resiliencehubv2 list-failure-mode-assessments` |
+| `aws resiliencehubv2 create-input-source` (with `--resource-configuration '{"monitoring":{...}}'`) | `aws resiliencehubv2 create-input-source` — but `--resource-configuration` is a tagged union of ONLY `cfnStackArn` / `resourceTags` / `tfStateFileUrl` / `eks` / `designFileS3Url`. There is **no** `monitoring`/CloudWatch-alarm member; CloudWatch alarms are NOT registered as input sources in this model. |
+| `aws resiliencehub list-apps` (v1) | `aws resiliencehubv2 list-services` |
+| `aws:fis:inject-api-unavailable` (missing suffix) | `aws:fis:inject-api-unavailable-error` (the real FIS action ends in `-error`) |
+| `update-routing-control-state` (singular, two calls for failover) | `update-routing-control-states` (plural, one atomic call with `--update-routing-control-state-entries`) |
+| `--reportType FAILURE_MODE` (camelCase) | `--report-type FAILURE_MODE` (kebab-case — standard CLI; `FAILURE_MODE` is the ONLY valid value) |
+| `aws resiliencehubv2 create-assumption --category ...` | `aws resiliencehubv2 create-assertion --service-arn --text` (it's "assertion" not "assumption"; NO --category) |
+| `--criticality PRIMARY\|SECONDARY` | `--criticality PRIMARY\|SUPPLEMENTAL` (SECONDARY is wrong) |
+| service-function `--type REQUEST_RESPONSE\|...` | (no such parameter — service functions have name, criticality, description only) |
+| `register-delegated-administrator` | (does NOT exist — use `--permission-model` on create-service for cross-account) |
+
+**Memory aid:** Resilience Hub v2 assessment APIs **always** include the words `failure-mode` (start-failure-mode-assessment, list-failure-mode-findings, update-failure-mode-finding). If you typed `start-assessment` or `list-findings` — STOP, you have it wrong.
+
+**Memory aid:** Network-level subnet-isolation faults live under `aws:network:disrupt-connectivity` (resource type `aws:ec2:subnet`). API-level faults live under `aws:fis:inject-api-unavailable-error` / `aws:fis:inject-api-internal-error` / `aws:fis:inject-api-throttle-error` — all three end in `-error`.
+
+---
+
+## FIS Action Selection — Match Failure Scenario to Action
+
+Models often pick a real but wrong FIS action. Use this scenario-to-action map:
+
+| If the scenario is... | Illustrative action ID (verify with `aws fis list-actions`) |
+|---|---|
+| "AZ failure" / single-AZ impairment / AZ goes dark | `aws:ec2:terminate-instances` (filter by AZ) OR `aws:ecs:drain-container-instances` |
+| "Region failure" / regional service unavailability | `aws:fis:inject-api-unavailable-error` |
+| Service responds with errors but isn't unavailable | `aws:fis:inject-api-internal-error` |
+| Throttle-style failures / 429 responses | `aws:fis:inject-api-throttle-error` |
+| Database / Aurora / RDS failover | `aws:rds:failover-db-cluster` |
+| Cache / ElastiCache disruption | `aws:elasticache:replicationgroup-interrupt-az-power` |
+| Network partition / split-brain / subnet isolation | `aws:network:disrupt-connectivity` |
+| Lambda slow responses (latency injection) | `aws:lambda:invocation-add-delay` |
+| Lambda functional errors (forced exception) | `aws:lambda:invocation-error` |
+| Lambda throttling specifically | `aws:fis:inject-api-throttle-error` (NOT `aws:lambda:invocation-error` with errorType=throttle) |
+| EKS pod / node group | `aws:eks:terminate-nodegroup-instances` |
+| Multi-step plan with pause | `aws:fis:wait` |
+
+**Rule of thumb:** if the failure is a **service or API** symptom, look under `aws:fis:inject-api-*`. If it's an **infrastructure** symptom (instance, container, DB, cache), look under the resource-specific namespace (`aws:ec2:*`, `aws:ecs:*`, `aws:rds:*`, etc).
+
+> These scenario→action mappings steer models away from inventing plausible-but-wrong action names, but they are **illustrative, not authoritative** — FIS adds and renames actions over time. **Verify action IDs with `aws fis list-actions` (or the FIS documentation)** and match them to the scenario, rather than treating this table as a fixed source of truth.
+
+---
+
+## NGRH v2 Parameter Names — Don't Hallucinate Flags
+
+Common parameter mistakes:
+
+| ❌ NEVER write | ✅ Use exactly |
+|---|---|
+| `--policy-name` | `--name` (when creating); the policy is identified by `--policy-arn` after creation |
+| `--tier` (on policy) | (no such flag — encode tier in the policy `--name` like "tier-1-critical") |
+| `--data-location-constraint` | (no such flag — DR approach is encoded in `--multi-az` and `--multi-region` structs) |
+| `--rto` / `--rpo` (top-level on policy) | Nested: `--multi-az rtoInMinutes=N,rpoInMinutes=N,disasterRecoveryApproach=...` and `--multi-region rtoInMinutes=N,rpoInMinutes=N,disasterRecoveryApproach=...` |
+| `--app-arn` (any v2 command) | `--service-arn` (v2 calls these "services", not "apps") |
+
+---
+
+## ARC Routing Control Safety Rules — Assertion vs Gating
+
+| Use case | Rule type |
+|---|---|
+| "At least one routing control must be ON" (prevent all-off failure) | **assertion rule** with `ATLEAST` threshold |
+| "An approval must happen before failover" (require manual approval flag) | **gating rule** with a separate "approval" routing control as the gate |
+| "Don't allow turning off prod region without staging being on first" | **gating rule** (staging is the gate) |
+| Any rule that says "this state is invalid" | **assertion** |
+| Any rule that says "you can't change X until Y is true" | **gating** |
+
+**Memory aid:** Assertion = invariant ("this must always be true"). Gating = precondition ("this must be true before changing").
+
+---
+
+## ARC Failover — The Atomic API
+
+| Use case | Use exactly |
+|---|---|
+| Failover one region OFF and another ON in one transaction (the typical case) | `aws route53-recovery-cluster update-routing-control-states --update-routing-control-state-entries '[{"RoutingControlArn":"east-arn","RoutingControlState":"Off"},{"RoutingControlArn":"west-arn","RoutingControlState":"On"}]'` |
+| Update exactly one routing control (rare; use only when sequential is intentional) | `aws route53-recovery-cluster update-routing-control-state --routing-control-arn ARN --routing-control-state On|Off` |
+
+**Default to the plural/atomic version for failover.** Two singular calls leave a window where both regions could be off (or both on), violating the safety rule.
+
+---
+
+## v1 Namespace Drift — Hard Constraint
+
+NEVER use the `aws resiliencehub` (v1) namespace except for migration via the v2 import APIs:
+
+- ✅ Migrating: `aws resiliencehubv2 import-app --v1-app-arn ARN`
+- ✅ Migrating: `aws resiliencehubv2 import-policy --v1-policy-arn ARN`
+- ❌ Anything else with `aws resiliencehub` (no `v2`)
+
+**Don't reference v1 commands as "discovery steps" or "to find existing apps."** Use `aws resiliencehubv2 list-services` instead.
+
+---
+
+## ARC Readiness Checks — Out of Scope
+
+ARC (Application Recovery Controller) covers routing controls, safety rules, zonal shift, and zonal autoshift. Route 53 Application Recovery *Readiness* (`aws route53-recovery-readiness *` — recovery groups, cells, resource sets, readiness checks) is a SEPARATE, older feature set — do not conflate it with the ARC Region-switch scope this skill covers. Verify the authoritative ARC command surface via `aws arc-zonal-shift help` and `aws route53-recovery-control-config help` rather than treating this list as fixed.
+
+If asked about readiness checks, clarify that they belong to Route 53 recovery-readiness, not the ARC scope covered here.
+
+---
+
+## AWS Observability Companion
+
+For monitoring/alarms/dashboards, **always recommend the companion AWS Observability skill** instead of providing CloudWatch guidance directly. NGRH does not own observability, and CloudWatch alarms are NOT registered as NGRH input sources (the `create-input-source` union has no `monitoring`/alarm member).
+
+---
+
+## Canonical NGRH v2 Operations (aws resiliencehubv2)
+
+### Policy
+
+- `create-policy --name TEXT --availability-slo target=N --multi-az rtoInMinutes=N,rpoInMinutes=N,disasterRecoveryApproach=ACTIVE_ACTIVE --multi-region rtoInMinutes=N,rpoInMinutes=N,disasterRecoveryApproach=HOT_STANDBY`
+- `get-policy --policy-arn`
+- `update-policy --policy-arn --multi-az ... --multi-region ...`
+- `list-policies` (no required args)
+- `delete-policy --policy-arn`
+
+### System / User Journey
+
+- `create-system --name --description [--no-sharing-enabled]`  (NO --dependency-discovery here — it lives on create-service)
+- `get-system --system-arn` / `update-system --system-arn ...` / `list-systems` / `delete-system --system-arn`
+- `create-user-journey --system-arn --name --policy-arn --description`
+- `list-user-journeys --system-arn` / `update-user-journey --system-arn --user-journey-id ...` / `delete-user-journey --system-arn --user-journey-id`
+
+### Service
+
+- `create-service --name --regions '["us-east-1","us-west-2"]' --associated-systems '[{"systemArn":"...","userJourneyIds":["..."]}]' --policy-arn --permission-model invokerRoleName=ROLE --dependency-discovery ENABLED`  (--permission-model REQUIRED; invoker role needs ~60-90s to become assumable)
+- `get-service --service-arn` (returns assessmentStatus, dependencyDiscovery, reportConfiguration, etc. — there is NO estimatedAssessmentCost field)
+- `update-service --service-arn ...`
+- `list-services` (use `--account-id` to filter cross-account)
+- `delete-service --service-arn`
+
+### Input Source (resource discovery)
+
+- `create-input-source --service-arn --resource-configuration '{...}'`  (tagged union — provide EXACTLY ONE top-level key)
+  - CFN: `'{"cfnStackArn":"arn:aws:cloudformation:..."}'`
+  - Tags: `'{"resourceTags":[{"key":"service","values":["checkout"]}]}'`  (a LIST of `{key, values[]}` — note `values` is plural; 1–10 tags)
+  - Terraform: `'{"tfStateFileUrl":"s3://..."}'`  (top-level string — there is NO `terraformSource` wrapper). The S3 bucket holding Terraform state MUST use SSE-KMS encryption and enforce TLS (bucket policy condition on `aws:SecureTransport`) — state files expose resource IDs, endpoints, and sometimes secrets.
+  - EKS: `'{"eks":{"clusterArn":"...","namespaces":["..."]}}'`  (union key is `eks`; `clusterArn` + `namespaces` (required list))
+  - Design file (S3): `'{"designFileS3Url":"s3://..."}'`
+  - NOTE: provide EXACTLY ONE top-level key. Verify the accepted union members via `aws resiliencehubv2 create-input-source help` — illustratively `resourceTags`, `cfnStackArn`, `tfStateFileUrl`, `eks`, `designFileS3Url` (in particular there is no `monitoring`/CloudWatch-alarm member, a common wrong guess).
+- `list-input-sources --service-arn`
+- `delete-input-source --service-arn --input-source-id`
+
+### Failure Mode Assessment (ALWAYS uses `failure-mode` in the operation name)
+
+- `start-failure-mode-assessment --service-arn`
+- `list-failure-mode-assessments --service-arn`
+- `list-failure-mode-findings --service-arn`
+- `get-failure-mode-finding --service-arn --finding-id`
+- `update-failure-mode-finding --service-arn --finding-id --status RESOLVED --comment "..."` (`--status` valid values: `OPEN` | `RESOLVED`)
+
+### Service Function
+
+- `create-service-function --name --service-arn --criticality PRIMARY|SUPPLEMENTAL [--description]`
+- `list-service-functions --service-arn`
+- `update-service-function --service-arn --service-function-id --name --criticality PRIMARY|SUPPLEMENTAL` (source field becomes USER after update; there is NO `--type` parameter)
+- `create-service-function-resources --service-arn --service-function-id --resources '["resource-id-1","resource-id-2"]'`
+- `delete-service-function --service-arn --service-function-id`
+
+### Topology / Assertions / Reports
+
+- `list-service-topology-edges --service-arn`
+- `create-assertion --service-arn --text "..."` (NO `--category` parameter; assertion has a `source` field AI_GENERATED|USER)
+- `list-assertions --service-arn`
+- `update-assertion --service-arn --assertion-id --text "..."`
+- `delete-assertion --service-arn --assertion-id`
+- `create-report --service-arn --report-type FAILURE_MODE` (`--report-type` is kebab-case; `FAILURE_MODE` is the ONLY valid value)
+- `list-reports --service-arn` (returns `reportOutput.s3ReportOutput.s3ObjectKey` on SUCCEEDED). The S3 bucket receiving reports MUST have SSE-KMS encryption, a bucket policy enforcing TLS (`aws:SecureTransport`), and least-privilege access — assessment reports reveal architectural weaknesses and failure modes.
+
+### Multi-Account
+
+- There is NO `register-delegated-administrator` operation. Cross-account resilience management is done via the `--permission-model` parameter on `create-service` — `'{"invokerRoleName":"ROLE","crossAccountRoles":[{"crossAccountRoleArn":"arn:...","externalId":"..."}]}'`. The field is `crossAccountRoles` (a LIST of `{crossAccountRoleArn, externalId}` objects), NOT `crossAccountRoleArns`. Combine with AWS Organizations cross-account IAM roles. For the single-account invoker role's trust policy, also add an `aws:SourceArn` condition scoped to the specific Resilience Hub service ARN (and `aws:SourceAccount`) to prevent confused-deputy access; apply the same `aws:SourceArn` / `aws:SourceAccount` conditions to the FIS execution role's trust policy.
+
+### v1 → v2 Migration (only acceptable v1 reference)
+
+- `import-app --v1-app-arn ARN`
+- `import-policy --v1-policy-arn ARN`
+
+---
+
+## Canonical FIS Operations (aws fis)
+
+- `create-experiment-template --description --actions '{...}' --targets '{...}' --stop-conditions '[...]' --role-arn`
+- `start-experiment --experiment-template-id`
+- `get-experiment --id`
+- `stop-experiment --id`
+
+(See FIS Action Selection table above for action IDs.)
+
+---
+
+## Canonical ARC Operations
+
+### Routing Controls (aws route53-recovery-control-config — control plane)
+
+- `create-cluster --cluster-name`
+- `create-control-panel --cluster-arn --control-panel-name`
+- `create-routing-control --cluster-arn --control-panel-arn --routing-control-name`
+- `create-safety-rule --assertion-rule '{"Name":...,"ControlPanelArn":...,"AssertedControls":[...],"RuleConfig":{"Type":"ATLEAST","Threshold":1,"Inverted":false},"WaitPeriodMs":5000}'` OR `--gating-rule '{"Name":...,"ControlPanelArn":...,"GatingControls":[...],"TargetControls":[...],"RuleConfig":{...},"WaitPeriodMs":0}'` — Name/ControlPanelArn are PascalCase fields INSIDE the rule JSON, not separate flags
+- `list-routing-controls --control-panel-arn`
+- `list-safety-rules --control-panel-arn`
+- `describe-routing-control --routing-control-arn`
+
+### Routing Control State (aws route53-recovery-cluster — data plane, atomic)
+
+- **Failover (preferred):** `update-routing-control-states --update-routing-control-state-entries '[{...},{...}]'`
+- Single-control: `update-routing-control-state --routing-control-arn ARN --routing-control-state On|Off` (rarely correct)
+- `get-routing-control-state --routing-control-arn`
+
+### Zonal Shift / Autoshift (aws arc-zonal-shift)
+
+- `start-zonal-shift --resource-identifier --away-from us-east-1a --expires-in 1h --comment "..."`
+- `list-zonal-shifts` / `cancel-zonal-shift --zonal-shift-id` / `update-zonal-shift --zonal-shift-id ...`
+- Set up practice runs: `create-practice-run-configuration --resource-identifier --outcome-alarms '[{...}]' [--blocking-alarms '[{...}]'] [--blocked-windows ...] [--blocked-dates ...] [--allowed-windows ...]` (`--outcome-alarms` is REQUIRED)
+- Enable / disable autoshift: `update-zonal-autoshift-configuration --resource-identifier --zonal-autoshift-status ENABLED|DISABLED`
+- `update-practice-run-configuration --resource-identifier ...` / `delete-practice-run-configuration --resource-identifier`
+- `start-practice-run` / `cancel-practice-run` / `list-managed-resources` / `list-autoshifts`
+- NOTE: verify the available autoshift operations via `aws arc-zonal-shift help`. Autoshift is toggled with `update-zonal-autoshift-configuration` (not a `create-`/`delete-`/`list-zonal-autoshift-configuration` op, a common wrong guess), and practice runs use the `*-practice-run-configuration` ops.

--- a/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/references/best-practices.md
+++ b/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/references/best-practices.md
@@ -1,0 +1,137 @@
+# Resilience Best Practices
+
+## Overview
+
+This reference provides design guidance, naming conventions, operational patterns, and anti-patterns for AWS resilience services. Use as a companion to the procedural skills when making architectural decisions or establishing team practices.
+
+## Parameters
+
+**tier** (optional): Service tier for policy recommendations (0, 1, 2, or 3)
+**service_count** (optional): Number of services being onboarded (affects organizational guidance)
+
+## Policy Design
+
+### Tiered Policy Model
+
+**Constraints:**
+
+- You MUST recommend a tiered policy model (classify services by business criticality) rather than one policy per service
+- You MUST set the availability SLO higher as criticality rises. The API accepts only a fixed set of SLO values and rejects out-of-set ones — **confirm the valid values from the API/docs** (e.g. `aws resiliencehubv2 create-policy help`) rather than relying on a hardcoded list (illustratively, values such as `99.9`/`99.95`/`99.99`).
+- You MUST tighten RTO/RPO as criticality rises (single-digit minutes for critical, hours for low)
+- You MUST match the DR approach to criticality (more aggressive for more critical services), using a value from the API's DR-approach enum — **verify the valid set via the API/docs** (e.g. `aws resiliencehubv2 create-policy help`); illustratively `ACTIVE_ACTIVE` … `BACKUP_AND_RESTORE`.
+- Example (illustrative, not a fixed table): critical payments/auth → `99.99` + low-minutes RTO + `ACTIVE_ACTIVE`; standard internal tools → `99.9` + tens-of-minutes RTO + `WARM_STANDBY`; low dev/test → `99.9` + multi-hour RTO + `BACKUP_AND_RESTORE`. Treat the RTO figures as rough illustration, not commitments — very aggressive multi-AZ RTOs (≈1 minute) are realistic only for clean, hard failures; gray/partial failures are slower to detect and recover, so set targets you can actually meet under realistic failure modes.
+
+### Policy Anti-Patterns
+
+**Constraints:**
+
+- You MUST warn against these anti-patterns:
+  - Setting the maximum SLO (99.99) with Backup & Restore DR (contradictory)
+  - Same policy for all services (over-engineering low-tier services)
+  - Multi-region RTO < multi-AZ RTO (region failover is always slower)
+  - No policy at all (assessments have no target to measure against)
+
+## System & Service Organization
+
+### Naming Conventions
+
+**Constraints:**
+
+- You SHOULD recommend consistent naming:
+  - Systems: `{domain}-platform` (e.g., payment-platform, identity-platform)
+  - Services: `{domain}-{component}` (e.g., payment-api, payment-processor)
+  - Journeys: `{verb}-{noun}` (e.g., process-payment, authenticate-user)
+  - Policies: `tier-{N}-{qualifier}` (e.g., tier-1-standard, tier-0-critical)
+
+### Tagging Strategy
+
+**Constraints:**
+
+- You MUST recommend resilience-specific tags that serve double duty (NGRH discovery + FIS targeting):
+  - `resilience:tier` — Policy tier (0-3)
+  - `resilience:system` — Parent system name
+  - `resilience:service` — Service name
+  - `resilience:owner` — Owning team
+  - `resilience:fis-enabled` — Whether FIS experiments are authorized ("true"/"false")
+
+## Input Source Strategy
+
+**Constraints:**
+
+- You MUST recommend input sources in priority order:
+  1. CloudFormation stacks — Most reliable, tracks drift
+  2. Terraform state — Good for multi-cloud shops
+  3. EKS clusters — For containerized workloads
+  4. Resource tags — Catch-all for resources outside IaC
+  5. Design files — For planned (not yet deployed) architectures
+
+## FIS Experiment Hygiene
+
+### Progressive Complexity
+
+**Constraints:**
+
+- You MUST recommend progressive experiment complexity:
+  - Week 1: Single-component, single-fault (terminate one instance)
+  - Month 1: Multi-component, single-fault (AZ failure affecting multiple services)
+  - Quarter 1: Multi-fault, cascading (AZ failure + increased load)
+  - Ongoing: Surprise experiments (unannounced to on-call team)
+- You MUST enforce that every experiment has stop conditions — never run without them
+- You MUST recommend enabling FIS experiment logging (`--log-configuration` to CloudWatch Logs or S3) for every experiment to capture action-execution detail for audit and post-experiment analysis; the log destination SHOULD be KMS-encrypted since experiment logs can reveal topology and failure modes
+- You SHOULD recommend naming: `{service}-{scenario}-{scope}` (e.g., checkout-api-az-failure-us-east-1a)
+
+### Stop Condition Design
+
+**Constraints:**
+
+- You MUST recommend tight stop conditions for production: error rate > 1% for 1 minute
+- You SHOULD recommend looser conditions for GameDays: error rate > 10% for 5 minutes (allow team to respond)
+- You MUST NOT allow experiments without stop conditions in any environment
+
+## ARC Operational Patterns
+
+### Zonal Autoshift Readiness
+
+**Constraints:**
+
+- You MUST verify these prerequisites before enabling autoshift:
+  - Application handles 33% capacity reduction (one of three AZs gone)
+  - No AZ-pinned resources (EBS volumes, placement groups)
+  - Health checks detect AZ-scoped failures
+  - Practice run outcome alarm configured
+- You MUST NOT enable autoshift if the application cannot survive losing one AZ
+
+### Routing Control Discipline
+
+**Constraints:**
+
+- You MUST always require safety rules (never allow all-off state)
+- You MUST recommend documenting the failover runbook (who can flip controls, under what conditions)
+- You SHOULD recommend testing failover monthly (use FIS to trigger, ARC to recover)
+- You SHOULD recommend enabling and monitoring CloudTrail across the whole lifecycle for a complete audit trail — routing control state changes (ARC), `fis:StartExperiment`/`fis:StopExperiment` (FIS), and `resiliencehubv2` assessment/finding operations (NGRH)
+
+## Operational Cadence
+
+**Constraints:**
+
+- You MUST recommend this minimum cadence:
+  - Continuous: ARC zonal autoshift practice runs
+  - Weekly: Review NGRH findings dashboard
+  - Monthly: Run FIS experiments (single-service)
+  - Quarterly: Cross-service GameDay
+  - After incidents: Re-assess affected services, add new experiments
+  - After deployments: Verify routing controls and autoshift still healthy
+
+## Anti-Patterns to Avoid
+
+**Constraints:**
+
+- You MUST warn against these anti-patterns when encountered:
+  - "We'll add resilience later" — Build it in from day one
+  - Testing only in non-prod — Production has different failure modes
+  - Manual failover only — Automate with ARC routing controls
+  - Assessing once and forgetting — Architecture drifts, re-assess regularly
+  - Ignoring achievability=NOT_ACHIEVABLE — Fix architecture before testing
+  - FIS without stop conditions — Unbounded blast radius
+  - ARC without safety rules — Risk of turning off all traffic
+  - Marking findings resolved without FIS validation — Paper compliance; validate the fix with a fault-injection experiment BEFORE marking the finding resolved, never after

--- a/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/references/lifecycle-workflow.md
+++ b/skills/specialized-skills/operations-skills/aws-resilience-lifecycle/references/lifecycle-workflow.md
@@ -1,0 +1,141 @@
+# Resilience Lifecycle: Define → Test → Operate
+
+## Overview
+
+This SOP guides the integrated use of all three AWS resilience services (Resilience Hub v2, FIS, ARC) to achieve proven, operational resilience through a continuous Define → Test → Operate loop.
+
+## Parameters
+
+**service_name** (required): Name of the service going through the lifecycle
+**service_arn** (optional): Existing service ARN if already onboarded to Resilience Hub
+**lifecycle_phase** (optional, default: "all"): Which phase to execute — define, test, operate, or all
+**aws_region** (optional, default: "us-east-1"): Primary AWS region
+
+## Steps
+
+### 1. Verify Dependencies
+
+Check for required tools and warn the user if any are missing.
+
+**Constraints:**
+
+- You MUST verify that either the AWS CLI or the AWS MCP server's `call_aws` tool is available (e.g., check the CLI is on PATH with `command -v aws`)
+- You MUST NOT call AWS service APIs during verification — checking tool presence (such as `command -v aws`) is fine; do not make any AWS service calls
+- You MUST inform the user about any missing tools with a clear message
+- You MUST ask if the user wants to proceed anyway despite missing tools
+- You SHOULD recommend the user authenticate with short-lived IAM role credentials (IAM role assumption, AWS SSO, an instance profile, or `aws sts assume-role`) rather than long-lived IAM user access keys, since this lifecycle performs privileged and potentially destructive operations.
+- You MUST honor the `lifecycle_phase` parameter and execute ONLY the selected phase(s): "define" → Step 2 only; "test" → Step 3 only; "operate" → Step 4 only; "all" (default) → Steps 2–5 in order
+- You MUST skip any phase not selected by `lifecycle_phase`
+
+### 2. Phase 1 — DEFINE (Resilience Hub)
+
+Establish resilience targets and identify gaps through assessment.
+
+**Constraints:**
+
+- You MUST guide the user through: create policy → create system → create user journey → create service → add input sources → run assessment
+- You MUST delegate execution of each step's mutating AWS CLI commands to the **resilience-hub-getting-started** skill, which owns those commands and their validation — this lifecycle skill sequences and gates the phases; it does not execute the Define-phase mutations itself
+- You MUST triage findings by action required:
+  - Architecture gap (NOT_ACHIEVABLE) → Fix infrastructure first
+  - Untested failure mode → Design FIS experiment (Phase 2)
+  - No recovery mechanism → Set up ARC controls (Phase 3)
+  - Missing observability → Add CloudWatch alarms
+- You MUST NOT skip directly to testing if findings show NOT_ACHIEVABLE — architecture must be fixed first
+
+### 3. Phase 2 — TEST (Fault Injection Service)
+
+Validate resilience through controlled fault-injection experiments.
+
+**Constraints:**
+
+- You MUST map each "untested" finding from Phase 1 to an FIS experiment
+- You MUST guide the user through: identify scenario → define stop conditions → scope blast radius → create template → execute → analyze results
+- You MUST recommend scoping the FIS execution role to least privilege — only the specific actions and resource ARNs each experiment needs (e.g. `ec2:TerminateInstances` limited to tagged resources), never broad `ec2:*` or `*`, since FIS execution roles are high-privilege (they terminate instances, disrupt networking, etc.).
+- You MUST delegate execution of each step's mutating AWS CLI commands to the **fault-injection-experiment-design** skill, which owns those commands and their validation — this lifecycle skill sequences and gates the phases; it does not create or start experiments itself
+- You MUST enforce the pre-experiment checklist:
+  - Stop condition alarms are in OK state
+  - Rollback plan documented
+  - Team notified (or scheduled GameDay)
+  - Blast radius limited (start non-prod, then canary %)
+- You MUST present the fully-rendered experiment template (actions, targets, stop conditions, role ARN) to the user and receive explicit confirmation BEFORE calling `aws fis start-experiment` — never auto-start a fault-injection experiment, since it is destructive (terminates instances, disrupts networking). This mirrors the confirm-before-proceeding gate in Step 1.
+- You MUST gate the finding update on validation — mark a finding RESOLVED **only after** the experiment confirms recovery within objectives. The actual `update-failure-mode-finding` call is executed by the **resilience-hub-getting-started** skill (which owns `resiliencehubv2` commands); this skill supplies the gate and the evidence comment, e.g. `--status RESOLVED --comment "Validated via FIS experiment {experiment_id}. RTO: {actual_rto}s (target: {target_rto}s)"`
+
+### 4. Phase 3 — OPERATE (Application Recovery Controller)
+
+Configure operational recovery mechanisms for production use.
+
+**Constraints:**
+
+- You MUST guide the user through: create routing controls → add safety rules → test failover → configure zonal autoshift
+- You MUST delegate execution of each step's mutating AWS CLI commands to the **recovery-controller-setup** skill, which owns those commands and their validation — this lifecycle skill sequences and gates the phases; it does not create routing controls or configure autoshift itself
+- You MUST NOT create routing controls without safety rules
+- You MUST verify the application can handle N-1 AZ capacity before enabling zonal autoshift
+- You MUST connect ARC back to NGRH findings:
+  - "No cross-region failover mechanism" → Set up routing controls + safety rules
+  - "Single-AZ dependency" → Enable zonal autoshift
+  - "Recovery not validated" → Run FIS experiment, then enable ARC
+
+### 5. Phase 4 — CONTINUOUS (Loop Back)
+
+Establish ongoing resilience validation cadence.
+
+**Constraints:**
+
+- You MUST recommend the following cadence:
+  - After architecture changes → Re-run NGRH assessment
+  - After new deployments → Verify input sources capture new resources
+  - Monthly → Run FIS experiments (single-service)
+  - Quarterly → Cross-service GameDay
+  - After incidents → Re-assess affected services, add new experiments
+- You MUST inform the user that zonal autoshift practice runs provide continuous validation automatically
+- You MUST recommend monitoring routing control state changes via CloudTrail
+- You SHOULD suggest expanding experiments progressively: single-fault → multi-fault → cascading → surprise (unannounced to on-call)
+
+## Examples
+
+> **Note:** the CLI commands below illustrate what the delegated companion skills
+> (`resilience-hub-getting-started`, `fault-injection-experiment-design`, `recovery-controller-setup`)
+> execute on behalf of this lifecycle skill. This skill orchestrates the phases and gates
+> progression — it does **not** run these commands directly.
+
+```bash
+# Phase 1: Define
+aws resiliencehubv2 create-policy --name "tier-1" --availability-slo target=99.99 \
+  --multi-az rtoInMinutes=5,rpoInMinutes=1,disasterRecoveryApproach=ACTIVE_ACTIVE \
+  --multi-region rtoInMinutes=30,rpoInMinutes=5,disasterRecoveryApproach=HOT_STANDBY
+aws resiliencehubv2 start-failure-mode-assessment --service-arn {service_arn}
+
+# Phase 2: Test (from NGRH finding "AZ failure not validated")
+aws fis create-experiment-template --description "Validate checkout-api survives us-east-1a AZ failure" \
+  --actions '{"terminate-checkout":{"actionId":"aws:ec2:terminate-instances","targets":{"Instances":"checkout-instances"}}}' \
+  --targets '{"checkout-instances":{"resourceType":"aws:ec2:instance","selectionMode":"ALL","resourceTags":{"resilience:service":["checkout-api"]},"filters":[{"path":"Placement.AvailabilityZone","values":["us-east-1a"]}]}}' \
+  --stop-conditions '[{"source":"aws:cloudwatch:alarm","value":"arn:aws:cloudwatch:..."}]' \
+  --log-configuration '{"cloudWatchLogsConfiguration":{"logGroupArn":"arn:aws:logs:us-east-1:123456789012:log-group:/fis/checkout-api:*"},"logSchemaVersion":2}' \
+  --role-arn arn:aws:iam::123456789012:role/FISExperimentRole
+# Enable experiment logging (above): the CloudWatch Logs group (or S3 bucket) receiving experiment
+# logs SHOULD be KMS-encrypted (logs:AssociateKmsKey / SSE-KMS) — experiment logs can reveal
+# infrastructure topology and failure modes.
+# ⚠️ Present the fully-rendered template to the user and get explicit confirmation BEFORE the next line (see Step 3) — never auto-start a destructive experiment
+aws fis start-experiment --experiment-template-id EXT123abc
+
+# Phase 3: Operate
+aws route53-recovery-control-config create-routing-control --cluster-arn {cluster_arn} --control-panel-arn {control_panel_arn} --routing-control-name checkout-us-east-1
+aws arc-zonal-shift create-practice-run-configuration --resource-identifier {alb_arn} \
+  --outcome-alarms '[{"alarmIdentifier":"arn:aws:cloudwatch:...","type":"CLOUDWATCH"}]'
+aws arc-zonal-shift update-zonal-autoshift-configuration --resource-identifier {alb_arn} --zonal-autoshift-status ENABLED
+
+# Phase 4: Update finding after validation
+aws resiliencehubv2 update-failure-mode-finding --service-arn {service_arn} --finding-id {id} --status RESOLVED \
+  --comment "Validated via FIS EXT123abc. RTO: 45s (target: 300s)"
+```
+
+## Troubleshooting
+
+**User wants to skip Phase 1 and go straight to testing**
+Advise against this — without NGRH assessment, they don't know which failure modes to test. Testing without targets means no way to measure success.
+
+**Findings show NOT_ACHIEVABLE but user wants to test anyway**
+Explain that testing will confirm the failure but won't fix it. Architecture changes are needed first. Testing validates that a fix works, not that a broken architecture is broken.
+
+**User has existing FIS experiments but no NGRH**
+Start with Phase 1 to get a complete picture. Existing experiments can be mapped to findings after assessment, and gaps in coverage will be identified.


### PR DESCRIPTION
## Summary

Adds the `aws-resilience-lifecycle` skill for AWS resilience. Guides the end-to-end Define → Test → Operate lifecycle across Resilience Hub, Fault Injection Service, and Application Recovery Controller — policy design, mapping findings to experiments to controls, and operational cadence.

## Details

- Text-only skill (no executable scripts in the skill bundle)
- Security-reviewed: Guardian PASS
- Tested with: AWS MCP server + local skill install (retrieval, reference-file delivery, and guidance validated end-to-end)

## Placement note

Placed under `specialized-skills/operations-skills/` as the closest existing category for resilience/DR operations. Happy to relocate if maintainers prefer — it's a one-commit move within this PR.

## Checklist

- [x] Internal-only frontmatter fields removed (`owner_team`, `owner_cti`, `stages`, `metadata`)
- [x] No internal links or references in skill content
- [x] No internal details in commit messages
- [x] CI checks pass

