### PR TITLE
fix(launch-with-aws): Harden launch-with-aws skill and scripts

### DIFF
--- a/plugins/aws-core/skills/launch-with-aws/SKILL.md
+++ b/plugins/aws-core/skills/launch-with-aws/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: launch-with-aws
 description: "Migrates vibe-coded web applications to AWS. Handles the full workflow from analysis through migration to deployment, producing deployable AWS Blocks infrastructure code. Supports full-stack apps built with vibe-coding platforms (Lovable, Bolt.new, Replit) and frontend web applications and websites: React, Vue, Angular, Next.js, Nuxt, Astro, SvelteKit, Gatsby, Vite, Svelte, Solid, Docusaurus, and others (static sites, SPAs, and SSR frameworks with static export). Triggers on: launch with AWS, launch on AWS, deploy to AWS, migrate to AWS, host my app on AWS, move my app to AWS, transfer my app to AWS. Activates when the user wants to migrate a vibe-coded app or frontend web app to AWS, even if they don't say 'migrate' explicitly."
-version: 1
+version: 2
 ---
 
 # Launch with AWS
@@ -107,6 +107,17 @@ python3 scripts/launch_with_aws.py auth-wait <pid>
 ```
 
 where `<pid>` is the `pid` value from the `auth-start` response. This blocks until the user completes browser sign-in (or times out after 600s). Returns `{"authenticated": true, "baseUrl": "..."}` on success.
+
+Sessions are capped at 90 days even if the identity provider does not set an expiration; after that the interactive flow is required again.
+
+To check the current session without authenticating, or to sign out:
+
+```bash
+python3 scripts/launch_with_aws.py session-status
+python3 scripts/launch_with_aws.py sign-out
+```
+
+`session-status` reports whether a session exists and how long until the token and overall session expire. `sign-out` best-effort revokes the refresh token and deletes the local `~/.launch-with-aws/session.json`. On shared or untrusted workstations, run `sign-out` when finished.
 
 ### 2. Create Launch
 

--- a/plugins/aws-core/skills/launch-with-aws/scripts/archive.py
+++ b/plugins/aws-core/skills/launch-with-aws/scripts/archive.py
@@ -7,16 +7,37 @@ import io
 import logging
 import os
 import re
+import stat
 import subprocess
 import tempfile
 import urllib.error
 import urllib.request
 import zipfile
 from typing import Optional, Set, Tuple
+from urllib.parse import urlparse
 
-from launch_config import GITHUB_ZIPBALL_TIMEOUT_SECS, MAX_ARCHIVE_BYTES
+from launch_config import (
+    GITHUB_ZIPBALL_TIMEOUT_SECS,
+    MAX_ARCHIVE_BYTES,
+    MAX_ARCHIVE_ENTRIES,
+    MAX_COMPRESSION_RATIO,
+    MAX_ENTRY_UNCOMPRESSED_BYTES,
+    MAX_UNCOMPRESSED_BYTES,
+)
 
 logger = logging.getLogger(__name__)
+
+# Chunk size for reading the GitHub download.
+_DOWNLOAD_CHUNK_BYTES = 64 * 1024
+
+# Hosts a GitHub zipball request may be redirected through: api.github.com
+# redirects to codeload and then to its S3-backed object store.
+_ALLOWED_REDIRECT_HOST_SUFFIXES = (
+    ".github.com",
+    ".githubusercontent.com",
+    ".amazonaws.com",
+)
+_ALLOWED_REDIRECT_HOSTS = frozenset({"github.com"})
 
 _SKIP_DIRS = frozenset(
     {
@@ -77,7 +98,7 @@ _SKIP_SUFFIXES = (".pem", ".key", ".p12", ".pfx", ".jks", ".keystore")
 _SKIP_NAME_PREFIXES = ("id_rsa", "id_ed25519", "id_ecdsa", "id_dsa")
 
 _GITHUB_URL_RE = re.compile(
-    r"^https?://github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?/?$",
+    r"^https://github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?/?$",
 )
 
 
@@ -201,11 +222,18 @@ def _has_git_metadata(root: str) -> bool:
 
 
 def parse_github_url(url: str) -> Optional[Tuple[str, str]]:
-    """Return (owner, repo) for a GitHub HTTPS URL, or None."""
+    """Return (owner, repo) for a GitHub HTTPS URL, or None.
+
+    Only https://github.com/<owner>/<repo> URLs are accepted, and `.` / `..`
+    segments are rejected.
+    """
     match = _GITHUB_URL_RE.match(url.strip())
     if not match:
         return None
-    return match.group(1), match.group(2)
+    owner, repo = match.group(1), match.group(2)
+    if any(segment in (".", "..") for segment in (owner, repo)):
+        return None
+    return owner, repo
 
 
 def sanitize_root_name(name: str) -> str:
@@ -227,6 +255,92 @@ def _is_secret_file(filename: str) -> bool:
     if any(lower.startswith(p) for p in _SKIP_NAME_PREFIXES):
         return True
     return False
+
+
+def _is_safe_entry_name(name: str) -> bool:
+    """Return True if a ZIP entry name is a plain relative path.
+
+    Rejects absolute paths, Windows drive/UNC prefixes, `..` segments, and
+    embedded NUL bytes.
+    """
+    if not name or "\x00" in name:
+        return False
+    if name.startswith("/") or name.startswith("\\"):
+        return False
+    # Windows drive letter (e.g. "C:\") or UNC ("\\host").
+    if re.match(r"^[A-Za-z]:", name) or name.startswith("\\\\"):
+        return False
+    normalized = name.replace("\\", "/")
+    return not any(segment == ".." for segment in normalized.split("/"))
+
+
+def _is_symlink_entry(info: zipfile.ZipInfo) -> bool:
+    """Return True if a ZIP entry encodes a Unix symlink."""
+    # The high 16 bits of external_attr hold the Unix mode for Unix-created
+    # entries.
+    mode = (info.external_attr >> 16) & 0xFFFF
+    return stat.S_ISLNK(mode)
+
+
+def validate_archive_bytes(data: bytes) -> None:
+    """Validate ZIP entry names, shape, and size limits.
+
+    All checks read the central-directory metadata only (nothing is
+    decompressed). Raises ArchiveError on the first violation.
+    """
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile as err:
+        raise ArchiveError("Downloaded file is not a valid zip archive.") from err
+
+    with zf:
+        infos = zf.infolist()
+
+        if len(infos) > MAX_ARCHIVE_ENTRIES:
+            raise ArchiveError(
+                f"Archive has {len(infos)} entries, exceeding the "
+                f"{MAX_ARCHIVE_ENTRIES} entry limit."
+            )
+
+        total_uncompressed = 0
+        roots: Set[str] = set()
+        for info in infos:
+            name = info.filename
+
+            if not _is_safe_entry_name(name):
+                raise ArchiveError(f"Archive contains an unsafe entry path: {name!r}")
+            if _is_symlink_entry(info):
+                raise ArchiveError(f"Archive contains a symlink entry: {name!r}")
+
+            size = info.file_size
+            if size > MAX_ENTRY_UNCOMPRESSED_BYTES:
+                raise ArchiveError(
+                    f"Archive entry {name!r} is {size // (1024 * 1024)} MiB "
+                    f"uncompressed, exceeding the "
+                    f"{MAX_ENTRY_UNCOMPRESSED_BYTES // (1024 * 1024)} MiB per-entry limit."
+                )
+            if info.compress_size > 0 and size / info.compress_size > MAX_COMPRESSION_RATIO:
+                raise ArchiveError(
+                    f"Archive entry {name!r} exceeds the {MAX_COMPRESSION_RATIO}:1 "
+                    "compression-ratio limit."
+                )
+
+            total_uncompressed += size
+            if total_uncompressed > MAX_UNCOMPRESSED_BYTES:
+                raise ArchiveError(
+                    f"Archive decompresses to over "
+                    f"{MAX_UNCOMPRESSED_BYTES // (1024 * 1024 * 1024)} GiB, "
+                    "exceeding the decompressed-size limit."
+                )
+
+            top = info.filename.replace("\\", "/").split("/", 1)[0]
+            if top:
+                roots.add(top)
+
+        if len(roots) > 1:
+            raise ArchiveError(
+                f"Archive must contain a single top-level directory; found {len(roots)}."
+            )
 
 
 def zip_local_repo(path: str, root_name: str) -> bytes:
@@ -282,11 +396,77 @@ def zip_local_repo(path: str, root_name: str) -> bytes:
             f"{MAX_ARCHIVE_BYTES // (1024 * 1024)} MiB limit. Remove large "
             "files or build artifacts and try again."
         )
+    validate_archive_bytes(data)
     return data
 
 
+def _is_allowed_redirect_host(hostname: Optional[str]) -> bool:
+    """Return True if a redirect target host is on the allowlist."""
+    if not hostname:
+        return False
+    hostname = hostname.lower()
+    if hostname in _ALLOWED_REDIRECT_HOSTS:
+        return True
+    return any(hostname.endswith(suffix) for suffix in _ALLOWED_REDIRECT_HOST_SUFFIXES)
+
+
+class _AllowlistRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that only follows redirects to allowlisted hosts.
+
+    GitHub zipball downloads 302 from api.github.com to codeload and then to an
+    S3 object store; redirects to any other host are refused.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        parsed = urlparse(newurl)
+        if parsed.scheme != "https":
+            raise ArchiveError(f"Refusing redirect to non-HTTPS URL during download: {newurl!r}")
+        if not _is_allowed_redirect_host(parsed.hostname):
+            raise ArchiveError(
+                f"Refusing redirect to disallowed host during download: {parsed.hostname!r}"
+            )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _read_capped(resp) -> bytes:
+    """Read a response body, aborting if it exceeds MAX_ARCHIVE_BYTES.
+
+    Pre-checks the declared Content-Length when present, then reads in chunks
+    against a running total so bodies without a Content-Length are also bounded.
+    """
+    declared = resp.headers.get("Content-Length")
+    if declared is not None:
+        try:
+            if int(declared) > MAX_ARCHIVE_BYTES:
+                raise ArchiveError(
+                    f"Downloaded archive is {int(declared) // (1024 * 1024)} MiB, "
+                    f"exceeding the {MAX_ARCHIVE_BYTES // (1024 * 1024)} MiB limit."
+                )
+        except ValueError:
+            pass
+
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = resp.read(_DOWNLOAD_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > MAX_ARCHIVE_BYTES:
+            raise ArchiveError(
+                f"Downloaded archive exceeds the "
+                f"{MAX_ARCHIVE_BYTES // (1024 * 1024)} MiB limit."
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def download_github_zip(url: str) -> bytes:
-    """Download a public GitHub repo's default-branch archive."""
+    """Download and validate a public GitHub repo's default-branch archive.
+
+    Follows only allowlisted redirects, caps the body at MAX_ARCHIVE_BYTES, and
+    validates the archive before returning the bytes.
+    """
     parsed = parse_github_url(url)
     if not parsed:
         raise ArchiveError(f"Not a GitHub repository URL: {url}")
@@ -294,9 +474,12 @@ def download_github_zip(url: str) -> bytes:
 
     zipball = f"https://api.github.com/repos/{owner}/{repo}/zipball"
     req = urllib.request.Request(zipball, headers={"Accept": "application/vnd.github+json"})
+    opener = urllib.request.build_opener(_AllowlistRedirectHandler())
     try:
-        with urllib.request.urlopen(req, timeout=GITHUB_ZIPBALL_TIMEOUT_SECS) as resp:
-            data = resp.read()
+        with opener.open(req, timeout=GITHUB_ZIPBALL_TIMEOUT_SECS) as resp:
+            data = _read_capped(resp)
+    except ArchiveError:
+        raise
     except urllib.error.HTTPError as err:
         if err.code in (401, 403, 404):
             raise ArchiveError(
@@ -308,9 +491,5 @@ def download_github_zip(url: str) -> bytes:
     except (urllib.error.URLError, OSError) as err:
         raise ArchiveError(f"Failed to download {url}: {err}") from err
 
-    if len(data) > MAX_ARCHIVE_BYTES:
-        raise ArchiveError(
-            f"Downloaded archive is {len(data) // (1024 * 1024)} MiB, exceeding "
-            f"the {MAX_ARCHIVE_BYTES // (1024 * 1024)} MiB limit."
-        )
+    validate_archive_bytes(data)
     return data

--- a/plugins/aws-core/skills/launch-with-aws/scripts/auth.py
+++ b/plugins/aws-core/skills/launch-with-aws/scripts/auth.py
@@ -35,9 +35,8 @@ from launch_config import (
     CALLBACK_TIMEOUT_SECS,
     CLIENT_NAME,
     DEFAULT_TOKEN_LIFETIME_SECS,
-    ENV_IDC_ISSUER_URL,
     ENV_SCOPES,
-    IDC_ISSUER_URL,
+    MAX_SESSION_LIFETIME_SECS,
     SCOPES,
     SESSION_DIR,
     SESSION_FILE_NAME,
@@ -45,6 +44,7 @@ from launch_config import (
     TOKEN_EXPIRY_BUFFER_SECS,
     ClientCredentials,
     StoredSession,
+    resolve_issuer_url,
 )
 
 __version__ = "0.1.0"
@@ -134,7 +134,7 @@ def _register_client() -> ClientCredentials:
         "clientType": "public",
         "grantTypes": ["authorization_code", "refresh_token"],
         "scopes": scopes,
-        "issuerUrl": os.environ.get(ENV_IDC_ISSUER_URL) or IDC_ISSUER_URL,
+        "issuerUrl": resolve_issuer_url(),
         "redirectUris": ["http://127.0.0.1"],
     }
 
@@ -145,8 +145,13 @@ def _register_client() -> ClientCredentials:
     if not client_id or not client_secret:
         raise RuntimeError("Client registration response missing credentials")
 
+    # Cap the local session lifetime at MAX_SESSION_LIFETIME_SECS. A
+    # clientSecretExpiresAt of 0 means the IdP set no expiry; otherwise use the
+    # sooner of the IdP value and the cap.
     expires_at_sec = response.get("clientSecretExpiresAt") or 0
-    client_expires_at = sys.maxsize if expires_at_sec == 0 else int(expires_at_sec)
+    now = int(time.time())
+    cap = now + MAX_SESSION_LIFETIME_SECS
+    client_expires_at = cap if expires_at_sec == 0 else min(int(expires_at_sec), cap)
 
     return ClientCredentials(
         client_id=client_id,
@@ -295,6 +300,61 @@ def get_access_token() -> str:
             pass
 
     raise SessionExpiredError("Session expired or not authenticated. Run auth-start to sign in.")
+
+
+def session_status() -> dict:
+    """Report the local session state without triggering authentication.
+
+    Returns a dict describing whether a session exists, whether its access
+    token is currently usable, and how long until the access token and the
+    overall session registration expire (seconds, clamped at 0).
+    """
+    session = load_session()
+    if not session:
+        return {"authenticated": False}
+
+    now = int(time.time())
+    token_valid = session.token_expires_at > now + TOKEN_EXPIRY_BUFFER_SECS
+    return {
+        "authenticated": token_valid,
+        "tokenExpiresInSecs": max(0, session.token_expires_at - now),
+        "sessionExpiresInSecs": max(0, session.client_expires_at - now),
+        "canRefresh": session.client_expires_at > now,
+    }
+
+
+def sign_out() -> dict:
+    """Sign out: delete the local session so the next call requires re-auth.
+
+    Best-effort revokes the refresh token, then removes the local session file.
+    Revocation failures do not block local deletion.
+    """
+    session = load_session()
+
+    if session and session.refresh_token:
+        try:
+            sso_oidc = _create_sso_oidc_client(SSO_OIDC_REGION)
+            # revoke_token is not exposed on all endpoints; call it only when
+            # available.
+            revoke = getattr(sso_oidc, "revoke_token", None)
+            if callable(revoke):
+                revoke(
+                    clientId=session.client_id,
+                    clientSecret=session.client_secret,
+                    token=session.refresh_token,
+                    tokenTypeHint="refresh_token",
+                )
+        except Exception:
+            pass
+
+    removed = False
+    try:
+        os.unlink(_session_file())
+        removed = True
+    except FileNotFoundError:
+        pass
+
+    return {"signedOut": True, "sessionRemoved": removed}
 
 
 # ── Non-blocking auth (auth-start / auth-wait) ──────────────────────────

--- a/plugins/aws-core/skills/launch-with-aws/scripts/launch_api_client.py
+++ b/plugins/aws-core/skills/launch-with-aws/scripts/launch_api_client.py
@@ -8,7 +8,9 @@ boto3 service model registration for the Launch with AWS service.
 """
 
 import json
+import logging
 import os
+import re
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -34,6 +36,22 @@ _SERVICE_MODEL_PATH = Path(__file__).parent.parent / "references" / "launchwitha
 
 SERVICE_NAME = "launchwithaws"
 API_VERSION = "2026-06-15"
+
+logger = logging.getLogger(__name__)
+
+# Replace UUIDs and long id-like runs in a request path with a placeholder.
+_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+_ID_SEGMENT_RE = re.compile(r"[A-Za-z0-9_-]{16,}")
+
+
+def _sanitize_path(path: str) -> str:
+    """Strip query strings and replace id-like path segments with <id>."""
+    path = path.split("?", 1)[0].split("#", 1)[0]
+    path = _UUID_RE.sub("<id>", path)
+    path = _ID_SEGMENT_RE.sub("<id>", path)
+    return path
 
 
 def _load_service_model() -> dict:
@@ -110,20 +128,42 @@ def create_client(
 
 
 class ApiError(Exception):
-    """Raised when a backend API request returns a non-success status."""
+    """Raised when a backend API request returns a non-success status.
 
-    def __init__(self, status: int, method: str, path: str, body: str) -> None:
-        super().__init__(f"{method} {path} failed ({status}): {body}")
+    The string representation exposes only the HTTP method, status, a sanitized
+    path template, and the structured error code. The raw response body is kept
+    on the instance (``body``) and logged at DEBUG for local diagnosis.
+    """
+
+    def __init__(
+        self,
+        status: int,
+        method: str,
+        path: str,
+        body: str,
+        error_code: Optional[str] = None,
+    ) -> None:
         self.status = status
         self.method = method
         self.path = path
         self.body = body
+        self.error_code = error_code
+
+        safe_path = _sanitize_path(path)
+        if error_code:
+            message = f"{method} {safe_path} failed ({status}): {error_code}"
+        else:
+            message = f"{method} {safe_path} failed ({status})"
+        super().__init__(message)
+
+        logger.debug("API error %s %s (%s): %s", method, path, status, body)
 
 
 def _client_error_to_api_error(err: ClientError, method: str, path: str) -> ApiError:
     status = err.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 500)
-    message = err.response.get("Error", {}).get("Message", str(err))
-    return ApiError(status, method, path, message)
+    error_code = err.response.get("Error", {}).get("Code")
+    raw_message = err.response.get("Error", {}).get("Message", str(err))
+    return ApiError(status, method, path, raw_message, error_code=error_code)
 
 
 def _get_base_url() -> str:

--- a/plugins/aws-core/skills/launch-with-aws/scripts/launch_config.py
+++ b/plugins/aws-core/skills/launch-with-aws/scripts/launch_config.py
@@ -29,6 +29,9 @@ TOKEN_EXPIRY_BUFFER_SECS = 300
 CALLBACK_TIMEOUT_SECS = 600.0
 DEFAULT_TOKEN_LIFETIME_SECS = 28800
 
+# Maximum local session lifetime; re-authentication is required after this.
+MAX_SESSION_LIFETIME_SECS = 90 * 24 * 3600  # 90 days
+
 SESSION_DIR = "~/.launch-with-aws"
 SESSION_FILE_NAME = "session.json"
 
@@ -39,7 +42,14 @@ UPLOAD_TIMEOUT_SECS = 300.0
 GITHUB_ZIPBALL_TIMEOUT_SECS = 120.0
 
 DEFAULT_COST_ESTIMATE_REGION = "us-east-1"
-MAX_ARCHIVE_BYTES = 500 * 1024 * 1024
+
+# Archive limits, checked against ZIP central-directory metadata (no
+# decompression) plus a streamed compressed-size cap.
+MAX_ARCHIVE_BYTES = 500 * 1024 * 1024  # 500 MiB compressed
+MAX_ARCHIVE_ENTRIES = 100_000
+MAX_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB total decompressed
+MAX_ENTRY_UNCOMPRESSED_BYTES = 100 * 1024 * 1024  # 100 MiB per entry
+MAX_COMPRESSION_RATIO = 100  # decompressed/compressed per entry
 
 # ── Models ───────────────────────────────────────────────────────────────
 
@@ -129,6 +139,50 @@ def _validate_base_url(url: str) -> str:
             )
 
     return url.rstrip("/")
+
+
+# IAM Identity Center issuer hosts accepted for the issuer URL override.
+_ALLOWED_ISSUER_HOST_SUFFIXES = (".amazonaws.com", ".awsapps.com")
+
+
+def validate_issuer_url(url: str) -> str:
+    """Validate an IdC issuer URL override, returning it unchanged if allowed.
+
+    Only https URLs whose host is on an allowed issuer domain are accepted.
+    """
+    parsed = urlparse(url)
+
+    if parsed.scheme != "https":
+        raise ConfigError(
+            f"Invalid {ENV_IDC_ISSUER_URL}: scheme must be https, got {parsed.scheme!r}. "
+            "Refusing to anchor the authentication flow on a non-HTTPS issuer."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ConfigError(f"Invalid {ENV_IDC_ISSUER_URL}: no hostname in {url!r}.")
+
+    if not any(
+        hostname == suffix.lstrip(".") or hostname.endswith(suffix)
+        for suffix in _ALLOWED_ISSUER_HOST_SUFFIXES
+    ):
+        raise ConfigError(
+            f"Invalid {ENV_IDC_ISSUER_URL}: host {hostname!r} is not in the allowed "
+            f'issuer domains ({", ".join(_ALLOWED_ISSUER_HOST_SUFFIXES)}). '
+            "Only official AWS IAM Identity Center endpoints are permitted."
+        )
+
+    return url
+
+
+def resolve_issuer_url() -> str:
+    """Return the IdC issuer URL, honoring a validated env-var override."""
+    override = os.environ.get(ENV_IDC_ISSUER_URL)
+    if override:
+        validated = validate_issuer_url(override)
+        logger.warning("Using non-default IdC issuer URL: %s", validated)
+        return validated
+    return IDC_ISSUER_URL
 
 
 class Config:

--- a/plugins/aws-core/skills/launch-with-aws/scripts/launch_with_aws.py
+++ b/plugins/aws-core/skills/launch-with-aws/scripts/launch_with_aws.py
@@ -12,10 +12,13 @@ Dependencies:
 """
 
 import json
+import logging
 import os
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
 
 # The scripts use PEP 604 union syntax (`str | None`) in signatures, which
 # fails at definition time on Python < 3.10; boto3 also requires 3.10+.
@@ -41,7 +44,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 import launch_api_client as api
 from archive import ArchiveError, parse_github_url, zip_local_repo
-from auth import SessionExpiredError, start_auth, wait_for_auth
+from auth import SessionExpiredError, session_status, sign_out, start_auth, wait_for_auth
 from launch_config import load_config
 
 
@@ -82,6 +85,16 @@ def cmd_auth_wait(pid: str) -> None:
     result = wait_for_auth(pid=int(pid))
     result["baseUrl"] = config.base_url
     _ok(result)
+
+
+def cmd_session_status() -> None:
+    """Report the local session state without triggering authentication."""
+    _ok(session_status())
+
+
+def cmd_sign_out() -> None:
+    """Sign out and delete the local session; requires re-auth next use."""
+    _ok(sign_out())
 
 
 def cmd_create_launch(source: str, name: str | None = None) -> None:
@@ -194,6 +207,8 @@ from typing import Any, Callable
 COMMANDS: dict[str, tuple[Callable[..., Any], int]] = {
     "auth-start": (cmd_auth_start, 0),
     "auth-wait": (cmd_auth_wait, 1),
+    "session-status": (cmd_session_status, 0),
+    "sign-out": (cmd_sign_out, 0),
     "create-launch": (cmd_create_launch, 1),
     "get-launch": (cmd_get_launch, 1),
     "list-launches": (cmd_list_launches, 0),
@@ -242,8 +257,10 @@ def main() -> None:
                 "signed in successfully."
             )
         _fail(f"{err}{hint}")
-    except Exception as err:
-        _fail(str(err))
+    except Exception:
+        # Log the full exception locally; return a generic message.
+        logger.debug("Unhandled error in command %s", command, exc_info=True)
+        _fail("The operation failed. Re-run with logging enabled for details.")
 
 
 if __name__ == "__main__":

--- a/skills/core-skills/launch-with-aws/SKILL.md
+++ b/skills/core-skills/launch-with-aws/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: launch-with-aws
 description: "Migrates vibe-coded web applications to AWS. Handles the full workflow from analysis through migration to deployment, producing deployable AWS Blocks infrastructure code. Supports full-stack apps built with vibe-coding platforms (Lovable, Bolt.new, Replit) and frontend web applications and websites: React, Vue, Angular, Next.js, Nuxt, Astro, SvelteKit, Gatsby, Vite, Svelte, Solid, Docusaurus, and others (static sites, SPAs, and SSR frameworks with static export). Triggers on: launch with AWS, launch on AWS, deploy to AWS, migrate to AWS, host my app on AWS, move my app to AWS, transfer my app to AWS. Activates when the user wants to migrate a vibe-coded app or frontend web app to AWS, even if they don't say 'migrate' explicitly."
-version: 1
+version: 2
 ---
 
 # Launch with AWS
@@ -107,6 +107,17 @@ python3 scripts/launch_with_aws.py auth-wait <pid>
 ```
 
 where `<pid>` is the `pid` value from the `auth-start` response. This blocks until the user completes browser sign-in (or times out after 600s). Returns `{"authenticated": true, "baseUrl": "..."}` on success.
