### PR TITLE
chore(agents-pay): bump OpenClaw package to 1.0.5 with onboarding improvements

### DIFF
--- a/plugins/aws-agents/skills/agents-pay/SKILL.md
+++ b/plugins/aws-agents/skills/agents-pay/SKILL.md
@@ -270,9 +270,10 @@ Add `--origin https://<host>` (repeatable) only to pin the agent to a known merc
 set; omitted, it may fetch any public HTTPS site.
 
 Written to `~/.agents-pay/config.json`, mode `0600`, via atomic replace. It
-pins:
+pins these policy keys (use hyphens for the corresponding CLI flags, e.g.
+`--allow-any-recipient`):
 
-| Rule | Effect |
+| Config key | Effect |
 |---|---|
 | `max_per_payment_usd` | Per-payment ceiling. Above it → refuse |
 | `allowed_networks` | Exact CAIP-2 networks |

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/PUBLISHING.md
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/PUBLISHING.md
@@ -9,6 +9,7 @@ OpenClaw package. The published artifact also contains the canonical
 - Initial release: `1.0.0`
 - Scoped install compatibility fix: `1.0.1`
 - Bundled canonical skill and external setup guidance: `1.0.2`
+- Setup discoverability improvements: `1.0.5`
 
 Do not publish until the package has passed the checks below and the publisher
 has given explicit approval.
@@ -67,7 +68,7 @@ Run this before requesting publication approval:
 npx --yes clawhub@0.23.1 package publish . \
   --family code-plugin \
   --name @aws/aws-agents-pay \
-  --version 1.0.2 \
+  --version 1.0.5 \
   --tags latest \
   --source-repo aws/agent-toolkit-for-aws \
   --source-commit <release-commit-sha> \

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/README.md
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/README.md
@@ -13,8 +13,17 @@ Install from ClawHub:
 openclaw plugins install clawhub:@aws/aws-agents-pay
 ```
 
-The encoded slash is required by OpenClaw when installing a scoped ClawHub
-package.
+## Getting started
+
+After installation, provision AWS resources and configure the plugin before
+activation. The bundled skill walks through each step:
+
+```bash
+openclaw skills read agents-pay    # or open skills/agents-pay/SKILL.md
+```
+
+For OpenClaw-specific configuration, see
+[`skills/agents-pay/references/openclaw-setup.md`](skills/agents-pay/references/openclaw-setup.md).
 
 The package bundles the canonical `agents-pay` skill. It guides users through
 human-run setup in a separate terminal while the plugin keeps only the two

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/package.json
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aws-agents-pay",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "Guarded x402 v2 payments for OpenClaw through AWS AgentCore Payments",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/skills/agents-pay/SKILL.md
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/skills/agents-pay/SKILL.md
@@ -270,9 +270,10 @@ Add `--origin https://<host>` (repeatable) only to pin the agent to a known merc
 set; omitted, it may fetch any public HTTPS site.
 
 Written to `~/.agents-pay/config.json`, mode `0600`, via atomic replace. It
-pins:
+pins these policy keys (use hyphens for the corresponding CLI flags, e.g.
+`--allow-any-recipient`):
 
-| Rule | Effect |
+| Config key | Effect |
 |---|---|
 | `max_per_payment_usd` | Per-payment ceiling. Above it → refuse |
 | `allowed_networks` | Exact CAIP-2 networks |

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/test/security.test.mjs
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/test/security.test.mjs
@@ -354,7 +354,7 @@ test("public package and runtime identities stay aligned", async () => {
     readFile(new URL("../README.md", import.meta.url), "utf8"),
   ]);
   assert.equal(packageJson.name, "@aws/aws-agents-pay");
-  assert.equal(packageJson.version, "1.0.3");
+  assert.equal(packageJson.version, "1.0.5");
   assert.equal(manifest.id, "aws-agents-pay");
   assert.equal(manifest.name, "AWS Agents Pay");
   assert.ok(packageJson.files.includes("skills"));

--- a/plugins/aws-agents/skills/agents-pay/scripts/agents_pay_admin.py
+++ b/plugins/aws-agents/skills/agents-pay/scripts/agents_pay_admin.py
@@ -79,8 +79,9 @@ def discover_deployed() -> dict[str, str | None]:
     Searches several relative paths so the command works whether you run from the
     project root, inside the agentcore/ directory, or a subdirectory of it.
 
