### PR TITLE
feat(auth): add aws-auth skill

### DIFF
--- a/skills/core-skills/aws-auth/SKILL.md
+++ b/skills/core-skills/aws-auth/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: aws-auth
+description: >
+  Adds user authentication to web and mobile apps with Amazon Cognito (user pools and identity
+  pools) and the AWS Amplify client auth libraries. Covers sign-up/sign-in flows and the login
+  page (Cognito-hosted UI / managed login), MFA, password policies, OAuth 2.0 / OIDC flows
+  (auth-code + PKCE, client credentials), social/SAML federation, tokens (ID/access/refresh,
+  rotation, revocation, storage), Cognito Lambda triggers, identity pools (temp AWS creds), and
+  gating API Gateway (or ALB) routes to signed-in users via Cognito/JWT authorizers. Applies when
+  adding a login or sign-up page, configuring a user pool or app client, choosing user pool vs
+  identity pool, wiring social/SAML, refreshing tokens, requiring sign-in on an API Gateway or
+  ALB, or debugging redirect_uri/token/MFA/CORS/federation errors. Does NOT cover Amplify Gen2
+  backend definitions (defineAuth, npx ampx → aws-amplify), IAM/STS/Identity Center (→ aws-iam),
+  or API Gateway/Lambda resource config beyond the authorizer (→ aws-serverless).
+version: 1
+---
+
+# AWS Auth (Amazon Cognito)
+
+Application-level user authentication and authorization with Amazon Cognito and the Amplify
+client auth libraries. Verify specific limits, quotas, and exact API shapes against official AWS
+documentation when precision matters; trust the docs over memory when they conflict.
+
+**Recommended:** The AWS MCP server provides streamlined access to the AWS APIs used in this skill (Cognito user pool/app client/identity pool setup, API Gateway authorizers). If it is unavailable, the AWS CLI commands shown throughout work directly — the skill has no hard dependency on MCP.
+
+**When NOT to use:** Amplify Gen2 backend code (`defineAuth`, `amplify/auth.ts`, `npx ampx`); IAM
+policy/role/trust-policy authoring, STS, or IAM Identity Center console SSO; API Gateway
+route/integration setup or Lambda function implementation (this skill covers only the Cognito/JWT
+authorizer configuration and the purpose of Cognito Lambda triggers).
+
+## User Pool vs Identity Pool — pick first
+
+These are different services that are frequently confused. Most apps need a **user pool**; add an
+**identity pool only if** the client must call AWS services directly.
+
+| You need... | Use | Why |
+|-------------|-----|-----|
+| Sign-up / sign-in, user directory, issue JWTs | **User pool** | It authenticates users and is an OIDC IdP |
+| The signed-in client to call S3/DynamoDB/etc. directly with AWS credentials | **Identity pool** | It exchanges a token for temporary AWS credentials via STS |
+| Both (sign in, then hit AWS resources from the browser/app) | User pool → identity pool | Identity pool trusts the user pool as its IdP |
+
+If your app only calls your own backend/API, you do **not** need an identity pool — send the user
+pool token to your API. See [identity-pools.md](references/identity-pools.md).
+
+## Critical Warnings
+
+**`update-user-pool-client` and `set-identity-pool-roles` are FULL REPLACE, not partial updates**: Any field you omit is reset to its default — calling `update-user-pool-client` with only the fields you want to change silently wipes `ExplicitAuthFlows`, token validity, `EnableTokenRevocation`, refresh-token rotation, and read/write attributes; `set-identity-pool-roles` likewise replaces the whole roles + `RoleMappings` structure. **Always read-modify-write**: `describe-user-pool-client` (or `get-identity-pool-roles`) first, then re-send every existing field plus your change. In an agent context the wipe is invisible — the call succeeds and only breaks later when a user hits the missing flow. See [managed-login-oauth.md](references/managed-login-oauth.md) and [identity-pools.md](references/identity-pools.md).
+
+**Don't use the implicit grant for new apps**: The implicit grant (`response_type=token`) is legacy and returns tokens in the URL fragment. Use the **authorization code grant with PKCE** (`response_type=code` + `code_challenge`) for SPAs and mobile — public clients, no client secret. See [managed-login-oauth.md](references/managed-login-oauth.md).
+
+**Don't store refresh tokens in localStorage for high-value apps**: `localStorage` is readable by any injected script (XSS). The Amplify client library defaults to `localStorage`; switch to `cookieStorage`, keep refresh-token lifetime short, and enable **refresh token rotation** + **token revocation** on the app client. See [tokens-and-sessions.md](references/tokens-and-sessions.md).
+
+**Access-token claim customization needs a paid feature plan**: The pre token generation trigger customizes the **ID token** on the entry-level plan (V1), but customizing the **access token** (V2/V3) requires a **paid feature plan** — check the [Cognito feature plans documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sign-in-feature-plans.html) for which plan currently includes this, as plan names and inclusions can change. Don't assume access-token claims work on the entry-level plan. See [lambda-triggers.md](references/lambda-triggers.md).
+
+**App client secret + SPA = broken auth**: A public client (browser/mobile) must have **no client secret**. If a secret is set, token calls fail unless a `SECRET_HASH` is sent, which a browser cannot protect. Generate a secret only for confidential (server-side) clients.
+
+**Don't bulk `admin-confirm-sign-up` UNCONFIRMED users**: When users are stuck `UNCONFIRMED`, prefer `resend-confirmation-code` so each user re-verifies via `confirm-sign-up` and proves email ownership (the code likely expired or went to spam). `admin-confirm-sign-up` flips the status instantly but confirms the account **without verifying the email** — the attribute stays unverified, which is dangerous when email drives password reset or account linking. Reserve it for trusted/migrated accounts. See [troubleshooting.md](references/troubleshooting.md).
+
+## Quick Navigation
+
+| You want to... | Go to |
+|----------------|-------|
+| Create a user pool, sign-up/sign-in, MFA, password policy, app clients | [user-pools.md](references/user-pools.md) |
+| Add hosted UI / managed login, OAuth flows, social or SAML login, callback URLs, **custom domain (ACM in us-east-1)** | [managed-login-oauth.md](references/managed-login-oauth.md) |
+| Handle ID/access/refresh tokens, rotation, revocation, **session termination (global sign-out vs revoke vs disable)** | [tokens-and-sessions.md](references/tokens-and-sessions.md) |
+| Give the client temporary AWS credentials, guest access, role mapping | [identity-pools.md](references/identity-pools.md) |
+| Protect an API Gateway API with Cognito tokens (**and enforce custom claims in the backend**) | [api-authorization.md](references/api-authorization.md) |
+| Add Cognito login in front of an Application Load Balancer (ALB `authenticate-cognito`) | [api-authorization.md](references/api-authorization.md) |
+| Machine-to-machine (client credentials) auth, resource servers, custom scopes | [managed-login-oauth.md](references/managed-login-oauth.md) |
+| Create user pool groups and add users to them (`cognito:groups`, `Precedence`) | [user-pools.md](references/user-pools.md) |
+| Customize claims, custom auth challenge flows, migrate users, validate sign-up | [lambda-triggers.md](references/lambda-triggers.md) |
+| Add **passkey / WebAuthn** sign-in (`USER_AUTH` flow, `AllowedFirstAuthFactors`, WebAuthn enrollment) | [passkeys.md](references/passkeys.md) |
+| Configure **threat protection** — compromised-credentials block, adaptive auth (risk-based MFA), log delivery to CloudWatch | [threat-protection.md](references/threat-protection.md) |
+| Something is broken (redirect, token, MFA, CORS, social login) | [troubleshooting.md](references/troubleshooting.md) |
+
+## Common Workflows
+
+**"Add sign-up and login to my React app"** → Create a user pool + a public app client (no secret), enable the hosted UI / managed login with the authorization code grant with PKCE, wire the Amplify client library. See [user-pools.md](references/user-pools.md) and [managed-login-oauth.md](references/managed-login-oauth.md).
+
+**"Add Google / social login"** → Register the social IdP on the user pool, map attributes, add the provider to the app client and hosted UI. See [managed-login-oauth.md](references/managed-login-oauth.md).
+
+**"Only authenticated users should call my API"** → HTTP API → JWT authorizer; REST API → Cognito user pools authorizer. See [api-authorization.md](references/api-authorization.md).
+
+**"Let the browser upload to S3 after login"** → User pool for sign-in, then an identity pool to vend scoped temporary credentials. See [identity-pools.md](references/identity-pools.md).
+
+## Troubleshooting
+
+| Error/Symptom | Likely Cause | Quick Fix |
+|---------------|-------------|-----------|
+| `redirect_mismatch` / redirect to wrong URL after login | Callback URL not registered, or scheme/trailing-slash/case differs | Add the exact callback URL (incl. scheme and path) to the app client's Allowed callback URLs |
+| Token calls fail with "unable to verify secret hash" | Client secret set on a public (SPA/mobile) client | Recreate the app client with no secret, or send `SECRET_HASH` from a confidential client |
+| Users get 401 from API Gateway with a valid token | Wrong token type or audience/issuer mismatch | HTTP JWT authorizer: issuer `https://cognito-idp.{region}.amazonaws.com/{userPoolId}`, audience = app client id; send the token the authorizer expects |
+| CORS errors calling the hosted UI / token endpoint | Browser calling `/oauth2/token` cross-origin, or missing CORS on your API | Do the code exchange with PKCE; don't proxy the token endpoint from the browser |
+| Social login user "already exists" / attribute conflict | Same email across providers creates separate users | Enable attribute mapping + account linking; treat email as non-unique across IdPs |
+
+Full tables in [troubleshooting.md](references/troubleshooting.md).
+
+## Security Considerations
+
+- Public clients (SPA/mobile): **no client secret**, authorization code grant **with PKCE**, request least-privilege scopes.
+- Enable **MFA** (TOTP or SMS), a strong password policy, and **advanced security / threat protection** where available.
+- Short access-token lifetime; enable **refresh token rotation** and **token revocation**; prefer `cookieStorage` over `localStorage`.
+- Identity pools: scope the authenticated IAM role tightly; disable unauthenticated (guest) access unless required.
+- Validate JWTs against the user pool JWKS (`iss`, `aud`/`client_id`, `token_use`, `exp`) on every protected request. Use a maintained library such as [`aws-jwt-verify`](https://github.com/awslabs/aws-jwt-verify) rather than hand-rolling verification.
+- Set security headers on the app's web pages: `Content-Security-Policy` (restrict script sources to mitigate token-stealing XSS), `Strict-Transport-Security` (HSTS), `X-Frame-Options`/`frame-ancestors` (clickjacking on login pages), and `X-Content-Type-Options: nosniff`.
+- Enable logging and monitoring: CloudTrail for Cognito API events (sign-up/sign-in/admin), user pool threat protection (adaptive auth + event logging), CloudWatch alarms on failed/throttled auth, and API Gateway access logging for authorizer decisions.
+- All Cognito and API endpoints are HTTPS/TLS only; enable encryption at rest with a customer-managed KMS key (and restricted key access) on CloudWatch Log groups, SNS topics used for MFA/notifications, and any identity-pool-fronted upload buckets.
+- If using SNS for MFA/notification delivery, enable server-side encryption (KMS) on the topic, and keep SMS/email message content limited to what the recipient needs — don't include more PII than the message requires.
+- References: [Amazon Cognito security features (user pools)](https://docs.aws.amazon.com/cognito/latest/developerguide/managing-security.html), [Amazon Cognito security (top-level, incl. identity pools)](https://docs.aws.amazon.com/cognito/latest/developerguide/security.html), and [IAM/STS best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html).
+
+## Where to Look When This Skill Is Silent
+
+When you need depth beyond this skill — exact parameter shapes, current limits, edge behaviors — fall back to the authoritative AWS sources rather than guessing. Pointers age much slower than content, so this map stays useful without the skill having to grow.
+
+- **API reference (exact params, defaults, errors):** [Cognito User Pools API](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/) and [Cognito Identity API](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/)
+- **Developer Guide (concepts, workflows):** [Amazon Cognito Developer Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/)
+- **Quotas, rate limits, session-cookie lifetime:** [Cognito quotas](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html)
+- **Feature plans / tier gating:** [Cognito feature plans](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sign-in-feature-plans.html)
+- **Pricing:** [Amazon Cognito pricing](https://aws.amazon.com/cognito/pricing/)
+- **CLI reference:** [aws cognito-idp](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/) and [aws cognito-identity](https://docs.aws.amazon.com/cli/latest/reference/cognito-identity/)
+
+## Not Covered By This Skill
+
+- **Amplify Gen2 backend** (`defineAuth`, `amplify/auth.ts`, `npx ampx sandbox`).
+- **IAM policy/role/trust-policy authoring, STS, IAM Identity Center console SSO.**
+- **API Gateway route/integration setup and Lambda function implementation** (this skill covers only the Cognito/JWT authorizer configuration and the purpose of Cognito Lambda triggers).

--- a/skills/core-skills/aws-auth/references/api-authorization.md
+++ b/skills/core-skills/aws-auth/references/api-authorization.md
@@ -1,0 +1,110 @@
+# Protecting APIs with Cognito
+
+## Overview
+
+This reference covers wiring a Cognito user pool to an Amazon API Gateway API (and ALB) so only
+authenticated requests get through. It covers only the **authorizer** side. Creating the API's
+routes, integrations, and backing Lambda belongs to the `aws-serverless` skill.
+
+## Choose the authorizer by API type
+
+| API type | Authorizer | Token used |
+|----------|-----------|------------|
+| **HTTP API** (API Gateway v2) | Built-in **JWT authorizer** | ID or access token |
+| **REST API** (API Gateway v1) | **Cognito user pools authorizer** (`COGNITO_USER_POOLS`) | ID token by default |
+| Application Load Balancer | ALB built-in `authenticate-cognito` action | Performs the OIDC login itself |
+
+## HTTP API — JWT authorizer
+
+The JWT authorizer validates the token's signature, issuer, and audience with no Lambda.
+
+```
+aws apigatewayv2 create-authorizer \
+  --api-id <api-id> \
+  --authorizer-type JWT \
+  --name cognito-jwt \
+  --identity-source '$request.header.Authorization' \
+  --jwt-configuration Audience=<app-client-id>,Issuer=https://cognito-idp.<region>.amazonaws.com/<pool-id>
+```
+
+- **Issuer** MUST be `https://cognito-idp.<region>.amazonaws.com/<userPoolId>`.
+- **Audience** MUST be the **app client id**.
+- Attach the authorizer to a route and (optionally) require scopes on the route.
+- Audience matching: the **ID token** carries `aud` = client id; the **access token** carries
+  `client_id` and `scope`. If you send access tokens, the JWT authorizer still validates against
+  the configured audience/issuer — send the token type your configuration expects and, for
+  scope-based authorization, use the access token.
+
+### What the JWT authorizer does NOT enforce
+
+The HTTP-API JWT authorizer validates only the signature, `iss`, `aud` / `client_id`,
+`exp`/`nbf`/`iat`, and — if you set `authorizationScopes` on the route — the `scope` /
+`scp` claim. It does **not** enforce arbitrary custom claims like `custom:tenant_id`,
+`cognito:groups`, or attributes added by a pre-token-generation Lambda. Those must be
+inspected in the backend / integration.
+
+API Gateway forwards the JWT claims into the request context. In a Lambda integration:
+
+```js
+// event.requestContext.authorizer.jwt.claims is a flat map of every claim in the token
+const tenantId = event.requestContext.authorizer.jwt.claims["custom:tenant_id"];
+const groups   = event.requestContext.authorizer.jwt.claims["cognito:groups"];  // string or array
+if (tenantId !== requestedTenant) {
+  return { statusCode: 403, body: "wrong tenant" };
+}
+```
+
+For heavier claim-based policy, use a Lambda authorizer (any custom logic) or Amazon
+Verified Permissions (Cedar policies over token claims) instead.
+
+## REST API — Cognito user pools authorizer
+
+```
+aws apigateway create-authorizer \
+  --rest-api-id <api-id> \
+  --name cognito-authorizer \
+  --type COGNITO_USER_POOLS \
+  --provider-arns arn:aws:cognito-idp:<region>:<account>:userpool/<pool-id> \
+  --identity-source method.request.header.Authorization
+```
+
+Then set the method's `authorizationType` to `COGNITO_USER_POOLS` and reference the authorizer.
+REST API Cognito authorizers validate the **ID token** by default.
+
+## Verifying tokens yourself (non-API-Gateway backends)
+
+If your backend isn't behind an API Gateway authorizer, validate the JWT on every request:
+
+1. Fetch the pool JWKS: `https://cognito-idp.<region>.amazonaws.com/<pool-id>/.well-known/jwks.json`.
+2. Verify the RS256 signature against the matching `kid`.
+3. Check `iss` (the issuer URL above), `exp`, `token_use` (`id` vs `access`), and
+   `aud`/`client_id`.
+
+Use a maintained JWT library (e.g. `aws-jwt-verify`) rather than hand-rolling verification.
+
+## Defense in depth
+
+The authorizer authenticates callers but is not the whole story:
+
+- Enable **AWS WAF** on the API Gateway stage (managed rules + rate-based rules) to blunt common
+  web exploits and volumetric/token-stuffing attacks.
+- Configure API Gateway **throttling / rate limiting** to cap brute-force attempts.
+- Validate and sanitize request inputs beyond the authorization token.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| 401 with a valid token | Issuer or audience mismatch, or wrong token type | Set issuer/audience exactly as above; send the token the authorizer expects |
+| 401 "Unauthorized" but token looks fine | `identity-source` header not sent or wrong casing | Send `Authorization: <token>`; match the configured identity source |
+| Works locally, 403 in prod | CORS preflight blocked (OPTIONS needs no auth) | Allow unauthenticated `OPTIONS`; configure CORS on the API |
+
+## Related
+
+- [tokens-and-sessions.md](tokens-and-sessions.md) for which token to send.
+- `aws-serverless` skill for API Gateway routes/integrations and Lambda implementation.
+
+## Authoritative sources
+
+- [Control access to HTTP APIs with JWT authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-jwt-authorizer.html)
+- [Control access to REST APIs using Cognito user pools as an authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html)

--- a/skills/core-skills/aws-auth/references/identity-pools.md
+++ b/skills/core-skills/aws-auth/references/identity-pools.md
@@ -1,0 +1,110 @@
+# Identity Pools (Federated Identities)
+
+## Overview
+
+An identity pool exchanges a proof of authentication (a user pool token, a third-party OIDC/SAML
+token, or a social access token) for **temporary AWS credentials** from AWS STS. Use it only when
+the client must call AWS services (S3, DynamoDB, etc.) **directly**. If the client only calls your
+own backend/API, you do not need an identity pool — send the user pool token to your API instead.
+
+## User pool vs identity pool (the core distinction)
+
+- **User pool** = authentication. "Who are you?" Issues JWTs.
+- **Identity pool** = authorization to AWS. "What AWS resources can this identity touch?" Vends
+  temporary AWS credentials via STS.
+
+They compose: the user signs in to the user pool, then the app passes the ID token to the identity
+pool, which returns temporary AWS credentials.
+
+## What each provider passes to an identity pool
+
+The token type is **provider-specific** — get it wrong and identity resolution fails at
+configuration time.
+
+| Provider | Authentication artifact |
+|----------|-------------------------|
+| Cognito user pool | ID token |
+| Generic OIDC IdP | ID token |
+| Google, Apple (OIDC providers) | ID token (`id_token`) |
+| Facebook, Login with Amazon | Access token |
+| SAML 2.0 IdP | SAML assertion |
+
+Google and Apple are OIDC providers: pass their **`id_token`** (Cognito reads it from the
+`accounts.google.com` / `appleid.apple.com` logins key). Only **Facebook** and **Login with
+Amazon** hand the identity pool an **access token**. Wiring Google (or Apple) with an access
+token fails identity resolution at config time.
+
+## Create and wire an identity pool
+
+```
+aws cognito-identity create-identity-pool \
+  --identity-pool-name my_app_identities \
+  --no-allow-unauthenticated-identities \
+  --cognito-identity-providers ProviderName=cognito-idp.<region>.amazonaws.com/<pool-id>,ClientId=<app-client-id>
+
+aws cognito-identity set-identity-pool-roles \
+  --identity-pool-id <identity-pool-id> \
+  --roles authenticated=<auth-role-arn>
+```
+
+**`set-identity-pool-roles` replaces the entire roles + `RoleMappings` structure — it is a full
+replace, not a merge.** To add or change one role mapping on a pool that already has roles or
+mappings, first read the current state with `aws cognito-identity get-identity-pool-roles
+--identity-pool-id <id>`, then re-send **all** existing roles and `RoleMappings` plus your addition
+in a single `set-identity-pool-roles` call. Sending only the new mapping silently drops the
+existing default role and every other mapping.
+
+**The authenticated role's trust policy MUST scope to this identity pool** to prevent
+confused-deputy attacks where another Cognito identity pool assumes the role. IAM role
+authoring itself belongs to the `aws-iam` skill, but this identity-pool-specific condition
+is not covered there:
+
+```json
+"Condition": {
+  "StringEquals":         { "cognito-identity.amazonaws.com:aud": "<identity-pool-id>" },
+  "ForAnyValue:StringLike": { "cognito-identity.amazonaws.com:amr": "authenticated" }
+}
+```
+
+The `:aud` condition binds the trust to your pool id; `:amr` = `authenticated` ensures the
+guest (unauthenticated) role can never assume the authenticated role. Mirror the pattern with
+`:amr` = `unauthenticated` on the guest role.
+
+Default to `--no-allow-unauthenticated-identities`. Only enable guest access
+(`--allow-unauthenticated-identities` plus an `unauthenticated=<guest-role-arn>` role) when guest
+access is genuinely required.
+
+## Two credential flows
+
+- **Enhanced (simplified) flow** — the recommended default. `GetCredentialsForIdentity` returns
+  credentials in one step; the pool decides the role.
+- **Basic (classic) flow** — the app calls `GetOpenIdToken` then `sts:AssumeRoleWithWebIdentity`
+  itself, for full control over the assumed role.
+
+## Role selection
+
+- **Default role** for all authenticated users.
+- **Rules-based** — choose a role from claims (e.g. a group claim).
+- **Role from token (`cognito:preferred_role`)** — the user pool group's associated role. When a
+  user is in multiple groups, the group with the **lowest `Precedence`** value wins; see the
+  "User pool groups" section in [user-pools.md](user-pools.md) for `create-group` /
+  `admin-add-user-to-group` and the `--precedence` field.
+- **Attributes for access control** — map user claims to STS **principal tags**, then gate access
+  in resource policies with `aws:PrincipalTag/...`. This is app-level ABAC via Cognito.
+
+Scope the authenticated role tightly (least privilege). The IAM policy language and role authoring
+itself belong to the `aws-iam` skill.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `NotAuthorizedException` / `Token is not from a supported provider` | Provider not registered on the pool, or wrong ClientId | Match `ProviderName` = `cognito-idp.<region>.amazonaws.com/<pool-id>` and the correct app client id |
+| `Access denied` after getting credentials | Authenticated role policy too narrow, or trust policy wrong | Fix the role's permissions (see `aws-iam`); ensure the role trusts `cognito-identity.amazonaws.com` with the pool id condition |
+| Guests unexpectedly allowed | Unauthenticated identities enabled | Disable guest access; remove the unauthenticated role |
+
+## Related
+
+- [tokens-and-sessions.md](tokens-and-sessions.md) for the token you feed in.
+- `aws-iam` skill for authoring the authenticated/guest IAM roles and their trust policies.
+- **Authoritative sources** (for guest access details, basic vs enhanced flow, developer-authenticated identities, and multi-provider linking — topics this skill intentionally does not cover): [Amazon Cognito identity pools (developer guide)](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html) and [External identity providers](https://docs.aws.amazon.com/cognito/latest/developerguide/external-identity-providers.html).

--- a/skills/core-skills/aws-auth/references/lambda-triggers.md
+++ b/skills/core-skills/aws-auth/references/lambda-triggers.md
@@ -1,0 +1,167 @@
+# Cognito Lambda Triggers
+
+## Overview
+
+Lambda triggers let you inject custom logic into user pool operations (sign-up, sign-in, token
+issuance, migration, messaging). This reference covers **which trigger to use for what** and the
+key gotchas. Implementing the Lambda function itself belongs to the `aws-serverless` skill.
+
+## Trigger catalog
+
+| Trigger | Fires when | Use for |
+|---------|-----------|---------|
+| **Pre sign-up** | A user/admin creates an account | Allow/deny sign-up; auto-**confirm** for trusted flows (see caveat below) |
+| **Post confirmation** | Account confirmed or password reset | Post-signup provisioning (add to a group, write to a DB, welcome email) |
+| **Pre authentication** | Before sign-in | Block sign-in based on custom rules |
+| **Post authentication** | After successful sign-in | Audit / analytics on login |
+| **Migrate user** | Sign-in or forgot-password for an unknown user | Lazily import users from a legacy directory/DB |
+| **Pre token generation** | Before tokens are issued | Add/modify/suppress token claims (see feature-plan note) |
+| **Custom message** | Cognito sends a verification/MFA message | Customize email/SMS content |
+| **Define / Create / Verify auth challenge** | Custom authentication flow | CAPTCHA, security questions, or a multi-step challenge sequence your app defines. **Do NOT use for email/SMS OTP passwordless** — Cognito supports those natively as first-auth factors (see [passkeys.md](passkeys.md) for `EMAIL_OTP` / `SMS_OTP` in `AllowedFirstAuthFactors`) |
+
+**Pre sign-up — auto-confirm vs auto-verify are different decisions.** Auto-*confirming* an account
+(letting the user skip the confirmation code) is fine for trusted flows. Auto-*verifying* the email
+or phone attribute (`autoVerifyEmail`/`autoVerifyPhone`) marks that contact as proven-owned, so only
+do it when ownership was established out-of-band — e.g. a federated IdP that already verified it.
+**Never auto-verify based solely on the domain of a self-asserted email**, or an attacker can get a
+verified attribute they don't own (which then drives password reset / account linking).
+
+## Migrate user — lazy import from a legacy directory
+
+The migrate-user trigger fires when Cognito encounters an unknown username during
+sign-in or forgot-password, letting you validate the credentials against a legacy
+system and import the user on the fly. Wire this if you're moving 10K+ users off
+an existing auth database without forcing everyone to reset their password.
+
+**Wire BOTH trigger sources for a real lazy-migration setup:**
+
+- **`UserMigration_Authentication`** — fires on `InitiateAuth`/`AdminInitiateAuth` for
+  an unknown user. Receives `event.request.password` (plaintext, so the Lambda can
+  verify against the legacy hash) and `event.request.userAttributes`. Must return
+  the user's attributes.
+- **`UserMigration_ForgotPassword`** — fires on `ForgotPassword` for an unknown user.
+  Does NOT receive the password. Return the user's attributes with
+  `email_verified: "true"` so Cognito can send the reset code.
+
+**App client must use `USER_PASSWORD_AUTH` (or `ADMIN_USER_PASSWORD_AUTH`) — SRP
+CANNOT WORK for migration.** SRP obscures the plaintext password from Cognito (and
+therefore from your Lambda), so the trigger has nothing to verify against the
+legacy database. Set `ExplicitAuthFlows` to include `ALLOW_USER_PASSWORD_AUTH` on
+the app client. Use TLS end-to-end; the plaintext password appears in the raw
+Lambda event, so log-sanitize aggressively.
+
+**Response contract:**
+
+- `userAttributes` — map of Cognito user attributes. Set `email_verified: "true"`
+  (or `phone_number_verified: "true"`) to skip re-verification.
+- `finalUserStatus` — usually `"CONFIRMED"` so the user can sign in immediately.
+  The default is `"RESET_REQUIRED"`, which forces a password reset on next sign-in.
+- `messageAction` — `"SUPPRESS"` to skip the default welcome message.
+
+The pool's own password policy is NOT enforced during migration — the legacy hash
+was created under its own rules. Consider forcing a rotate-on-next-login for users
+whose legacy hash doesn't meet your current policy.
+
+## Pre token generation — feature plan matters
+
+- **V1 (`V1_0`)**: customizes the **ID token** only. Available on the entry-level plan.
+- **V2 (`V2_0`)**: customizes the **access token** (and ID token). Requires a **paid feature
+  plan** — check the [Cognito feature plans documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sign-in-feature-plans.html) for which plan currently includes this.
+- **V3 (`V3_0`)**: like V2, and also applies to **machine-to-machine** (client-credentials) access
+  tokens. Requires a **paid feature plan** — same caveat, verify against current docs.
+
+Verify the feature-plan requirement against the AWS documentation — plan names and inclusions can
+change. Do not assume access-token claim customization works on the entry-level plan; choose the
+trigger version to match the fields your function expects.
+
+## Custom authentication challenge flow
+
+Wire the three challenge triggers only when you need a **custom** challenge sequence your app
+defines: CAPTCHA on high-risk sign-in, security-question fallback, hardware-token wrap, or a
+multi-step approval flow. It runs as three triggers in sequence:
+
+1. **Define auth challenge** — the state machine: decides the next challenge or issues tokens.
+2. **Create auth challenge** — generates and delivers the challenge.
+3. **Verify auth challenge response** — checks the user's answer, sets `answerCorrect`.
+
+Drive it from the client with `initiate-auth --auth-flow CUSTOM_AUTH` then
+`respond-to-auth-challenge`.
+
+**Do NOT use this flow for email/SMS OTP passwordless.** Cognito offers native email/SMS
+OTP as first-auth factors on supported feature plans, without any custom triggers — set
+`EMAIL_OTP` or `SMS_OTP` in the pool's `SignInPolicy.AllowedFirstAuthFactors` and use the
+`USER_AUTH` flow. Custom-auth adds three Lambdas, three invoke-permission grants, and a
+bespoke state machine to maintain — the native path is a single `update-user-pool` call.
+See [passkeys.md](passkeys.md) for the `USER_AUTH` flow and `AllowedFirstAuthFactors` mechanics
+(the same wiring covers passkeys, email OTP, and SMS OTP).
+
+## Notification recipients (custom message / MFA)
+
+Send verification codes and MFA messages only to attributes that are already verified, or are
+being verified in this same flow (e.g. the address the user just entered at sign-up, before it's
+confirmed) — never to an unverified, caller-supplied address that was set for another purpose
+(e.g. an attribute updated outside the verification flow). Otherwise a caller-controlled email/phone
+value could be used to redirect a code meant for the account owner to an address the caller
+chose.
+
+## Gotchas
+
+- A trigger that returns an error **halts** the originating Cognito API call and returns an error
+  to the user. **Fail closed** for triggers that make an authentication or authorization decision
+  (pre sign-up, pre authentication, verify auth challenge, pre token generation, migrate user):
+  return an error rather than allowing the operation to proceed on an unexpected condition or a
+  failed dependency call. Fail-open is acceptable only for non-authoritative side-effect triggers
+  such as post-authentication analytics or custom messaging, where an error should not block the
+  user's sign-in. Example deny path (pre sign-up, Node.js):
+
+  ```js
+  if (isBlockedDomain(event.request.userAttributes.email)) {
+    throw new Error("Sign-up not permitted for this domain."); // halts sign-up; do not return normally
+  }
+  ```
+
+- Triggers must return the event with the expected response fields populated, or Cognito rejects
+  the response.
+- Keep triggers fast; they run inline on the auth path and add latency to every affected request.
+- Grant Cognito permission to invoke the function (`lambda:InvokeFunction` for
+  `cognito-idp.amazonaws.com` with the pool as source). **The console and CDK wire this
+  automatically** — the CDK `UserPool` construct adds the `AWS::Lambda::Permission` when you set
+  `lambdaTriggers` or call `addTrigger` (note it sets `aws:SourceArn` but **not**
+  `aws:SourceAccount`). Only the raw **CLI / API / CloudFormation** paths need a manual
+  `lambda add-permission` / `AWS::Lambda::Permission`. When you add it yourself, include both
+  `aws:SourceArn` (the user pool ARN) and `aws:SourceAccount` (your account id) on the Lambda
+  resource policy to prevent confused-deputy attacks. Via the CLI, `--source-arn` alone is not
+  enough — you **must also pass `--source-account`**, and you must run `add-permission` once per
+  Lambda you wire (each trigger function needs its own grant):
+
+  ```
+  aws lambda add-permission \
+    --function-name <trigger-fn-name-or-arn> \
+    --statement-id cognito-<trigger>-invoke \
+    --action lambda:InvokeFunction \
+    --principal cognito-idp.amazonaws.com \
+    --source-arn arn:aws:cognito-idp:<region>:<account>:userpool/<pool-id> \
+    --source-account <account>          # REQUIRED alongside --source-arn; omitting it leaves a confused-deputy gap
+  ```
+
+  The resulting resource-policy statement carries both conditions:
+
+  ```json
+  "Condition": {
+    "ArnLike":      { "aws:SourceArn":     "arn:aws:cognito-idp:<region>:<account>:userpool/<pool-id>" },
+    "StringEquals": { "aws:SourceAccount": "<account>" }
+  }
+  ```
+
+- Trigger functions receive user PII (email, phone, custom attributes). Avoid logging full event
+  payloads, and encrypt the function's CloudWatch Logs group with a KMS key.
+
+## Related
+
+- [tokens-and-sessions.md](tokens-and-sessions.md) for what the claims feed into.
+- `aws-serverless` skill for authoring and deploying the Lambda functions.
+
+## Authoritative sources
+
+- [Customizing user pool workflows with Lambda triggers](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html)
+- [Pre token generation Lambda trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html)

--- a/skills/core-skills/aws-auth/references/managed-login-oauth.md
+++ b/skills/core-skills/aws-auth/references/managed-login-oauth.md
@@ -1,0 +1,301 @@
+# Managed Login & OAuth Flows
+
+## Overview
+
+Cognito serves two versions of its hosted sign-in pages, chosen **per domain** via
+`ManagedLoginVersion`: the classic hosted UI (`ManagedLoginVersion` 1) and **managed login**
+(`ManagedLoginVersion` 2), which adds a no-code visual branding designer and native support
+for passkeys and email/SMS OTP as first-factor sign-in. They are separate domain versions
+selected at domain-creation time — not two names for the same thing. Both are hosted, OAuth
+2.0–compliant authorization servers with built-in sign-up, sign-in, MFA, password reset, and
+social/SAML login. **Prefer `ManagedLoginVersion` 2 for new integrations** — managed login
+is the successor brand to the classic hosted UI, and passkey / native-OTP factors
+require v2. Prefer the hosted pages over a custom login page for faster, more secure
+time-to-market; build a custom UI only when branding requirements are strict (and you accept
+owning MFA, reset, and federation UX).
+
+## Set up the domain
+
+```
+aws cognito-idp create-user-pool-domain \
+  --user-pool-id <pool-id> \
+  --domain my-app-login \
+  --managed-login-version 2      # 2 = managed login (branding designer); 1 = classic hosted UI
+  # Cognito prefix domain: my-app-login.auth.<region>.amazoncognito.com
+```
+
+### Managed login v2 needs a branding style per app client
+
+**The console auto-assigns a default branding style when you enable managed login v2; the CLI
+and API do not.** Cognito documents managed login as unavailable for an app client until a
+branding style exists, so a domain created with `--managed-login-version 2` produces a broken
+login page for every client that has no style. After the app client is created, run:
+
+```
+aws cognito-idp create-managed-login-branding \
+  --user-pool-id <pool-id> \
+  --client-id <client-id> \
+  --use-cognito-provided-values
+```
+
+`--use-cognito-provided-values` seeds Cognito's default look; the branding can be customized
+later. Run this **per app client** that uses the domain (each client owns its own style).
+Omit this on `ManagedLoginVersion` 1 (classic hosted UI) — v1 has no branding designer and
+does not require this step.
+
+### Custom domain (production branding)
+
+For a production custom domain like `auth.mycompany.com` instead of the default
+`<prefix>.auth.<region>.amazoncognito.com`:
+
+1. **ACM certificate must be in `us-east-1`** — regardless of your user pool's region.
+   Cognito serves the hosted pages via CloudFront under the hood, and CloudFront
+   distributions require certs in us-east-1. The certificate's primary name (or a SAN)
+   must match the exact custom domain (`auth.mycompany.com`).
+2. **Create the user pool domain with the certificate:**
+
+   ```
+   aws cognito-idp create-user-pool-domain \
+     --user-pool-id <pool-id> \
+     --domain auth.mycompany.com \
+     --custom-domain-config CertificateArn=arn:aws:acm:us-east-1:<account>:certificate/<uuid> \
+     --managed-login-version 2
+   ```
+
+3. **Point DNS at Cognito's CloudFront distribution.** The response contains the
+   distribution FQDN as `CloudFrontDomain` (in the create response) / `CloudFrontDistribution`
+   (in `describe-user-pool-domain`). Set a `CNAME` — or a Route 53 alias A record — from
+   `auth.mycompany.com` to that CloudFront FQDN.
+
+**Parent-domain gotcha.** Cognito refuses the subdomain if the parent domain
+(`mycompany.com`) has no `A` record — an SOA record is NOT sufficient. If your apex isn't
+behind a real `A` record (e.g. Route 53 with no landing page), add a dummy `A` record for
+validation and remove it after Cognito accepts the domain.
+
+**Timing.** Provisioning can take several minutes; `describe-user-pool-domain` reports
+`Status: CREATING` until CloudFront is ready. Wait for `ACTIVE` before pointing DNS.
+
+## Configure OAuth on the app client
+
+**`update-user-pool-client` replaces the entire client configuration — any field you omit is
+reset to its default.** It is not a partial update (`PATCH`); it is a full replace (`PUT`). Calling
+it with only the OAuth parameters against an existing client silently wipes everything else you set
+before — `ExplicitAuthFlows`, `AccessTokenValidity`/`IdTokenValidity`, `EnableTokenRevocation`,
+refresh-token rotation, read/write attributes, and more. In an agent context that is a one-shot
+outage: the client keeps working just enough that the wipe is invisible until a user hits the
+missing flow.
+
+**Always read-modify-write.** Describe the client first, keep every existing field, add or change
+only what you were asked to, then re-send the full set.
+
+**Most reliable method — round-trip the exact config with `--cli-input-json`.** Rather than
+re-typing every flag by hand (easy to drop a field, which then silently resets), take the
+`describe` output, delete the three read-only fields that `update` rejects
+(`ClientSecret`, `CreationDate`, `LastModifiedDate`), apply your change, and feed the whole object
+back. Every other field is preserved verbatim:
+
+```
+# 1. Read current config into the exact shape update expects (strip read-only fields).
+aws cognito-idp describe-user-pool-client \
+  --user-pool-id <pool-id> --client-id <client-id> \
+  --query 'UserPoolClient' --output json \
+  | jq 'del(.ClientSecret, .CreationDate, .LastModifiedDate)' > client.json
+
+# 2. Apply only the requested change (add callback2 + the `profile` scope), keeping the rest.
+jq '.CallbackURLs += ["https://app.example.com/callback2"] | .AllowedOAuthScopes += ["profile"]' \
+  client.json > client-updated.json
+
+# 3. Re-send the FULL object. Unspecified fields would reset; here nothing is omitted.
+aws cognito-idp update-user-pool-client --cli-input-json file://client-updated.json
+```
+
+If you instead pass individual `--flags`, you must repeat **every** existing field (from the
+describe) alongside your change, or the omitted ones reset to default. The `--cli-input-json`
+round-trip above avoids that trap.
+
+The same full-replace rule applies to `set-identity-pool-roles` (it replaces the whole roles +
+`RoleMappings` structure) — see [identity-pools.md](identity-pools.md).
+
+## OAuth flow selection
+
+| Flow | `allowed-o-auth-flows` | Use for |
+|------|------------------------|---------|
+| **Authorization code + PKCE** | `code` | SPAs and mobile (public clients) — **default choice** |
+| Authorization code (with secret) | `code` | Server-side/confidential clients |
+| Client credentials | `client_credentials` | Machine-to-machine (no user); requires a resource server + custom scopes and a client secret |
+| Implicit (`token`) | `implicit` | **Legacy only** — returns tokens in the URL fragment; avoid for new apps |
+
+**Authorization code + PKCE** is the secure default for browser/mobile. The authorize request adds
+`code_challenge`/`code_challenge_method=S256`; the token exchange sends the matching
+`code_verifier`. No client secret is used.
+
+## Machine-to-machine (client credentials) & resource servers
+
+`client_credentials` is the OAuth flow for **service-to-service** auth with **no user**. It needs a
+**resource server** that declares **custom scopes**, plus a **confidential app client** (with a
+secret) that has the flow enabled and those scopes granted.
+
+1. Create a resource server with custom scopes. A scope's full identifier is
+   `<resource-server-identifier>/<scope-name>` (e.g. `https://api.example.com/orders.read`):
+
+   ```
+   aws cognito-idp create-resource-server \
+     --user-pool-id <pool-id> \
+     --identifier https://api.example.com \
+     --name orders-api \
+     --scopes ScopeName=orders.read,ScopeDescription="Read orders" \
+              ScopeName=orders.write,ScopeDescription="Write orders"
+   ```
+
+2. Create a **confidential** app client (with a secret), enable the `client_credentials` flow, and
+   grant the custom scopes — no `openid`/user scopes, because there is no user:
+
+   ```
+   aws cognito-idp create-user-pool-client \
+     --user-pool-id <pool-id> --client-name svc-client \
+     --generate-secret \
+     --allowed-o-auth-flows-user-pool-client \
+     --allowed-o-auth-flows client_credentials \
+     --allowed-o-auth-scopes https://api.example.com/orders.read
+   ```
+
+3. The service fetches an **access token** from the token endpoint (HTTP Basic auth with
+   `client_id:client_secret`) — no user login, no hosted UI:
+
+   ```
+   curl -X POST https://<domain>/oauth2/token \
+     -H 'Authorization: Basic <base64(client_id:client_secret)>' \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     -d 'grant_type=client_credentials&scope=https://api.example.com/orders.read'
+   ```
+
+- The response is an **access token only** — **no ID token and no refresh token**. Request a new
+  token when it expires.
+- The access token's `scope` claim carries the granted scopes; enforce them at your API (require
+  the scope on the route or check the `scope` claim). See [api-authorization.md](api-authorization.md).
+- `client_credentials` requires a user pool **domain** and a **client secret**, so it is only for
+  confidential clients — never public browser/mobile clients. Cognito's token endpoint does NOT
+  return `invalid_scope`: requesting a scope the client wasn't granted is silently dropped from
+  the response `scope` claim, or the request fails with `invalid_grant` — do not branch on
+  `invalid_scope`. The documented error set for `/oauth2/token` is `invalid_request`,
+  `invalid_client`, `invalid_grant`, `unauthorized_client`, and `unsupported_grant_type`. See
+  [token endpoint docs](https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html).
+
+## Authorize → token exchange (code + PKCE)
+
+1. Redirect the browser to:
+   `https://<domain>/oauth2/authorize?response_type=code&client_id=<id>&redirect_uri=<callback>&scope=openid+email&code_challenge=<challenge>&code_challenge_method=S256&state=<state>`
+2. Cognito redirects back to `redirect_uri?code=<code>&state=<state>`.
+3. Exchange the code at `/oauth2/token` with `grant_type=authorization_code`, the `code`, the
+   `redirect_uri`, and the `code_verifier`. Response contains `id_token`, `access_token`,
+   `refresh_token`.
+
+**`state` and `nonce` (CSRF + replay protection — use both alongside PKCE):** generate `state` as a
+cryptographically random, single-use value (e.g. 32 bytes from a CSPRNG), store it bound to the
+browser session, and **reject the callback if the returned `state` doesn't match**. For OIDC, also
+send a random `nonce` on the authorize request and verify the `nonce` claim in the returned ID
+token. PKCE protects the code exchange; `state`/`nonce` protect against CSRF and replay — they are
+complementary, not alternatives.
+
+The Amplify client library performs this whole flow for you; see
+[tokens-and-sessions.md](tokens-and-sessions.md).
+
+## Social & SAML federation
+
+**Never put the IdP `client_secret` on the command line.** Interpolating it into
+`--provider-details "...client_secret=${G_SECRET}..."` exposes it via `ps`, shell history, and the
+agent transcript. Pass `--provider-details` by **file reference** instead: write the details to a
+`umask 077` temp file, pass `file://`, and delete it. Never echo or log the secret value.
+
+```
+# Example: Google — read the secret from Secrets Manager into a locked-down temp file,
+# pass it by file reference (never on the command line), then delete the file.
+umask 077
+DETAILS=$(mktemp)
+G_SECRET=$(aws secretsmanager get-secret-value \
+  --secret-id google-idp-secret --query SecretString --output text)
+cat > "$DETAILS" <<JSON
+{"client_id":"<g-id>","client_secret":"${G_SECRET}","authorize_scopes":"openid email profile"}
+JSON
+unset G_SECRET
+
+aws cognito-idp create-identity-provider \
+  --user-pool-id <pool-id> \
+  --provider-name Google --provider-type Google \
+  --provider-details "file://${DETAILS}" \
+  --attribute-mapping email=email,name=name
+
+rm -f "$DETAILS"
+```
+
+Then add the provider to the app client's `--supported-identity-providers` (e.g. `COGNITO Google`).
+SAML and OIDC third-party IdPs use `--provider-type SAML|OIDC` with the metadata URL/document.
+
+**Secret handling:** store the social IdP `client_secret` in AWS Secrets Manager, read it at
+configuration time, pass it only by `file://` reference (as above), and never commit it to source.
+
+**Attribute mapping matters:** map the IdP's email/name claims to user pool attributes. Without
+account linking, the same person signing in via different IdPs (or via email + Google) creates
+**separate** users. Treat email as non-unique across providers and link deliberately.
+
+## Multi-tenant SAML — routing users to their tenant's IdP
+
+A common B2B SaaS pattern: one Cognito user pool, each enterprise tenant brings their own SAML
+IdP (Okta, Azure AD, Ping), and each tenant's users must land on **their** IdP without seeing
+the managed-login provider picker. Two `/authorize` query parameters do this — both silently
+redirect through the Authorize endpoint straight to the tenant's IdP:
+
+- **`identity_provider=<ProviderName>`** — pass the IdP's `ProviderName` (as configured on
+  `CreateIdentityProvider`) directly on the authorize URL. Use when the client already knows
+  which tenant the user belongs to.
+
+  ```
+  https://<domain>/oauth2/authorize?response_type=code&identity_provider=TenantASAML&client_id=<id>&redirect_uri=<url>
+  ```
+
+- **`idp_identifier=<friendly-id>`** — pass an IdP *identifier* configured on the IdP via
+  `IdpIdentifiers` (an array of up to 50 friendly names per IdP). Useful when a single IdP
+  owns multiple aliases, or when identifiers match the tenants' email domains and managed
+  login can auto-route by asking the user for their email.
+
+  ```
+  aws cognito-idp create-identity-provider \
+    --user-pool-id <pool-id> \
+    --provider-name TenantASAML --provider-type SAML \
+    --idp-identifiers tenant-a.example.com corp.tenant-a.io \
+    --provider-details MetadataURL=https://tenant-a.example.com/saml/metadata.xml \
+    --attribute-mapping email=...
+  # then on /authorize:
+  #   idp_identifier=tenant-a.example.com
+  ```
+
+Add the IdP to the app client's `--supported-identity-providers` (each tenant IdP still needs
+to be a supported provider on the client). Since the routing parameters bypass the picker, users
+never see other tenants' IdPs — the tenant list stays private per tenant.
+
+## Callback URL rules
+
+Registered callback and logout URLs must match **exactly** — scheme, host, path, and trailing
+slash all count. HTTP (not HTTPS) is allowed only for **loopback** addresses — `http://localhost`,
+`http://127.0.0.1`, and `http://[::1]` — for local dev; every other web URL must be HTTPS.
+**Custom application schemes** (e.g. `myapp://callback`) are also allowed — that's how native
+mobile apps receive the redirect, which matters because this skill steers mobile apps to the
+authorization-code + PKCE flow. A mismatch produces `redirect_mismatch`.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `redirect_mismatch` | Callback URL not registered exactly | Add the exact URL to Allowed callback URLs |
+| `invalid_grant` on token exchange | Reused/expired code, or missing `code_verifier` | Exchange the code once, promptly, with the matching verifier |
+| Social login loops or drops attributes | Missing attribute mapping / provider not on client | Map attributes; add the IdP to the app client |
+
+## Related
+
+- [tokens-and-sessions.md](tokens-and-sessions.md) for handling the returned tokens.
+- [troubleshooting.md](troubleshooting.md) for redirect/CORS/federation issues.
+
+## Authoritative sources
+
+- [User pool managed login / hosted UI](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-managed-login.html)
+- [User pool endpoints & managed login reference (OAuth 2.0 `/authorize`, `/token`, PKCE)](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-userpools-server-contract-reference.html)

--- a/skills/core-skills/aws-auth/references/passkeys.md
+++ b/skills/core-skills/aws-auth/references/passkeys.md
@@ -1,0 +1,123 @@
+# Passkeys (FIDO2 / WebAuthn) in Cognito
+
+## Overview
+
+Cognito supports passkeys — FIDO2/WebAuthn credentials backed by Face ID, Touch
+ID, platform authenticators, or hardware security keys — as a **first-factor**
+sign-in method. Passkeys can be the only method, or coexist with passwords so
+users choose per session.
+
+## Feature-plan gate
+
+Passkeys require the **Essentials** or **Plus** feature plan. NOT available on
+Lite. Set at pool creation or via `update-user-pool --user-pool-tier ESSENTIALS`.
+
+## Two integration paths
+
+Passkeys work through **exactly one of these two paths** — the classic hosted
+UI (managed login v1) does NOT support passkeys:
+
+- **Managed login v2** — hosted flow. Create the pool domain with
+  `--managed-login-version 2`; Cognito renders the passkey prompt automatically.
+- **`USER_AUTH` runtime auth flow** — custom UI. App client's `ExplicitAuthFlows`
+  must include `ALLOW_USER_AUTH`; call `InitiateAuth` with `AuthFlow=USER_AUTH`.
+
+## Pool-level configuration
+
+Two settings enable passkeys at the pool:
+
+1. **`Policies.SignInPolicy.AllowedFirstAuthFactors`** — declares which factors
+   the pool offers as the first step. Include `WEB_AUTHN` to allow passkeys;
+   add `PASSWORD` too for coexistence.
+
+   ```
+   aws cognito-idp update-user-pool \
+     --user-pool-id <pool-id> \
+     --policies 'SignInPolicy={AllowedFirstAuthFactors=[PASSWORD, WEB_AUTHN]}' \
+     ... (re-send every other existing field — full-replace API)
+   ```
+
+   Accepted values: `PASSWORD | EMAIL_OTP | SMS_OTP | WEB_AUTHN` (the enum also
+   lists `SOFTWARE_TOKEN` but docs mark it unusable — do not include).
+
+2. **`WebAuthnConfiguration`** — lives on the pool's **MFA configuration**, NOT
+   on `SignInPolicy`. Set via `set-user-pool-mfa-config`:
+
+   ```
+   aws cognito-idp set-user-pool-mfa-config \
+     --user-pool-id <pool-id> \
+     --web-authn-configuration RelyingPartyId=auth.example.com,UserVerification=preferred
+   ```
+
+   - `RelyingPartyId` — the origin the passkey is bound to. Must match your
+     app's domain.
+   - `UserVerification` — `required` or `preferred` only (Cognito does NOT
+     accept the WebAuthn-spec `discouraged`).
+
+## App client configuration
+
+Include `ALLOW_USER_AUTH` in `ExplicitAuthFlows`:
+
+```
+aws cognito-idp update-user-pool-client \
+  --user-pool-id <pool-id> --client-id <client-id> \
+  --explicit-auth-flows ALLOW_USER_AUTH ALLOW_USER_SRP_AUTH ALLOW_REFRESH_TOKEN_AUTH \
+  ... (re-send every other existing field — full-replace API)
+```
+
+`ALLOW_USER_AUTH` is distinct from `ALLOW_USER_SRP_AUTH`. Add both if you want
+passkey users AND password/SRP users on the same client.
+
+## Password + passkey coexistence
+
+Yes — passkeys and passwords coexist on the **same pool and same app client**;
+no need to split. Configure both `PASSWORD` and `WEB_AUTHN` in
+`AllowedFirstAuthFactors` and `ALLOW_USER_AUTH` in `ExplicitAuthFlows`.
+
+What each user sees depends on which factors THEY have registered:
+
+- Users with an enrolled passkey → managed login v2 offers passkey first, with
+  password fallback.
+- Users without → password sign-in, with a prompt to add a passkey after.
+
+## `USER_AUTH` sign-in flow (custom UI)
+
+**Agent-directed** — client picks the factor up front via `PREFERRED_CHALLENGE`:
+
+```
+aws cognito-idp initiate-auth \
+  --client-id <client-id> \
+  --auth-flow USER_AUTH \
+  --auth-parameters USERNAME=alice@example.com,PREFERRED_CHALLENGE=WEB_AUTHN
+```
+
+Valid `PREFERRED_CHALLENGE`: `PASSWORD | PASSWORD_SRP | WEB_AUTHN | EMAIL_OTP | SMS_OTP`.
+
+**User-directed** — omit `PREFERRED_CHALLENGE`; server returns
+`ChallengeName: SELECT_CHALLENGE` with `AvailableChallenges: [...]` filtered to
+what the user has registered. Client then responds via
+`respond-to-auth-challenge` with `ANSWER=<picked>`.
+
+## Enrollment (registering a passkey)
+
+Two-call flow, authorized by user access token — user must be signed in first:
+
+```
+aws cognito-idp start-web-authn-registration \
+  --access-token <user-access-token>            # returns PublicKeyCreationOptions
+
+aws cognito-idp complete-web-authn-registration \
+  --access-token <user-access-token> \
+  --credential file://attestation.json           # browser's attestation
+```
+
+WebAuthn APIs authorize via the user's access token (scope
+`aws.cognito.signin.user.admin`), NOT via IAM. Companion APIs:
+`list-web-authn-credentials`, `delete-web-authn-credential`.
+
+## Authoritative sources
+
+- [`SignInPolicyType`](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignInPolicyType.html) — `AllowedFirstAuthFactors` enum
+- [`WebAuthnConfigurationType`](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_WebAuthnConfigurationType.html) — on `SetUserPoolMfaConfig`
+- [`InitiateAuth`](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html) — `USER_AUTH` flow
+- [Sign-in with passkeys](https://docs.aws.amazon.com/cognito/latest/developerguide/authentication.html)

--- a/skills/core-skills/aws-auth/references/threat-protection.md
+++ b/skills/core-skills/aws-auth/references/threat-protection.md
@@ -1,0 +1,156 @@
+# Threat Protection & Adaptive Authentication
+
+## Overview
+
+Cognito's threat protection (formerly "advanced security features") detects and
+responds to suspicious sign-in activity: compromised (breached) passwords,
+risky patterns (new device, unusual IP), and risk-based adaptive MFA.
+
+## Feature-plan gate
+
+Threat protection features require the **Plus** feature plan:
+
+- `AdvancedSecurityMode = AUDIT | ENFORCED` — Plus only.
+- Adaptive-auth risk configuration — Plus only.
+- Threat-protection log delivery (`userAuthEvents` event source) — Plus only.
+
+Attempting these on a lower tier returns `FeatureUnavailableInTierException`.
+Set via `update-user-pool --user-pool-tier PLUS`.
+
+## `AdvancedSecurityMode` — three modes
+
+Lives on `UserPool.UserPoolAddOns.AdvancedSecurityMode` (nested, not top-level):
+
+| Mode | Behavior |
+|------|----------|
+| `OFF` | Threat protection disabled |
+| `AUDIT` | Records risk assessments; takes NO action. Data-gathering mode |
+| `ENFORCED` | Records AND applies your configured risk responses |
+
+Toggle via `update-user-pool` (NOT `set-risk-configuration`):
+
+```
+aws cognito-idp update-user-pool \
+  --user-pool-id <pool-id> \
+  --user-pool-add-ons AdvancedSecurityMode=ENFORCED \
+  ... (re-send every other existing field — full-replace API)
+```
+
+## Compromised-credentials protection
+
+Detects passwords on known-breached lists. Configure via `set-risk-configuration`:
+
+```
+aws cognito-idp set-risk-configuration \
+  --user-pool-id <pool-id> \
+  --compromised-credentials-risk-configuration \
+    'Actions={EventAction=BLOCK},EventFilter=[SIGN_IN,SIGN_UP,PASSWORD_CHANGE]'
+```
+
+- `EventAction`: **`BLOCK`** (reject the auth attempt) or **`NO_ACTION`** (log only).
+- `EventFilter`: any subset of `SIGN_IN | SIGN_UP | PASSWORD_CHANGE`. Defaults
+  to all three when omitted.
+- Omit `--client-id` for pool-wide config; include it to scope to one client.
+
+## Adaptive authentication (risk-based MFA)
+
+Cognito classifies each sign-in as **No Risk / Low / Medium / High**. The API
+exposes **three configurable action tiers** (`LowAction` / `MediumAction` /
+`HighAction`) — `No Risk` proceeds without triggering any Action.
+
+```
+aws cognito-idp set-risk-configuration \
+  --user-pool-id <pool-id> \
+  --account-takeover-risk-configuration '
+    NotifyConfiguration={
+      SourceArn=arn:aws:ses:us-east-1:<account>:identity/no-reply@example.com,
+      From=no-reply@example.com
+    },
+    Actions={
+      LowAction={EventAction=NO_ACTION,Notify=false},
+      MediumAction={EventAction=MFA_IF_CONFIGURED,Notify=true},
+      HighAction={EventAction=MFA_REQUIRED,Notify=true}
+    }'
+```
+
+### `EventAction` — four values per tier
+
+| Value | Behavior |
+|-------|----------|
+| `NO_ACTION` | Allow the sign-in |
+| `MFA_IF_CONFIGURED` | Require MFA if the user has it set up; allow otherwise (**optional MFA**) |
+| `MFA_REQUIRED` | Require MFA; block if user has no MFA method (**required MFA**) |
+| `BLOCK` | Reject the sign-in outright |
+
+Do NOT collapse `MFA_IF_CONFIGURED` and `MFA_REQUIRED` — they behave differently.
+Typical: `Low → NO_ACTION`, `Medium → MFA_IF_CONFIGURED`, `High → MFA_REQUIRED`
+or `BLOCK`.
+
+### `NotifyConfiguration`
+
+- **`SourceArn`** is **required** and must be a verified SES identity ARN.
+- Optional: `From`, `ReplyTo`, and per-outcome message bodies (`BlockEmail`,
+  `MfaEmail`, `NoActionEmail`, each with `Subject`/`HtmlBody`/`TextBody`).
+
+## Log delivery to CloudWatch
+
+Route threat-protection events to CloudWatch/S3/Firehose via
+`set-log-delivery-configuration`:
+
+```
+aws cognito-idp set-log-delivery-configuration \
+  --user-pool-id <pool-id> \
+  --log-configurations '[
+    {
+      "EventSource": "userAuthEvents",
+      "LogLevel": "INFO",
+      "CloudWatchLogsConfiguration": {"LogGroupArn": "arn:aws:logs:<region>:<account>:log-group:<name>"}
+    }
+  ]'
+```
+
+**Enum-pair rules** (Cognito rejects mismatched pairs):
+
+| `EventSource` | `LogLevel` | Purpose | Tier |
+|---------------|------------|---------|------|
+| `userAuthEvents` | `INFO` | Threat-protection sign-in events | Plus |
+| `userNotification` | `ERROR` | Message-delivery errors (SMS, email) | Lite+ |
+
+**Encrypt the target CloudWatch Logs log group with a customer-managed KMS key** —
+threat-protection events contain user PII (IP addresses, user identifiers) and sign-in
+risk metadata. Either set the KMS key at log-group creation, or associate one after the
+fact:
+
+```
+aws logs associate-kms-key \
+  --log-group-name /aws/cognito/<pool-id> \
+  --kms-key-id arn:aws:kms:<region>:<account>:key/<key-id>
+```
+
+The KMS key policy must allow the `logs.<region>.amazonaws.com` service principal
+`kms:Encrypt*` / `kms:Decrypt*` / `kms:GenerateDataKey*` / `kms:Describe*` scoped to
+the log group ARN via `kms:EncryptionContext:aws:logs:arn`.
+
+## Inspect current state
+
+```
+aws cognito-idp describe-user-pool --user-pool-id <pool-id>          # AdvancedSecurityMode
+aws cognito-idp describe-risk-configuration --user-pool-id <pool-id> # risk config
+aws cognito-idp get-log-delivery-configuration --user-pool-id <pool-id>
+```
+
+## Gotchas
+
+- `UserPoolAddOns` block may be absent if threat protection never enabled —
+  inspect defensively: `pool.get("UserPoolAddOns", {}).get("AdvancedSecurityMode")`.
+- Downgrading Plus → lower tier fails while `AdvancedSecurityMode` is
+  `AUDIT`/`ENFORCED`. Set to `OFF` first, then change tier.
+- `set-risk-configuration` with only `UserPoolId` clears the config to defaults
+  — always read-modify-write.
+
+## Authoritative sources
+
+- [Threat protection](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-threat-protection.html)
+- [`SetRiskConfiguration`](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SetRiskConfiguration.html)
+- [`SetLogDeliveryConfiguration`](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SetLogDeliveryConfiguration.html)
+- [Feature plans](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sign-in-feature-plans.html)

--- a/skills/core-skills/aws-auth/references/tokens-and-sessions.md
+++ b/skills/core-skills/aws-auth/references/tokens-and-sessions.md
@@ -1,0 +1,209 @@
+# Tokens & Sessions
+
+## Overview
+
+Cognito issues three JWTs after authentication. Knowing which token to use where — and how to
+refresh, rotate, revoke, and store them safely — prevents most auth bugs.
+
+## The three tokens
+
+| Token | Contents | Use it for | Lifetime |
+|-------|----------|------------|----------|
+| **ID token** | Identity claims (name, email, etc.) | Proving **who** the user is (identity) to your app; identity-based checks you run yourself. NOT the credential for scope-based API authorization | Short-lived, configurable per app client — check the current default and valid range in the [Cognito quotas docs](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) or via `aws cognito-idp describe-user-pool-client` |
+| **Access token** | Groups, scopes, user claims | **Authorizing API calls** — scope- and group-based access to your API and OAuth-scoped resources. This is the token meant for authorization | Short-lived, configurable per app client — check the current default and valid range in the [Cognito quotas docs](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) or via `aws cognito-idp describe-user-pool-client` |
+| **Refresh token** | Opaque | Getting new ID and access tokens without re-login | Long-lived, configurable per app client — check the current default and min/max range in the [Cognito quotas docs](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) or via `aws cognito-idp describe-user-pool-client` |
+
+ID and access tokens are short-lived; the refresh token is long-lived. Send the token your
+consumer expects: an API Gateway JWT authorizer can be configured for either, but the audience
+(`aud`) claim is present on the ID token while the access token carries `client_id` and `scope` —
+match the authorizer's `audience`/identity source to the token you send. See
+[api-authorization.md](api-authorization.md).
+
+For **authorization** decisions, use the **access token** — it carries `scope` and
+`cognito:groups`, so scope- or group-based checks belong there. The **ID token** proves identity
+and is fine for identity-based checks you perform inside your own app, but it is not the token to
+gate API access with.
+
+### InitiateAuth-issued access tokens don't carry custom scopes
+
+An important architectural fact: `InitiateAuth` and `AdminInitiateAuth` issue access tokens that
+carry only the reserved scope `aws.cognito.signin.user.admin` — **custom scopes are NEVER
+included regardless of what's configured in the app client's `AllowedOAuthScopes`**. This is
+independent of the auth flow (SRP, USER_PASSWORD_AUTH, USER_AUTH — all the same). Custom scopes
+are only issued through the OAuth 2.0 endpoints: `/oauth2/authorize` (hosted UI / managed-login
+authorization-code + PKCE flow) and `/oauth2/token` (for token-grant endpoints including
+`client_credentials`).
+
+If your API Gateway route requires a custom scope like `https://api.example.com/orders.read`, an
+InitiateAuth-signed user cannot pass it — the scope is simply not in their access token. Three
+workarounds:
+
+1. Switch the sign-in flow to hosted UI / OAuth (authorization-code + PKCE) — the standard fix.
+2. Authorize on `cognito:groups` (or a custom claim) at the API instead of on scopes.
+3. Use a V2/V3 pre-token-generation Lambda trigger to inject scopes into the access token via
+   `scopesToAdd` — requires the Essentials or Plus feature plan (V3 for machine-to-machine).
+
+Adding the scope to `AllowedOAuthScopes` on the app client does NOT fix this — the config is
+already relevant only to the OAuth endpoints.
+
+## Refresh token rotation
+
+Enable rotation so each refresh returns a **new** refresh token and invalidates the old one,
+limiting the blast radius of a stolen token.
+
+```
+aws cognito-idp update-user-pool-client \
+  --user-pool-id <pool-id> --client-id <client-id> \
+  --refresh-token-rotation Feature=ENABLED,RetryGracePeriodSeconds=30
+```
+
+**`update-user-pool-client` is a full replace, not a partial update** — any field you omit reverts
+to its default. The one-flag command above is safe **only** on a client that has no other
+configuration to lose. On an already-configured client, describe it first and re-send every
+existing field alongside the rotation flag, or you will silently wipe its auth flows, token
+validity, and scopes. See the read-modify-write pattern in
+[managed-login-oauth.md](managed-login-oauth.md).
+
+- `RetryGracePeriodSeconds` (0–60) lets the rotated-out token stay valid briefly for client
+  retries. `0` invalidates it immediately on a successful refresh.
+- Refresh with the `GetTokensFromRefreshToken` API (or the token endpoint `grant_type=refresh_token`).
+- **Rotation disables the `REFRESH_TOKEN_AUTH` flow.** An app client with rotation enabled cannot
+  use `InitiateAuth`/`AdminInitiateAuth` with `AuthFlow=REFRESH_TOKEN_AUTH` — that call is rejected
+  at runtime. So `ALLOW_REFRESH_TOKEN_AUTH` and refresh-token rotation are **not** a valid
+  combination: leave `ALLOW_REFRESH_TOKEN_AUTH` out of the client's `--explicit-auth-flows` when
+  rotation is on, and refresh via `GetTokensFromRefreshToken` (or the token endpoint) instead.
+
+## Session termination — pick the right API
+
+Three APIs end sessions, each with different reach:
+
+| API | What it kills | Use for |
+|-----|---------------|---------|
+| `RevokeToken` / `/oauth2/revoke` | ONE refresh token + the access/ID tokens issued from it | Signing out a single device |
+| `AdminUserGlobalSignOut` | **All** refresh tokens for the user (across every session) | Stolen device / password compromise |
+| `AdminDisableUser` | All tokens **AND** blocks future auth attempts | Account termination / suspected compromise |
+
+`RevokeToken` requires token revocation enabled on the app client
+(`EnableTokenRevocation=true`). Revoking a refresh token invalidates every access/ID token
+issued from it; other refresh tokens for the same user are unaffected.
+`AdminUserGlobalSignOut` invalidates the user's identity, access, and refresh tokens across
+all sessions — but the user's account is still active, so they can sign back in and get
+fresh tokens. `AdminDisableUser` goes further: existing tokens die AND new auth attempts
+fail (`NotAuthorizedException: User is disabled`).
+
+### Nuance: access tokens against non-Cognito resource servers
+
+All three APIs invalidate server-side session state. When a downstream resource server
+verifies the token:
+
+- **Cognito's own user-pool APIs** check revocation state and reject revoked tokens
+  immediately.
+- **External resource servers** that verify the JWT locally (signature + `exp` + `iss` +
+  `aud`) have no way to know a token was revoked. Already-issued access tokens remain
+  usable against those servers until natural `exp`.
+
+The mitigation is short access-token lifetimes (5–15 minutes) plus refresh-token
+revocation for the long-tail lockout — force the client to refresh, at which point the
+revoked refresh token blocks the flow.
+
+### The hosted-UI / managed-login session cookie is SEPARATE
+
+Signing out via any of the three APIs above does **not** clear the managed-login session
+cookie. A user with a valid cookie can hit `/oauth2/authorize` and receive fresh tokens
+without ever presenting a refresh token — so a "kill all sessions" flow that only calls
+`AdminUserGlobalSignOut` leaves that back door open. For a full teardown, also redirect
+the user through:
+
+```
+https://<domain>/logout?client_id=<id>&logout_uri=<url>
+```
+
+The `/logout` endpoint clears the cookie and returns the user to `logout_uri` (which
+must be registered as an Allowed sign-out URL on the app client).
+
+## Token revocation (single-session detail)
+
+Enable revocation on the app client so any of the APIs above can invalidate a session.
+Revocation adds `jti` / `origin_jti` claims to issued tokens, slightly increasing token
+size.
+
+```
+aws cognito-idp update-user-pool-client \
+  --user-pool-id <pool-id> --client-id <client-id> \
+  --enable-token-revocation \
+  ... (re-send every other existing field — full-replace API)
+```
+
+Revoke via the API:
+
+```
+aws cognito-idp revoke-token \
+  --client-id <client-id> \
+  --token <refresh-token>
+```
+
+Or the OAuth endpoint (for public clients that don't want to expose the API):
+
+```
+POST https://<domain>/oauth2/revoke
+Content-Type: application/x-www-form-urlencoded
+
+client_id=<id>&token=<refresh-token>
+```
+
+## Frontend token storage (security)
+
+The Amplify client library defaults to **`localStorage`**, which is readable by any injected
+script — an XSS foothold can exfiltrate tokens. For anything sensitive:
+
+- Prefer **`cookieStorage`** with `Secure` and `SameSite=Strict`. Note that Amplify's cookie store **cannot** be `HttpOnly` — the SDK reads tokens client-side to attach them to requests, so setting `HttpOnly` would break token retrieval. For true `HttpOnly` storage, use a **backend-for-frontend (BFF)** that holds tokens server-side.
+- Keep the refresh token lifetime short and enable **rotation + revocation**.
+- Never place tokens in URLs or logs.
+
+There is no perfect browser storage; reducing token lifetime and enabling rotation/revocation
+matters more than the storage location alone.
+
+## Amplify client library (using an existing user pool)
+
+This is the client SDK (`aws-amplify` / `@aws-amplify/auth`) pointed at a user pool you configured —
+**not** the Amplify Gen2 backend (`amplify/auth.ts`), which belongs to the `aws-amplify` skill.
+
+```ts
+import { Amplify } from 'aws-amplify';
+import { signIn, signInWithRedirect, fetchAuthSession } from 'aws-amplify/auth';
+
+Amplify.configure({
+  Auth: { Cognito: { userPoolId: '<pool-id>', userPoolClientId: '<client-id>' } },
+});
+
+// Direct SRP / username-password sign-in (your own UI, no hosted UI):
+await signIn({ username, password });
+
+// Hosted UI / managed login via the OAuth authorization-code + PKCE flow:
+await signInWithRedirect();   // redirects to the hosted UI; Amplify completes the code+PKCE exchange on return
+
+const { tokens } = await fetchAuthSession();   // tokens.idToken / tokens.accessToken
+```
+
+`signIn({ username, password })` runs the **SRP / username-password** flow directly against the
+user pool — it does **not** use the hosted UI or the OAuth code+PKCE exchange. The hosted-UI
+authorization-code + PKCE flow goes through **`signInWithRedirect()`**; that is the call that
+performs the code+PKCE exchange. Either way, Amplify handles token storage and automatic refresh.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Users forced to re-login every hour | Not refreshing; only using ID/access token | Use the refresh token (or Amplify auto-refresh) to get new tokens |
+| `NotAuthorizedException: Refresh Token has been revoked` | Rotation invalidated the old token | Store and use the newest refresh token from each refresh |
+| Token accepted then suddenly rejected | Revocation or expiry | Re-authenticate; check `exp` and revocation state |
+
+## Related
+
+- [managed-login-oauth.md](managed-login-oauth.md) for obtaining tokens.
+- [api-authorization.md](api-authorization.md) for validating tokens at the API.
+
+## Authoritative sources
+
+- [Understanding user pool JSON web tokens (JWTs)](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-with-identity-providers.html)
+- [Ending user sessions with token revocation](https://docs.aws.amazon.com/cognito/latest/developerguide/token-revocation.html)

--- a/skills/core-skills/aws-auth/references/troubleshooting.md
+++ b/skills/core-skills/aws-auth/references/troubleshooting.md
@@ -1,0 +1,63 @@
+# Auth Troubleshooting
+
+## Overview
+
+The most common Cognito failures, by symptom, with root cause and fix.
+
+## Redirect & hosted UI
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `redirect_mismatch` after login | Callback URL not registered exactly (scheme/host/path/trailing slash/case) | Add the exact callback URL to the app client's Allowed callback URLs; localhost must be `http://localhost:<port>`, all else HTTPS |
+| Login page 400 "invalid_request" | Missing/invalid `response_type`, `client_id`, or unsupported scope | Send `response_type=code`, a valid client id, and scopes the client allows |
+| `invalid_grant` at `/oauth2/token` | Code reused, expired, or `code_verifier` missing/wrong | Exchange the code once, promptly, with the matching PKCE verifier |
+| CORS error hitting hosted UI or token endpoint | Browser calling `/oauth2/token` cross-origin, or proxying it | Do the code+PKCE exchange client-side per the flow; don't proxy the token endpoint |
+
+## Client secret / auth flow
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `NotAuthorizedException: Unable to verify secret hash` | Client secret set on a public (SPA/mobile) client | Recreate the app client with no secret, or compute `SECRET_HASH` in a server-side client |
+| `InvalidParameterException: Auth flow not enabled` | The flow isn't in the client's explicit auth flows | Add e.g. `ALLOW_USER_SRP_AUTH` / `ALLOW_REFRESH_TOKEN_AUTH` (note: `ALLOW_REFRESH_TOKEN_AUTH` is incompatible with refresh-token rotation — with rotation on, use `GetTokensFromRefreshToken` instead) |
+| Password auth rejected | `ALLOW_USER_PASSWORD_AUTH` disabled (good default) | Use SRP; enable password auth only for migration/server flows |
+
+## Tokens & sessions
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Forced re-login every hour | Not using the refresh token | Refresh via `GetTokensFromRefreshToken` / Amplify auto-refresh |
+| `Refresh Token has been revoked` | Rotation invalidated the old refresh token | Always use the newest refresh token returned by each refresh |
+| API returns 401 with a "valid" token | Issuer/audience mismatch or wrong token type | Issuer `https://cognito-idp.<region>.amazonaws.com/<pool-id>`, audience = client id; send the expected token (see api-authorization.md) |
+
+## MFA & sign-up
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| TOTP enrollment fails | Software MFA not enabled on the pool | `set-user-pool-mfa-config --software-token-mfa-configuration Enabled=true` |
+| Users stuck `UNCONFIRMED` | Verification code expired, never entered, or went to spam | Prefer `resend-confirmation-code` so each user re-verifies via `confirm-sign-up` — this proves email ownership. `admin-confirm-sign-up` flips the status instantly but confirms the account **without verifying the email**, leaving the attribute unverified (risky when email drives password reset / account linking); reserve it for trusted or migrated accounts and set the attribute verified separately only when ownership is established another way. |
+| Sign-up blocked unexpectedly | Pre sign-up trigger returned an error | Inspect the trigger's logic/logs; it halts the sign-up on error |
+
+## Federation
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Social user "already exists" / duplicate accounts | Same email across IdPs creates separate users | Enable attribute mapping and deliberate account linking; treat email as non-unique across providers |
+| Missing name/email after social login | IdP claims not mapped to pool attributes | Set `--attribute-mapping` on the identity provider |
+| SAML login fails | Metadata stale or attribute mapping wrong | Refresh IdP metadata; verify NameID/attribute mapping |
+
+## Identity pools
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Token is not from a supported provider` | Provider/ClientId not registered on the identity pool | Match `cognito-idp.<region>.amazonaws.com/<pool-id>` and the app client id |
+| `Access denied` after credentials returned | Authenticated role policy too narrow / trust policy wrong | Fix the role (see `aws-iam`); ensure it trusts `cognito-identity.amazonaws.com` for the pool |
+
+## Related
+
+- [managed-login-oauth.md](managed-login-oauth.md), [tokens-and-sessions.md](tokens-and-sessions.md),
+  [api-authorization.md](api-authorization.md), [identity-pools.md](identity-pools.md).
+
+## Authoritative sources
+
+- [Amazon Cognito user pools — Developer Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html)
+- [Managed login & federation error responses (redirect/token errors)](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-userpools-server-contract-reference.html)

--- a/skills/core-skills/aws-auth/references/user-pools.md
+++ b/skills/core-skills/aws-auth/references/user-pools.md
@@ -1,0 +1,168 @@
+# Cognito User Pools
+
+## Overview
+
+A user pool is a managed user directory and OpenID Connect (OIDC) identity provider. It handles
+sign-up, sign-in, MFA, password policies, and issues JWTs (ID, access, refresh). Use this
+reference to create and configure a user pool and its app clients.
+
+## Create a user pool (email sign-in)
+
+```
+# Create the pool first. Do NOT pass --mfa-configuration ON|OPTIONAL to create-user-pool:
+# at create time that requires --sms-configuration (an SmsConfiguration with an SnsCallerArn)
+# or the call fails with InvalidParameterException. Enable MFA after creation (below).
+aws cognito-idp create-user-pool \
+  --pool-name my-app-users \
+  --auto-verified-attributes email \
+  --username-attributes email \
+  --policies '{"PasswordPolicy":{"MinimumLength":12,"RequireUppercase":true,"RequireLowercase":true,"RequireNumbers":true,"RequireSymbols":true}}'
+
+# Require MFA and enable the TOTP (software token) factor — no SMS/SNS needed for TOTP.
+aws cognito-idp set-user-pool-mfa-config \
+  --user-pool-id <pool-id> \
+  --mfa-configuration ON \
+  --software-token-mfa-configuration Enabled=true
+```
+
+The example uses a strong default (12+ chars, all character classes, mandatory TOTP MFA). A
+shorter/relaxed password policy or a non-mandatory MFA posture is possible but should be
+treated as a **non-production exception** — for example, in a local/dev-only pool:
+
+```
+# Development-only variant, for local testing — do not use in production.
+# Same rule: don't pass --mfa-configuration to create-user-pool; relax MFA (OPTIONAL/OFF) via
+# set-user-pool-mfa-config afterward if you need it.
+aws cognito-idp create-user-pool \
+  --pool-name my-app-users-dev \
+  --auto-verified-attributes email \
+  --username-attributes email \
+  --policies '{"PasswordPolicy":{"MinimumLength":12,"RequireUppercase":true,"RequireLowercase":true,"RequireNumbers":true,"RequireSymbols":true}}'
+```
+
+- `--username-attributes email` lets users sign in with their email as the username. Choose this
+  or `--alias-attributes`; it is fixed at creation and cannot be changed later.
+- `--auto-verified-attributes email` sends a verification code on sign-up.
+- The feature plan (tier) governs advanced features (threat protection, access-token
+  customization, email OTP). The tiers are **Lite** (entry-level), **Essentials**, and **Plus**;
+  set the tier via `--user-pool-tier` where supported. Which tier includes a given feature can
+  change, so verify feature-to-tier inclusion against the
+  [Cognito feature plans docs](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sign-in-feature-plans.html).
+
+## App clients
+
+An app client represents one application that talks to the pool. Create one per app/frontend.
+
+```
+# Public client (SPA / mobile): NO secret; token revocation + refresh rotation enabled.
+# NOTE: with rotation enabled, do NOT include ALLOW_REFRESH_TOKEN_AUTH — that flow is
+# incompatible with refresh-token rotation. Refresh via GetTokensFromRefreshToken instead.
+aws cognito-idp create-user-pool-client \
+  --user-pool-id <pool-id> \
+  --client-name web-spa \
+  --no-generate-secret \
+  --explicit-auth-flows ALLOW_USER_SRP_AUTH \
+  --enable-token-revocation \
+  --refresh-token-rotation Feature=ENABLED,RetryGracePeriodSeconds=30
+
+# Confidential client (server-side): WITH secret; token revocation + refresh rotation enabled.
+# Set --explicit-auth-flows explicitly so the default set (which includes ALLOW_REFRESH_TOKEN_AUTH)
+# is not picked up — again, that flow conflicts with rotation.
+aws cognito-idp create-user-pool-client \
+  --user-pool-id <pool-id> \
+  --client-name backend \
+  --generate-secret \
+  --explicit-auth-flows ALLOW_USER_SRP_AUTH \
+  --enable-token-revocation \
+  --refresh-token-rotation Feature=ENABLED,RetryGracePeriodSeconds=30
+```
+
+**Rule:** public clients (browser/mobile) MUST use `--no-generate-secret`. A secret on a public
+client breaks token calls because the browser cannot protect the `SECRET_HASH`. Generate a secret
+only for confidential clients running on a server you control.
+
+**Refresh-token rotation makes the `ALLOW_REFRESH_TOKEN_AUTH` (`REFRESH_TOKEN_AUTH`) flow
+unavailable at runtime**: an app client with rotation enabled cannot use
+`InitiateAuth`/`AdminInitiateAuth` with `AuthFlow=REFRESH_TOKEN_AUTH` — that call is rejected. So
+omit `ALLOW_REFRESH_TOKEN_AUTH` from `--explicit-auth-flows` when rotation is on (and set the flows
+explicitly on the confidential client so it isn't inherited from the default set), and refresh
+tokens with the `GetTokensFromRefreshToken` API instead.
+
+Prefer SRP (`ALLOW_USER_SRP_AUTH`) over `ALLOW_USER_PASSWORD_AUTH` so raw passwords never leave
+the client. Enable `ALLOW_USER_PASSWORD_AUTH` only for migration or server-side flows.
+
+## MFA
+
+- `--mfa-configuration` = `OFF` | `OPTIONAL` | `ON`. Default to `ON` (mandatory) for production
+  pools. `OPTIONAL` (opt-in) or `OFF` are non-production exceptions — mark them clearly as such
+  when used. **Set MFA with `set-user-pool-mfa-config`, not `create-user-pool`:**
+  `create-user-pool --mfa-configuration ON|OPTIONAL` only succeeds if you also pass
+  `--sms-configuration` (an `SmsConfiguration` with an `SnsCallerArn`), otherwise it fails with
+  `InvalidParameterException`. For TOTP or email MFA (no SMS), leave MFA unset at creation and
+  configure it afterward with `set-user-pool-mfa-config`.
+- Software TOTP (authenticator apps) is the recommended second factor; SMS incurs cost and is
+  weaker. Enable TOTP with `set-user-pool-mfa-config --software-token-mfa-configuration Enabled=true`
+  — note this call alone only makes TOTP *available*; `--mfa-configuration` (above) is what
+  actually requires it.
+- Email OTP as a factor requires a supported feature plan.
+
+## Sign-up / sign-in flows (programmatic)
+
+| Action | API |
+|--------|-----|
+| Register a user | `sign-up` (public) or `admin-create-user` (admin) |
+| Confirm sign-up | `confirm-sign-up` with the emailed code, or `admin-confirm-sign-up` |
+| Sign in | `initiate-auth` (SRP or `USER_PASSWORD_AUTH`) → returns tokens or a challenge |
+| Respond to MFA/other challenge | `respond-to-auth-challenge` |
+| Forgot password | `forgot-password` → `confirm-forgot-password` |
+
+Most web/mobile apps should use the **hosted UI / managed login** or the Amplify client library
+instead of calling these APIs directly. See [managed-login-oauth.md](managed-login-oauth.md) and
+[tokens-and-sessions.md](tokens-and-sessions.md).
+
+## Custom attributes
+
+Add custom attributes at creation with a `custom:` prefix (e.g. `custom:tenant_id`). You can also
+add them **after the pool exists** with `aws cognito-idp add-custom-attributes` (up to **50**
+custom attributes total). Once defined, a custom attribute cannot be renamed or deleted, and its
+mutability is fixed — mark mutable attributes explicitly at definition time.
+
+## User pool groups
+
+Groups let you label users and (optionally) attach an IAM role for identity-pool role mapping.
+
+```
+aws cognito-idp create-group \
+  --user-pool-id <pool-id> --group-name admins \
+  --role-arn <admins-role-arn> --precedence 1
+
+aws cognito-idp admin-add-user-to-group \
+  --user-pool-id <pool-id> --username <user> --group-name admins
+```
+
+- A user's groups appear in the `cognito:groups` claim; the chosen group role surfaces as
+  `cognito:preferred_role`.
+- **`--precedence`** breaks ties when a user belongs to multiple groups: the group with the
+  **lowest** precedence value wins for `cognito:preferred_role` / identity-pool "role from token".
+  Lower number = higher priority.
+- This is what the identity-pool "role from token" selection in
+  [identity-pools.md](identity-pools.md) depends on.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `InvalidParameterException: Cannot modify the username attributes` | `username-attributes` fixed at creation | Recreate the pool with the desired setting |
+| `NotAuthorizedException: Unable to verify secret hash` | Secret set on a client used without `SECRET_HASH` | Use a no-secret public client, or compute `SECRET_HASH` server-side |
+| `UsernameExistsException` | User already registered | Use sign-in or `admin-get-user`; for social users see federation notes |
+
+## Related
+
+- [managed-login-oauth.md](managed-login-oauth.md) for the login UI and OAuth flows.
+- [tokens-and-sessions.md](tokens-and-sessions.md) for what to do with the tokens.
+- [lambda-triggers.md](lambda-triggers.md) to validate sign-up or customize the flow.
+
+## Authoritative sources
+
+- [Amazon Cognito user pools — Developer Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html)
+- [`aws cognito-idp` CLI reference](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/)


### PR DESCRIPTION
## Summary

Adds the `aws-auth` skill for Amazon Cognito. Covers user pools, identity pools,
managed login / hosted UI, OAuth 2.0 flows (authorization code + PKCE, client
credentials), social and SAML federation, tokens (rotation, revocation, session
termination), Cognito Lambda triggers, passkeys / WebAuthn, threat protection,
and API Gateway / ALB authorization.

## Details

- Text-only skill (no executable code)
- Security-reviewed: Guardian PASS
- Tested with: Kiro (against AWS MCP preprod endpoint)

## Checklist

- [x] Internal-only frontmatter fields removed (`owner_team`, `owner_cti`, `stages`, `metadata`, `categories`)
- [x] No internal links or references in skill content
- [x] No internal details in commit messages
- [x] CI checks pass
