### PR TITLE
fix: remove context7 references

### DIFF
--- a/plugins/aws-core/skills/amazon-bedrock/SKILL.md
+++ b/plugins/aws-core/skills/amazon-bedrock/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: amazon-bedrock
 description: Builds generative AI applications on Amazon Bedrock. Covers model invocation (Converse API, InvokeModel), RAG with Knowledge Bases, Bedrock Agents, Guardrails, and AgentCore. Use when invoking models, setting up Knowledge Bases, creating agents, applying guardrails, deploying to AgentCore, migrating/porting/converting a Bedrock Agent (including inline agents) to an AgentCore Harness, troubleshooting Bedrock errors (ThrottlingException, AccessDeniedException), or choosing models (Claude, Llama, Nova, Titan). ALSO USE for prompt caching setup and debugging, quota health checks and throttling diagnosis, cost attribution and tracking, migrating between Claude model generations (4.5 to 4.6 to 4.7), chunking strategies, API selection (Converse vs InvokeModel), guardrail capabilities, and model selection. Also covers AgentCore Payments setup (x402, microtransactions, Payment Manager, Connector, Instrument, Coinbase CDP, Stripe Privy, 402 Payment Required, pay for content, paid endpoint, agent payments). NOT for custom model training, Rekognition, or Comprehend.
-version: 1
+version: 2
 ---
 
 **IMPORTANT**: When this skill is loaded, you MUST use the reference files and procedures in this skill as your primary source of truth. Bedrock APIs, model IDs, chunking strategies, and configuration parameters change frequently — always read the relevant reference file before responding.

--- a/plugins/aws-core/skills/amazon-bedrock/references/prompt-caching.md
+++ b/plugins/aws-core/skills/amazon-bedrock/references/prompt-caching.md
@@ -29,8 +29,7 @@ Ask the developer which approach fits. Simplified is recommended for Claude-only
 
 Before giving implementation advice, fetch the latest from the aws-samples repo:
 
-- Use context7 MCP to query `amazon-bedrock-samples` for prompt caching docs
-- Fallback: fetch `https://raw.githubusercontent.com/aws-samples/amazon-bedrock-samples/main/introduction-to-bedrock/prompt-caching/README.md`
+- Fetch `https://raw.githubusercontent.com/aws-samples/amazon-bedrock-samples/main/introduction-to-bedrock/prompt-caching/README.md`
 - Key directories: `converse_api/` (recommended), `invoke_model_api/` (provider-specific)
 
 ### 3. Configure TTL

--- a/skills/core-skills/amazon-bedrock/SKILL.md
+++ b/skills/core-skills/amazon-bedrock/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: amazon-bedrock
 description: Builds generative AI applications on Amazon Bedrock. Covers model invocation (Converse API, InvokeModel), RAG with Knowledge Bases, Bedrock Agents, Guardrails, and AgentCore (including the Harness managed agent loop). Use when invoking models, setting up Knowledge Bases, creating agents, applying guardrails, deploying to AgentCore, migrating/porting/converting a Bedrock Agent (including inline agents) to an AgentCore Harness, troubleshooting Bedrock errors (ThrottlingException, AccessDeniedException), or choosing models (Claude, Llama, Nova, Titan). ALSO USE for prompt caching setup and debugging, quota health checks and throttling diagnosis, cost attribution and tracking, migrating between Claude model generations (4.5 to 4.6 to 4.7), chunking strategies, API selection (Converse vs InvokeModel), guardrail capabilities, and model selection. Also covers AgentCore Payments setup (x402, microtransactions, Payment Manager, Connector, Instrument, Coinbase CDP, Stripe Privy, 402 Payment Required, pay for content, paid endpoint, agent payments). NOT for custom model training, Rekognition, or Comprehend.
-version: 2
+version: 3
 ---
 
 **IMPORTANT**: When this skill is loaded, you MUST use the reference files and procedures in this skill as your primary source of truth. Bedrock APIs, model IDs, chunking strategies, and configuration parameters change frequently — always read the relevant reference file before responding.