-    CLI 0.20.x writes targets.<target>.resources.payments[]; older layouts used a
-    top-level payments[]. Both are handled.
+    CLI 0.20.x writes targets.<target>.resources.payments[]; 0.26.x writes
+    payments as objects keyed by name. Older layouts used a top-level payments[].
+    All three are handled.
     """
     out: dict[str, str | None] = {"manager_arn": None, "connector_id": None, "role_arn": None}
     state_path = _find_deployed_state()
@@ -97,10 +98,24 @@ def discover_deployed() -> dict[str, str | None]:
             payments = data.get("payments")
         if not payments:
             return out
-        pay = payments[0]
+        # 0.26.x: payments is a dict keyed by name
+        if isinstance(payments, dict):
+            pay = next(iter(payments.values()), {})
+        # 0.20.x and older: payments is a list
+        elif isinstance(payments, list):
+            pay = payments[0] if payments else {}
+        else:
+            return out
         connectors = pay.get("connectors") or []
         out["manager_arn"] = pay.get("managerArn")
-        out["connector_id"] = connectors[0].get("connectorId") if connectors else None
+        # 0.26.x: connectors may be a dict keyed by name
+        if isinstance(connectors, dict):
+            first_connector = next(iter(connectors.values()), {})
+        elif isinstance(connectors, list):
+            first_connector = connectors[0] if connectors else {}
+        else:
+            first_connector = {}
+        out["connector_id"] = first_connector.get("connectorId") if first_connector else None
         out["role_arn"] = pay.get("processPaymentRoleArn")
     except Exception:  # noqa: BLE001 - convenience only; never fatal
         pass

--- a/plugins/aws-agents/skills/agents-pay/scripts/agents_pay_admin.py
+++ b/plugins/aws-agents/skills/agents-pay/scripts/agents_pay_admin.py
@@ -49,12 +49,24 @@ AGENT_NAME = "aws-agents-pay"
 
 # Where the AgentCore CLI records what `agentcore deploy` created. Read so the
 # operator never has to copy a manager ARN or connector ID by hand.
-DEPLOYED_STATE = Path("agentcore/.cli/deployed-state.json")
+DEPLOYED_STATE_CANDIDATES = [
+    Path("agentcore/.cli/deployed-state.json"),   # from project root (parent of agentcore/)
+    Path(".cli/deployed-state.json"),              # from inside the agentcore/ directory
+    Path("../.cli/deployed-state.json"),           # from a subdirectory of agentcore/
+]
 
 
 def admin_config_path(explicit: str | None) -> Path:
     """Resolve an operator-selected path for administrative commands only."""
     return Path(explicit or os.environ.get("AGENTS_PAY_CONFIG") or DEFAULT_CONFIG)
+
+
+def _find_deployed_state() -> Path | None:
+    """Return the first existing deployed-state.json candidate, or None."""
+    for candidate in DEPLOYED_STATE_CANDIDATES:
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def discover_deployed() -> dict[str, str | None]:
@@ -64,14 +76,18 @@ def discover_deployed() -> dict[str, str | None]:
     Purely a convenience: nothing security-relevant is decided from this file, and
     a wrong or missing value surfaces as a plain error from the service.
 
+    Searches several relative paths so the command works whether you run from the
+    project root, inside the agentcore/ directory, or a subdirectory of it.
+
     CLI 0.20.x writes targets.<target>.resources.payments[]; older layouts used a
     top-level payments[]. Both are handled.
     """
     out: dict[str, str | None] = {"manager_arn": None, "connector_id": None, "role_arn": None}
-    if not DEPLOYED_STATE.exists():
+    state_path = _find_deployed_state()
+    if state_path is None:
         return out
     try:
-        data = json.loads(DEPLOYED_STATE.read_text())
+        data = json.loads(state_path.read_text())
         payments = None
         targets = data.get("targets") or {}
         target = targets.get("default") or (next(iter(targets.values()), {}) if targets else {})
@@ -328,10 +344,13 @@ def cmd_create_instrument(args: argparse.Namespace) -> int:
     connector_id = args.connector_id or os.environ.get("PAYMENT_CONNECTOR_ID") or discovered["connector_id"]
 
     if not manager_arn or not connector_id:
