### PR TITLE
chore: add payments team as aws-agents code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,7 @@
 *                           @aws/agent-toolkit-admins
 
-/plugins/                   @aws/agent-toolkit-admins @aws/agentcore-payments
-
 ## Alphabetical listing of Agent Plugins
 /plugins/aws-agents               @aws/agent-toolkit-admins @aws/agentcore-devex-devs @aws/agentcore-devex-pms @aws/agentcore-payments
-/plugins/aws-agents-for-devsecops @aws/agent-toolkit-admins @aws/aws-agentic-devsecops @coffeencoke @tipuq @HuiSF @ljainiaz @adthiru @AhmetAhunbayAWS @aws/agentcore-payments
-/plugins/aws-core                 @aws/agent-toolkit-admins @aws/agentcore-payments
-/plugins/aws-data-analytics       @aws/agent-toolkit-admins @npmajisha @risears @mitczach @harshabattapady @shoukasg @sanjolia @dhruvyadav2007 @mukeshsahay @aws/agentcore-payments
+/plugins/aws-agents-for-devsecops @aws/agent-toolkit-admins @aws/aws-agentic-devsecops @coffeencoke @tipuq @HuiSF @ljainiaz @adthiru @AhmetAhunbayAWS
+/plugins/aws-core                 @aws/agent-toolkit-admins
+/plugins/aws-data-analytics       @aws/agent-toolkit-admins @npmajisha @risears @mitczach @harshabattapady @shoukasg @sanjolia @dhruvyadav2007 @mukeshsahay

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,9 @@
 *                           @aws/agent-toolkit-admins
 
+/plugins/                   @aws/agent-toolkit-admins @aws/agentcore-payments
+
 ## Alphabetical listing of Agent Plugins
-/plugins/aws-agents               @aws/agent-toolkit-admins @aws/agentcore-devex-devs @aws/agentcore-devex-pms
-/plugins/aws-agents-for-devsecops @aws/agent-toolkit-admins @aws/aws-agentic-devsecops @coffeencoke @tipuq @HuiSF @ljainiaz @adthiru @AhmetAhunbayAWS
-/plugins/aws-core                 @aws/agent-toolkit-admins
-/plugins/aws-data-analytics       @aws/agent-toolkit-admins @npmajisha @risears @mitczach @harshabattapady @shoukasg @sanjolia @dhruvyadav2007 @mukeshsahay
+/plugins/aws-agents               @aws/agent-toolkit-admins @aws/agentcore-devex-devs @aws/agentcore-devex-pms @aws/agentcore-payments
+/plugins/aws-agents-for-devsecops @aws/agent-toolkit-admins @aws/aws-agentic-devsecops @coffeencoke @tipuq @HuiSF @ljainiaz @adthiru @AhmetAhunbayAWS @aws/agentcore-payments
+/plugins/aws-core                 @aws/agent-toolkit-admins @aws/agentcore-payments
+/plugins/aws-data-analytics       @aws/agent-toolkit-admins @npmajisha @risears @mitczach @harshabattapady @shoukasg @sanjolia @dhruvyadav2007 @mukeshsahay @aws/agentcore-payments


### PR DESCRIPTION
This PR adds `@aws/agentcore-payments` as a code owner for `/plugins/aws-agents` and preserves every existing CODEOWNERS rule and owner

## Pre-req
GitHub currently reports `@aws/agentcore-payments` as an unknown CODEOWNERS entry. A repository or organization admin must grant the team write access to `aws/agent-toolkit-for-aws` before GitHub can request reviews from it. 

OOS but I wanna call out: The validator also reports two pre-existing invalid owners on the devsecops rule: `@aws/aws-agentic-devsecops` and `@HuiSF`.