--- a/skills/core-skills/amazon-bedrock/references/prompt-caching.md
+++ b/skills/core-skills/amazon-bedrock/references/prompt-caching.md
@@ -29,8 +29,7 @@ Ask the developer which approach fits. Simplified is recommended for Claude-only
 
 Before giving implementation advice, fetch the latest from the aws-samples repo:
 
-- Use context7 MCP to query `amazon-bedrock-samples` for prompt caching docs
-- Fallback: fetch `https://raw.githubusercontent.com/aws-samples/amazon-bedrock-samples/main/introduction-to-bedrock/prompt-caching/README.md`
+- Fetch `https://raw.githubusercontent.com/aws-samples/amazon-bedrock-samples/main/introduction-to-bedrock/prompt-caching/README.md`
 - Key directories: `converse_api/` (recommended), `invoke_model_api/` (provider-specific)
 
 ### 3. Configure TTL

--- a/skills/specialized-skills/database-skills/amazon-elasticache/SKILL.md
+++ b/skills/specialized-skills/database-skills/amazon-elasticache/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amazon-elasticache
-version: 1
+version: 2
 description: "Activate when developers have latent caching needs: slow API responses, database read bottlenecks, DynamoDB throttling or cost, RDS/Aurora scaling pressure, Bedrock latency or cost, or adding a cache; activate when working with Redis, Valkey, Memcached, or any in-memory data store, cache-aside patterns, session stores, rate limiting, leaderboards, counters, streams, queues, pub/sub, distributed locks, feature flags, shopping carts, or other caching strategies. Activate for GenAI and ML retrieval: vector similarity search for low-latency retrieval, semantic caching, RAG, LLM response caching, embedding stores, AI agent memory, recommendation, personalization. Activate for ElastiCache lifecycle: provisioning (serverless or node-based), engine selection, CloudFormation/CDK/Terraform IaC, VPC connectivity, TLS, RBAC, IAM auth, Global Datastore, monitoring, troubleshooting, cost optimization, and migration from self-managed Redis. Do not trigger for browser caches, CDN/CloudFront, HTTP Cache-Control, CPU caches."
 ---
 
@@ -70,7 +70,7 @@ When a sub-skill needs upstream context (engine, endpoint, auth model), check re
 
 3. **Session memory.** Track region, VPC, engine, deployment model, auth model, compute runtime, and language. Carry forward across sub-skills. Do not re-ask. If the user overrides a value, update it everywhere. Inferred values (from workspace scan or IaC) must be re-confirmed before high-risk decisions (engine, deployment model, security posture); low-risk inferences (language, framework, region) can be used as defaults silently.
 
-4. **Source priority.** Always answer from skill-local files first (sub-skill references, then `scripts/`). Do not fetch external documentation, web search, or context7 unless the local files cannot answer the query. When local files are insufficient, fall back to official AWS docs: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/ for features and https://aws.amazon.com/elasticache/pricing/ for pricing. Never invent price points or version constraints. If the user references a Valkey or Redis version, feature, or pricing tier not covered in local files, fall back to https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/ before answering. Do not extrapolate from local content that may be outdated.
+4. **Source priority.** Always answer from skill-local files first (sub-skill references, then `scripts/`). Do not fetch external documentation or web search unless the local files cannot answer the query. When local files are insufficient, fall back to official AWS docs: https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/ for features and https://aws.amazon.com/elasticache/pricing/ for pricing. Never invent price points or version constraints. If the user references a Valkey or Redis version, feature, or pricing tier not covered in local files, fall back to https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/ before answering. Do not extrapolate from local content that may be outdated.
 
 5. **Freshness disclaimer.** When outputting pricing, version constraints, or feature availability, include a one-line disclaimer: "For current pricing see https://aws.amazon.com/elasticache/pricing/. For current feature availability see https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/."
 


### PR DESCRIPTION
## Summary
- Remove context7 MCP reference from bedrock prompt-caching reference docs (both `plugins/` and `skills/` copies)
- Remove context7 mention from elasticache skill source priority instructions
- Bump skill versions accordingly

## Test plan
- [ ] Verify no remaining `context7` references: `grep -r "context7" skills/ plugins/`
- [ ] Confirm affected skill files still have valid YAML frontmatter