+
+Sessions are capped at 90 days even if the identity provider does not set an expiration; after that the interactive flow is required again.
+
+To check the current session without authenticating, or to sign out:
+
+```bash
+python3 scripts/launch_with_aws.py session-status
+python3 scripts/launch_with_aws.py sign-out
+```
+
+`session-status` reports whether a session exists and how long until the token and overall session expire. `sign-out` best-effort revokes the refresh token and deletes the local `~/.launch-with-aws/session.json`. On shared or untrusted workstations, run `sign-out` when finished.
 
 ### 2. Create Launch
 

--- a/skills/core-skills/launch-with-aws/scripts/archive.py
+++ b/skills/core-skills/launch-with-aws/scripts/archive.py
@@ -7,16 +7,37 @@ import io
 import logging
 import os
 import re
+import stat
 import subprocess
 import tempfile
 import urllib.error
 import urllib.request
 import zipfile
 from typing import Optional, Set, Tuple
+from urllib.parse import urlparse
 
-from launch_config import GITHUB_ZIPBALL_TIMEOUT_SECS, MAX_ARCHIVE_BYTES
+from launch_config import (
+    GITHUB_ZIPBALL_TIMEOUT_SECS,
+    MAX_ARCHIVE_BYTES,
+    MAX_ARCHIVE_ENTRIES,
+    MAX_COMPRESSION_RATIO,
+    MAX_ENTRY_UNCOMPRESSED_BYTES,
+    MAX_UNCOMPRESSED_BYTES,
+)
 
 logger = logging.getLogger(__name__)
