### PR TITLE
feat(redshift): add migrating-to-amazon-redshift skill

### DIFF
--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/SKILL.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: migrating-to-amazon-redshift
+description: "Guides an end-to-end data-warehouse migration to Amazon Redshift — discovery, schema/SQL/stored-procedure/macro/script conversion, data migration, validation, performance comparison, and reporting. Source-routed via `references/<source>/`; Teradata (Vantage) is the supported source; additional sources are added as their own `references/<source>/` sets. Text-only knowledge (no executable code) — the AI generates all execution at runtime. Applies when a user wants to migrate Teradata to Amazon Redshift, convert Teradata DDL/SQL/stored procedures/macros/BTEQ to Redshift/RSQL, or assess Teradata-to-Redshift migration complexity. Applies only to migrations targeting Amazon Redshift; migrations to other platforms (Snowflake, BigQuery, Databricks, etc.) are out of scope regardless of source. Does not cover general Redshift administration, performance tuning, or troubleshooting of existing Redshift clusters (no migration involved), or sources not listed under references/."
+version: 1
+---
+
+# Migrating to Amazon Redshift
+
+## What this skill is
+
+This skill is **AI guidance, not an execution framework**. It is **entirely Markdown
+knowledge** (rules, mappings, patterns, best practices) — **no executable code**. All
+execution — conversion, the discovery/migration/validation runners, dependencies, and
+infrastructure — **you (the AI) generate at runtime** from this knowledge, tailored to the
+customer's environment.
+
+Principle: **knowledge over shipped code → less drift, nothing for the customer to run or
+depend on, reliable first-time results.** Do not look for a pyproject, a tools package, an
+orchestrator engine, or shipped scripts — there are none by design; you generate execution.
+
+> **Runtime:** this skill works **with or without the AWS MCP server** — step guidance uses AWS
+> CLI syntax. Running it **with the AWS MCP server is recommended** for sandboxed execution and
+> audit logging; without it, the AI runs the generated scripts on the host shell (assumes Bash,
+> Python 3, and AWS CLI + credentials). Do not assume MCP-only tools are available.
+
+## Source routing
+
+This skill migrates a supported **source data warehouse to Amazon Redshift**. First identify the
+**source system**, then load that source's knowledge under `references/<source>/`:
+
+- **Teradata (Vantage)** → `references/teradata/` — supported (all references below).
+- *Other sources (e.g. Snowflake, Oracle) — unsupported; each is added as its own `references/<source>/` set when ready.*
+
+The **workflow is source-agnostic** (discovery → convert → migrate → validate → performance →
+report); only the **conversion knowledge** is source-specific. Everything below is the Teradata set.
+
+## When to use
+
+- Migrating a Teradata system (Vantage) to Amazon Redshift.
+- Converting Teradata DDL, SQL, stored procedures, macros, or BTEQ to Redshift/RSQL.
+- Assessing Teradata→Redshift migration complexity/effort.
+
+## Operating principles
+
+- **Discovery is strictly read-only (SELECT-only) on the source.** Never change production
+  state: no DDL/DML, and never enable logging (`BEGIN/REPLACE QUERY LOGGING`). If DBQL is
+  empty, mark it `unavailable` and fall back to always-on `DBC.AMPUsageV` — see
+  `references/teradata/discovery-queries.md`.
+- **Skill provides knowledge; you generate execution.** Read the `references/` to reason and
+  convert — apply the rules in `references/teradata/conversion-rules.md` directly for conversion, and
+  generate the discovery/migration/validation runners (and the read-only discovery collector
+  from `references/teradata/discovery-queries.md`) tailored to the environment.
+- **Generate, don't assume a framework.** Assume the environment has Bash, Python 3, and AWS
+  CLI + credentials. Any Python lib a generated script needs (`teradatasql`, `boto3`, …) is
+  `pip install`-ed on demand by that script / its run-instructions — pin exact versions.
+  Teradata **TTU** (BTEQ/TPT) is **Linux/Windows-only — not macOS**; prefer **WRITE_NOS** +
+  **`teradatasql`** (cross-platform, no client) for discovery/extract unless a TTU/Linux host exists.
+- **Credentials:** use a **read-only** Teradata user; prefer IAM roles over IAM users. For
+  **production**, reference credentials from **AWS Secrets Manager or Systems Manager
+  Parameter Store**. For **local development only**, a git-ignored `.env` file or profile may
+  be used — never commit it. Never hard-code or echo secrets. In a portable
+  bundle, reference a **co-located credentials file** and ship a `credentials.env.example` template — the
+  real file is git-ignored.
+- **Persist state in files.** All generated output goes under a git-ignored `output/` in the
+  user's working dir; keep `output/state.md` current so work is resumable.
+
+## Workflow (phases)
+
+Run in order; each phase's `result/` feeds the next (see `references/teradata/orchestration.md`).
+
+1. **Discovery** — inventory the source. → `references/teradata/discovery-queries.md` (read-only collection SQL + BTEQ driver template the AI generates) → `output/discovery/result/inventory.json`
+2. **Conversion** — schema + code. Apply the conversion rules directly, flag the
+   manual-rewrite long tail, and fix Redshift errors from the references. →
+   `references/teradata/conversion-rules.md`, `references/teradata/data-type-mapping.md`,
+   `references/teradata/architecture-mapping.md`, `references/teradata/stored-procedure-migration.md`,
+   `references/teradata/bteq-to-rsql.md`, `references/teradata/common-errors.md`
+3. **Data migration** — extract → S3 → COPY, restartable. → `references/teradata/data-migration-patterns.md`
+4. **Validation** — counts/aggregates/sampling. → `references/teradata/validation-patterns.md`
+5. **Performance** — baseline vs Redshift; size the target. → `references/teradata/performance.md`, `references/teradata/sizing.md`
+6. **Reporting** — aggregate all phases. → `references/teradata/reporting.md`
+
+## Conversion (how the AI applies it)
+
+There is no converter to run — convert by **applying the rules in
+`references/teradata/conversion-rules.md` directly** (with the type / architecture / stored-procedure /
+BTEQ references): apply the deterministic rules to the well-understood bulk, **flag the
+manual-rewrite constructs** with their suggested rewrites, assign a **confidence** per object,
+and fix any Redshift errors using `references/teradata/common-errors.md`. The reference docs are the
+single source of truth; `conversion-rules.md` includes golden input→output examples to match.
+
+## Execution modes (connectivity)
+
+- **Connected** — your host can reach Teradata/Redshift → run the generated scripts in place.
+- **Disconnected** — it can't → generate a self-contained bundle under `output/<phase>/`
+  (script + co-located credentials template + relative `result/` + `run-instructions.md`); the
+  operator runs it on a reachable host and copies `result/` back. The copied-back `result/` is
+  the durable state — read it (+ `state.md`) and continue.
+
+## Project-workspace layout (per migration run)
+
+```
+<project-workspace>/
+  migration-config.yaml          # operator-authored: endpoints, scope, strategy
+  .gitignore                     # ignores output/
+  output/                        # everything generated (git-ignored)
+    state.md                     # progress cursor
+    discovery/   …  result/inventory.json
+    conversion/  …  result/{ddl,sql,procedures,rsql}/  manual_review.json
+    data_migration/ … result/{extract,load,templates}/  migration_manifest.json
+    validation/  …  result/validation_report.json
+    performance/ …  result/{perf_baseline,perf_compare}.json
+    reporting/      result/migration_report.md
+```
+
+## Security considerations
+
+- **No shipped code or dependencies.** This skill is text-only — the customer runs nothing from
+  it. Any runner the AI generates MUST pin exact dependency versions, validate/sanitize inputs
+  (file paths, SQL, shell args), and never print or log credentials, secrets, or PII.
+- **Least privilege + ephemeral credentials.** Use a **read-only** Teradata user for discovery. On AWS
+  prefer **IAM roles over IAM users** and **IAM auth over username/password**. Keep secrets in
+  **AWS Secrets Manager / Parameter Store** — never hard-code, echo, or commit them (credentials files
+  are git-ignored; ship only `*.example` templates).
+- **Data in transit / at rest.** Use TLS to both engines; stage extracts in an **encrypted S3
+  bucket** (SSE) with a least-privilege bucket policy; load via `COPY … IAM_ROLE` (not access
+  keys). Enable encryption on the target Redshift cluster.
+- **Blast radius.** Discovery is **read-only** by design. Migration writes to the target —
+  validate against a **throwaway / non-production Redshift** first, and never point a generated
+  write-path at production without explicit operator confirmation.
+- **No secret leakage in artifacts.** Generated `output/…` (manifests, reports, `state.md`) MUST
+  NOT embed credentials or endpoints beyond what the operator supplies in `migration-config.yaml`.
+- **COPY `IAM_ROLE` hardening.** Scope the role's policy to the specific staging prefix (not
+  bucket-wide `s3:*`), and include condition keys in its trust policy (`aws:SourceAccount` /
+  `aws:SourceArn`, or `sts:ExternalId` for cross-account) to prevent confused-deputy assumption —
+  per Redshift IAM-role authorization best practices.
+- **Logging & monitoring.** Enable CloudTrail (S3 data events on the staging bucket + Redshift
+  management events), Redshift audit logging (connection/user-activity logs to S3 or CloudWatch),
+  and CloudWatch alarms on COPY failures or unusual staging-bucket access during the migration.
+
+The AWS MCP server (recommended runtime) additionally provides sandboxed execution and audit
+logging for the generated scripts.
+
+## References (specialized knowledge)
+
+| File | Topic |
+|------|-------|
+| `references/teradata/orchestration.md` | phase workflow + state model |
+| `references/teradata/conversion-rules.md` | the 72 conversion rules (source of truth) |
+| `references/teradata/data-type-mapping.md` | TD→RS type mapping |
+| `references/teradata/architecture-mapping.md` | PI→DISTKEY, PPI→SORTKEY, Join Index→MV |
+| `references/teradata/stored-procedure-migration.md` | SP → PL/pgSQL |
+| `references/teradata/bteq-to-rsql.md` | BTEQ → RSQL |
+| `references/teradata/common-errors.md` | common Redshift errors + fixes |
+| `references/teradata/discovery-queries.md` | DBC system-view inventory queries |
+| `references/teradata/data-migration-patterns.md` | COPY/TPT/micro-batch/checkpoint |
+| `references/teradata/validation-patterns.md` | row-count/aggregate/sample compare |
+| `references/teradata/performance.md` | representative-query extraction + compare |
+| `references/teradata/sizing.md` | RG node type + count from the source profile |
+| `references/teradata/reporting.md` | migration status-report generation |

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/architecture-mapping.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/architecture-mapping.md
@@ -1,0 +1,102 @@
+# Architecture mapping — Teradata → Redshift
+
+> AI-facing knowledge. Pairs with `conversion-rules.md` (the mechanics) — this doc is the
+> *why/when* so the AI makes sound physical-design choices, not just syntactic ones.
+
+## Purpose
+
+Teradata and Redshift distribute and organize data very differently. A syntactically correct
+DDL conversion can still perform badly if distribution/sort/encoding are chosen poorly. The
+conversion rules in `conversion-rules.md` apply the **mechanical** mapping (e.g.
+`PRIMARY INDEX (x)` → `DISTKEY(x)`); use this doc to **reason about and improve** those choices
+using discovery data (table sizes, cardinality, join/filter patterns).
+
+## Core construct mapping
+
+| Teradata | Redshift | Notes |
+|----------|----------|-------|
+| `PRIMARY INDEX (col)` (single) | `DISTKEY(col)` | TD PI drives data distribution; DISTKEY is the closest analog. Distribution only — **uniqueness is not enforced** in Redshift. |
+| `PRIMARY INDEX (a, b, …)` (multi) | Mechanical default = `DISTSTYLE EVEN` (per `conversion-rules.md`); this optimization pass may upgrade to `DISTKEY(col)` on one high-cardinality join col (or `DISTSTYLE AUTO`) | Redshift DISTKEY is single-column. Don't blindly pick the first PI column. |
+| `UNIQUE PRIMARY INDEX (col)` | `DISTKEY(col)` + enforce uniqueness upstream | Redshift does not enforce PK/unique constraints; declare them (informational) for the optimizer, but dedup in the load/ETL. |
+| `PARTITION BY RANGE_N(col …)` (PPI) | `SORTKEY(col)` | TD partitions for pruning; Redshift uses sort keys + zone maps for the same effect. Date/timestamp PPIs → date `SORTKEY`. |
+| Secondary Index (SI), Hash Index | *(none)* | No direct equivalent. Rely on SORTKEY + zone maps; for selective lookups consider a `SORTKEY` on the filter column. |
+| Join Index | Materialized View | Pre-computed/aggregated join → `CREATE MATERIALIZED VIEW`. |
+| `SET TABLE` | `CREATE TABLE` + dedup logic | Redshift allows duplicate rows; if SET (no-dupes) semantics matter, dedup on load (`ROW_NUMBER()`/staging). |
+| `MULTISET TABLE` | `CREATE TABLE` | Direct — duplicates allowed in both. |
+| `COMPRESS` / `COMPRESS (vals)` | `ENCODE az64` / `ENCODE bytedict` | Column compression. Let `ENCODE AUTO` decide unless you have a reason; bytedict suits low-cardinality. |
+| `NO PRIMARY INDEX` (NoPI) | `DISTSTYLE EVEN` | Even, round-robin distribution. |
+| `COLLECT STATISTICS` | `ANALYZE` | Run after load; Redshift also auto-analyzes. |
+
+## Choosing DISTSTYLE / DISTKEY
+
+Decide per table using discovery data (`inventory.json` sizes + join/filter info):
+
+- **`DISTSTYLE ALL`** — small dimension tables (roughly < ~2–3M rows / a few hundred MB). Replicates
+  the table to every node → eliminates redistribution on joins. Best default for dimensions.
+- **`DISTKEY(col)`** — large fact tables. Choose the **column most often joined** to other large
+  tables (typically the FK to the biggest dimension), with **high cardinality** and **even
+  distribution** (avoid skew). Co-locating both sides of a frequent join on the same DISTKEY is
+  the biggest performance win.
+- **`DISTSTYLE EVEN`** — large tables with no dominant join column, or staging tables.
+- **`DISTSTYLE AUTO`** — reasonable default when unsure; Redshift manages it. Prefer explicit KEY/ALL
+  once you know the workload (from `performance.md` query analysis).
+
+**Avoid skew:** don't pick a DISTKEY with heavy value concentration (e.g. a status flag, or a
+nullable FK with many NULLs) — it overloads one slice.
+
+## Choosing SORTKEY
+
+- Put the **most common range/filter column first** — usually the date/timestamp used in `WHERE`.
+  Map TD PPI columns here directly.
+- **Compound SORTKEY** (default) — great when queries filter on a leading prefix of the keys.
+- **Interleaved SORTKEY** — only when queries filter on different subsets of columns unpredictably;
+  higher maintenance cost (`VACUUM REINDEX`). Default to compound.
+- Keep it short (1–3 columns).
+
+## Worked example
+
+```sql
+-- Teradata
+CREATE MULTISET TABLE sales (
+    sale_id     INTEGER,
+    store_id    INTEGER,
+    sale_dt     DATE,
+    amount      DECIMAL(15,2) COMPRESS
+)
+PRIMARY INDEX (store_id)
+PARTITION BY RANGE_N(sale_dt BETWEEN DATE '2020-01-01' AND DATE '2030-12-31' EACH INTERVAL '1' MONTH);
+
+-- Redshift (script does the mechanical mapping; reasoning below)
+CREATE TABLE sales (
+    sale_id   INTEGER,
+    store_id  INTEGER,
+    sale_dt   DATE,
+    amount    DECIMAL(15,2) ENCODE az64
+)
+DISTKEY(store_id)     -- store_id is the join FK to the store dimension, high-cardinality → good
+SORTKEY(sale_dt);     -- from the monthly PPI; most queries filter by date range
+```
+
+If `store` is small, also consider `DISTSTYLE ALL` on `store` so the `sales`↔`store` join is local.
+
+## How this pairs with conversion
+
+Applying `conversion-rules.md` gives the mechanical result (single-col PI → DISTKEY, PPI →
+SORTKEY, multi-col PI → `DISTSTYLE EVEN`, COMPRESS → ENCODE). Treat that as the **starting
+point**, then revisit DISTKEY/DISTSTYLE/SORTKEY per the heuristics above using discovery sizes
+and the representative-query analysis from `performance.md`.
+
+## Case sensitivity (collation)
+
+Teradata defaults to **NOT CASESPECIFIC** in Teradata-session mode, so most string
+comparisons/joins are case-insensitive; Redshift is **case-sensitive by default**. To preserve
+semantics **without** wrapping columns in `UPPER()` (which defeats sort-key use and sargability),
+set **`COLLATE CASE_INSENSITIVE`** at the column or database level on tables this migration
+creates. Reserve `UPPER()` for ad-hoc queries against pre-existing case-sensitive columns. This
+affects most TD string columns — treat it as a default, not an edge case. (See the clause rule in
+`conversion-rules.md`.)
+
+## TODO / extend
+
+- Add table-size thresholds for ALL vs KEY tuned to the target node type (RA3 vs serverless).
+- Worked examples for a couple of real `BANKING_DW` / `tpcds` tables from discovery output.

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/bteq-to-rsql.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/bteq-to-rsql.md
@@ -1,0 +1,126 @@
+# BTEQ → RSQL Conversion Guide
+
+## Command mapping
+
+| BTEQ | RSQL / Redshift | Notes |
+|------|-----------------|-------|
+| .LOGON host/user,pass | DSN via odbc.ini | Use IAM temp credentials |
+| .LOGOFF / .QUIT | \q | Disconnect / exit |
+| .QUIT N | \exit N | Exit with return code |
+| .RUN FILE=path | \i path | Include/run file |
+| .IMPORT VARTEXT 'delim' FILE=path | COPY table FROM 's3://…' IAM_ROLE 'arn' DELIMITER 'delim' | Load via S3 |
+| .EXPORT [REPORT] FILE=path | UNLOAD ('SELECT …') TO 's3://…' | Export via S3 |
+| .IF ERRORCODE <> 0 THEN .GOTO label | \if :ERROR <> 0 / \echo / \exit N / \endif | Error handling |
+| .IF ACTIVITYCOUNT = 0 THEN .GOTO label | \if :ACTIVITYCOUNT = 0 / \echo / \exit 1 / \endif | Row-count check |
+| .IF ERRORLEVEL > 0 | -- commented out | No direct equivalent |
+| .GOTO label / .LABEL name | -- commented out | No labels in RSQL |
+| .SET WIDTH n | -- (not needed) | RSQL handles width |
+| DATABASE dbname; | SET search_path TO schema; | Schema context |
+| BT; / ET; | BEGIN; / COMMIT; | Transaction control |
+| LOGON … (bare, no dot) | -- commented out | Remove bare LOGON |
+
+## Key patterns
+
+### Error handling
+
+```
+-- BTEQ
+.IF ERRORCODE <> 0 THEN .GOTO ERROR_HANDLER
+...
+.LABEL ERROR_HANDLER
+.QUIT 12
+
+-- RSQL
+\if :ERROR <> 0
+  \echo "Error — jumping to ERROR_HANDLER"
+  \exit 12
+\endif
+```
+
+### Data loading
+
+```
+-- BTEQ
+.IMPORT VARTEXT '|' FILE=data.txt
+USING (col1 VARCHAR(50), col2 INTEGER)
+INSERT INTO schema.table VALUES (:col1, :col2);
+
+-- Redshift
+COPY schema.table FROM 's3://bucket/data.txt'
+IAM_ROLE 'arn:aws:iam::acct:role/role' DELIMITER '|';
+```
+
+### Data export
+
+```
+-- BTEQ
+.EXPORT REPORT FILE=output.txt
+SELECT * FROM schema.table;
+
+-- Redshift
+UNLOAD ('SELECT * FROM schema.table')
+TO 's3://bucket/output/' IAM_ROLE 'arn:aws:iam::acct:role/role';
+```
+
+### Transaction control
+
+```
+-- BTEQ
+BT;
+DELETE FROM staging_table ALL;
+INSERT INTO staging_table SELECT * FROM source;
+ET;
+
+-- RSQL
+BEGIN;
+DELETE FROM staging_table;
+INSERT INTO staging_table SELECT * FROM source;
+COMMIT;
+```
+
+## Shell wrapper pattern
+
+For complex BTEQ scripts, use a shell wrapper + RSQL:
+
+```bash
+#!/bin/bash
+set -e
+export PGHOST="redshift-cluster.region.redshift.amazonaws.com"
+export PGPORT="5439"
+export PGDATABASE="mydb"
+export PGSSLMODE="verify-full"   # enforce TLS; never let the connection fall back to cleartext
+
+# Ephemeral IAM-based credentials (preferred over static passwords). One API call —
+# each call mints new credentials. No eval; parse fields explicitly.
+read -r PGUSER PGPASSWORD < <(aws redshift get-cluster-credentials-with-iam \
+  --cluster-identifier my-cluster --db-name mydb \
+  --query '[DbUser, DbPassword]' --output text)
+export PGUSER PGPASSWORD
+# (Serverless: aws redshift-serverless get-credentials --workgroup-name <wg> --db-name mydb)
+# Env-var exposure caveat: exported values are visible to same-user processes; on shared
+# hosts prefer a ~/.pgpass file (chmod 0600) over exporting PGPASSWORD.
+
+rsql -f converted_script.sql || { echo "Script failed"; exit 1; }
+```
+
+## Data migration utilities
+
+- **Teradata Parallel Transporter (TPT)** — parallel unload from Teradata.
+- **AWS SCT extractor agents** — automate extraction, scale horizontally.
+- **Teradata Vantage** — unload directly to S3, then COPY into Redshift.
+- For large volumes consider AWS Direct Connect or Snowball.
+
+## Rules
+
+- `.LOGON` → DSN-based connection; `.IMPORT` → COPY from S3; `.EXPORT` → UNLOAD to S3.
+- Comment out `.GOTO`, `.LABEL`, `.IF ERRORLEVEL` (no equivalent).
+- `DATABASE` → `SET search_path`; `BT`/`ET` → `BEGIN`/`COMMIT`.
+- Apply SQL-level conversions to embedded SQL within the script.
+
+## Validation caveat (no TTU host)
+
+BTEQ/TTU is **Linux/Windows only — not macOS**, so on many operator hosts you **cannot execute
+the source BTEQ** to capture a Teradata baseline. In that case, validate the converted RSQL **on
+the Redshift side**: run it against the target and reconcile results to the migrated base tables
+(row counts / aggregates) rather than diffing against Teradata BTEQ output. Record in the report
+that no source-side BTEQ baseline was available.

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/common-errors.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/common-errors.md
@@ -1,0 +1,91 @@
+# Common Errors, Edge Cases, and Resolutions
+
+## Redshift-specific errors
+
+- **"number of segments exceeds the max allowed (30)"** — complex joins (e.g.
+  MicroStrategy). Remove the full outer join VLDB property; simplify joins.
+- **"correlated subquery pattern is not supported"** — flatten nested correlated
+  subqueries; rewrite as CTEs or JOINs.
+- **Reserved-word collision** — double-quote aliases (`returns`, `interval`,
+  `language`, `position`, `result`, `trim`, `user`, `type`, `default`, `comment`,
+  `value`, `year`, `month`, `day`, `zone`, …).
+- **SUBSTR not recognized** — #1 failure cause; replace every `SUBSTR(` with
+  `SUBSTRING(`.
+- **Window function missing frame** — add explicit frame:
+  `SUM(x) OVER (ORDER BY d ROWS UNBOUNDED PRECEDING)`.
+- **Derived column order** — Redshift requires a derived column be defined before
+  it's referenced in the same SELECT.
+
+```sql
+-- Teradata (forward reference allowed)
+SELECT pricepaid,
+  CASE WHEN discount > 10 THEN 'Yes' ELSE 'No' END discount_flag,
+  pricepaid - retailprice AS discount
+FROM sales;
+
+-- Redshift (define before use)
+SELECT pricepaid,
+  pricepaid - retailprice AS discount,
+  CASE WHEN discount > 10 THEN 'Yes' ELSE 'No' END discount_flag
+FROM sales;
+```
+
+## Conversion edge cases (flag for manual review)
+
+- **QUALIFY** — Redshift supports QUALIFY natively; keep as-is (when QUALIFY directly follows
+  FROM, the FROM relation must have an alias — add one). Reshape to a CTE with
+  `ROW_NUMBER()` and filter in `WHERE` **only** when mixed with `GROUP BY` (dedupe-then-aggregate)
+  — see `conversion-rules.md`.
+- **RESET WHEN** (HIGH) — CTE with LAG/SUM grouping.
+- **EXPAND ON** (HIGH) — `generate_series()` or recursive CTE.
+- **TD_NORMALIZE_OVERLAP** (HIGH) — CTE with LAG/SUM grouping.
+- **TD_UNPIVOT** (HIGH) — CROSS JOIN with CASE expressions.
+- **NONSEQUENCED temporal** (HIGH) — full rewrite required.
+- **ALTER TABLE MODIFY** (HIGH) — not supported; DROP+ADD column or recreate table.
+- **Cursors** (HIGH) — prefer set-based rewrites.
+- **Triggers** (HIGH) — not supported; rewrite as Lambda/Step Functions/app logic.
+
+### QUALIFY example
+
+```sql
+-- Plain QUALIFY: keep as-is — native in Redshift. One restriction: when QUALIFY directly
+-- follows FROM, the FROM relation must carry an alias (here: o)
+SELECT * FROM orders o
+QUALIFY ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date DESC) = 1;
+
+-- QUALIFY mixed with GROUP BY (dedupe-then-aggregate): reshape to a CTE
+WITH ranked AS (
+  SELECT *, ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date DESC) AS rn
+  FROM orders
+)
+SELECT * FROM ranked WHERE rn = 1;
+```
+
+## Comparison operators
+
+```sql
+-- Integer comparison: don't quote integers
+WHERE integer_sk > -13            -- (TD allowed '-13')
+
+-- LIKE ANY/ALL → split into OR clauses
+WHERE (col LIKE 'val1') OR (col LIKE 'val2') OR (col LIKE 'val3')
+
+-- Timezone conversion
+CONVERT_TIMEZONE('US/Eastern', col)   -- source must be TIMESTAMP w/o TZ
+```
+
+## Data migration challenges
+
+- **Large volumes (100TB+)** — TPT parallel unload; Direct Connect or Snowball by
+  bandwidth; Vantage unloads directly to S3.
+- **Storage footprint** — Redshift uses 1MB blocks; small tables may grow (expected).
+- **Character encoding** — TD often ISO-8859-1, RS default UTF-8; size VARCHARs for
+  multibyte; set COPY encoding (UTF8/UTF16/…/ISO88591).
+
+## SCT considerations
+
+- **Handled**: secondary indexes → sort keys; join indexes → materialized views;
+  PK/FK as optimizer hints (not enforced).
+- **Not handled**: range partitioning (manual timeseries setup), SET-table
+  uniqueness (needs dedup logic), TITLE keyword, FALLBACK/JOURNAL (removed).
+- Run the SCT assessment report before automated conversion to gauge complexity.

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/conversion-rules.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/conversion-rules.md
@@ -1,0 +1,381 @@
+# Teradata → Redshift Conversion Rules (72 validated rules)
+
+> AI-facing knowledge: the validated Teradata→Redshift conversion rules the AI applies
+> directly when converting DDL / SQL / stored procedures / macros / BTEQ. **These rules ARE
+> the source of truth** — the skill ships no converter; the AI applies them at conversion time
+> and reasons from them to fix Redshift errors and handle the manual-rewrite long tail below.
+
+Validated across 518 test cases (94.6% pass rate on the source corpus).
+
+## Critical rules by impact
+
+| Priority | Rule | Impact |
+|----------|------|--------|
+| 1 | SUBSTR → SUBSTRING | #1 failure cause (64% of TPC-DS failures) |
+| 2 | Reserved word aliases | Must double-quote: "returns", "interval", "language", etc. |
+| 3 | Column alias in ROLLUP | Use the underlying column name (or position), never the alias |
+| 4 | MERGE INTO alias | Redshift MERGE allows **no target alias** (source alias only) — drop it and qualify with the table name |
+| 5 | NULL (TYPE) → NULL::TYPE | Common in MDM views |
+| 6 | MOD(a,b) → (a % b) | Arithmetic operator difference |
+| 7 | CASCADE CONSTRAINTS → CASCADE | DDL simplification |
+| 8 | STRTOK → SPLIT_PART | String function mapping |
+| 9 | UPDATE table alias | Remove alias from target (RS cannot alias UPDATE target) |
+| 10 | QUANTILE(n, col) → NTILE(n) OVER (ORDER BY col) - 1 | Window function mapping |
+
+## SQL function replacements
+
+| Teradata | Redshift | Notes |
+|----------|----------|-------|
+| SEL | SELECT | Statement shorthand |
+| ZEROIFNULL(x) | COALESCE(x, 0) | Null handling |
+| NULLIFZERO(x) | NULLIF(x, 0) | Null handling |
+| CHARACTERS(x) | LENGTH(x) | String length |
+| INDEX(str, sub) | STRPOS(str, sub) | String position |
+| SUBSTR(x, y, z) | SUBSTRING(x, y, z) | **Critical** — not supported in RS |
+| CSUM(col, order) | SUM(col) OVER (ORDER BY order ROWS UNBOUNDED PRECEDING) | Cumulative sum |
+| MAVG(col, n, order) | AVG(col) OVER (ORDER BY order ROWS BETWEEN n-1 PRECEDING AND CURRENT ROW) | Moving average |
+| MOD(a, b) | (a % b) | Modulo operator |
+| STRTOK(x, ...) | SPLIT_PART(x, ...) | String tokenizer |
+| QUANTILE(n, col) | NTILE(n) OVER (ORDER BY col) - 1 | Quantile function |
+
+## Statement transformations
+
+| Teradata | Redshift | Notes |
+|----------|----------|-------|
+| CREATE VOLATILE TABLE | CREATE TEMP TABLE | Remove ON COMMIT PRESERVE ROWS |
+| COLLECT STATISTICS | ANALYZE | Statistics gathering |
+| LOCKING table FOR ACCESS | (remove) | Redshift uses MVCC |
+| HASHROW/HASHBUCKET | (remove); if a row fingerprint is needed → `MD5(NVL(a::VARCHAR,'') \|\| …)` | No exact RS equivalent — MD5 values **differ** from TD HASHROW (different algorithms); use only as a within-Redshift fingerprint, not to match TD values |
+| (expr)(TYPE) | CAST(expr AS TYPE) | Inline type cast |
+| DELETE FROM t ALL | DELETE FROM t | Remove ALL keyword |
+| MERGE INTO t alias USING | MERGE INTO t USING … (drop the target alias; rewrite alias refs to `t`) | RS MERGE supports a **source** alias only — target alias (bare or AS) is a syntax error |
+| NULL (TYPE) | NULL::TYPE | Typed NULL cast |
+| SET QUERY_BAND | -- comment out | Use SET query_group instead |
+| UPDATE t alias SET alias.col | UPDATE t SET col | RS cannot alias UPDATE target |
+| RENAME TABLE t1 TO t2 | ALTER TABLE t1 RENAME TO t2 | DDL syntax |
+| CREATE INDEX | (remove) | Not supported in RS |
+
+## Clause handling
+
+| Teradata | Redshift | Notes |
+|----------|----------|-------|
+| date + INTERVAL 'N' DAY | DATEADD(day, N, date) | Date arithmetic |
+| ADD_MONTHS(date, n) | DATEADD(month, n, date) | Month arithmetic |
+| (CASESPECIFIC) | (remove) | RS default is case-sensitive |
+| col (NOT CASESPECIFIC) | column/DB `COLLATE CASE_INSENSITIVE` (**preferred**); `UPPER(col)` only as an ad-hoc fallback | RS supports case-insensitive collation. TD default is NOT CASESPECIFIC in session mode → affects **most** TD columns; set collation at CREATE time to keep join/filter semantics + sargability (UPPER() kills sortkey use) |
+| col (FORMAT 'fmt') | TO_CHAR(col, 'fmt') | Date/number formatting |
+| col (TITLE 'title') | col AS "title" | Column alias |
+| SELECT TOP N | SELECT ... LIMIT N | Move to end of query |
+| QUALIFY ... | **keep as-is** — Redshift supports QUALIFY natively; if QUALIFY directly follows FROM, the FROM relation **must have an alias** (`FROM t x QUALIFY …`) | Reshape to a CTE **only** when QUALIFY is mixed with `GROUP BY` (dedupe-then-aggregate) |
+| SAMPLE n | ORDER BY RANDOM() LIMIT n | RS has no `TABLESAMPLE`; use random-order + LIMIT |
+
+## Reserved words requiring double-quoting as aliases
+
+```
+returns, interval, language, position, result, trim, user, type,
+default, comment, action, condition, connection, current, input,
+output, session, system, value, year, month, day, hour, minute,
+second, zone
+```
+
+## DDL conversion
+
+### Clauses to strip (Teradata-specific, no RS equivalent)
+
+| Clause | Action |
+|--------|--------|
+| FALLBACK / NO FALLBACK | Remove (RS has automatic RA3/S3 redundancy) |
+| NO BEFORE JOURNAL / NO AFTER JOURNAL | Remove |
+| CHECKSUM = DEFAULT | Remove |
+| MERGEBLOCKRATIO = n / DEFAULT MERGEBLOCKRATIO | Remove |
+| CHARACTER SET x | Remove (RS default is UTF-8) |
+| DATE FORMAT 'fmt' | Remove |
+| WITH DATA | Remove (not needed in RS CTAS) |
+
+### Table type conversion
+
+| Teradata | Redshift | Notes |
+|----------|----------|-------|
+| CREATE SET TABLE | CREATE TABLE | Add dedup logic if needed (RS allows duplicates) |
+| CREATE MULTISET TABLE | CREATE TABLE | Direct replacement |
+| CREATE VOLATILE TABLE | CREATE TEMP TABLE | Remove ON COMMIT PRESERVE ROWS |
+
+### Index and key conversion
+
+| Teradata | Redshift | Notes |
+|----------|----------|-------|
+| UNIQUE PRIMARY INDEX (col) | DISTKEY(col) | Uniqueness not enforced in RS |
+| PRIMARY INDEX (col) | DISTKEY(col) | Single column only |
+| PRIMARY INDEX (col1, col2) | DISTSTYLE EVEN | Deterministic default: multi-col PI has no single-col equivalent. The optimization pass (`architecture-mapping.md`) may upgrade to DISTKEY on the highest-cardinality join col |
+| PARTITION BY RANGE_N(col) | SORTKEY(col) | Range partition → sort key |
+| Secondary Index | SORTKEY (partial) | Consider as additional sort key |
+| Join Index | Materialized View | Use CREATE MATERIALIZED VIEW |
+| CREATE INDEX | Remove | Not supported in RS |
+
+### Compression and encoding
+
+| Teradata | Redshift |
+|----------|----------|
+| COMPRESS ('val1','val2') | ENCODE bytedict |
+| COMPRESS (no values) | ENCODE az64 |
+
+Recommended encodings: CHAR/VARCHAR <250 → LZO; 250+ → ZSTD; DATE/TIMESTAMP/INT/
+NUMERIC → AZ64; DOUBLE/FLOAT → ZSTD; first sort-key column → RAW. Use `ENCODE AUTO`
+/ `DISTSTYLE AUTO` / `SORTKEY AUTO` when unsure — Redshift will optimize.
+
+## Constructs requiring manual rewrite (no deterministic mapping)
+
+These have **no direct Redshift equivalent** — flag them for review and apply the suggested
+structural rewrite rather than a mechanical substitution. Confidence should drop when they appear,
+and each should land in the `manual_review.json` backlog (see `reporting.md`) with its location.
+
+| Teradata construct | Suggested Redshift rewrite |
+|--------------------|----------------------------|
+| `QUALIFY` **mixed with `GROUP BY`** | Plain `QUALIFY` is native in Redshift — keep it (add a FROM alias when QUALIFY directly follows FROM). Only the dedupe-then-aggregate case (QUALIFY + GROUP BY) needs a CTE (`rn=1`) then `GROUP BY`. |
+| `SAMPLE n` | `ORDER BY RANDOM() LIMIT n` (Redshift has no `TABLESAMPLE`). |
+| `RESET WHEN` | Windowed running calc with a grouping key (LAG/SUM over a partition that restarts on the condition). |
+| `EXPAND ON <period>` | Expand the period with `generate_series()` or a recursive CTE. |
+| `TD_NORMALIZE_OVERLAP` | CTE using LAG/SUM grouping to merge overlapping periods. |
+| `TD_UNPIVOT` | `CROSS JOIN` with `CASE` expressions (or `UNION ALL`). |
+| `NONSEQUENCED` (temporal) | No RS equivalent — rewrite the temporal semantics explicitly. |
+| `ALTER TABLE … MODIFY` | Not supported — `DROP`/re-`CREATE` the column or table. |
+| `PERIOD(...)` type | Split into two columns (see `data-type-mapping.md`). |
+| Cursors / triggers / join indexes | Set-based rewrite / Lambda+Step Functions / Materialized View (see `stored-procedure-migration.md`, `architecture-mapping.md`). |
+
+**Workflow:** apply the deterministic rules above to the well-understood bulk, then flag each
+manual-rewrite construct with its suggested rewrite. This is the same split the old converter used
+(mechanical rules vs. flagged review items) — now applied directly by the AI.
+
+## Complexity assessment
+
+Score a file by summing a weight per matched construct, then map the total to a rating.
+**Weights:** low = 1, medium = 3, high = 8.
+
+**Pattern → complexity catalog** (what to scan for; extends the rule tables above):
+
+| Complexity | Constructs |
+|------------|-----------|
+| **Low (1)** | SEL, ZEROIFNULL/NULLIFZERO, CHARACTERS, INDEX→STRPOS, FALLBACK/journal/CHECKSUM/MERGEBLOCKRATIO strip, BYTEINT, COMPRESS, TOP-N, MOD, CASCADE CONSTRAINTS, STRTOK, RENAME TABLE, CREATE INDEX removal, QUERY_BAND, bare LOGON, COLLECT STATISTICS, LOCKING FOR ACCESS, VOLATILE TABLE |
+| **Medium (3)** | PRIMARY INDEX→DISTKEY, UNIQUE PI, PARTITION BY→SORTKEY, QUALIFY+GROUP BY, SAMPLE, CASESPECIFIC, FORMAT clause, MERGE INTO, HASHROW/HASHBUCKET, CLOB, INTERVAL type, JOIN INDEX→MV, QUANTILE, ADD_MONTHS, BTEQ `.LOGON`/`.IMPORT`/`.EXPORT`/`.IF` |
+| **High (8)** | PERIOD type, BLOB, UDT, stored procedures, macros, cursors, triggers, RESET WHEN, EXPAND ON, TD_NORMALIZE_OVERLAP, TD_UNPIVOT, NONSEQUENCED, ALTER TABLE MODIFY |
+
+| Score | Rating | Estimate |
+|-------|--------|----------|
+| < 50 | LOW | 1-2 weeks |
+| 50-199 | MEDIUM | 2-6 weeks |
+| 200-499 | HIGH | 6-12 weeks |
+| 500+ | VERY HIGH | 3-6 months |
+
+## Worked examples (golden input → output)
+
+Concrete targets a correct conversion should match.
+
+**DDL** (MULTISET + FALLBACK + PI + PPI + COMPRESS):
+
+```sql
+-- Teradata
+CREATE MULTISET TABLE sales (
+    id INTEGER, store_id INTEGER, sale_dt DATE, amt DECIMAL(15,2) COMPRESS
+) FALLBACK
+PRIMARY INDEX (store_id)
+PARTITION BY RANGE_N(sale_dt BETWEEN DATE '2020-01-01' AND DATE '2030-12-31' EACH INTERVAL '1' MONTH);
+-- Redshift
+CREATE TABLE sales (
+    id INTEGER, store_id INTEGER, sale_dt DATE, amt DECIMAL(15,2) ENCODE az64
+)
+DISTKEY(store_id)
+SORTKEY(sale_dt);
+```
+
+**SQL** (SEL + TOP + SUBSTR + ZEROIFNULL + reserved-word alias):
+
+```sql
+-- Teradata
+SEL TOP 50 SUBSTR(name,1,3), ZEROIFNULL(amt) AS returns FROM t;
+-- Redshift
+SELECT SUBSTRING(name,1,3), COALESCE(amt, 0) AS "returns" FROM t
+LIMIT 50;
+```
+
+**Stored procedure** (fragment):
+
+```sql
+-- Teradata:  REPLACE PROCEDURE p(OUT c INTEGER) ... SET c = ACTIVITY_COUNT;
+-- Redshift:  CREATE OR REPLACE PROCEDURE p(INOUT c INTEGER) LANGUAGE plpgsql AS $$ ...
+--              GET DIAGNOSTICS c = ROW_COUNT; ... $$;
+```
+
+**BTEQ → RSQL** (error handling):
+
+```
+-- Teradata:  .IF ERRORCODE <> 0 THEN .GOTO ERR
+-- RSQL:       \if :ERROR <> 0
+--               \echo 'error'
+--               \exit 1
+--             \endif
+```
+
+## Conversion confidence (deterministic rubric)
+
+Score confidence per object from the **complexity of the rules applied** (not a free-form
+guess), so it is reproducible across models and drives the HITL gate in `orchestration.md`:
+
+| Highest-weight construct in the object | Confidence | Action |
+|----------------------------------------|-----------|--------|
+| Only **Low**-weight rules applied | ≥ 0.95 | auto-accept |
+| Any **Medium**-weight construct | ≤ 0.85 | accept; note in report |
+| Any **High**-weight / manual-rewrite construct | ≤ 0.70 | **auto-flag** → `manual_review.json` |
+| Unconvertible kind (trigger, join index, UDT) | 0.0 | always flag |
+
+Weights are the Low/Medium/High tiers in the complexity catalog above. Same input → same
+confidence regardless of model.
+
+## `manual_review.json` (contract)
+
+Produced by conversion, consumed by `reporting.md`. One entry per flagged object:
+
+```json
+{
+  "items": [
+    {
+      "object": "BANKING_DW.proc_x",
+      "object_kind": "procedure|table|view|macro|bteq|sql",
+      "construct": "multi-result macro",
+      "location": "file/line or statement index",
+      "snippet": "…offending source…",
+      "suggested_rewrite": "…from the manual-rewrite table above…",
+      "confidence": 0.7,
+      "status": "open|accepted|rewritten"
+    }
+  ],
+  "summary": { "objects": 0, "needs_review": 0, "min_confidence": 1.0 }
+}
+```
+
+The `summary` shape matches what the `orchestration.md` HITL gate reports.
+
+## Golden corpus (acceptance scoring key)
+
+Input→output pairs the conversion must reproduce, each tagged with the rule it exercises. Use as
+the yardstick for the model-matrix consistency test (`docs/test-plan.md`, Scenario A): a converted
+object is "correct" when it matches the intent below **and** runs on Redshift.
+
+### Critical-10 (one per critical rule)
+
+| # rule | Teradata | Redshift |
+|--------|----------|----------|
+| 1 SUBSTR | `SELECT SUBSTR(name,1,5) FROM t;` | `SELECT SUBSTRING(name,1,5) FROM t;` |
+| 2 reserved alias | `SELECT SUM(amt) AS returns FROM t;` | `SELECT SUM(amt) AS "returns" FROM t;` |
+| 3 ROLLUP alias | `SELECT region r, SUM(amt) FROM t GROUP BY ROLLUP(r);` | `SELECT region r, SUM(amt) FROM t GROUP BY ROLLUP(region);` |
+| 4 MERGE alias | `MERGE INTO tgt t USING src s ON t.id=s.id …` | `MERGE INTO tgt USING src s ON tgt.id=s.id …` (no target alias; qualify with table name) |
+| 5 NULL(TYPE) | `SELECT NULL (DATE) FROM t;` | `SELECT NULL::DATE FROM t;` |
+| 6 MOD | `SELECT MOD(id,10) FROM t;` | `SELECT (id % 10) FROM t;` |
+| 7 CASCADE | `DROP TABLE t CASCADE CONSTRAINTS;` | `DROP TABLE t CASCADE;` |
+| 8 STRTOK | `SELECT STRTOK(name,',',2) FROM t;` | `SELECT SPLIT_PART(name,',',2) FROM t;` |
+| 9 UPDATE alias | `UPDATE a FROM t1 AS a, s SET c='x' WHERE a.id=s.id;` | `UPDATE t1 SET c='x' FROM s WHERE t1.id=s.id;` |
+| 10 QUANTILE | `SELECT QUANTILE(4,salary) FROM emp;` | `SELECT NTILE(4) OVER (ORDER BY salary)-1 FROM emp;` |
+
+### Manual-rewrite constructs
+
+**QUALIFY — native in Redshift (keep as-is); reshape to a CTE only when mixed with `GROUP BY`:**
+
+```sql
+-- TD plain QUALIFY → RS keeps it (native). Redshift restriction: when QUALIFY directly
+-- follows FROM, the FROM relation must have an alias — add one if the TD source lacks it.
+SELECT id, k, d FROM t src QUALIFY ROW_NUMBER() OVER (PARTITION BY k ORDER BY d DESC) = 1;
+
+-- TD QUALIFY mixed with GROUP BY (dedupe-then-aggregate) → RS must reshape to a CTE:
+-- TD:
+SELECT k, SUM(amt) FROM t GROUP BY k
+  QUALIFY ROW_NUMBER() OVER (PARTITION BY k ORDER BY ts DESC) = 1;
+-- RS:
+WITH deduped AS (
+  SELECT t.*, ROW_NUMBER() OVER (PARTITION BY k ORDER BY ts DESC) AS rn FROM t
+)
+SELECT k, SUM(amt) FROM deduped WHERE rn = 1 GROUP BY k;
+```
+
+**PERIOD type → two columns:**
+
+```sql
+-- TD
+CREATE TABLE emp (id INT, employment PERIOD(DATE));
+-- RS
+CREATE TABLE emp (id INT, employment_start DATE, employment_end DATE);
+```
+
+**RESET WHEN → windowed grouping (running total restarts when flag=1):**
+
+```sql
+-- TD
+SELECT id, amt,
+       SUM(amt) OVER (ORDER BY id RESET WHEN flag = 1 ROWS UNBOUNDED PRECEDING) AS running
+FROM t;
+-- RS: build a group id that increments on each reset, then sum within the group
+WITH g AS (
+  SELECT id, amt,
+         SUM(CASE WHEN flag = 1 THEN 1 ELSE 0 END) OVER (ORDER BY id ROWS UNBOUNDED PRECEDING) AS grp
+  FROM t
+)
+SELECT id, amt,
+       SUM(amt) OVER (PARTITION BY grp ORDER BY id ROWS UNBOUNDED PRECEDING) AS running
+FROM g;
+```
+
+**TD_UNPIVOT → UNION ALL:**
+
+```sql
+-- TD
+SELECT * FROM TD_UNPIVOT(
+  ON sales USING VALUE_COLUMNS('v') UNPIVOT_COLUMN('quarter') COLUMN_LIST('q1','q2','q3','q4')
+) AS x;
+-- RS
+SELECT id, 'q1' AS quarter, q1 AS v FROM sales
+UNION ALL SELECT id, 'q2', q2 FROM sales
+UNION ALL SELECT id, 'q3', q3 FROM sales
+UNION ALL SELECT id, 'q4', q4 FROM sales;
+```
+
+> EXPAND ON, TD_NORMALIZE_OVERLAP, NONSEQUENCED, ALTER TABLE MODIFY, cursors, triggers, join
+> indexes → apply the manual-rewrite table above and record each in `manual_review.json`.
+
+### Full DDL (MULTISET + multi-col PI + PPI + COMPRESS + FALLBACK)
+
+```sql
+-- TD
+CREATE MULTISET TABLE sales (
+    a INTEGER, b INTEGER, dt DATE, amt DECIMAL(15,2) COMPRESS
+) FALLBACK
+PRIMARY INDEX (a, b)
+PARTITION BY RANGE_N(dt BETWEEN DATE '2020-01-01' AND DATE '2030-12-31' EACH INTERVAL '1' MONTH);
+-- RS  (multi-col PI → DISTSTYLE EVEN; PPI → SORTKEY; COMPRESS → ENCODE; FALLBACK dropped)
+CREATE TABLE sales (
+    a INTEGER, b INTEGER, dt DATE, amt DECIMAL(15,2) ENCODE az64
+)
+DISTSTYLE EVEN
+SORTKEY(dt);
+```
+
+### Macro (type-2, returns rows)
+A macro ending in a `SELECT` becomes a procedure returning a **refcursor** (not `RAISE INFO`) —
+see `stored-procedure-migration.md` → *Multi-statement macro pattern (type 2)*.
+
+### BTEQ → RSQL block
+
+```
+-- TD (BTEQ)
+.IF ERRORCODE <> 0 THEN .GOTO ERR
+.IMPORT VARTEXT '|' FILE=data.txt
+BT;
+INSERT INTO staging SELECT * FROM src;
+ET;
+-- RS (RSQL)
+\if :ERROR <> 0
+  \echo 'error'
+  \exit 1
+\endif
+-- COPY staging FROM 's3://bucket/data.txt' IAM_ROLE 'arn:aws:iam::acct:role/role' DELIMITER '|';
+BEGIN;
+INSERT INTO staging SELECT * FROM src;
+COMMIT;
+```

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/data-migration-patterns.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/data-migration-patterns.md
@@ -1,0 +1,229 @@
+# Data migration patterns
+
+> AI-facing knowledge: patterns + templates the AI uses to **generate** extract/load scripts.
+> Distilled from the proven pre-restructure `tools/data_migration/` implementation.
+
+## Purpose
+Move table data from Teradata to Redshift reliably and restartably, producing
+`output/data_migration/result/migration_manifest.json` for validation to consume.
+
+## The pipeline, per table
+
+```
+estimate volume ─▶ extract (TD → file) ─▶ stage to S3 ─▶ COPY into Redshift ─▶ confirm row count
+```
+
+Each table is independent: a failure on one is recorded and the rest continue (see *Checkpointing*).
+
+## 1. Estimate volume (before moving anything)
+Drives chunking decisions and is reused by validation as the authoritative source count.
+
+- **Size:** `SELECT SUM(CurrentPerm) AS size_bytes FROM DBC.TableSizeV WHERE DataBaseName = ? AND TableName = ?`
+  — `CurrentPerm` is split across AMPs, so it **must be summed per table** for total on-disk bytes.
+- **Row count:** exact `SELECT COUNT(*) FROM schema.table`. Teradata's catalog has no reliable
+  live row count, and the exact count is reused by validation, so pay the `COUNT(*)` cost once.
+
+## 2. Extract — three paths
+All write **directly to S3 (no local-disk hop)** and return the `s3://` **prefix** (a
+directory of split part-files, per §3 — not a single object).
+
+### When-to-use matrix
+
+| Path | When to use | Mechanism | Output | Notes |
+|------|-------------|-----------|--------|-------|
+| **WRITE_NOS** (canonical) | Vantage **≥ 17.05** (verify per edition) *and* the cluster is allowed direct S3 egress. **Runs in-database — no Teradata client needed (invoke over any SQL client incl. `teradatasql`), so it works from macOS.** Test cluster is 20.00 → default here. | In-database `WRITE_NOS` — the SQL engine writes **Parquet to S3 in parallel, one object per AMP**, with no external host. | Parquet | No TPT host to install/operate; parallelism = AMP count; native multi-object output already satisfies the split rule (§3). Needs an `AUTHORIZATION` object (IAM role / access keys) and outbound S3 access from the DB nodes. |
+| **TPT** | Older Vantage (< 17.05) **or** locked-down sites with no direct DB→S3 egress. **Requires the Teradata client (TTU: `tbuild`/BTEQ) on a Linux/Windows host — not available on macOS**; extract on that TPT host, then stage to S3. | Teradata Parallel Transporter EXPORT operator → `DATACONNECTOR CONSUMER` file-writer on the dedicated TPT host. | **Delimited** (pipe/CSV) | High-throughput, partitioned. **The DataConnector operator does not natively emit Parquet** — its `Format` values are `Delimited`/`Binary`/`Text`/`Formatted`/`Unformatted`. For Parquet use WRITE_NOS; on TPT, extract delimited and COPY as CSV (§4). Verify object-store/format support for **your** TPT version before relying on it. |
+| **`teradatasql`** (Python driver) | The **cross-platform, no-client** host-side path (pip-installable — **works on macOS**). Use when there is **no TTU/Linux host** for TPT (and WRITE_NOS isn't available), or for small/medium tables and smoke tests. | `SELECT * FROM table` over `teradatasql` → pyarrow Parquet, written as **multiple row-group part-files** → `s3.put_object` per part. | Parquet | Streams rows through the Python process — not for huge tables. Split into part-files (§3) rather than buffering one giant object in memory. |
+
+**Format:** prefer **Parquet** (WRITE_NOS / interim) over delimited — better COPY throughput
+and type fidelity. **Delimited (CSV/pipe) is the fallback**, and is the *only* native option
+on the TPT path.
+
+> **Operator-host prerequisites.** TPT and BTEQ require the Teradata client (**TTU**), which is
+> **Linux/Windows only — not macOS**. On a Mac (or any host without TTU) the viable extract paths
+> are **WRITE_NOS** (in-database, no client) and **`teradatasql`** (pure-Python, cross-platform);
+> use TPT only when a Linux TTU host exists.
+
+### WRITE_NOS export (canonical — template the AI generates)
+
+```sql
+/* WRITE_NOS export — <schema>.<table> → S3 (parallel Parquet, one object per AMP) */
+SELECT * FROM WRITE_NOS (
+  ON ( SELECT * FROM <schema>.<table> )
+  USING
+    LOCATION('/s3/<bucket>.s3.amazonaws.com/<staging-prefix>/<schema>/<table>/<strategy>/')
+    AUTHORIZATION(<auth-object-or-role>)     /* Prefer an IAM-role auth object; access keys only as fallback where roles can't attach. Never inline secrets */
+    STOREDAS('PARQUET')
+    /* MAXOBJECTSIZE intentionally omitted — its valid range is narrow + version-specific */
+    /* (Teradata examples use '4MB'; verify your version). WRITE_NOS then writes objects   */
+    /* smaller than the 100MB–1GB COPY sweet spot — fine: many small Parquet files still   */
+    /* parallelize COPY across slices (§3).                                                */
+    COMPRESSION('SNAPPY')
+) AS d;
+```
+
+`WRITE_NOS` emits multiple Parquet objects under the prefix automatically (one or more per
+AMP), so the split rule in §3 is satisfied with no extra work.
+Requires Vantage ≥ 17.05 (verify per edition) and DB-node outbound access to S3.
+
+### TPT export script (fallback — template the AI generates)
+
+```
+/* TPT EXPORT job — <schema>.<table> (delimited; NOT Parquet — see the matrix above) */
+DEFINE JOB EXPORT_<schema>_<table>
+(
+  DEFINE OPERATOR td_export
+    TYPE EXPORT  SCHEMA *
+    ATTRIBUTES ( VARCHAR TdpId=@TdpId, VARCHAR UserName=@UserName,
+                 VARCHAR UserPassword=@UserPassword,
+                 VARCHAR SelectStmt='SELECT * FROM <schema>.<table>;' );
+  DEFINE OPERATOR file_writer
+    TYPE DATACONNECTOR CONSUMER  SCHEMA *
+    ATTRIBUTES ( VARCHAR Format='Delimited', VARCHAR TextDelimiter='|',
+                 VARCHAR FileName='<schema>.<table>-${JOBID}.csv',
+                 VARCHAR OpenMode='Write' );
+  APPLY TO OPERATOR (file_writer) SELECT * FROM OPERATOR (td_export);
+);
+```
+
+Connection-dependent attributes (`@TdpId`, working dirs) stay as named placeholders the
+operator fills in. Emit **multiple part-files** (one per producer instance) to satisfy the
+split rule in §3 rather than a single delimited file; then COPY as CSV (§4).
+
+## 3. Stage to S3 — key layout + file splitting
+**Staging-bucket security (set up once per migration):** enable default encryption (SSE-S3 or
+SSE-KMS); deny non-TLS access via a bucket-policy condition (`"aws:SecureTransport": "false"` →
+Deny); enable S3 access logging or CloudTrail S3 data events (audit who touched extracted data);
+add a lifecycle rule to auto-expire staged objects after cutover.
+Partition by table and strategy so each table's loads are isolated and auditable. Each
+table is a **prefix (directory) of multiple part-files**, not a single object:
+
+```
+<staging-prefix>/<schema>/<table>/<strategy>/        ← the prefix COPY reads
+    part-0001.parquet
+    part-0002.parquet
+    …
+```
+
+Parse `s3://bucket/prefix/` into `(bucket, prefix)`; keep the trailing slash so keys
+concatenate cleanly. The manifest's `s3_path` records this **prefix** (see the schema below).
+
+### File-splitting rule (why multiple objects)
+A **single** object per table makes Redshift COPY load on **one slice**, serializing the
+whole table through a single stream — needlessly slow for large tables (e.g. Scenario B's
+`store_sales`, ~2.9M rows). Split every table into multiple objects so COPY parallelizes
+across slices:
+
+- **Count:** a **multiple of the cluster's total slice count** (so every slice gets even
+  work). Small tables can stay as one file.
+- **Size:** target **~100 MB–1 GB per object** (compressed). Below ~100 MB the per-file
+  overhead dominates; above ~1 GB you lose parallelism granularity.
+- **Per path:** WRITE_NOS produces one or more objects per AMP automatically (already
+  split — usually nothing more to do); TPT emits one file per producer instance; the interim
+  `teradatasql` path writes one part-file per row-group batch.
+
+Cluster slice count comes from the sizing profile (`sizing.md`) / the target node config.
+
+## 4. Load — Redshift COPY from S3
+Full-load is **truncate-then-COPY** so a re-run is idempotent (no duplicate rows). COPY the
+**prefix** (not a single file) so it fans the split part-files (§3) across all slices in
+parallel:
+
+```sql
+TRUNCATE <schema>.<table>;
+COPY <schema>.<table>
+FROM 's3://.../<schema>/<table>/<strategy>/'   -- prefix: all part-files under it load in parallel
+IAM_ROLE '<role-arn>'   -- scope this role to s3:GetObject/List on the staging prefix only (no s3:*);
+                        -- trust policy: add aws:SourceAccount/aws:SourceArn (or sts:ExternalId) condition keys
+FORMAT AS PARQUET;
+```
+
+COPY reads **every object under the prefix**, so the file-splitting rule in §3 (slice-multiple
+count, ~100 MB–1 GB each) is what makes this load parallel rather than single-slice. Then read
+rows loaded with `SELECT pg_last_copy_count();`.
+
+> On the **TPT (delimited) path**, load the same prefix with `FORMAT AS CSV` + the delimited
+> options in the matrix below instead of `FORMAT AS PARQUET`.
+>
+> **COPY caveats (learned the hard way):**
+>
+> - **`REGION` is rejected with `FORMAT AS PARQUET`** ("REGION argument is not supported for
+>   PARQUET based COPY"). The **staging bucket must be in the cluster's region**. (Region is
+>   still needed to build the S3 client, just not in the COPY.)
+> - The IAM role must be attached to the cluster and allowed to read the staging bucket.
+> - COPY matches Parquet columns **by name** — column order need not match, but names must.
+
+### COPY option matrix (by format)
+
+| Concern | Parquet (preferred) | Delimited (CSV/text fallback) |
+|---------|---------------------|-------------------------------|
+| Format clause | `FORMAT AS PARQUET` | `FORMAT AS CSV` or `DELIMITER '\|'` |
+| NULLs | encoded in Parquet | `NULL AS '\\N'` (must match extract) |
+| Dates/times | native types | `TIMEFORMAT 'auto'`, `DATEFORMAT 'auto'` |
+| Compression | columnar (built-in) | `GZIP` / `BZIP2` on the staged files |
+| Bad-row tolerance | n/a (schema-checked) | `MAXERROR <n>` only if a few bad rows are acceptable — default 0 |
+| Encoding | — | `ENCODING 'UTF8'` |
+
+## 5. Confirm row count
+Immediately compare the exact source `COUNT(*)` (from step 1) to `pg_last_copy_count()`.
+**A mismatch is a load failure, not a success** — record it in `failed_tables` with phase
+`validate`; never report a partial load as `success`. Deeper checks live in `validation-patterns.md`.
+
+## Strategies
+
+| Strategy | Status | Semantics |
+|----------|--------|-----------|
+| `full-load` | implemented | TRUNCATE + COPY. Idempotent; safe to re-run. |
+| `incremental` | future | Append rows since a high-water-mark column. Must use an append load, **not** the truncate path. |
+| `cdc` | future | Change-data-capture apply. Needs change feed design. |
+
+Reject unknown strategies loudly; fail unimplemented ones with a clear message rather than silently doing a full load.
+
+## Checkpointing (restartability)
+Track per-table status so a re-run resumes and skips completed tables. This is the
+`migration_manifest.json` — it is also the hand-off to validation.
+
+### `migration_manifest.json` schema
+
+```json
+{
+  "tables": [
+    {
+      "source_table": "sales.orders",
+      "target_table": "sales.orders",
+      "s3_path": "s3://stage/sales/orders/full-load/",
+      "source_row_count": 1280344,
+      "target_row_count": 1280344,
+      "status": "success",
+      "duration_seconds": 84,
+      "data_size_bytes": 690847232
+    }
+  ],
+  "failed_tables": [
+    { "table": "sales.returns", "error": "COPY: invalid timestamp", "phase": "load", "retryable": true }
+  ],
+  "summary": { "total": 2, "success": 1, "failed": 1, "skipped": 0 }
+}
+```
+
+- `failed_tables[].phase` is one of `extract` | `stage` | `load` | `validate`.
+- `retryable` flags transient failures (network, throttling) vs structural ones (bad type).
+- `summary` is derived: a non-zero `failed` count pauses the pipeline for review (see `orchestration.md`).
+
+## Security & reliability rules
+
+- Use a **read-only** Teradata user for extraction. Never hard-code or echo credentials. For
+  **production**, reference credentials from **AWS Secrets Manager or Parameter Store**; for
+  **local development testing only**, a git-ignored credentials file (with a committed
+  `credentials.env.example` template) may be used — the real file is never committed.
+- **Validate every identifier** (schema/table) against `^[A-Za-z_][A-Za-z0-9_]*$` before inlining
+  it into `COUNT(*)` or `COPY` — those positions can't be parameterized, so this is the injection guard.
+- Make connections injectable so generated scripts are testable without live TD/RS/S3.
+- Put an explicit **timeout** on every extract, COPY, and S3 call — no indefinite waits.
+
+## See also
+
+- `architecture-mapping.md` / `data-type-mapping.md` — target table DDL, DISTKEY/SORTKEY, type/encoding caveats.
+- `sizing.md` — target node config / **cluster slice count** used by the file-splitting rule (§3).
+- `validation-patterns.md` — consumes `migration_manifest.json` (source counts, table list).
+- `orchestration.md` — where data migration sits in the phase pipeline and its HITL gate.

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/data-type-mapping.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/data-type-mapping.md
@@ -1,0 +1,75 @@
+# Teradata → Redshift Data Type Mapping
+
+## Complete type map
+
+| Teradata Type | Redshift Type | Notes |
+|---------------|---------------|-------|
+| BYTEINT | SMALLINT | Smallest integer type in RS |
+| SMALLINT | SMALLINT | Direct mapping |
+| INTEGER | INTEGER | Direct mapping |
+| BIGINT | BIGINT | Direct mapping |
+| FLOAT | DOUBLE PRECISION | Floating point |
+| DECIMAL(p,s) | DECIMAL(p,s) | Preserve precision and scale |
+| NUMBER | NUMERIC | Bare `NUMBER` is flexible-scale (**holds fractions**) — do **not** default to `DECIMAL(38,0)` (drops every fraction). Choose from discovery stats: integer-only observed → `DECIMAL(38,0)`; fractional observed → `DECIMAL(38,18)` or `DOUBLE PRECISION`; stats unavailable → **flag for review** |
+| NUMERIC(p,s) | NUMERIC(p,s) | Preserve precision and scale |
+| CHAR(n) | CHAR(n) | Fixed-length string |
+| VARCHAR(n) | VARCHAR(adjusted_n) | **See multibyte sizing below** |
+| CLOB | `VARCHAR(65535)` if ≤ 64 KB, else **flag → S3 offload** | RS stored VARCHAR max = **65,535 bytes** (not 16 MB — that limit is SUPER/in-memory). TD CLOB holds up to 2 GB; offload large CLOBs to S3 and keep a VARCHAR reference column (same as BLOB). |
+| BLOB | VARBYTE(1000000) | Or store in S3 with reference |
+| BYTE(n) / VARBYTE(n) | VARBYTE(n) | Binary data |
+| DATE | DATE | Direct mapping |
+| TIME | TIME | Direct mapping |
+| TIMESTAMP | TIMESTAMP | Direct mapping |
+| TIMESTAMP WITH TIME ZONE | TIMESTAMPTZ | Timezone-aware |
+| INTERVAL | VARCHAR | Use DATEADD/DATEDIFF for arithmetic |
+| JSON | SUPER | RS native semi-structured type |
+| XML | VARCHAR(MAX) | No native XML type in RS |
+| PERIOD(DATE) | Two DATE columns | Split into start_date, end_date |
+| PERIOD(TIMESTAMP) | Two TIMESTAMP columns | Split into start_ts, end_ts |
+
+## VARCHAR multibyte sizing
+
+Teradata `VARCHAR(n)` measures **characters**; Redshift `VARCHAR(n)` measures **bytes**, and
+UTF-8 uses up to 4 bytes/char — so size by the column's **character set**, never by a
+length tier (a length-only cap silently rejects multibyte rows on COPY). Always clamp to the
+65,535-byte max.
+
+| Source column | Redshift size |
+|---------------|---------------|
+| Known multibyte (`CHARACTER SET UNICODE`/`GRAPHIC`, or discovery shows `MAX(OCTET_LENGTH) > n`) | `min(4 * n, 65535)` |
+| Known single-byte (`LATIN` / ASCII) | `n` (as-is) |
+| Unknown | `min(2 * n, 65535)` + note to verify |
+
+If `4 * n` would exceed 65,535, clamp to `VARCHAR(65535)` and **flag** if the source can
+actually exceed that byte length (candidate for S3 offload, like CLOB).
+
+## PERIOD type handling
+
+No Redshift equivalent — split into two columns:
+
+```sql
+-- Teradata
+CREATE TABLE employee (emp_id INTEGER, employment_period PERIOD(DATE));
+
+-- Redshift
+CREATE TABLE employee (
+    emp_id INTEGER,
+    employment_start_date DATE,
+    employment_end_date DATE
+);
+```
+
+## Decimal rounding difference
+
+- **Teradata**: banker's rounding — `CAST(22.2345 AS DECIMAL(5,3))` → 22.234
+- **Redshift**: standard rounding — `CAST(22.2345 AS DECIMAL(5,3))` → 22.235
+
+This can cause data-validation mismatches; document it for the customer.
+
+## Other notes
+
+- Views: create with `WITH NO SCHEMA BINDING` so base tables can be dropped/recreated
+  without dropping dependent views.
+- COPY encodings supported: UTF8, UTF16, UTF16LE, UTF16BE, ISO88591.
+- Redshift default timezone is UTC (cannot be set at the database level; only per-user
+  or via client tools).

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/discovery-queries.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/discovery-queries.md
@@ -1,0 +1,326 @@
+# Discovery — DBC system-view queries
+
+> AI-facing knowledge: the read-only `DBC` catalog queries the AI uses to **build** a
+> discovery runner for the customer's environment, and the `inventory.json` contract the
+> runner produces. This doc is the knowledge — the AI generates the actual runner
+> (connected) or a portable bundle (disconnected); see `references/teradata/orchestration.md`.
+
+## Purpose
+
+Inventory the source Teradata system — version/parallelism, databases, objects (tables,
+views, macros, procedures), storage, AMP skew, and an always-available workload signal —
+to produce `output/discovery/result/inventory.json`. Every later phase (conversion,
+migration, validation, performance, reporting) reads this contract.
+
+**All queries are SELECT-only against `DBC` catalog views.** No DDL/DML, no user-table
+data — safe for a DBA to run on production.
+
+> **Source of truth:** the queries in this doc ARE the source of truth. The skill ships no
+> executable collector — the AI generates the runner (a BTEQ driver or a `teradatasql`
+> script) at run time from the SQL below, adapting to how the customer can reach the source.
+> See **Execution modes** for the BTEQ driver template the AI should emit.
+
+## DBC views used
+
+| View | Purpose | Grain |
+|------|---------|-------|
+| `DBC.DBCInfoV` | Teradata version / release | system |
+| `DBC.DiskSpaceV` | permanent space per database (CurrentPerm/MaxPerm) | per AMP → SUM |
+| `DBC.TableSizeV` | permanent space per table and per AMP (skew) | per table × AMP → SUM |
+| `DBC.TablesV` | object counts by `TableKind` | per database |
+| `DBC.ColumnsV` | column inventory for DDL/conversion | per column |
+| `DBC.IndicesV` | PI / PPI / secondary indexes | per index column |
+| `DBC.AMPUsageV` | cumulative CPU/IO by account+user (always-on) | per AMP → SUM |
+| `DBC.DBQLogTbl` | query history (workload) — often disabled | per query |
+| `DBC.ResUsageSpma` | system resource time series — often disabled | per node × sample |
+
+`amp_count` comes from the number of distinct `Vproc` rows in `DBC.TableSizeV` (or
+`HASHAMP()+1`). `node_count` is best-effort and not always derivable offline.
+
+## System & version
+
+```sql
+-- DBC.DBCInfoV → td_version
+SELECT TRIM(InfoKey) || '|' || TRIM(InfoData) AS rec
+FROM DBC.DBCInfoV
+WHERE InfoKey IN ('VERSION', 'RELEASE')
+ORDER BY InfoKey;
+```
+
+**Collection manifest** (provenance for `collection_meta`: `collected_at` + `td_version`).
+Both rows read `DBC.DBCInfoV` on purpose — a constant `SELECT` with no `FROM` fails inside a
+`UNION` (Failure 3888), so the timestamp row is anchored to a 1-row catalog read:
+
+```sql
+SELECT 'collected_at|' || CAST(CURRENT_TIMESTAMP(0) AS VARCHAR(40)) AS rec
+FROM DBC.DBCInfoV WHERE InfoKey = 'VERSION'
+UNION ALL
+SELECT 'td_version|' || TRIM(InfoData) FROM DBC.DBCInfoV WHERE InfoKey = 'VERSION';
+```
+
+## Storage & skew
+
+```sql
+-- Per database (summed across AMPs). HAVING drops empty databases.
+SELECT TRIM(DatabaseName) || '|' ||
+       TRIM(CAST(SUM(CurrentPerm) AS BIGINT)) || '|' ||
+       TRIM(CAST(SUM(MaxPerm)     AS BIGINT)) AS rec
+FROM DBC.DiskSpaceV
+GROUP BY DatabaseName
+HAVING SUM(CurrentPerm) > 0
+ORDER BY SUM(CurrentPerm) DESC;
+
+-- Per table (summed across AMPs) — total sizes + largest-table ranking.
+SELECT TRIM(DataBaseName) || '|' || TRIM(TableName) || '|' ||
+       TRIM(CAST(SUM(CurrentPerm) AS BIGINT)) AS rec
+FROM DBC.TableSizeV
+GROUP BY DataBaseName, TableName
+HAVING SUM(CurrentPerm) > 0
+ORDER BY SUM(CurrentPerm) DESC;
+
+-- Per AMP (Vproc) — drives system-wide skew and AMP count (~#AMPs rows).
+SELECT TRIM(CAST(Vproc AS INTEGER)) || '|' ||
+       TRIM(CAST(SUM(CurrentPerm) AS BIGINT)) AS rec
+FROM DBC.TableSizeV
+GROUP BY Vproc
+ORDER BY Vproc;
+```
+
+**System skew** is derived from the per-AMP space: `system_skew_pct = (1 - avg/max) * 100`
+over each AMP's `SUM(CurrentPerm)`. High skew on the source is a signal for choosing
+Redshift `DISTKEY`/`DISTSTYLE` (see `references/teradata/architecture-mapping.md`).
+
+## Object inventory
+
+```sql
+-- Counts by TableKind: T=table, V=view, M=macro, P=procedure; others → 'other'.
+SELECT TRIM(DatabaseName) || '|' || TRIM(TableKind) || '|' ||
+       TRIM(CAST(COUNT(*) AS BIGINT)) AS rec
+FROM DBC.TablesV
+GROUP BY DatabaseName, TableKind
+ORDER BY DatabaseName, TableKind;
+```
+
+For the **conversion** phase, extract column and index detail per table, and the DDL.
+
+> **These are NOT part of the fixed discovery bundle** (the 14 inventory queries above /
+> below). They are parameterized or dynamic, so the AI runs them **on demand during
+> conversion**, not as static bundle files:
+>
+> - **Connected mode:** bind `DatabaseName` per user database (loop over the databases found
+>   in `dbc_tablesv`), and loop `SHOW TABLE`/`SHOW VIEW` over each object.
+> - **Disconnected mode:** the operator either substitutes the target database name into the
+>   `WHERE` before running (dropping the `?`), or the AI templates one file per database.
+>   `SHOW TABLE`/`SHOW VIEW` must be expanded to concrete object names first — they cannot
+>   ship as a single static file.
+> Their output is per-conversion, not part of `inventory.json`.
+
+```sql
+-- Columns (feeds data-type-mapping + DDL generation).  ? = one user database
+SELECT DatabaseName, TableName, ColumnName, ColumnType, ColumnLength,
+       DecimalTotalDigits, DecimalFractionalDigits, Nullable, DefaultValue, ColumnId
+FROM DBC.ColumnsV
+WHERE DatabaseName = ?            -- scope to user databases
+ORDER BY DatabaseName, TableName, ColumnId;
+
+-- Indexes → PI/PPI/secondary (feeds PI→DISTKEY, PPI→SORTKEY).  ? = one user database
+SELECT DatabaseName, TableName, IndexNumber, IndexType, UniqueFlag, ColumnName, ColumnPosition
+FROM DBC.IndicesV
+WHERE DatabaseName = ?
+ORDER BY DatabaseName, TableName, IndexNumber, ColumnPosition;
+```
+
+Authoritative DDL comes from `SHOW` (dynamic — expand `<db>.<table>` from `dbc_tablesv`):
+
+```sql
+SHOW TABLE <db>.<table>;     -- canonical DDL (PI/PPI, COMPRESS, MULTISET, etc.)
+SHOW VIEW <db>.<view>;
+```
+
+## Workload signal
+
+`DBC.AMPUsageV` is the **always-available** coarse signal (cumulative since last reset);
+richer history (`DBQLogTbl`, `ResUsageSpma`) is often disabled — see
+`references/teradata/performance.md` for those plus sizing.
+
+```sql
+-- Coarse cumulative CPU/IO by account+user (always on).
+SELECT TRIM(AccountName) || '|' || TRIM(UserName) || '|' ||
+       TRIM(CAST(SUM(CpuTime) AS BIGINT)) || '|' ||
+       TRIM(CAST(SUM(DiskIO)  AS BIGINT)) AS rec
+FROM DBC.AMPUsageV
+GROUP BY AccountName, UserName
+HAVING SUM(CpuTime) > 0
+ORDER BY SUM(CpuTime) DESC;
+```
+
+## Availability (optional sources may be off)
+
+DBQL and ResUsage are frequently disabled on a source system. Probe each with a row
+count; **0 rows → mark the source `unavailable` and continue** — the inventory always
+parses without them.
+
+**Never enable logging on the source.** Do not run `BEGIN QUERY LOGGING` /
+`REPLACE QUERY LOGGING` (or any DDL/DCL) on the customer's production system — discovery
+is strictly SELECT-only, and changing logging state is a production change with storage
+and privilege implications. If DBQL is empty, fall back to `DBC.AMPUsageV` (always-on
+cumulative CPU/IO by account) as the workload signal, and note the reduced granularity
+in the inventory. Only the *customer's own DBA* may choose to enable DBQL, on their
+change process — it is never a step this migration performs.
+
+```sql
+SELECT 'dbql'     || '|' || TRIM(CAST(COUNT(*) AS BIGINT)) AS rec FROM DBC.DBQLogTbl;
+SELECT 'resusage' || '|' || TRIM(CAST(COUNT(*) AS BIGINT)) AS rec FROM DBC.ResUsageSpma;
+```
+
+Wrap each optional source as `{status, reason, row_count}` in the contract (below) rather
+than assuming it is present.
+
+## `inventory.json` contract
+
+Facts only — no Redshift/target judgments — so the same shape can describe other sources
+later. Optional workload sources are availability-wrapped.
+
+```json
+{
+  "collection_meta": {
+    "collected_at": "2026-06-24T03:00:00",
+    "td_version": "20.00.30.77",
+    "source_host": "<host>",
+    "available_sources": ["ampusage", "dbql"]
+  },
+  "system": { "amp_count": 24, "node_count": 2, "td_version": "20.00.30.77" },
+  "storage": {
+    "total_current_perm_bytes": 0,
+    "total_max_perm_bytes": 0,
+    "by_database": [{ "database": "tpcds", "current_perm_bytes": 0, "max_perm_bytes": 0, "is_system": false }],
+    "top_tables": [{ "database": "tpcds", "table": "store_sales", "current_perm_bytes": 0 }]
+  },
+  "skew": {
+    "amp_space": [{ "vproc": 0, "current_perm_bytes": 0 }],
+    "system_skew_pct": 0.0
+  },
+  "objects": {
+    "by_database": [{ "database": "tpcds", "tables": 24, "views": 0, "macros": 0, "procedures": 0, "other": 0 }]
+  },
+  "workload": {
+    "cpu_io_by_user": [{ "account": "$M", "user": "tester", "cpu_time": 0.0, "disk_io": 0.0 }],
+    "query_log":     { "status": "unavailable", "reason": "DBQL logging off (0 rows)", "row_count": 0 },
+    "resource_usage":{ "status": "available",   "reason": "", "row_count": 0 },
+    "query_stats": null,
+    "resource_stats": null
+  }
+}
+```
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `system.amp_count` | distinct `Vproc` in TableSizeV | parallelism driver for sizing |
+| `system.node_count` | best-effort | often null offline |
+| `storage.by_database[].is_system` | name allowlist | `DBC`, `TD*`, `TDaaS_*`, `Sys*`, … excluded from user storage |
+| `skew.system_skew_pct` | `(1 - avg/max) * 100` over per-AMP perm | DISTKEY signal |
+| `objects.by_database[]` | `TablesV.TableKind` | `T/V/M/P`, else `other` |
+| `workload.query_log` / `resource_usage` | probe row counts | `unavailable` when 0 rows |
+| `workload.query_stats` / `resource_stats` | DBQL / ResUsage | populated only when available — see `performance.md` |
+
+## Gotchas (learned on a live Vantage 20.00)
+
+- **`TableSizeV` has no `RowCount` column** and is **per-AMP** → always `SUM(CurrentPerm)
+  GROUP BY` table/AMP. For row counts use `SELECT COUNT(*)` per table (or collected stats),
+  never TableSizeV.
+- **PI on a PPI table reports `IndexType='Q'`**, not `'P'` — identify the primary index by
+  `IndexNumber = 1` rather than filtering `IndexType='P'`, or PPI tables lose their PI.
+- **Constant `SELECT` without `FROM` fails inside a `UNION`** (Failure 3888). Anchor any
+  literal row to a 1-row catalog read, e.g. `... FROM DBC.DBCInfoV WHERE InfoKey='VERSION'`.
+- **`GROUP BY 1` fails when column 1 contains an aggregate** (Failure 3625) → group by the
+  underlying expression, not the positional alias.
+- `DBC.AMPUsageV` is **cumulative since the last reset** — treat it as a coarse relative
+  signal, not an absolute window.
+
+## Execution modes
+
+The AI generates the collector at run time — nothing executable ships with the skill.
+Pick the mode from how the customer can reach the source:
+
+- **Connected** — the AI generates a runner (e.g. `teradatasql`) that runs the queries and
+  writes `result/inventory.json` directly.
+- **Disconnected** — the AI emits a portable bundle the operator runs on a reachable host:
+  each query as a static `.sql` file plus a thin BTEQ driver (or plain SQL), returning the
+  dumps that are then parsed into `inventory.json`.
+
+In both modes the queries above are the single source; the generated driver only runs them.
+
+> **Client prerequisite.** The **BTEQ driver** needs the Teradata client (TTU) — **Linux/Windows
+> only, not macOS**. On a host without TTU (e.g. macOS), generate the **`teradatasql`** collector
+> instead (pure-Python, cross-platform); reserve the BTEQ driver for hosts that already have TTU.
+
+### BTEQ driver template (disconnected mode)
+
+The AI emits one `.sql` file per query under a `sql/` subfolder, alongside a driver
+`collect.btq`. This is a **template to generate, not a shipped file**; it is READ-ONLY
+(SELECT against `DBC` only) and safe for a DBA to run on production.
+
+**Fixed bundle contract — generate exactly these 14 files with these names.** The `.sql`
+stem, the `.EXPORT` CSV stem, and the parser key are all the same string, so the names are a
+contract, not a free choice. Where one `DBC` view backs several queries, the grain suffix
+disambiguates:
+
+| `.sql` file (→ same-stem `.csv`) | DBC view | grain / purpose |
+|----------------------------------|----------|-----------------|
+| `manifest` | DBCInfoV | provenance: collected_at + td_version |
+| `dbc_dbcinfov` | DBCInfoV | version / release |
+| `dbc_diskspacev` | DiskSpaceV | per-database perm space |
+| `dbc_tablesizev_by_table` | TableSizeV | per-table size (top tables) |
+| `dbc_tablesizev_by_amp` | TableSizeV | per-AMP space (skew + AMP count) |
+| `dbc_tablesv` | TablesV | object counts by TableKind |
+| `dbc_ampusagev` | AMPUsageV | cumulative CPU/IO by account+user |
+| `dbc_dbqlogtbl` | DBQLogTbl | availability probe (row count) |
+| `dbc_dbqlogtbl_summary` | DBQLogTbl | overall stats |
+| `dbc_dbqlogtbl_by_statement` | DBQLogTbl | statement-type mix |
+| `dbc_dbqlogtbl_by_user` | DBQLogTbl | top users |
+| `dbc_dbqlogtbl_by_hour` | DBQLogTbl | count by hour (peak_hour) |
+| `dbc_resusagespma` | ResUsageSpma | availability probe (row count) |
+| `dbc_resusagespma_summary` | ResUsageSpma | CPU-busy% summary |
+
+`ColumnsV` / `IndicesV` / `SHOW` are **not** in this bundle — they run during conversion (see
+"Object inventory" above). Driver step order follows the table top-to-bottom. Example driver:
+
+```bteq
+/* collect.btq — generated BTEQ driver (READ-ONLY). Run from the bundle root. */
+.LOGON <HOST>/<USER>
+.SET WIDTH 500
+.SET TITLEDASHES OFF
+.SET FOLDLINE OFF
+
+.EXPORT REPORT FILE=dbc_diskspacev.csv
+.RUN FILE = sql/dbc_diskspacev.sql
+.EXPORT RESET
+
+/* ... one .EXPORT REPORT / .RUN FILE / .EXPORT RESET triple per query ... */
+
+.LOGOFF
+.QUIT
+```
+
+BTEQ dot-commands used, and why:
+
+| Command | Purpose |
+|---------|---------|
+| `.LOGON <HOST>/<USER>` | connect; BTEQ prompts for the password (never hard-code it) |
+| `.SET WIDTH 500` | widen the line so long pipe-delimited records aren't truncated |
+| `.SET TITLEDASHES OFF` | suppress the `---` dashed separator row under column titles |
+| `.SET FOLDLINE OFF` | keep each record on one physical line (no wrapping) |
+| `.EXPORT REPORT FILE=<view>.csv` | send the next query's output to a text file (`REPORT`, not `DATA` which is binary) |
+| `.RUN FILE = sql/<view>.sql` | run the query from its static `.sql` file |
+| `.EXPORT RESET` | close the current export before the next one |
+
+Each query emits one `TRIM(...) || '|' || TRIM(...)` record per row (pipe-delimited), so
+the output parses without a header. If a view is unavailable (DBQL/ResUsage logging off, or
+no permission) that step yields an empty/short file and collection continues.
+
+**How a human runs the bundle:** edit the `.LOGON` line (`<HOST>`/`<USER>`), then from the
+bundle root (so the relative `sql/` paths resolve) run `bteq < collect.btq` (BTEQ prompts
+for the password) and return every `dbc_*.csv` plus `manifest.csv` produced.
+
+> Source endpoints (host/port/user) come from `migration-config.yaml` — operator-provided,
+> never hard-coded in the skill.

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/orchestration.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/orchestration.md
@@ -1,0 +1,122 @@
+# Orchestration — phase workflow & state model
+
+> AI-facing knowledge (the AI reads this to drive the migration); it is **not** executed code.
+> The patterns below were proven in the pre-restructure `tools/orchestrator.py` engine; here
+> they are guidance for how *you (the AI)* sequence phases and persist state in files.
+
+## Purpose
+Describe how the AI sequences a Teradata→Redshift migration end to end, how state is
+persisted so work is resumable, and how execution adapts to the customer's connectivity.
+
+## Phases
+Run in order; each phase's `result/` is the durable hand-off that feeds the next.
+
+| # | Phase | Reads | Produces (`output/<phase>/result/`) |
+|---|-------|-------|-------------------------------------|
+| 1 | **Discovery** | `references/teradata/discovery-queries.md` | `discovery/result/inventory.json` |
+| 2 | **Conversion** (incl. code review) | `conversion-rules.md`, `data-type-mapping.md`, `architecture-mapping.md`, `stored-procedure-migration.md`, `bteq-to-rsql.md`, `common-errors.md` | `conversion/result/{ddl,sql,procedures,rsql}/`, `manual_review.json` |
+| 3 | **Data migration** | `data-migration-patterns.md`, `inventory.json` | `data_migration/result/{extract,load,templates}/`, `migration_manifest.json` |
+| 4 | **Validation** | `validation-patterns.md`, `migration_manifest.json` | `validation/result/validation_report.json` |
+| 5 | **Performance** | `performance.md` | `performance/result/{perf_baseline,perf_compare}.json` |
+| 6 | **Reporting** | `reporting.md` + every prior `result/` | `reporting/result/migration_report.md` |
+
+> Conversion folds in a **code-review gate**: low conversion confidence (scored per the rubric
+> in `conversion-rules.md`) or constructs with no deterministic rule (functions, triggers, join
+> indexes, `RESET WHEN`) are written to `manual_review.json` and pause the run — see
+> *HITL gate* below.
+
+## Phase status lifecycle
+Every phase has exactly one explicit status. Record it in `state.md` so the run is observable.
+
+```
+PENDING ──▶ RUNNING ──▶ SUCCESS        (continue to next phase)
+                   │
+                   ├──▶ SKIPPED         (phase not applicable this run; continue)
+                   ├──▶ NEEDS_REVIEW    (HITL pause — a human must decide, then resume)
+                   └──▶ FAILED          (stop — diagnose, fix, resume)
+```
+
+- **SUCCESS / SKIPPED** let the pipeline proceed.
+- **NEEDS_REVIEW / FAILED** stop the run. Resume re-enters at the first non-`SUCCESS` phase,
+  which is what makes resume idempotent (already-`SUCCESS` phases are not redone).
+
+## HITL gate (when to pause for human review)
+Pause the phase as `NEEDS_REVIEW` — do **not** silently proceed — when:
+
+- **Conversion:** an object's **conversion confidence < threshold** (default `0.70`, matching the rubric's High-weight auto-flag ceiling in `conversion-rules.md`; scored per
+  the rubric in `conversion-rules.md`), any **manual-review items** are flagged, or the object
+  kind has no deterministic rule (function / trigger / join index). Summarize as
+  `{objects, needs_review, min_confidence}`.
+- **Data migration:** **any** table failed to extract/stage/load. Validating a partial load
+  as if it were complete hides real problems — pause instead.
+- **Validation:** any table's status is `fail` and the operator has not accepted the diff.
+
+After a human decides, record the decision and call resume.
+
+## State model (resumability)
+
+- All generated artifacts live under `output/` (git-ignored) in the user's working dir.
+- `output/state.md` is the **single source of truth** for progress — the durable cursor that
+  survives process restarts, machine changes, and disconnected copy-backs.
+- **Durable vs ephemeral:** the per-phase status + the pointer to each phase's `result/` are
+  durable (written to `state.md` / files). Live in-memory objects (the discovery `inventory`,
+  the migration `manifest`) are **ephemeral** — intentionally not persisted. On a resumed run
+  the AI re-derives them by reading the prior phase's `result/` (e.g. re-read `inventory.json`)
+  rather than expecting them in memory.
+- After every phase transition, update `state.md` **before** starting the next phase.
+
+### `state.md` schema (example)
+
+```markdown
+# Migration run state
+run_id: acme-edw-2026-06-29
+source_db: teradata
+strategy: full-load
+updated: 2026-06-29T17:40:00Z
+
+| phase          | status        | result pointer                                   | note |
+|----------------|---------------|--------------------------------------------------|------|
+| discovery      | success       | output/discovery/result/inventory.json           | 3 schemas, 214 tables |
+| conversion     | needs_review  | output/conversion/result/manual_review.json      | 7 objects < 0.8 confidence |
+| data_migration | pending       | —                                                | |
+| validation     | pending       | —                                                | |
+| performance    | pending       | —                                                | |
+| reporting      | pending       | —                                                | |
+```
+
+Keep one row per phase. `result pointer` is the relative path the next phase reads.
+
+## Hand-off contract between phases
+
+- A phase may start only when the **previous phase's status is `SUCCESS`** (or `SKIPPED` when
+  not applicable) and its `result/` artifact exists and is readable.
+- Each phase reads **only** its declared inputs (see the Phases table) — never another phase's
+  in-memory state. This keeps every phase independently runnable and testable.
+- A phase writes its outputs to `result/` **before** marking itself `SUCCESS`, so a crash
+  between "wrote files" and "marked success" simply re-runs the phase (idempotent).
+
+## Decision points (guidance for the AI)
+
+- **Full vs incremental load** — default to `full-load` (truncate-and-reload, idempotent). Use
+  incremental/CDC only when the table is too large to reload in the cutover window *and* a
+  reliable high-water-mark column exists. See `data-migration-patterns.md`.
+- **Connected vs disconnected** — see Execution modes. Decide once at run start; it changes
+  whether you run scripts in place or emit a bundle.
+- **Stop vs continue on a failed object** — a single failed table or low-confidence conversion
+  pauses the run for review; it does not abort the whole migration. Other tables already
+  `SUCCESS` are preserved.
+
+## Execution modes
+
+- **Connected** — agent host can reach TD/RS → it runs generated scripts in place and writes
+  `result/` directly.
+- **Disconnected** — agent emits a self-contained `output/<phase>/` bundle (script + co-located
+  creds template + relative `result/` + `run-instructions.md`); the operator runs it on a
+  reachable host and copies `result/` back. The copied-back `result/` (+ `state.md`) is the
+  durable state — read it and continue from the first non-`SUCCESS` phase.
+
+## See also
+
+- `SKILL.md` — phase list and project-workspace layout (keep this table in sync with it).
+- `data-migration-patterns.md` — `migration_manifest.json` contract consumed by validation.
+- `validation-patterns.md` — `validation_report.json` consumed by reporting.

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/performance.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/performance.md
@@ -1,0 +1,149 @@
+# Performance — baseline, comparison & Redshift sizing
+
+> AI-facing knowledge: how to extract a representative Teradata workload, compare it
+> against Redshift after migration, and size the target cluster from the source profile.
+> The AI generates the extraction/replay runner; this doc is the knowledge.
+
+## Purpose
+
+1. Establish a Teradata **performance baseline** (workload + resource profile) →
+   `output/performance/result/perf_baseline.json`.
+2. **Compare** the same queries on Redshift after migration →
+   `output/performance/result/perf_compare.json`.
+3. Feed **Redshift sizing** from the source `inventory.json` (see Sizing below).
+
+Inputs come from `references/teradata/discovery-queries.md` (`inventory.json`) plus the two
+workload sources here. Both are **read-only**.
+
+> **Source of truth:** the DBQL/ResUsage extraction queries in this doc ARE the source of
+> truth. The skill ships no executable collector — the AI generates the runner at run time
+> (BTEQ driver template in `references/teradata/discovery-queries.md` → Execution modes).
+
+## Workload extraction (DBQL)
+
+`DBC.DBQLogTbl` holds query history. It is **often disabled** — probe first
+(`SELECT COUNT(*) FROM DBC.DBQLogTbl`); 0 rows → mark `query_log` unavailable and skip the
+rich stats (the baseline still produces from AMPUsage + ResUsage).
+
+```sql
+-- Overall stats (one row; empty when logging off).
+SELECT TRIM(CAST(COUNT(*) AS BIGINT)) || '|' ||
+       TRIM(CAST(COUNT(DISTINCT UserName) AS INTEGER)) || '|' ||
+       TRIM(CAST(CAST(AVG(AMPCPUTime) AS DECIMAL(18,4)) AS VARCHAR(40))) || '|' ||
+       TRIM(CAST(CAST(MAX(AMPCPUTime) AS DECIMAL(18,4)) AS VARCHAR(40))) || '|' ||
+       TRIM(CAST(SUM(TotalIOCount) AS BIGINT)) AS rec
+FROM DBC.DBQLogTbl
+HAVING COUNT(*) > 0;
+
+-- Mix by StatementType (ETL vs BI → WLM queues).
+SELECT TRIM(StatementType) || '|' || TRIM(CAST(COUNT(*) AS BIGINT)) AS rec
+FROM DBC.DBQLogTbl GROUP BY StatementType ORDER BY COUNT(*) DESC;
+
+-- Top query-issuing users.
+SELECT TRIM(UserName) || '|' || TRIM(CAST(COUNT(*) AS BIGINT)) || '|' ||
+       TRIM(CAST(CAST(SUM(AMPCPUTime) AS DECIMAL(18,4)) AS VARCHAR(40))) AS rec
+FROM DBC.DBQLogTbl GROUP BY UserName ORDER BY COUNT(*) DESC;
+
+-- Concurrency/peak proxy: query count by hour-of-day.
+SELECT TRIM(CAST(EXTRACT(HOUR FROM StartTime) AS INTEGER)) || '|' ||
+       TRIM(CAST(COUNT(*) AS BIGINT)) AS rec
+FROM DBC.DBQLogTbl
+GROUP BY EXTRACT(HOUR FROM StartTime)
+ORDER BY EXTRACT(HOUR FROM StartTime);
+```
+
+`peak_hour` = the hour bucket with the max count; it sizes Concurrency Scaling / WLM slots.
+
+## Resource extraction (ResUsage)
+
+`DBC.ResUsageSpma` is the per-node system resource time series — node-level CPU/memory.
+It is enabled at **node level** (`ctl`/`dbscontrol`), **not via SQL**.
+
+> The shared test cluster now has `ResUsageSpma` logging **ON at a 60s interval**, so this
+> query was validated against real samples (see the validated note below).
+
+```sql
+-- System resource summary (one row; empty when logging off).
+--   cpu_busy% = (CPUUExec + CPUUServ) / (CPUUExec + CPUUServ + CPUIdle) * 100   [VALIDATED]
+-- NOTE: ResUsageSpma.MemSize is NOT physical node RAM (see validated note below) — do not
+-- derive total RAM from it. Source RAM for sizing comes from node spec / operator.
+SELECT TRIM(CAST(COUNT(*) AS BIGINT)) || '|' ||
+       TRIM(CAST(COUNT(DISTINCT NodeID) AS INTEGER)) || '|' ||
+       TRIM(CAST(CAST(AVG((CPUUExec + CPUUServ) * 100.0
+            / NULLIFZERO(CPUUExec + CPUUServ + CPUIdle)) AS DECIMAL(6,2)) AS VARCHAR(20))) || '|' ||
+       TRIM(CAST(CAST(MAX((CPUUExec + CPUUServ) * 100.0
+            / NULLIFZERO(CPUUExec + CPUUServ + CPUIdle)) AS DECIMAL(6,2)) AS VARCHAR(20))) AS rec
+FROM DBC.ResUsageSpma
+HAVING COUNT(*) > 0;
+```
+
+**Gotcha:** `EXTRACT(HOUR FROM ResUsageSpma.TheTimestamp)` fails (Failure 5326) — a
+per-hour ResUsage breakdown needs a different time column/derivation than the DBQL
+`StartTime` form above. Keep ResUsage to the summary until the time grain is validated.
+
+> **Validated live (2026-06-24, 12,272 samples / 2 nodes):** the cpu-busy formula is
+> correct; the dev cluster is near-idle (avg **0.05%**, max **2.13%**). `MemSize` is **not**
+> physical RAM (~126,844 per sample — not bytes), so the RAM-from-MemSize derivation was
+> dropped. Source RAM for memory-bound sizing must come from node spec / operator — see
+> `references/teradata/sizing.md`.
+
+## Baseline → compare
+
+- **Representative-query selection** — take the top queries by frequency × cost from DBQL
+  (`by_user` / statement mix), capture each query's TD runtime and `AMPCPUTime`/IO.
+- **Replay** — run the *converted* queries (converted per `references/teradata/conversion-rules.md`) on
+  Redshift; capture runtime/cost from `SVL_QUERY_REPORT` / `STL_QUERY`.
+- **Compare** — per-query and aggregate deltas; flag regressions.
+
+**Fairness notes:** control for warm vs cold cache (run twice, report warm), match
+concurrency (the dev cluster has a **system concurrency limit of 2**), and document
+WLM/queue settings on both sides. Compare like-for-like result sets.
+
+### `perf_baseline.json` (Teradata)
+
+```json
+{
+  "source": "teradata",
+  "window": { "from": null, "to": null, "note": "DBQL retention window" },
+  "query_stats": {
+    "total_queries": 0, "distinct_users": 0,
+    "avg_amp_cpu": 0.0, "max_amp_cpu": 0.0, "total_io": 0,
+    "by_statement": [{ "statement_type": "Select", "count": 0 }],
+    "by_hour": [{ "hour": 0, "count": 0 }],
+    "top_users": [{ "user": "tester", "count": 0, "cpu": 0.0 }],
+    "peak_hour": null, "peak_hour_count": 0
+  },
+  "resource_stats": {
+    "sample_count": 0, "node_count": 2,
+    "avg_cpu_busy_pct": null, "max_cpu_busy_pct": null
+  },
+  "representative_queries": [
+    { "id": "q1", "sql": "...", "td_runtime_s": 0.0, "amp_cpu": 0.0, "io": 0 }
+  ]
+}
+```
+
+### `perf_compare.json` (Redshift vs Teradata)
+
+```json
+{
+  "pairs": [
+    { "id": "q1", "td_runtime_s": 0.0, "rs_runtime_s": 0.0, "delta_pct": 0.0, "status": "ok|regression" }
+  ],
+  "aggregate": { "queries": 0, "median_delta_pct": 0.0, "regressions": 0 },
+  "notes": "warm-cache, concurrency-matched"
+}
+```
+
+`query_stats` / `resource_stats` reuse the `inventory.json` workload shape
+(`references/teradata/discovery-queries.md`) — populated only when DBQL / ResUsage are available.
+
+## Redshift sizing
+
+Sizing the Redshift target from this profile (RG node type + count, CPU- vs memory-bound
+decision, concurrency/WLM) is covered in **`references/teradata/sizing.md`**. Performance feeds it
+the workload signals: `resource_stats.avg_cpu_busy_pct` (bottleneck) and `query_stats`
+(peak-hour concurrency + statement mix for WLM).
+
+> Source endpoints come from `migration-config.yaml` — operator-provided, never hard-coded
+> in the skill.

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/reporting.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/reporting.md
@@ -1,0 +1,84 @@
+# Reporting — migration status report
+
+> AI-facing knowledge: how to aggregate every phase's artifacts into a single report.
+
+## Purpose
+
+Roll up the per-phase `result/` artifacts into one customer-facing migration report at
+`output/reporting/result/migration_report.md` (plus optional `.json` for machines / `.html` for
+sharing). The report answers: what was migrated, how much was automated, what passed validation,
+how performance compares, and what manual work remains.
+
+## Inputs (the data contracts it aggregates)
+
+| Phase | Artifact | What the report pulls |
+|-------|----------|------------------------|
+| Discovery | `discovery/result/inventory.json` | object counts by type, total tables/rows/size |
+| Conversion | converted DDL/SQL/RSQL + `conversion/result/manual_review.json` | objects converted, confidence scores, manual-review backlog |
+| Data migration | `data_migration/result/migration_manifest.json` | tables loaded, row counts, bytes, per-table status |
+| Validation | `validation/result/validation_report.json` | per-table pass/fail, mismatches |
+| Performance | `performance/result/perf_baseline.json`, `perf_compare.json` | TD vs RS runtimes, regressions |
+
+Read whatever artifacts exist (a partial run still produces a partial report — note missing phases
+rather than failing).
+
+## Report sections
+
+1. **Executive summary** — scope (databases/objects/rows), **% automated** (objects converted at
+   high confidence with no manual-review items ÷ total), validation pass rate, headline perf delta,
+   count of open manual items.
+2. **Discovery** — inventory snapshot (objects by type, largest tables).
+3. **Conversion** — converted vs flagged, confidence distribution, unconvertible kinds
+   (function/trigger/join-index). Pull the backlog from `manual_review.json`.
+4. **Data migration** — tables migrated, total rows/bytes, failures (from the manifest).
+5. **Validation** — pass/fail per table, summary of mismatches and tolerances applied.
+6. **Performance** — per-query and aggregate TD→RS deltas; call out regressions.
+7. **Manual-review backlog** — consolidated list (construct, location, suggested fix, owner)
+   sourced from conversion confidence + flagged items.
+8. **Risks & next steps** — anything blocking cutover.
+
+## `migration_report.json` (machine-readable shape)
+
+```json
+{
+  "generated_at": "ISO-8601",
+  "scope": {"databases": 2, "tables": 31, "rows": 19500000},
+  "summary": {
+    "objects_total": 0, "objects_converted": 0, "pct_automated": 0.0,
+    "validation_pass_rate": 0.0, "manual_review_items": 0,
+    "perf_delta_pct_median": 0.0
+  },
+  "phases": {
+    "discovery":   {"status": "complete", "artifact": "discovery/result/inventory.json"},
+    "conversion":  {"status": "complete", "converted": 0, "flagged": 0, "low_confidence": 0},
+    "data_migration": {"status": "complete", "tables_loaded": 0, "tables_failed": 0, "rows": 0},
+    "validation":  {"status": "complete", "tables_passed": 0, "tables_failed": 0},
+    "performance": {"status": "complete", "regressions": 0}
+  },
+  "manual_review": [
+    {"object": "db.proc_x", "construct": "QUALIFY+GROUP BY", "confidence": 0.7, "suggestion": "…"}
+  ],
+  "risks": []
+}
+```
+
+## How automation % + backlog roll up
+
+- The conversion phase assigns a **confidence score** (per the rubric in
+  `conversion-rules.md`) and **manual-review items** per object. Count an object as "automated"
+  when confidence is high **and** it has zero manual-review items **and** it isn't an
+  unconvertible kind. `pct_automated` = automated ÷ total objects.
+- The **backlog** = union of all objects with manual-review items or below the confidence threshold,
+  carrying the construct + suggested fix straight from the conversion output (`manual_review.json`) — that's the actionable
+  to-do list for the team.
+
+## Generation notes
+
+- The AI generates the report script/templating at runtime; this doc is the **structure + contract**,
+  not code.
+- Keep numbers traceable: every figure should be derivable from a named artifact above.
+
+## TODO / extend
+
+- `manual_review.json` schema is defined in `conversion-rules.md` (producer). The report reads its `items[]` (object, object_kind, construct, suggested_rewrite, confidence, status) + `summary` for the backlog and % automated.
+- Add an HTML template once a sample full run exists.

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/sizing.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/sizing.md
@@ -1,0 +1,138 @@
+# Redshift sizing (from the source profile)
+
+> AI-facing knowledge: how to draft a Redshift target cluster from the source
+> `inventory.json` (see `references/teradata/discovery-queries.md`) and workload signals (see
+> `references/teradata/performance.md`). Facts in, a sizing recommendation out.
+
+## Philosophy
+
+Target **RG (Graviton) provisioned** nodes. **Node count is driven by parallelism or
+memory — never by raw data volume.** Teradata `ResUsage` decides the bottleneck:
+
+- **CPU-bound** (avg CPU busy ≥ threshold) → size by **parallelism**: source AMPs → target
+  slices, `node_count = ceil(target_slices / slices_per_node)`.
+- **memory-bound** (below threshold) → size by **RAM**: target aggregate RAM ≈ source RAM,
+  `node_count = ceil(total_ram_gib / ram_per_node)`.
+- **ResUsage unavailable** → fall back to **parallelism** (AMP count is always known) at
+  lower confidence; flag that CPU- vs memory-bound was not verified.
+
+Managed storage on RG is decoupled and large, so storage is **only a capacity check**,
+never the node-count driver.
+
+> Target is **RG (Graviton), not RA3.**
+
+## RG node specs
+
+> **Verify against the live API before sizing** — node specs and limits change as AWS updates
+> the lineup. Treat the table below as a **fallback/example snapshot** (per the AWS *Amazon
+> Redshift Management Guide* — "Clusters and nodes in Amazon Redshift → Node type details"),
+> and confirm current values at runtime:
+> `aws redshift describe-orderable-cluster-options --query 'OrderableClusterOptions[?starts_with(NodeType, \`rg.\`)].{NodeType:NodeType}' --output table`
+> plus the Management Guide spec table for vCPU/RAM/slices/storage.
+
+Resolve the full candidate list and per-node specs **at runtime** (API + Management Guide).
+Illustration of the *shape* of one fetched record (example row, retrieved 2026-07; do not
+reuse the values — fetch current ones):
+
+| RG node (example) | vCPU | RAM | default slices/node | managed storage / node | node range (create) |
+|---------|------|-----|---------------------|------------------------|---------------------|
+| `rg.xlarge` (multi-node) | 4 | 32 GiB | 2 | 32 TB | 2–16 |
+
+Minimum cluster = 2 nodes. "Default slices per node" is the create-time value (elastic
+resize keeps the cluster's *total* slice count constant while changing node count). For
+RA3→RG equivalences, consult the current AWS documentation/API rather than fixed mappings —
+node lineups and equivalences change.
+
+> **Node-count clamp bounds:** clamp to the **create-time node range** — not the
+> elastic-resize maximums — since the skill provisions a new cluster. The Logic below consumes
+> `max_nodes(node_type)` **fetched at runtime** from `aws redshift
+> describe-orderable-cluster-options`; the table above is illustrative only and is never read
+> by the Logic.
+>
+> Source: <https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html#rs-rg-nodes-table>
+
+## Inputs (from `inventory.json`)
+
+| Input | Field | Use |
+|-------|-------|-----|
+| Source AMPs | `system.amp_count` | parallelism → target slices |
+| CPU busy % | `workload.resource_stats.avg_cpu_busy_pct` | bottleneck decision |
+| Source RAM | node hardware spec / operator (**not** ResUsage — see note) | memory-bound path |
+| Storage | `storage.total_current_perm_bytes` | capacity check only |
+| Workload mix / peak | `workload.query_stats` (DBQL) | Concurrency Scaling + WLM |
+
+## Logic
+
+Resolve per-node specs **at runtime** before sizing — `slices(n)`, `ram_gib(n)`, `max_nodes(n)`
+for each candidate node type — from `aws redshift describe-orderable-cluster-options` (node
+types + node ranges) and the Management Guide spec table (slices/RAM). The logic below is
+**symbolic**: it references only those fetched values, never literal numbers. Candidates are
+ordered smallest→largest (e.g. `rg.xlarge` → `rg.4xlarge` → `rg.12xlarge`).
+
+```
+fetch candidates C = ordered list of RG node types with slices(c), ram_gib(c), max_nodes(c)
+
+if resource_stats.avg_cpu_busy_pct is not null:
+    if avg_cpu_busy_pct >= CPU_BOUND_PCT:        # cpu-bound
+        target_slices = max(slices(C[0]) * 2, ceil(amp_count * SLICE_PER_AMP))
+        node_type  = smallest c in C where target_slices <= slices(c) * max_nodes(c)
+        node_count = clamp(ceil(target_slices / slices(node_type)), 2, max_nodes(node_type))
+    else:                                         # memory-bound
+        node_type  = smallest c in C where total_ram_gib <= ram_gib(c) * max_nodes(c)
+        node_count = clamp(ceil(total_ram_gib / ram_gib(node_type)), 2, max_nodes(node_type))
+else:                                             # ResUsage absent → fallback
+    size by parallelism (as cpu-bound), confidence = low
+
+# The Logic targets the smallest multi-node production type (rg.xlarge today) as the floor.
+# rg.large has the same slice count but half the vCPU/RAM per slice — consider it for
+# cost-sensitive workloads. Storage is only a capacity check; raise node_count if the
+# fetched managed-storage-per-node capacity is exceeded.
+```
+
+## Recommendation shape
+
+```json
+{
+  "node_type": "rg.xlarge",
+  "node_count": 2,
+  "sizing_basis": "parallelism: AMP->slices (cpu-bound per ResUsage)",
+  "bottleneck": "cpu-bound|memory-bound|unknown",
+  "basis_detail": { "source_amps": 24, "slice_per_amp": 1.0, "target_slices": 24, "slices_per_node": 2 },
+  "storage_check": { "source_total_current_perm_bytes": 0, "cluster_managed_capacity_bytes": 0, "sufficient": true },
+  "concurrency_notes": "peak-hour arrival → Concurrency Scaling / WLM slots",
+  "wlm_notes": "statement mix → ETL vs BI queues",
+  "assumptions": ["DRAFT: AMP->slice ratio and CPU-bound threshold are placeholders pending calibration."],
+  "confidence": "low|medium|high"
+}
+```
+
+Confidence is `high` only when both ResUsage and DBQL are present; `medium` with ResUsage
+only; `low` on the parallelism fallback.
+
+## Calibration placeholders (not yet validated)
+
+- `slice_per_amp = 1.0` — Graviton slices are more powerful, so a 1:1 AMP:slice mapping is
+  likely **conservative**. Calibrate against a real workload.
+- `cpu_bound_pct = 60` — the avg-CPU-busy threshold separating CPU- vs memory-bound.
+
+## ResUsage validation (live cluster, 2026-06-24)
+
+Validated against `DBC.ResUsageSpma` (logging ON @60s; 12,272 samples, 2 nodes):
+
+- ✅ **CPU-busy formula is correct**: `(CPUUExec + CPUUServ) / (CPUUExec + CPUUServ +
+  CPUIdle) * 100`. The dev cluster is near-idle (avg 0.05%, max 2.13%) — plausible, so the
+  cpu-bound path and the bottleneck decision are sound.
+- ⚠️ **`ResUsageSpma.MemSize` is NOT physical node RAM** (observed ~126,844 per sample —
+  not bytes, ≈124 MB-scale). The earlier `MemSize × nodes / 1 GiB` derivation yields ~0 and
+  is **invalid**. **Source aggregate RAM must come from the node hardware spec or operator
+  input (`migration-config`), not from ResUsage.** Until a reliable RAM source is wired in,
+  the **parallelism (CPU-bound) path is the dependable one**; the memory-bound branch needs
+  a RAM input before it can be trusted.
+
+## Placement (resolved)
+
+This sizing logic is deterministic, but per the team's **text-only** decision the skill ships
+**no scripts** — it stays here as knowledge and the AI applies it at runtime (same as
+conversion). No `scripts/` helper.
+
+> Source endpoints come from `migration-config.yaml` — operator-provided, never hard-coded in the skill.

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/stored-procedure-migration.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/stored-procedure-migration.md
@@ -1,0 +1,125 @@
+# Stored Procedure & Macro Migration — Teradata → Redshift PL/pgSQL
+
+## Stored procedure rules
+
+| Teradata | Redshift PL/pgSQL | Notes |
+|----------|-------------------|-------|
+| REPLACE PROCEDURE | CREATE OR REPLACE PROCEDURE | Add `LANGUAGE plpgsql AS $$ … $$` |
+| OUT param | INOUT param | Redshift PL/pgSQL requirement |
+| SET var = ACTIVITY_COUNT | GET DIAGNOSTICS var = ROW_COUNT | Row count after DML |
+| DECLARE EXIT HANDLER FOR SQLEXCEPTION | EXCEPTION WHEN OTHERS THEN | Exception block |
+| SQLCODE | SQLERRM | Text message, no numeric code in RS |
+| DEFAULT param_value | (remove) | DEFAULT not supported on RS params |
+| FORMAT 'fmt' in params | (remove) | Not applicable |
+
+## Macro rules
+
+**Classify the macro first** — it decides the target and whether the *caller* changes:
+
+1. **Single-SELECT macro → `VIEW`** (or inline SQL) — preserves the returned result set; no caller change.
+2. **Multi-statement, one result set → `PROCEDURE` returning a refcursor** (or a temp table the caller reads) — caller changes from `EXEC macro` to `CALL proc` + fetch; **flag in `manual_review.json`**.
+3. **Multi-statement, *multiple* result sets → split into N single-cursor `PROCEDURE`s.** Redshift opens **only one cursor per session**, so one procedure cannot return several refcursors — emit one procedure per result set (verified on the acceptance run). **Flag in `manual_review.json`.**
+4. **Multi-statement, no result set → `PROCEDURE`** (pattern below).
+
+| Teradata | Redshift | Notes |
+|----------|----------|-------|
+| CREATE/REPLACE MACRO | CREATE OR REPLACE PROCEDURE | Macros don't exist in RS |
+| :param binding | direct variable reference | PL/pgSQL uses names directly |
+| DEFAULT values | (remove) | Not supported |
+| EXEC macro_name | CALL procedure_name | Execution syntax |
+
+## PL/pgSQL wrapper template
+
+```sql
+CREATE OR REPLACE PROCEDURE schema.procedure_name(
+    IN p_param1 VARCHAR(100),
+    INOUT p_param2 INTEGER
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_row_count INTEGER;
+    v_error_msg VARCHAR(500);
+BEGIN
+    -- body
+
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    RAISE INFO 'Step 1 completed: % rows affected', v_row_count;
+
+EXCEPTION WHEN OTHERS THEN
+    v_error_msg := SQLERRM;
+    RAISE EXCEPTION 'Procedure failed: %', v_error_msg;
+END;
+$$;
+```
+
+## Key paradigm shifts
+
+- **Transaction model**: TD auto-commits each statement (outside BT/ET); Redshift
+  atomic SPs (default) wrap everything in one transaction; non-atomic SPs auto-commit
+  each DML/DDL outside BEGIN/COMMIT.
+- **Error handling**: `SQLCODE` (numeric) → `SQLERRM` (text).
+- **Logging**: prefer `RAISE INFO/NOTICE/WARNING` over INSERT into log tables (avoids
+  table-level locking). Messages land in `SVL_STORED_PROC_MESSAGES` (7-day retention);
+  aggregate to permanent tables daily if needed.
+- **Parameter defaults**: not supported — require all params at the call site.
+- **Row count**: `ACTIVITY_COUNT` → `GET DIAGNOSTICS var = ROW_COUNT`.
+- **Cursors**: similar syntax but different performance; prefer set-based rewrites.
+
+## DECIMAL overflow prevention
+
+`param * 0.8` (DECIMAL) can hit 128-bit overflow in Redshift. Cast first:
+
+```sql
+v_result := CAST(p_amount AS DECIMAL(38,10)) * 0.8;
+```
+
+## DATEADD returns TIMESTAMP
+
+Redshift `DATEADD` returns TIMESTAMP even for DATE input. Cast when DATE is expected:
+
+```sql
+v_date := CAST(DATEADD(day, 30, v_date) AS DATE);
+```
+
+## Multi-statement macro pattern (type 2 — returns a result set)
+
+```sql
+-- Teradata macro (ends in a SELECT → returns rows to the caller)
+REPLACE MACRO schema.my_macro (p_date DATE) AS (
+    DELETE FROM staging WHERE load_date < :p_date;
+    INSERT INTO staging SELECT * FROM source WHERE load_date = :p_date;
+    SELECT COUNT(*) FROM staging WHERE load_date = :p_date;
+);
+
+-- Redshift procedure — return the result set via a refcursor (preserves semantics)
+CREATE OR REPLACE PROCEDURE schema.my_macro(IN p_date DATE, INOUT rc REFCURSOR)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    DELETE FROM staging WHERE load_date < p_date;
+    INSERT INTO staging SELECT * FROM source WHERE load_date = p_date;
+    OPEN rc FOR SELECT COUNT(*) FROM staging WHERE load_date = p_date;
+END;
+$$;
+-- caller:  BEGIN; CALL schema.my_macro(DATE '2026-01-01', 'rc'); FETCH ALL FROM rc; COMMIT;
+```
+
+> The earlier `RAISE INFO` form only *logs* the count — it does **not** return rows. Use the
+> refcursor (or a temp table the caller reads), and **flag type-2 macros** in
+> `manual_review.json` (caller changes from `EXEC` to `CALL` + fetch).
+>
+> **Multiple result sets:** Redshift allows **one open cursor per session**, so a macro that
+> returns *several* result sets cannot become one procedure with N refcursors — **split it into
+> N single-cursor procedures** (one per result set), each called separately. (On the acceptance
+> run a 3-result-set AML macro became 3 procedures; a 2-result-set macro became 2.)
+
+## UDF conversion quick reference
+
+| Teradata | Redshift |
+|----------|----------|
+| ORDERED_CONCAT | LISTAGG |
+| INSTR | STRPOS or REGEXP_INSTR |
+| STRTOK_SPLIT_TO_TABLE | SPLIT_PART + REGEXP_COUNT |
+| Sel / Format / Substr / Oreplace | SELECT / TO_CHAR / SUBSTRING / REPLACE |
+| P_INTERSECT | Custom UDF (PERIOD not supported) |

--- a/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/validation-patterns.md
+++ b/skills/specialized-skills/analytics-skills/migrating-to-amazon-redshift/references/teradata/validation-patterns.md
@@ -1,0 +1,130 @@
+# Validation patterns
+
+> AI-facing knowledge: comparison strategies the AI uses to **generate** validation scripts.
+> Distilled from the proven pre-restructure `tools/validation/data_validator.py`.
+
+## Purpose
+Prove the migrated data matches the source, producing
+`output/validation/result/validation_report.json` for reporting to consume. Input is the
+table list + source counts from `migration_manifest.json` (see `data-migration-patterns.md`).
+
+## The five checks
+Run per table; each contributes to the table's pass/fail verdict.
+
+| Check | What it compares | Source SQL | Target SQL |
+|-------|------------------|-----------|-----------|
+| **row_counts** | total rows | `SELECT COUNT(*) FROM t` | `SELECT COUNT(*) FROM t` |
+| **aggregates** | numeric integrity | `SUM/MIN/MAX/AVG(col)`; `COUNT(DISTINCT key)` | same |
+| **sample_data** | row-level fidelity | dialect-aware sample (below) | `... ORDER BY key LIMIT n` |
+| **schema_comparison** | column parity | `information_schema.columns` (best-effort) | `information_schema.columns` |
+| **null_analysis** | NULL distribution | `COUNT(*) WHERE col IS NULL` | same |
+
+A run defaults to all five; callers can select a subset.
+
+## Tolerance & matching rules
+
+- **Counts (row counts, COUNT DISTINCT, NULL counts):** **exact** match required. Any difference is a failure.
+- **Numeric aggregates (SUM/MIN/MAX/AVG):** match within a **relative tolerance** to absorb
+  float/decimal representation differences between engines:
+  - `FLOAT_TOLERANCE = 0.0001` (0.01%).
+  - Equal values match. If source is `0`, target must be `0`. Otherwise match when
+    `abs(src - tgt) / abs(src) <= FLOAT_TOLERANCE`.
+  - Use exact comparison for integer/decimal keys where any drift is meaningful; reserve the
+    tolerance for floating aggregates.
+- **NULL handling:** a `NULL` aggregate is treated as `0` for comparison (`... or 0`) so an
+  empty column doesn't crash the compare; NULL **counts** themselves are compared exactly.
+
+## Sample comparison (dialect-aware)
+Teradata and Redshift differ in row-limit syntax, so generate the source query per dialect and
+always order by a stable key so both sides return the same rows:
+
+```sql
+-- Teradata source
+SELECT TOP <n> * FROM <table> ORDER BY <key>;
+-- Redshift source (non-teradata) and Redshift target
+SELECT * FROM <table> ORDER BY <key> LIMIT <n>;
+```
+
+Compare the returned row sets for equality. Default sample size `100`. For stronger coverage,
+sample on a hashed key set rather than just the top-N.
+
+## Schema comparison (best-effort)
+
+- Pull columns from `information_schema.columns` (name, type, nullable) ordered by `ordinal_position`.
+- Redshift supports `information_schema`; **Teradata may not** — if the source query fails, treat
+  schema validation as **best-effort and pass** rather than failing the table (don't block a
+  good data load on a metadata-source limitation). Compare column **count** and **names**
+  (case-insensitive); type parity is informational given the TD→RS type mapping.
+
+## Status determination
+Per table, collect the failing checks; the table is `fail` if **any** check fails, else `pass`.
+A check that **raises an exception** marks the table `fail` (never swallow the error silently).
+
+```
+failures = [
+  row_count   if row_count present and not match,
+  aggregates  if any aggregate not match,
+  sample_data if sample rows differ,
+  schema      if schema mismatch,
+  null        if any null count differs,
+]
+status = "fail" if failures else "pass"
+```
+
+`warning` is reserved for non-blocking discrepancies (e.g. best-effort schema skipped).
+
+## `validation_report.json` schema
+
+```json
+{
+  "tables": [
+    {
+      "table": "sales.orders",
+      "row_count": { "source": 1280344, "target": 1280344, "match": true },
+      "aggregates": [
+        { "column": "amount", "metric": "SUM", "source": 98123.45, "target": 98123.45, "match": true }
+      ],
+      "nulls": [
+        { "column": "ship_date", "source_nulls": 12, "target_nulls": 12, "match": true }
+      ],
+      "schema_match": true,
+      "sample_match": true,
+      "status": "pass"
+    }
+  ],
+  "summary": { "total": 1, "passed": 1, "failed": 0, "warnings": 0 },
+  "confidence_score": 1.0
+}
+```
+
+- `summary` counts tables by status.
+- `confidence_score` = `passed / total` (0.0–1.0) — the headline migration-quality number for the report.
+
+## How failures feed back
+
+- A `fail` table is surfaced in the report with its specific failing checks and the source/target
+  values, so the operator can see *what* diverged, not just *that* it did.
+- Failures map back to `migration_manifest.json` tables → the operator can **re-migrate just the
+  failed tables** (full-load is idempotent: truncate + reCOPY) and re-validate, rather than redoing
+  the whole run. See `data-migration-patterns.md`.
+- The validation phase pauses as `NEEDS_REVIEW` when any table fails and the diff hasn't been
+  accepted — see the HITL gate in `orchestration.md`.
+
+## Security & reliability rules
+
+- **Validate every identifier** (table, column, schema) before inlining it into SQL — same
+  injection guard as data migration (`^[a-zA-Z_][a-zA-Z0-9_.]*$` for dotted names).
+- Use a **read-only** connection on both sides; put a timeout on every query.
+- Run aggregate/sample checks on a representative column set (keys + key numeric/date columns) —
+  validating every column on every row doesn't scale; counts + targeted aggregates + sampling
+  give high confidence at reasonable cost.
+- To inspect COPY load failures, use the **documented** views only: `SYS_LOAD_ERROR_DETAIL`
+  (Serverless + provisioned) or `STL_LOAD_ERRORS` (provisioned). There is no
+  `SVL_LOAD_ERRORS` — do not invent system-view names; if unsure, verify against the
+  public system-tables reference before citing one.
+
+## See also
+
+- `data-migration-patterns.md` — produces `migration_manifest.json` (source counts, table list) consumed here.
+- `reporting.md` — consumes `validation_report.json` (`confidence_score`, per-table status).
+- `orchestration.md` — validation's place in the pipeline and its HITL gate.


### PR DESCRIPTION
## Summary

Adds the `migrating-to-amazon-redshift` skill for Amazon Redshift. Covers end-to-end data-warehouse migration: discovery, schema/SQL/stored-procedure/macro/script conversion, data migration, validation, performance comparison, and reporting. Source-routed via `references/<source>/`; Teradata (Vantage) is the supported source.

## Details

- Text-only (no executable code)
- Security-reviewed: Guardian PASS
- Tested with: Kiro (multiple frontier models)

## Checklist

- [x] No internal links or references in skill content
- [x] No internal details in commit messages
- [x] CI checks pass
