### PR TITLE
feat(resilience): add resilience-hub-multi-account skill

### DIFF
--- a/skills/specialized-skills/operations-skills/resilience-hub-multi-account/SKILL.md
+++ b/skills/specialized-skills/operations-skills/resilience-hub-multi-account/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: resilience-hub-multi-account
+description: >
+  Configures AWS Resilience Hub v2 for multi-account resilience management across an AWS
+  Organization. Covers the per-service cross-account permission model, cross-account IAM
+  roles, and centralized assessment from a single account. Applies when the user wants to set
+  up org-wide resilience or assess workloads that span multiple AWS accounts.
+version: 1
+---
+
+# Multi-Account Resilience Hub v2 Setup
+
+## Overview
+
+Domain expertise for configuring Resilience Hub v2 to assess services across multiple
+AWS accounts from a central account. All CLI commands in this skill use the **`aws resiliencehubv2`**
+namespace — the Resilience Hub **v2** API surface — which is distinct from the legacy `aws resiliencehub`
+(v1) commands (the `service: [resiliencehub, ...]` metadata tags the service family, not the CLI namespace).
+Resilience Hub v2 supports two complementary multi-account mechanisms: (1) an **AWS Organizations
+integration** — the management account enables trusted access, creates the service-linked role, and
+designates a **delegated administrator** account for organization-wide policy management and visibility;
+and (2) the **per-service cross-account permission model** — an invoker role in the central account that
+assumes cross-account roles in member accounts for per-service resource discovery. This skill configures
+(2); the Organizations integration (1) is set up separately (management account + console — see below).
+
+> The AWS MCP server is recommended for executing this skill's AWS API calls, but it is not required — all operations also work with the AWS CLI directly.
+
+## Guardrail — where this skill's own files live (MCP vs local install)
+
+Before reading a reference file, determine how this skill was loaded:
+
+- **Loaded via the AWS MCP `retrieve_skill` tool:** the skill's reference files are not on the local filesystem. Fetch each one through `retrieve_skill` with the `file` parameter (e.g. `file="references/multi-account-procedure.md"`) — do NOT `file_read` these paths locally or search the filesystem for them.
+- **Installed locally** (e.g. `.kiro/skills/resilience-hub-multi-account/` or `~/.claude/skills/resilience-hub-multi-account/`): read reference files from the local skill directory using the relative paths shown here.
+
+This applies only to the skill's own reference files; always read and write user or session data in the working directory, never through `retrieve_skill`.
+
+## How centralized multi-account assessment works
+
+Two paths, used depending on your goal:
+
+> **Decision rule (read first):** To **run cross-account resilience assessments** — i.e. assess workloads/resources that live in member accounts from a central account (the common request, including phrasings like *"centralized resilience management across my Organization"* or *"central assessment account"*) — use the **per-service cross-account permission model** (path 2 below): an invoker role + cross-account roles + `create-service --permission-model`. **Do NOT use or recommend `aws organizations register-delegated-administrator` (or any delegated-administrator registration) as the setup step for cross-account assessments.** The Organizations delegated-administrator integration (path 1) is a *separate, optional* feature scoped to organization-wide **policy management and visibility only** — it is not how you set up or run cross-account assessments. Only follow path 1 when the request is explicitly about org-wide policy governance, not assessment.
+
+- **Organization-wide governance** (centralized policies, cross-account visibility): use the **AWS
+  Organizations integration**. From the **management account**, enable trusted access for Resilience Hub,
+  create the service-linked role, and **register a delegated administrator** account. This is done via
+  Organizations trusted access + the Resilience Hub console — there is **no `resiliencehubv2`
+  `register-delegated-administrator` CLI operation**. The delegated administrator then selects a home
+  Region where organization-level data is aggregated. See the AWS docs page *Setting up Organizations
+  integration*.
+- **Per-service cross-account resource discovery** (assessing a service whose resources span accounts):
+  register each service with a **per-service cross-account permission model** — an invoker role in the
+  central account plus cross-account role ARNs for each member account. **This skill's steps configure
+  this path.** Use this command form:
+
+```
+aws resiliencehubv2 create-service --name {service} --regions {regions} \
+  --permission-model '{"invokerRoleName":"ResilienceHubAssessmentRole","crossAccountRoles":[{"crossAccountRoleArn":"arn:aws:iam::{member_account_id}:role/ResilienceHubAccess","externalId":"{external_id}"}]}'
+```
+
+> The `externalId` is a shared secret that defends against confused-deputy attacks — generate a cryptographically random value and store it in AWS Secrets Manager or SSM Parameter Store (SecureString); never commit it to source control or embed it in templates without a dynamic `{{resolve:secretsmanager:...}}` reference, and ensure it is not emitted in plaintext by CI/CD logs or infrastructure-as-code output (use CloudFormation `NoEcho` parameters and mask it in pipeline logs).
+
+The cross-account role (in the member account) trusts the central account's invoker role. You can
+configure multiple cross-account role ARNs per service — the `resiliencehubv2` API enforces a maximum (illustratively 5), so **verify the accepted limit from the API/model rather than assuming a fixed number**. Note: this per-service model is independent of
+the Organizations integration above — there is no `register-delegated-administrator` operation in the
+`resiliencehubv2` CLI; organization-wide delegated-administrator registration is performed via AWS
+Organizations trusted access and the Resilience Hub console, not a `resiliencehubv2` API call.
+
+## Configure multi-account setup
+
+To set up cross-account assessment, follow the procedure exactly.
+See [references/multi-account-procedure.md](references/multi-account-procedure.md).
+
+## Troubleshooting
+
+### Cross-account assessment fails with AccessDenied
+
+Verify: (1) the cross-account role ARN in the permission model matches exactly, (2) the
+cross-account role trust policy allows the central account's invoker role to assume it,
+(3) the externalId matches if configured.
+
+### No resources discovered in a member account
+
+Confirm the cross-account role has read permissions for the in-scope resource types
+(CloudFormation, EC2, RDS, etc.) and that input sources point to valid resources in the
+correct region.
+
+### Looking for a delegated-administrator setup
+
+Resilience Hub v2 **does** support an AWS Organizations integration with a delegated administrator for
+organization-wide policy management and visibility — but it's configured from the **management account**
+via Organizations trusted access + the Resilience Hub console (create the service-linked role, then
+register the delegated administrator), **not** through a `resiliencehubv2` CLI operation (there is no
+`register-delegated-administrator` API). To assess a *single service* whose resources span accounts, use
+the per-service cross-account permission model in this skill. The two are complementary.
+
+## Security Considerations
+
+- **Least privilege & read-only:** scope member-account cross-account roles to read-only discovery permissions (`cloudformation:Describe*`, `ec2:Describe*`, `rds:Describe*`, etc.) rather than write/mutate actions.
+- **Scope cross-account trust narrowly:** trust only the specific central invoker role ARN rather than the whole account where possible.
+- **Enable logging & monitoring:** ensure AWS CloudTrail is enabled in both the central and member accounts to log cross-account `sts:AssumeRole` calls, and alarm on failed or unexpected AssumeRole attempts against the cross-account roles.
+- **Further reading:** see [IAM best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html), [The confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), and [Security in AWS Resilience Hub](https://docs.aws.amazon.com/resilience-hub/latest/userguide/security.html) for cross-account hardening guidance.

--- a/skills/specialized-skills/operations-skills/resilience-hub-multi-account/references/multi-account-procedure.md
+++ b/skills/specialized-skills/operations-skills/resilience-hub-multi-account/references/multi-account-procedure.md
@@ -1,0 +1,120 @@
+# Multi-Account Resilience Hub v2 Setup
+
+## Overview
+
+This SOP guides you through configuring Resilience Hub v2 to assess a service whose resources span multiple AWS accounts, using the per-service **permission model** (cross-account IAM roles assumed by an invoker role). Note: for *organization-wide* governance (centralized policies + visibility), Resilience Hub v2 also offers an **AWS Organizations integration** with a **delegated administrator**, configured from the management account via Organizations trusted access + the Resilience Hub console (not a `resiliencehubv2` CLI operation). This SOP covers the per-service cross-account path; the two are complementary. Use when the customer has multiple AWS accounts and wants a central account to run assessments against workloads in member accounts.
+
+## Parameters
+
+**central_account_id** (required): AWS account ID that runs assessments centrally
+**member_account_id** (optional): A member account ID hosting workloads. The Steps below configure a single member account; for each additional member account in scope, repeat Steps 3–4 **and** extend Step 2's `sts:AssumeRole` permissions policy so its `Resource` array lists the cross-account role ARN in every member account (the central invoker role needs assume permission for all of them, or discovery for the later accounts fails with `AccessDenied`).
+**org_id** (optional): AWS Organizations ID (e.g., "o-abc123") for trust policy conditions
+**invoker_role_name** (optional, default: "ResilienceHubAssessmentRole"): IAM role in the central account that Resilience Hub assumes
+**cross_account_role_name** (optional, default: "ResilienceHubAccess"): IAM role in member accounts
+**external_id** (optional): External ID for cross-account role assumption
+**service_name** (required for Step 4): Name for the service to register in Resilience Hub
+**regions** (required for Step 4): JSON array of the regions the service spans (e.g. `'["us-east-1"]'`)
+**service_arn** (derived): The service ARN returned by `create-service` in Step 4 — capture it from that response for use in Step 5 (not supplied as an input)
+
+## Steps
+
+### 1. Verify Dependencies
+
+Check for required tools and warn the user if any are missing.
+
+**Constraints:**
+
+- You MUST verify that either the AWS CLI (e.g., `aws --version`) or the AWS MCP server's `call_aws` tool is available
+- You MUST NOT run any AWS API calls or mutating commands during this verification — a lightweight availability check such as `aws --version` is acceptable, but do not invoke any `resiliencehubv2` or `iam` operations
+- You MUST inform the user about any missing tools with a clear message
+- You MUST ask if the user wants to proceed anyway despite missing tools
+
+### 2. Create the Invoker Role in the Central Account
+
+Set up the IAM role Resilience Hub assumes in the central account.
+
+**Constraints:**
+
+- You MUST inform the customer that the central account needs an invoker IAM role that Resilience Hub assumes to perform assessments
+- You MUST recommend the role trust the `resiliencehub.amazonaws.com` service principal
+- You MUST inform the customer this role needs `sts:AssumeRole` permission for the member-account cross-account roles
+- You MUST run the following AWS CLI command (use the AWS MCP server's `call_aws` tool when connected, otherwise the AWS CLI directly): `aws iam create-role --role-name {invoker_role_name} --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"resiliencehub.amazonaws.com"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"aws:SourceAccount":"{central_account_id}"}}}]}'`
+- The invoker role's trust policy **MUST be emitted exactly as written in the `create-role` command above — do not reconstruct, summarize, or simplify it.** The `"Condition":{"StringEquals":{"aws:SourceAccount":"{central_account_id}"}}` block is the confused-deputy guard and is **REQUIRED**: it MUST appear verbatim in the trust policy you submit, scoping trust so only the central account's Resilience Hub service principal can assume the role. **Never drop the `Condition` block from the invoker role's trust policy**, even when the user does not explicitly ask for hardening.
+- The `create-role` command above only sets the **trust policy** (who may assume the invoker role). You MUST ALSO attach a **permissions policy** that lets the invoker role assume each cross-account role — without it, cross-account discovery fails with `AccessDenied`. The `Resource` array MUST list the cross-account role ARN for **every** member account in scope (add an entry per account; scope to the specific ARNs, never `*`) — a single-account `Resource` will cause `AccessDenied` for the other accounts. Run: `aws iam put-role-policy --role-name {invoker_role_name} --policy-name AssumeCrossAccountResilienceRoles --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sts:AssumeRole","Resource":["arn:aws:iam::{member_account_id}:role/{cross_account_role_name}"]}]}'`
+
+### 3. Configure Cross-Account IAM Roles in Member Accounts
+
+Set up IAM roles in member accounts that the central invoker role can assume.
+
+**Constraints:**
+
+- You MUST inform the customer that each member account needs an IAM role with a trust policy allowing the central account's invoker role to assume it
+- You MUST recommend using the `aws:PrincipalOrgID` condition to restrict access to the organization
+- You MUST recommend an `externalId` condition for defense in depth
+- You SHOULD recommend generating the `externalId` with a secure random generator (e.g. `aws secretsmanager get-random-password --password-length 32 --exclude-punctuation`) and storing it in AWS Secrets Manager / SSM Parameter Store, referenced dynamically at deploy time rather than hardcoded
+- You MUST inform the customer that the cross-account role only needs READ-ONLY permissions for resource discovery (e.g. `cloudformation:Describe*`, `ec2:Describe*`, `rds:Describe*`); recommend it not include any write/mutate permissions
+- You SHOULD recommend deploying the role via CloudFormation StackSets for consistency across accounts
+- You MUST run the following AWS CLI command in each member account (use the AWS MCP server's `call_aws` tool when connected, otherwise the AWS CLI directly): `aws iam create-role --role-name {cross_account_role_name} --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::{central_account_id}:role/{invoker_role_name}"},"Action":"sts:AssumeRole","Condition":{"StringEquals":{"sts:ExternalId":"{external_id}","aws:PrincipalOrgID":"{org_id}"}}}]}'`, then attach an explicit least-privilege read-only discovery policy with `aws iam put-role-policy` (the AWS docs attach the broad `ReadOnlyAccess` managed policy for simplicity, but we recommend a tighter least-privilege policy instead — avoid `ReadOnlyAccess`): `aws iam put-role-policy --role-name {cross_account_role_name} --policy-name ResilienceHubDiscovery --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["cloudformation:DescribeStacks","cloudformation:ListStackResources","ec2:DescribeInstances","rds:DescribeDBInstances","elasticloadbalancing:DescribeLoadBalancers"],"Resource":"*"}]}'` (this action list is illustrative, not exhaustive — Resilience Hub's required discovery permissions grow as it adds support for new resource types, so consult the current [Resilience Hub IAM permissions reference](https://docs.aws.amazon.com/resilience-hub/latest/userguide/security-iam.html) and extend the action list to cover the resource types actually in scope rather than treating the list above as complete)
+- You MUST omit the `sts:ExternalId` condition key from the trust policy if `external_id` is not provided, and omit `aws:PrincipalOrgID` if `org_id` is not provided; if neither is provided, omit the `Condition` block entirely — leaving an empty `""` placeholder makes the role unassumable. You SHOULD warn the customer that omitting **both** conditions removes the confused-deputy guard entirely (any principal the trust policy names could assume the role), and you SHOULD NOT proceed without at least one of `aws:PrincipalOrgID` or `sts:ExternalId` — treat supplying one as the secure default, and recommend both together for defense in depth.
+
+### 4. Create Services with the Cross-Account Permission Model
+
+Register services that span member accounts using the permission model.
+
+**Constraints:**
+
+- You MUST inform the customer that this is run from the central account
+- You MUST run the following AWS CLI command (use the AWS MCP server's `call_aws` tool when connected, otherwise the AWS CLI directly): `aws resiliencehubv2 create-service --name {service_name} --regions '{regions}' --permission-model '{"invokerRoleName":"{invoker_role_name}","crossAccountRoles":[{"crossAccountRoleArn":"arn:aws:iam::{member_account_id}:role/{cross_account_role_name}","externalId":"{external_id}"}]}'`
+- You MUST include the permission model with cross-account role ARNs for each member account
+- You MUST omit the `externalId` field from each `crossAccountRoles` entry if `external_id` is not provided — this MUST match Step 3, where the trust policy omits the `sts:ExternalId` condition in that case. Passing a placeholder/empty `externalId` that the member-account trust policy does not expect will cause the cross-account `AssumeRole` to fail.
+- You SHOULD recommend using an external ID for additional security
+- You MUST NOT invent a `register-delegated-administrator` **`resiliencehubv2` CLI operation** — there is none. Organization-wide delegated-administrator registration is done via AWS Organizations trusted access + the Resilience Hub console, separately from this per-service `create-service` flow (do not conflate the two)
+- You MUST capture the `serviceArn` from the `create-service` response (`{service_arn}`) and reuse it in Step 5's verification commands
+
+### 5. Verify Cross-Account Visibility
+
+Confirm the central account can assess resources across accounts.
+
+**Constraints:**
+
+- You MUST run the following AWS CLI command (use the AWS MCP server's `call_aws` tool when connected, otherwise the AWS CLI directly): `aws resiliencehubv2 list-services` to verify the cross-account services were created
+- You MUST run the following AWS CLI command (use the AWS MCP server's `call_aws` tool when connected, otherwise the AWS CLI directly): `aws resiliencehubv2 list-input-sources --service-arn {service_arn}` to confirm resources in member accounts were discovered
+- You MUST inform the customer that if discovery fails, the most likely cause is the member-account IAM role trust policy or missing resource-discovery permissions
+
+## Security Considerations
+
+See [SKILL.md](../SKILL.md) for the full Security Considerations. When executing only from this procedure, surface these controls to the customer:
+
+- **Scope cross-account trust narrowly:** the cross-account role should trust only the specific central invoker-role ARN (not the whole account), gated with `aws:PrincipalOrgID` and an `externalId` condition, and grant read-only discovery permissions only — never write/mutate actions. For read-only `Describe*` discovery actions that do not support resource-level permissions, `"Resource": "*"` is acceptable (as in Step 3); for any actions that do support resource-level ARNs, scope `Resource` to the specific ARNs in scope rather than `*`.
+- **Rotate the `externalId` periodically:** treat it as a shared secret — generate it randomly, store it in AWS Secrets Manager / SSM Parameter Store, reference it dynamically, rotate on a schedule, and never hardcode it or emit it in plaintext (CI/CD logs, IaC output).
+- **Avoid leaking the `externalId` to shell history:** because it is a shared secret, avoid passing the `externalId` — or any policy document / permission-model payload containing it — where it is captured in shell history (`~/.bash_history`) and process listings. **When using the AWS CLI directly,** prefer a `file://…` payload reference (or `--cli-input-json file://…`), or disable history for the session (`set +o history`). **When using the AWS MCP server's `call_aws` tool,** pass the payload as inline JSON — the tool does not access the local filesystem, so `file://` references do not apply — and source the `externalId` from a secret store (Secrets Manager / SSM SecureString) at call time rather than hardcoding it. Either way, do not commit or log the real secret.
+- **Monitor for unauthorized access:** enable AWS CloudTrail in both the central and member accounts to log cross-account `sts:AssumeRole` calls, and alarm on failed or unexpected AssumeRole attempts against the cross-account roles.
+
+## Examples
+
+```bash
+# Create a cross-account service from the central account
+aws resiliencehubv2 create-service --name "payment-api" --regions '["us-east-1"]' \
+  --permission-model '{"invokerRoleName":"ResilienceHubAssessmentRole","crossAccountRoles":[{"crossAccountRoleArn":"arn:aws:iam::222222222222:role/ResilienceHubAccess","externalId":"{external_id}"}]}'
+
+# The externalId is a shared secret that defends against confused-deputy attacks —
+# generate a cryptographically random value and store it in Secrets Manager rather than
+# hardcoding a static value, then reference the secret at deploy time:
+#   aws secretsmanager create-secret --name resilience-hub/cross-account-external-id \
+#     --generate-random-password --password-length 32
+
+# Verify the service and its discovered resources
+aws resiliencehubv2 list-services
+aws resiliencehubv2 list-input-sources --service-arn {service_arn}
+```
+
+## Troubleshooting
+
+**Cross-account assessment fails with AccessDenied**
+The IAM role in the member account either doesn't exist, has an incorrect trust policy, or lacks resource discovery permissions. Verify: (1) the cross-account role ARN matches exactly, (2) the trust policy allows the central account's invoker role to assume it, (3) the externalId matches if configured.
+
+**No resources discovered in a member account**
+Confirm the cross-account role has read permissions for the resource types in scope (CloudFormation, EC2, RDS, etc.) and that the input source points to valid resources in that account's region.
+
+**Looking for a delegated-administrator setup**
+Resilience Hub v2 **does** support an AWS Organizations integration with a delegated administrator for organization-wide policy management and visibility — set it up from the **management account** via Organizations trusted access + the Resilience Hub console (create the service-linked role, then register the delegated administrator). It is not a `resiliencehubv2` CLI operation. To assess a single service whose resources span accounts, use the per-service cross-account permission model in this SOP; the two are complementary.


### PR DESCRIPTION
## Summary

Adds the `resilience-hub-multi-account` skill for AWS Resilience Hub. Covers multi-account assessment across an AWS Organization via the per-service cross-account permission model (central invoker role + member cross-account roles).

## Details

- Text-only skill (no executable scripts in the skill bundle)
- Security-reviewed: Guardian PASS
- Tested with: AWS MCP server + local skill install (retrieval, reference-file delivery, and guidance validated end-to-end)

## Placement note

Placed under `specialized-skills/operations-skills/` as the closest existing category for resilience/DR operations. Happy to relocate if maintainers prefer — it's a one-commit move within this PR.

## Checklist

- [x] Internal-only frontmatter fields removed (`owner_team`, `owner_cti`, `stages`, `metadata`)
- [x] No internal links or references in skill content
- [x] No internal details in commit messages
- [x] CI checks pass