+
+# Chunk size for reading the GitHub download.
+_DOWNLOAD_CHUNK_BYTES = 64 * 1024
+
+# Hosts a GitHub zipball request may be redirected through: api.github.com
+# redirects to codeload and then to its S3-backed object store.
+_ALLOWED_REDIRECT_HOST_SUFFIXES = (
+    ".github.com",
+    ".githubusercontent.com",
+    ".amazonaws.com",
+)
+_ALLOWED_REDIRECT_HOSTS = frozenset({"github.com"})
 
 _SKIP_DIRS = frozenset(
     {
@@ -77,7 +98,7 @@ _SKIP_SUFFIXES = (".pem", ".key", ".p12", ".pfx", ".jks", ".keystore")
 _SKIP_NAME_PREFIXES = ("id_rsa", "id_ed25519", "id_ecdsa", "id_dsa")
 
 _GITHUB_URL_RE = re.compile(
-    r"^https?://github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?/?$",
+    r"^https://github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?/?$",
 )
 
 
@@ -201,11 +222,18 @@ def _has_git_metadata(root: str) -> bool:
 
 
 def parse_github_url(url: str) -> Optional[Tuple[str, str]]:
-    """Return (owner, repo) for a GitHub HTTPS URL, or None."""
+    """Return (owner, repo) for a GitHub HTTPS URL, or None.
+
+    Only https://github.com/<owner>/<repo> URLs are accepted, and `.` / `..`
+    segments are rejected.
+    """
     match = _GITHUB_URL_RE.match(url.strip())
     if not match:
         return None
-    return match.group(1), match.group(2)
+    owner, repo = match.group(1), match.group(2)
+    if any(segment in (".", "..") for segment in (owner, repo)):
+        return None
+    return owner, repo
 
 
 def sanitize_root_name(name: str) -> str:
@@ -227,6 +255,92 @@ def _is_secret_file(filename: str) -> bool:
     if any(lower.startswith(p) for p in _SKIP_NAME_PREFIXES):
         return True
     return False
+
+
+def _is_safe_entry_name(name: str) -> bool:
+    """Return True if a ZIP entry name is a plain relative path.
+
+    Rejects absolute paths, Windows drive/UNC prefixes, `..` segments, and
+    embedded NUL bytes.
+    """
+    if not name or "\x00" in name:
+        return False
+    if name.startswith("/") or name.startswith("\\"):
+        return False
+    # Windows drive letter (e.g. "C:\") or UNC ("\\host").
+    if re.match(r"^[A-Za-z]:", name) or name.startswith("\\\\"):
+        return False
+    normalized = name.replace("\\", "/")
+    return not any(segment == ".." for segment in normalized.split("/"))
+
+
+def _is_symlink_entry(info: zipfile.ZipInfo) -> bool:
+    """Return True if a ZIP entry encodes a Unix symlink."""
+    # The high 16 bits of external_attr hold the Unix mode for Unix-created
+    # entries.
+    mode = (info.external_attr >> 16) & 0xFFFF
+    return stat.S_ISLNK(mode)
+
+
+def validate_archive_bytes(data: bytes) -> None:
+    """Validate ZIP entry names, shape, and size limits.
+
+    All checks read the central-directory metadata only (nothing is
+    decompressed). Raises ArchiveError on the first violation.
+    """
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile as err:
+        raise ArchiveError("Downloaded file is not a valid zip archive.") from err
+
+    with zf:
+        infos = zf.infolist()
+
+        if len(infos) > MAX_ARCHIVE_ENTRIES:
+            raise ArchiveError(
+                f"Archive has {len(infos)} entries, exceeding the "
+                f"{MAX_ARCHIVE_ENTRIES} entry limit."
+            )
+
+        total_uncompressed = 0
+        roots: Set[str] = set()
+        for info in infos:
+            name = info.filename
+
+            if not _is_safe_entry_name(name):
+                raise ArchiveError(f"Archive contains an unsafe entry path: {name!r}")
+            if _is_symlink_entry(info):
+                raise ArchiveError(f"Archive contains a symlink entry: {name!r}")
+
+            size = info.file_size
+            if size > MAX_ENTRY_UNCOMPRESSED_BYTES:
+                raise ArchiveError(
+                    f"Archive entry {name!r} is {size // (1024 * 1024)} MiB "
+                    f"uncompressed, exceeding the "
+                    f"{MAX_ENTRY_UNCOMPRESSED_BYTES // (1024 * 1024)} MiB per-entry limit."
+                )
+            if info.compress_size > 0 and size / info.compress_size > MAX_COMPRESSION_RATIO:
+                raise ArchiveError(
+                    f"Archive entry {name!r} exceeds the {MAX_COMPRESSION_RATIO}:1 "
+                    "compression-ratio limit."
+                )
+
+            total_uncompressed += size
+            if total_uncompressed > MAX_UNCOMPRESSED_BYTES:
+                raise ArchiveError(
+                    f"Archive decompresses to over "
+                    f"{MAX_UNCOMPRESSED_BYTES // (1024 * 1024 * 1024)} GiB, "
+                    "exceeding the decompressed-size limit."
+                )
+
+            top = info.filename.replace("\\", "/").split("/", 1)[0]
+            if top:
+                roots.add(top)
+
+        if len(roots) > 1:
+            raise ArchiveError(
+                f"Archive must contain a single top-level directory; found {len(roots)}."
+            )
 
 
 def zip_local_repo(path: str, root_name: str) -> bytes:
@@ -282,11 +396,77 @@ def zip_local_repo(path: str, root_name: str) -> bytes:
             f"{MAX_ARCHIVE_BYTES // (1024 * 1024)} MiB limit. Remove large "
             "files or build artifacts and try again."
         )
+    validate_archive_bytes(data)
     return data
 
 
+def _is_allowed_redirect_host(hostname: Optional[str]) -> bool:
+    """Return True if a redirect target host is on the allowlist."""
+    if not hostname:
+        return False
+    hostname = hostname.lower()
+    if hostname in _ALLOWED_REDIRECT_HOSTS:
+        return True
+    return any(hostname.endswith(suffix) for suffix in _ALLOWED_REDIRECT_HOST_SUFFIXES)
+
+
+class _AllowlistRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that only follows redirects to allowlisted hosts.
+
+    GitHub zipball downloads 302 from api.github.com to codeload and then to an
+    S3 object store; redirects to any other host are refused.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        parsed = urlparse(newurl)
+        if parsed.scheme != "https":
+            raise ArchiveError(f"Refusing redirect to non-HTTPS URL during download: {newurl!r}")
+        if not _is_allowed_redirect_host(parsed.hostname):
+            raise ArchiveError(
+                f"Refusing redirect to disallowed host during download: {parsed.hostname!r}"
+            )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _read_capped(resp) -> bytes:
+    """Read a response body, aborting if it exceeds MAX_ARCHIVE_BYTES.
+
+    Pre-checks the declared Content-Length when present, then reads in chunks
+    against a running total so bodies without a Content-Length are also bounded.
+    """
+    declared = resp.headers.get("Content-Length")
+    if declared is not None:
+        try:
+            if int(declared) > MAX_ARCHIVE_BYTES:
+                raise ArchiveError(
+                    f"Downloaded archive is {int(declared) // (1024 * 1024)} MiB, "
+                    f"exceeding the {MAX_ARCHIVE_BYTES // (1024 * 1024)} MiB limit."
+                )
+        except ValueError:
+            pass
+
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = resp.read(_DOWNLOAD_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > MAX_ARCHIVE_BYTES:
+            raise ArchiveError(
+                f"Downloaded archive exceeds the "
+                f"{MAX_ARCHIVE_BYTES // (1024 * 1024)} MiB limit."
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def download_github_zip(url: str) -> bytes:
-    """Download a public GitHub repo's default-branch archive."""
+    """Download and validate a public GitHub repo's default-branch archive.
+
+    Follows only allowlisted redirects, caps the body at MAX_ARCHIVE_BYTES, and
+    validates the archive before returning the bytes.
+    """
     parsed = parse_github_url(url)
     if not parsed:
         raise ArchiveError(f"Not a GitHub repository URL: {url}")
@@ -294,9 +474,12 @@ def download_github_zip(url: str) -> bytes:
 
     zipball = f"https://api.github.com/repos/{owner}/{repo}/zipball"
     req = urllib.request.Request(zipball, headers={"Accept": "application/vnd.github+json"})
+    opener = urllib.request.build_opener(_AllowlistRedirectHandler())
     try:
-        with urllib.request.urlopen(req, timeout=GITHUB_ZIPBALL_TIMEOUT_SECS) as resp:
-            data = resp.read()
+        with opener.open(req, timeout=GITHUB_ZIPBALL_TIMEOUT_SECS) as resp:
+            data = _read_capped(resp)
+    except ArchiveError:
+        raise
     except urllib.error.HTTPError as err:
         if err.code in (401, 403, 404):
             raise ArchiveError(
@@ -308,9 +491,5 @@ def download_github_zip(url: str) -> bytes:
     except (urllib.error.URLError, OSError) as err:
         raise ArchiveError(f"Failed to download {url}: {err}") from err
 
-    if len(data) > MAX_ARCHIVE_BYTES:
-        raise ArchiveError(
-            f"Downloaded archive is {len(data) // (1024 * 1024)} MiB, exceeding "
-            f"the {MAX_ARCHIVE_BYTES // (1024 * 1024)} MiB limit."
-        )
+    validate_archive_bytes(data)
     return data

--- a/skills/core-skills/launch-with-aws/scripts/auth.py
+++ b/skills/core-skills/launch-with-aws/scripts/auth.py
@@ -35,9 +35,8 @@ from launch_config import (
     CALLBACK_TIMEOUT_SECS,
     CLIENT_NAME,
     DEFAULT_TOKEN_LIFETIME_SECS,
-    ENV_IDC_ISSUER_URL,
     ENV_SCOPES,
-    IDC_ISSUER_URL,
+    MAX_SESSION_LIFETIME_SECS,
     SCOPES,
     SESSION_DIR,
     SESSION_FILE_NAME,
@@ -45,6 +44,7 @@ from launch_config import (
     TOKEN_EXPIRY_BUFFER_SECS,
     ClientCredentials,
     StoredSession,
+    resolve_issuer_url,
 )
 
 __version__ = "0.1.0"
@@ -134,7 +134,7 @@ def _register_client() -> ClientCredentials:
         "clientType": "public",
         "grantTypes": ["authorization_code", "refresh_token"],
         "scopes": scopes,
-        "issuerUrl": os.environ.get(ENV_IDC_ISSUER_URL) or IDC_ISSUER_URL,
+        "issuerUrl": resolve_issuer_url(),
         "redirectUris": ["http://127.0.0.1"],
     }
 
@@ -145,8 +145,13 @@ def _register_client() -> ClientCredentials:
     if not client_id or not client_secret:
         raise RuntimeError("Client registration response missing credentials")
 
+    # Cap the local session lifetime at MAX_SESSION_LIFETIME_SECS. A
+    # clientSecretExpiresAt of 0 means the IdP set no expiry; otherwise use the
+    # sooner of the IdP value and the cap.
     expires_at_sec = response.get("clientSecretExpiresAt") or 0
-    client_expires_at = sys.maxsize if expires_at_sec == 0 else int(expires_at_sec)
+    now = int(time.time())
+    cap = now + MAX_SESSION_LIFETIME_SECS
+    client_expires_at = cap if expires_at_sec == 0 else min(int(expires_at_sec), cap)
 
     return ClientCredentials(
         client_id=client_id,
@@ -295,6 +300,61 @@ def get_access_token() -> str:
             pass
 
     raise SessionExpiredError("Session expired or not authenticated. Run auth-start to sign in.")
+
+
+def session_status() -> dict:
+    """Report the local session state without triggering authentication.
+
+    Returns a dict describing whether a session exists, whether its access
+    token is currently usable, and how long until the access token and the
+    overall session registration expire (seconds, clamped at 0).
+    """
+    session = load_session()
+    if not session:
+        return {"authenticated": False}
+
+    now = int(time.time())
+    token_valid = session.token_expires_at > now + TOKEN_EXPIRY_BUFFER_SECS
+    return {
+        "authenticated": token_valid,
+        "tokenExpiresInSecs": max(0, session.token_expires_at - now),
+        "sessionExpiresInSecs": max(0, session.client_expires_at - now),
+        "canRefresh": session.client_expires_at > now,
+    }
+
+
+def sign_out() -> dict:
+    """Sign out: delete the local session so the next call requires re-auth.
+
+    Best-effort revokes the refresh token, then removes the local session file.
+    Revocation failures do not block local deletion.
+    """
+    session = load_session()
+
+    if session and session.refresh_token:
+        try:
+            sso_oidc = _create_sso_oidc_client(SSO_OIDC_REGION)
+            # revoke_token is not exposed on all endpoints; call it only when
+            # available.
+            revoke = getattr(sso_oidc, "revoke_token", None)
+            if callable(revoke):
+                revoke(
+                    clientId=session.client_id,
+                    clientSecret=session.client_secret,
+                    token=session.refresh_token,
+                    tokenTypeHint="refresh_token",
+                )
+        except Exception:
+            pass
+
+    removed = False
+    try:
+        os.unlink(_session_file())
+        removed = True
+    except FileNotFoundError:
+        pass
+
+    return {"signedOut": True, "sessionRemoved": removed}
 
 
 # ── Non-blocking auth (auth-start / auth-wait) ──────────────────────────

--- a/skills/core-skills/launch-with-aws/scripts/launch_api_client.py
+++ b/skills/core-skills/launch-with-aws/scripts/launch_api_client.py
@@ -8,7 +8,9 @@ boto3 service model registration for the Launch with AWS service.
 """
 
 import json
+import logging
 import os
+import re
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -34,6 +36,22 @@ _SERVICE_MODEL_PATH = Path(__file__).parent.parent / "references" / "launchwitha
 
 SERVICE_NAME = "launchwithaws"
 API_VERSION = "2026-06-15"
+
+logger = logging.getLogger(__name__)
+
+# Replace UUIDs and long id-like runs in a request path with a placeholder.
+_UUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+_ID_SEGMENT_RE = re.compile(r"[A-Za-z0-9_-]{16,}")
+
+
+def _sanitize_path(path: str) -> str:
+    """Strip query strings and replace id-like path segments with <id>."""
+    path = path.split("?", 1)[0].split("#", 1)[0]
+    path = _UUID_RE.sub("<id>", path)
+    path = _ID_SEGMENT_RE.sub("<id>", path)
+    return path
 
 
 def _load_service_model() -> dict:
@@ -110,20 +128,42 @@ def create_client(
 
 
 class ApiError(Exception):
-    """Raised when a backend API request returns a non-success status."""
+    """Raised when a backend API request returns a non-success status.
 
-    def __init__(self, status: int, method: str, path: str, body: str) -> None:
-        super().__init__(f"{method} {path} failed ({status}): {body}")
+    The string representation exposes only the HTTP method, status, a sanitized
+    path template, and the structured error code. The raw response body is kept
+    on the instance (``body``) and logged at DEBUG for local diagnosis.
+    """
+
+    def __init__(
+        self,
+        status: int,
+        method: str,
+        path: str,
+        body: str,
+        error_code: Optional[str] = None,
+    ) -> None:
         self.status = status
         self.method = method
         self.path = path
         self.body = body
+        self.error_code = error_code
+
+        safe_path = _sanitize_path(path)
+        if error_code:
+            message = f"{method} {safe_path} failed ({status}): {error_code}"
+        else:
+            message = f"{method} {safe_path} failed ({status})"
+        super().__init__(message)
+
+        logger.debug("API error %s %s (%s): %s", method, path, status, body)
 
 
 def _client_error_to_api_error(err: ClientError, method: str, path: str) -> ApiError:
     status = err.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 500)
-    message = err.response.get("Error", {}).get("Message", str(err))
-    return ApiError(status, method, path, message)
+    error_code = err.response.get("Error", {}).get("Code")
+    raw_message = err.response.get("Error", {}).get("Message", str(err))
+    return ApiError(status, method, path, raw_message, error_code=error_code)
 
 
 def _get_base_url() -> str:

--- a/skills/core-skills/launch-with-aws/scripts/launch_config.py
+++ b/skills/core-skills/launch-with-aws/scripts/launch_config.py
@@ -29,6 +29,9 @@ TOKEN_EXPIRY_BUFFER_SECS = 300
 CALLBACK_TIMEOUT_SECS = 600.0
 DEFAULT_TOKEN_LIFETIME_SECS = 28800
 
+# Maximum local session lifetime; re-authentication is required after this.
+MAX_SESSION_LIFETIME_SECS = 90 * 24 * 3600  # 90 days
+
 SESSION_DIR = "~/.launch-with-aws"
 SESSION_FILE_NAME = "session.json"
 
@@ -39,7 +42,14 @@ UPLOAD_TIMEOUT_SECS = 300.0
 GITHUB_ZIPBALL_TIMEOUT_SECS = 120.0
 
 DEFAULT_COST_ESTIMATE_REGION = "us-east-1"
-MAX_ARCHIVE_BYTES = 500 * 1024 * 1024
+
+# Archive limits, checked against ZIP central-directory metadata (no
+# decompression) plus a streamed compressed-size cap.
+MAX_ARCHIVE_BYTES = 500 * 1024 * 1024  # 500 MiB compressed
+MAX_ARCHIVE_ENTRIES = 100_000
+MAX_UNCOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB total decompressed
+MAX_ENTRY_UNCOMPRESSED_BYTES = 100 * 1024 * 1024  # 100 MiB per entry
+MAX_COMPRESSION_RATIO = 100  # decompressed/compressed per entry
 
 # ── Models ───────────────────────────────────────────────────────────────
 
@@ -129,6 +139,50 @@ def _validate_base_url(url: str) -> str:
             )
 
     return url.rstrip("/")
+
+
+# IAM Identity Center issuer hosts accepted for the issuer URL override.
+_ALLOWED_ISSUER_HOST_SUFFIXES = (".amazonaws.com", ".awsapps.com")
+
+
+def validate_issuer_url(url: str) -> str:
+    """Validate an IdC issuer URL override, returning it unchanged if allowed.
+
+    Only https URLs whose host is on an allowed issuer domain are accepted.
+    """
+    parsed = urlparse(url)
+
+    if parsed.scheme != "https":
+        raise ConfigError(
+            f"Invalid {ENV_IDC_ISSUER_URL}: scheme must be https, got {parsed.scheme!r}. "
+            "Refusing to anchor the authentication flow on a non-HTTPS issuer."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ConfigError(f"Invalid {ENV_IDC_ISSUER_URL}: no hostname in {url!r}.")
+
+    if not any(
+        hostname == suffix.lstrip(".") or hostname.endswith(suffix)
+        for suffix in _ALLOWED_ISSUER_HOST_SUFFIXES
+    ):
+        raise ConfigError(
+            f"Invalid {ENV_IDC_ISSUER_URL}: host {hostname!r} is not in the allowed "
+            f'issuer domains ({", ".join(_ALLOWED_ISSUER_HOST_SUFFIXES)}). '
+            "Only official AWS IAM Identity Center endpoints are permitted."
+        )
+
+    return url
+
+
+def resolve_issuer_url() -> str:
+    """Return the IdC issuer URL, honoring a validated env-var override."""
+    override = os.environ.get(ENV_IDC_ISSUER_URL)
+    if override:
+        validated = validate_issuer_url(override)
+        logger.warning("Using non-default IdC issuer URL: %s", validated)
+        return validated
+    return IDC_ISSUER_URL
 
 
 class Config:

--- a/skills/core-skills/launch-with-aws/scripts/launch_with_aws.py
+++ b/skills/core-skills/launch-with-aws/scripts/launch_with_aws.py
@@ -12,10 +12,13 @@ Dependencies:
 """
 
 import json
+import logging
 import os
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
 
 # The scripts use PEP 604 union syntax (`str | None`) in signatures, which
 # fails at definition time on Python < 3.10; boto3 also requires 3.10+.
@@ -41,7 +44,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 import launch_api_client as api
 from archive import ArchiveError, parse_github_url, zip_local_repo
-from auth import SessionExpiredError, start_auth, wait_for_auth
+from auth import SessionExpiredError, session_status, sign_out, start_auth, wait_for_auth
 from launch_config import load_config
 
 
@@ -82,6 +85,16 @@ def cmd_auth_wait(pid: str) -> None:
     result = wait_for_auth(pid=int(pid))
     result["baseUrl"] = config.base_url
     _ok(result)
+
+
+def cmd_session_status() -> None:
+    """Report the local session state without triggering authentication."""
+    _ok(session_status())
+
+
+def cmd_sign_out() -> None:
+    """Sign out and delete the local session; requires re-auth next use."""
+    _ok(sign_out())
 
 
 def cmd_create_launch(source: str, name: str | None = None) -> None:
@@ -194,6 +207,8 @@ from typing import Any, Callable
 COMMANDS: dict[str, tuple[Callable[..., Any], int]] = {
     "auth-start": (cmd_auth_start, 0),
     "auth-wait": (cmd_auth_wait, 1),
+    "session-status": (cmd_session_status, 0),
+    "sign-out": (cmd_sign_out, 0),
     "create-launch": (cmd_create_launch, 1),
     "get-launch": (cmd_get_launch, 1),
     "list-launches": (cmd_list_launches, 0),
@@ -242,8 +257,10 @@ def main() -> None:
                 "signed in successfully."
             )
         _fail(f"{err}{hint}")
-    except Exception as err:
-        _fail(str(err))
+    except Exception:
+        # Log the full exception locally; return a generic message.
+        logger.debug("Unhandled error in command %s", command, exc_info=True)
+        _fail("The operation failed. Re-run with logging enabled for details.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Hardens the `launch-with-aws` scripts:

- Input and archive validation (repo URL restrictions, redirect allowlisting, zip entry/size/shape checks with
  bounded downloads).
- Session handling: cap local session lifetime, validate the issuer URL override, and add `session-status` /
  `sign-out` commands.
- Concise, sanitized error messages surfaced to the user; full detail only at DEBUG.

Skill `version` bumped to 2. Applied to both the `core-skills` and `aws-core`plugin copies.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [x] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
