### PR TITLE
feat(aws-agents): use AWS MCP Server instead of AWS Knowledge MCP

### DIFF
--- a/plugins/aws-agents/.mcp.json
+++ b/plugins/aws-agents/.mcp.json
@@ -1,8 +1,14 @@
 {
   "mcpServers": {
-    "awsknowledge": {
-      "type": "http",
-      "url": "https://knowledge-mcp.global.api.aws"
+    "aws-mcp": {
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws@1.6.4",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--skip-auth",
+        "--metadata",
+        "INSTALL_SOURCE=agent-toolkit-agents"
+      ]
     }
   }
 }

--- a/plugins/aws-agents/mcp.json
+++ b/plugins/aws-agents/mcp.json
@@ -1,9 +1,16 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
   "mcpServers": {
-    "awsknowledge": {
-      "type": "streamable-http",
-      "url": "https://knowledge-mcp.global.api.aws"
+    "aws-mcp": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws@1.6.4",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--skip-auth",
+        "--metadata",
+        "INSTALL_SOURCE=agent-toolkit-agents"
+      ]
     }
   }
 }


### PR DESCRIPTION
Closes #223

Replace `awsknowledge` (standalone AWS Knowledge MCP Server) with `aws-mcp` (unified AWS MCP Server), matching `aws-core` and `aws-data-analytics`.