+        checked = ", ".join(str(p) for p in DEPLOYED_STATE_CANDIDATES)
         print(
-            "Could not determine the manager ARN and connector ID. Either run this from\n"
-            "your AgentCore project directory (so agentcore/.cli/deployed-state.json can\n"
-            "be read), or pass --manager-arn and --connector-id.",
+            f"Could not find deployed-state.json (checked: {checked}).\n\n"
+            "This file is created by `agentcore deploy`. To resolve:\n"
+            "  \u2022 Run this command from the directory that CONTAINS the agentcore/ folder, OR\n"
+            "  \u2022 Run from inside the agentcore/ directory itself, OR\n"
+            "  \u2022 Pass --manager-arn and --connector-id explicitly.",
             file=sys.stderr,
         )
         return 1
@@ -428,12 +447,18 @@ def cmd_new_session(args: argparse.Namespace) -> int:
 
     manager_arn = resolve_manager_arn(args.manager_arn)
     if not manager_arn:
+        checked = ", ".join(str(p) for p in DEPLOYED_STATE_CANDIDATES)
         print(
-            "Could not determine the payment manager ARN. Either run this from your\n"
-            "AgentCore project directory (so agentcore/.cli/deployed-state.json can be\n"
-            "read), pass --manager-arn, or set PAYMENT_MANAGER_ARN.",
+            f"Could not determine the payment manager ARN.\n\n"
+            f"Searched for deployed-state.json at: {checked}\n\n"
+            "This file is created by `agentcore deploy`. To resolve:\n"
+            "  \u2022 Run this command from the directory that CONTAINS the agentcore/ folder, OR\n"
+            "  \u2022 Run from inside the agentcore/ directory itself, OR\n"
+            "  \u2022 Pass --manager-arn explicitly, OR\n"
+            "  \u2022 Set PAYMENT_MANAGER_ARN in your environment.",
             file=sys.stderr,
         )
+        return 1
         return 1
 
     print("About to create a payment session:")
@@ -495,11 +520,13 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     if not os.environ.get("PAYMENT_MANAGER_ARN"):
         discovered = discover_deployed()
         if discovered["manager_arn"]:
-            print(f"\n       Found in {DEPLOYED_STATE}: run this to fix the above ->")
+            state_path = _find_deployed_state()
+            print(f"\n       Found in {state_path}: run this to fix the above ->")
             print(f"         export PAYMENT_MANAGER_ARN={discovered['manager_arn']}")
         else:
-            print(f"\n       No {DEPLOYED_STATE} here. Run from your AgentCore project")
-            print("       directory, or set the variables by hand.")
+            print(f"\n       deployed-state.json not found (checked: {', '.join(str(p) for p in DEPLOYED_STATE_CANDIDATES)}).")
+            print("       Run from the directory that CONTAINS the agentcore/ folder,")
+            print("       from inside it, or set the variables by hand.")
 
     # This design never needs provider secrets in the runtime process.
     leaked = [


### PR DESCRIPTION
## Summary

Bumps the `@aws/aws-agents-pay` OpenClaw package to 1.0.5 with setup discoverability and UX improvements.

## Changes

**README.md**
- Added "Getting started" section pointing users to the bundled skill and `openclaw-setup.md` after installation
- Removed stale "encoded slash" sentence that no longer applies

**references/openclaw-setup.md**
- Added link to the [AgentCore Payments getting started guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/payments-getting-started.html)

**PUBLISHING.md**
- Added 1.0.5 to the release versions log
- Updated dry-run example to use `--version 1.0.5`

**scripts/agents_pay_admin.py**
- Hardened `deployed-state.json` discovery: now checks `agentcore/.cli/deployed-state.json`, `.cli/deployed-state.json`, and `../.cli/deployed-state.json` so the command works whether you run from the project root, inside `agentcore/`, or a subdirectory
- Improved error messages when manager ARN / connector ID cannot be found — now lists exact paths checked and clear resolution steps

**Version + test alignment**
- `package.json` → 1.0.5
- `test/security.test.mjs` → version assertion updated

## Motivation

After `openclaw plugins install clawhub:@aws/aws-agents-pay`, the plugin errors because required config (payment manager ARN, etc.) isn't set. The README previously had no guidance on what to do next. These changes bridge the gap between install and activation without duplicating the comprehensive setup docs in the skill.

The `deployed-state.json` lookup fix addresses confusion when running admin commands from the installed skill path or from inside the `agentcore/` directory.