### PR TITLE
feat(social-messaging): add aws-social-messaging skill

### DIFF
--- a/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/SKILL.md
+++ b/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: aws-social-messaging
+description: Manages WhatsApp messaging through AWS End User Messaging Social. Covers managing templates (create, update, delete, library), sending messages (utility/marketing/auth templates and freeform), uploading and managing media, configuring event destinations for delivery tracking, and troubleshooting delivery failures. Applicable when a user needs to send WhatsApp messages, create or manage templates, upload media, configure delivery notifications, or diagnose messaging issues.
+version: 1
+---
+
+# AWS End User Messaging Social — WhatsApp
+
+## Overview
+
+WhatsApp messaging via AWS End User Messaging Social: template management, sending, media handling, event destinations, and delivery troubleshooting.
+
+**Recommended setup:** Use the [AWS MCP server](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/mcp-server.html) for sandboxed execution, audit logging, and enterprise controls.
+
+**Without AWS MCP:** This skill works with any agent that has AWS CLI access. All commands use standard AWS CLI syntax.
+
+## Common Tasks
+
+### 1. Verify Dependencies
+
+**Constraints:**
+
+- The AWS MCP server is recommended for seamless API execution but not required — all commands use standard AWS CLI syntax
+- You MUST verify the AWS CLI is installed and configured with appropriate credentials
+- You SHOULD recommend the user assume an IAM role with ephemeral credentials
+- You MUST inform the user if any required tool is missing and how to install/configure it
+- You MUST ask the user if they want to proceed despite any missing tools
+- If the `aws socialmessaging` subcommand is not recognized, the user must update to the latest AWS CLI version
+- Required IAM permissions (scope to specific WABA and phone number ARNs):
+  - Templates: `social-messaging:CreateWhatsAppMessageTemplate`, `social-messaging:GetWhatsAppMessageTemplate`, `social-messaging:ListWhatsAppMessageTemplates`, `social-messaging:UpdateWhatsAppMessageTemplate`, `social-messaging:DeleteWhatsAppMessageTemplate`, `social-messaging:ListWhatsAppTemplateLibrary`, `social-messaging:CreateWhatsAppMessageTemplateFromLibrary`
+  - Sending: `social-messaging:SendWhatsAppMessage`
+  - Media: `social-messaging:PostWhatsAppMessageMedia`, `social-messaging:CreateWhatsAppMessageTemplateMedia`, `social-messaging:GetWhatsAppMessageMedia`, `social-messaging:DeleteWhatsAppMessageMedia`
+  - Events: `social-messaging:PutWhatsAppBusinessAccountEventDestinations`
+  - Diagnostics: `social-messaging:GetLinkedWhatsAppBusinessAccount`, `social-messaging:GetLinkedWhatsAppBusinessAccountPhoneNumber`, `social-messaging:ListLinkedWhatsAppBusinessAccounts`
+  - Supporting: `sns:ListSubscriptionsByTopic`, `iam:PassRole` (for event destination role)
+
+### 2. Manage Templates
+
+Create, update, and delete message templates (utility, marketing, authentication).
+
+- `create-whatsapp-message-template`: base64-encode `--template-definition` (blob type)
+- `create-whatsapp-message-template-from-library`: use pre-approved Meta library templates
+- `list-whatsapp-template-library`: browse available library templates
+- `get-whatsapp-message-template`: retrieve template details by `--id` (WABA) and `--meta-template-id`
+- `update-whatsapp-message-template`: modify existing template content
+- `delete-whatsapp-message-template`: requires `--template-name` (NOT `--meta-template-name`); always include `--delete-all-languages`
+- `list-whatsapp-message-templates`: response fields are `templateStatus` and `templateCategory` (NOT `status`/`category`)
+- Templates with `{{N}}` parameters MUST include `"parameter_format": "positional"` (exception: AUTHENTICATION — Meta handles OTP parameters automatically) and `"example"`
+- Meta reviews all templates (minutes to 24h); MUST NOT send with PENDING/REJECTED
+- Choosing the wrong category causes reclassification (UTILITY → MARKETING) which changes pricing — see [managing-templates.md — Choosing the Right Category](references/managing-templates.md) for guidance on selecting UTILITY vs MARKETING vs AUTHENTICATION
+- You MUST confirm the intended category (UTILITY, MARKETING, or AUTHENTICATION) with the user before creating a template — explain the categorization criteria and reclassification risk if the choice is ambiguous
+
+See [managing-templates.md](references/managing-templates.md).
+
+### 3. Send Messages
+
+#### Template Messages (no 24h restriction)
+
+- Use for: transactional updates (utility), promotions (marketing), verification codes (authentication)
+- Collect: phone number ID, recipient (E.164 with `+`), template name, language, parameters
+- Marketing templates may include image headers
+- `--message` is blob type — MUST base64-encode JSON
+
+#### Freeform Messages (24h window required)
+
+- Use for: customer service replies within 24h of customer's last inbound message
+- Supports: text, image, document, video, audio — see [WhatsApp Cloud API media reference](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media) for supported format and size constraints
+- No API to check window status — user must confirm from logs or event history
+- Media URLs MUST be publicly accessible HTTPS and remain available for the full 30-day message availability window (Meta can re-fetch anytime). For sensitive content (receipts, invoices, PII), upload via `post-whatsapp-message-media` and reference by media ID instead — presigned URLs cannot satisfy the 30-day availability requirement
+
+**Constraints for all sends:**
+
+- Before executing any API call, validate parameter formats:
+  - Phone number IDs match `phone-number-id-*` pattern
+  - WABA IDs match `waba-*` pattern
+  - Recipient numbers are E.164 with `+` prefix (e.g., `+14155551234`), or Business-Scoped User ID (BSUID) via the `"recipient"` field
+  - Template names contain only lowercase letters, numbers, and underscores
+  - Language codes use Meta's locale format with underscores (e.g., `en_US`, `pt_BR`)
+  - `--meta-api-version` is `v{Major}.{Minor}` format (e.g., `v21.0`)
+- `"messaging_product"` MUST be `"whatsapp"` in the JSON body; check [Meta's Graph API changelog](https://developers.facebook.com/docs/graph-api/changelog) for the supported Meta Graph API version
+- `--message` is blob type — MUST base64-encode the JSON payload
+- A successful `messageId` means queued, not delivered
+- You MUST ask for all required parameters upfront in a single prompt
+- You MUST accept parameters as individual values, JSON objects, or file references
+- You MUST explain each step before executing
+- You SHOULD confirm all parameters with the user before executing
+- You MUST respect the user's decision to abort
+- You MUST NOT send more than 5 messages per batch without user confirmation
+- You MUST NOT create or access credentials directly
+
+See [sending-messages.md](references/sending-messages.md).
+
+### 4. Manage Media
+
+Upload, retrieve, and delete media for messages and template headers.
+
+- `post-whatsapp-message-media`: upload media, returns reusable media ID
+- `create-whatsapp-message-template-media`: upload media specifically for template headers
+- `get-whatsapp-message-media`: retrieve media metadata/URL by ID
+- `delete-whatsapp-message-media`: remove uploaded media
+
+See [managing-media.md](references/managing-media.md).
+
+### 5. Configure Event Destinations
+
+Set up delivery tracking, template status notifications, and reclassification alerts.
+
+Set up delivery tracking, template status notifications, and reclassification alerts. A WABA can only have one event destination. See [configuring-event-destinations.md](references/configuring-event-destinations.md) for prerequisites (IAM role, SNS topic with KMS encryption, HTTPS-only subscription endpoints, condition keys) and full security controls.
+
+### 6. Troubleshoot Delivery
+Diagnostic flow: WABA status → phone number → templates → event destinations → quotas.
+
+- `get-linked-whatsapp-business-account`: registration MUST be COMPLETE
+- `get-linked-whatsapp-business-account-phone-number`: verify phone number health
+- `list-linked-whatsapp-business-accounts`: list all WABAs
+- Template reclassified: detectable via event destinations (real-time) or by listing templates and comparing categories; delete and recreate
+- 24h window expired: use template message instead
+- Rate limiting: new WABAs have lower limits; increases with quality
+- Recipient without WhatsApp: silently dropped
+
+See [troubleshooting-delivery.md](references/troubleshooting-delivery.md).
+
+## Quick Reference — Common Errors
+
+- **Access denied**: verify IAM permissions scoped to WABA/phone number ARNs
+- **Template rejected**: body must match category; include `parameter_format` and `example`
+- **Template reclassified**: configure event destinations to detect; delete and recreate
+- **24h window expired**: use template message instead of freeform
+- **Send fails**: `--origination-phone-number-id` is the ID (not phone number); recipient E.164 with `+`
+- **Queued but not delivered**: 200 = queued; configure event destinations for status
+- **Media URL inaccessible**: must be publicly accessible HTTPS
+
+## Security Considerations
+
+- Use least-privilege IAM policies scoped to specific `social-messaging:` actions and WABA/phone number ARNs
+- Use ephemeral credentials (IAM roles) instead of long-lived access keys
+- Store secrets in AWS Secrets Manager or Parameter Store — never in code or environment variables
+- Enable CloudTrail for auditing all `social-messaging` API calls; encrypt logs with KMS CMK
+- Encrypt SNS topics for event destinations with KMS (callbacks contain recipient metadata)
+- Encrypt CloudWatch Logs with KMS if monitoring social-messaging activity
+- Avoid sensitive data in template parameters and freeform message content (they appear in CloudTrail logs)
+- Validate recipient phone numbers to prevent unauthorized messaging
+- Verify SNS subscription endpoints are authorized by your team — validate that all subscribed email addresses and systems belong to personnel/systems that should receive sensitive delivery status and recipient metadata before confirming subscriptions. Use HTTPS-only endpoints
+- Add condition keys (`aws:SourceArn`, `aws:SourceAccount`) to SNS topic policies to prevent confused deputy attacks
+- Implement rate limiting via service quotas and CloudWatch alarms on send rates
+
+## Additional Resources
+
+- [AWS End User Messaging Social User Guide](https://docs.aws.amazon.com/social-messaging/latest/userguide/what-is-service.html)
+- [AWS CLI socialmessaging Reference](https://docs.aws.amazon.com/cli/latest/reference/socialmessaging/)
+- [Getting Started with WhatsApp](https://docs.aws.amazon.com/social-messaging/latest/userguide/getting-started-whatsapp.html)
+- [Managing Event Destinations](https://docs.aws.amazon.com/social-messaging/latest/userguide/managing-event-destinations-add.html)
+- [Service Quotas](https://docs.aws.amazon.com/social-messaging/latest/userguide/quotas.html)
+- [IAM Security Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
+- [Confused Deputy Prevention](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html)
+- [SNS Data Protection Best Practices](https://docs.aws.amazon.com/sns/latest/dg/sns-security-best-practices.html)
+- [AWS Well-Architected Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)

--- a/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/configuring-event-destinations.md
+++ b/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/configuring-event-destinations.md
@@ -1,0 +1,160 @@
+# Configuring Event Destinations
+
+> **Security:** Encrypt SNS topics with KMS; callbacks may contain recipient metadata. See [SKILL.md — Security Considerations](../SKILL.md#security-considerations).
+
+## Contents
+
+- [Overview](#overview)
+- [Configure Event Destination](#configure-event-destination)
+- [Prerequisites](#prerequisites)
+- [Verify Configuration](#verify-configuration)
+- [Event Payload Examples](#event-payload-examples)
+
+## Overview
+
+Event destinations deliver real-time notifications for:
+
+- Message delivery status (sent, delivered, read, failed)
+- Template status changes (approved, rejected)
+- Template reclassification (UTILITY → MARKETING)
+
+Without event destinations, delivery failures and reclassifications are invisible.
+
+## Configure Event Destination
+
+A WABA can only have **one** event destination at a time.
+
+```bash
+aws socialmessaging put-whatsapp-business-account-event-destinations \
+  --id "waba-XXXXXXXXXXXXXXXXXXXX" \
+  --event-destinations '[{"eventDestinationArn":"arn:aws:sns:us-east-1:123456789012:whatsapp-events","roleArn":"arn:aws:iam::123456789012:role/WhatsAppEventDeliveryRole"}]'
+
+```
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--id` | Yes | WABA ID (format: `waba-XXXX`) |
+| `--event-destinations` | Yes | Array with one entry: SNS topic ARN + IAM role ARN |
+
+## Prerequisites
+
+### 1. SNS Topic
+
+Create an SNS topic with KMS encryption:
+
+```bash
+aws sns create-topic --name whatsapp-events --attributes '{"KmsMasterKeyId":"alias/aws/sns"}'
+
+```
+
+### 2. IAM Role
+
+The role must:
+
+- Trust `social-messaging.amazonaws.com` in its assume-role policy
+- Have `sns:Publish` permission on the SNS topic
+
+Trust policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "social-messaging.amazonaws.com"},
+    "Action": "sts:AssumeRole",
+    "Condition": {
+      "StringEquals": {"aws:SourceAccount": "123456789012"},
+      "ArnLike": {"aws:SourceArn": "arn:aws:social-messaging:*:123456789012:*"}
+    }
+  }]
+}
+
+```
+
+Permission policy (attach to the role):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "sns:Publish",
+    "Resource": "arn:aws:sns:us-east-1:123456789012:whatsapp-events"
+  }]
+}
+
+```
+
+### 3. SNS Topic Policy
+
+Add a resource policy to allow `social-messaging.amazonaws.com` to publish, with condition keys to prevent confused deputy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowSocialMessagingPublish",
+    "Effect": "Allow",
+    "Principal": {"Service": "social-messaging.amazonaws.com"},
+    "Action": "sns:Publish",
+    "Resource": "arn:aws:sns:us-east-1:123456789012:whatsapp-events",
+    "Condition": {
+      "StringEquals": {"aws:SourceAccount": "123456789012"},
+      "ArnLike": {"aws:SourceArn": "arn:aws:social-messaging:*:123456789012:*"}
+    }
+  },
+  {
+    "Sid": "DenyNonSSL",
+    "Effect": "Deny",
+    "Principal": "*",
+    "Action": "sns:Publish",
+    "Resource": "arn:aws:sns:us-east-1:123456789012:whatsapp-events",
+    "Condition": {
+      "Bool": {"aws:SecureTransport": "false"}
+    }
+  }]
+}
+
+```
+
+## Verify Configuration
+
+Check SNS subscriptions are confirmed:
+
+```bash
+aws sns list-subscriptions-by-topic \
+  --topic-arn "arn:aws:sns:us-east-1:123456789012:whatsapp-events"
+
+```
+
+Subscriptions must show `"SubscriptionArn"` (not `"PendingConfirmation"`).
+
+Verify SNS subscription endpoints are authorized personnel/systems — use access policies to restrict who can subscribe. Use HTTPS-only endpoints for encryption in transit.
+
+## Event Payload Examples
+
+Delivery receipt:
+
+```json
+{
+  "eventType": "MESSAGE_STATUS_UPDATE",
+  "messageId": "wamid.XXXX",
+  "status": "delivered",
+  "recipientId": "+14155551234"
+}
+
+```
+
+Template reclassification:
+
+```json
+{
+  "eventType": "TEMPLATE_STATUS_UPDATE",
+  "templateName": "order_update",
+  "previousCategory": "UTILITY",
+  "newCategory": "MARKETING"
+}
+```

--- a/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/managing-media.md
+++ b/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/managing-media.md
@@ -1,0 +1,69 @@
+# Managing WhatsApp Media
+
+> **Security:** S3 buckets used for media storage should have default encryption enabled (SSE-S3 or SSE-KMS) and enforce `aws:SecureTransport` in the bucket policy. Media files may contain sensitive content (receipts, invoices, PII). See [SKILL.md — Security Considerations](../SKILL.md#security-considerations).
+
+## Upload Media
+
+### Option 1: From S3 Bucket
+
+```bash
+aws socialmessaging post-whatsapp-message-media \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX" \
+  --source-s3-file '{"bucketName":"my-media-bucket","key":"images/receipt.png"}'
+```
+
+### Option 2: From Presigned URL
+
+```bash
+aws socialmessaging post-whatsapp-message-media \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX" \
+  --source-s3-presigned-url '{"url":"https://my-bucket.s3.amazonaws.com/image.png","headers":{}}'
+```
+
+> **Security:** When generating presigned URLs, set a short expiration (15–30 minutes) to limit the window of access. See [SKILL.md — Security Considerations](../SKILL.md#security-considerations).
+
+Returns a reusable media ID for sending messages without re-uploading.
+
+## Upload Media for Template Headers
+
+```bash
+aws socialmessaging create-whatsapp-message-template-media \
+  --id "waba-XXXXXXXXXXXXXXXXXXXX" \
+  --source-s3-file '{"bucketName":"my-media-bucket","key":"templates/promo-header.jpg"}'
+```
+
+Use the returned media handle in template `HEADER` component's `header_handle` field.
+
+## Get Media
+
+```bash
+aws socialmessaging get-whatsapp-message-media \
+  --media-id "XXXXXXXXXXXXXXXXXXXX" \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX"
+```
+
+Returns media metadata and a download URL.
+
+> **Sensitive data:** The returned download URL may be logged in CloudTrail and provides temporary access to media content — treat it as sensitive. Similarly, `post-whatsapp-message-media` input parameters (S3 bucket/key, presigned URLs) appear in CloudTrail logs.
+
+## Delete Media
+
+```bash
+aws socialmessaging delete-whatsapp-message-media \
+  --media-id "XXXXXXXXXXXXXXXXXXXX" \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX"
+```
+
+## Supported Media Types
+
+Limits per [WhatsApp Cloud API media reference](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media) — check Meta's documentation for supported formats and size constraints.
+
+## Usage in Messages
+
+Once uploaded, reference media by ID instead of URL:
+
+```json
+{"type":"image","image":{"id":"XXXXXXXXXXXXXXXXXXXX","caption":"Your receipt"}}
+```
+
+This avoids requiring publicly accessible URLs for each send.

--- a/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/managing-templates.md
+++ b/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/managing-templates.md
@@ -1,0 +1,178 @@
+# Managing WhatsApp Message Templates
+
+> **Security:** Template parameters appear in CloudTrail logs — avoid embedding sensitive data. See [SKILL.md — Security Considerations](../SKILL.md#security-considerations).
+
+## Contents
+
+- [Create a Template](#create-a-template)
+- [Create from Library](#create-from-library)
+- [Check Approval Status](#check-approval-status)
+- [Get Template Details](#get-template-details)
+- [Update a Template](#update-a-template)
+- [Delete a Template](#delete-a-template)
+
+## Create a Template
+
+The `--template-definition` parameter is a blob type — base64-encode the JSON.
+
+### Utility Template (transactional)
+
+```bash
+TEMPLATE_DEF=$(printf '%s' '{"name":"order_shipment_update","category":"UTILITY","language":"en_US","parameter_format":"positional","components":[{"type":"BODY","text":"Your order #{{1}} has shipped. Track: {{2}}","example":{"body_text":[["ORD-12345","https://example.com/track/12345"]]}}]}' | base64 | tr -d '\n')
+
+aws socialmessaging create-whatsapp-message-template \
+  --id "waba-XXXXXXXXXXXXXXXXXXXX" \
+  --template-definition "$TEMPLATE_DEF"
+
+```
+
+### Marketing Template (with image header)
+
+First, upload the header image using `create-whatsapp-message-template-media` to get a media handle (see [managing-media.md](managing-media.md#upload-media-for-template-headers)). Then use the returned handle in the template:
+
+```bash
+TEMPLATE_DEF=$(printf '%s' '{"name":"seasonal_promotion","language":"en_US","category":"MARKETING","parameter_format":"positional","components":[{"type":"HEADER","format":"IMAGE","example":{"header_handle":["4::aW1hZ2UvanBlZw==:ARb..."]}},{"type":"BODY","text":"Hi {{1}}! Get {{2}}% off all items through {{3}}.","example":{"body_text":[["Jane","25","June 30"]]}}]}' | base64 | tr -d '\n')
+
+aws socialmessaging create-whatsapp-message-template \
+  --id "waba-XXXXXXXXXXXXXXXXXXXX" \
+  --template-definition "$TEMPLATE_DEF"
+
+```
+
+### Authentication Template (verification codes)
+
+```bash
+TEMPLATE_DEF=$(printf '%s' '{"name":"login_verification","language":"en_US","category":"AUTHENTICATION","components":[{"type":"BODY","text":"{{1}} is your verification code.","example":{"body_text":[["847293"]]}},{"type":"FOOTER","text":"This code expires in 10 minutes."},{"type":"BUTTONS","buttons":[{"type":"OTP","otp_type":"COPY_CODE","text":"Copy code"}]}]}' | base64 | tr -d '\n')
+
+aws socialmessaging create-whatsapp-message-template \
+  --id "waba-XXXXXXXXXXXXXXXXXXXX" \
+  --template-definition "$TEMPLATE_DEF"
+
+```
+
+Authentication templates do not require `parameter_format` — Meta handles the OTP parameter automatically. The `COPY_CODE` button type lets recipients tap to copy the code.
+
+### Expected Output
+
+```json
+{
+  "metaTemplateId": "123456789",
+  "templateStatus": "PENDING",
+  "templateCategory": "UTILITY"
+}
+
+```
+
+### Rules
+
+- `parameter_format`: MUST be `"positional"` when using `{{N}}` parameters
+- `example`: MUST include sample values for each component — Meta requires this for review
+- UTILITY body MUST be clearly transactional; ambiguous text gets reclassified as MARKETING
+- Template names: lowercase letters, numbers, underscores only
+
+### Choosing the Right Category
+
+Meta enforces strict categorization rules. Choosing the wrong category causes **reclassification** (UTILITY → MARKETING), which changes pricing and may disrupt sending. Select the correct category upfront:
+
+| Category | Use When | Key Signals |
+|----------|----------|-------------|
+| **UTILITY** | Confirming or updating an existing transaction the user initiated | Order confirmations, shipping updates, appointment reminders, payment receipts, account alerts |
+| **MARKETING** | Promoting products/services, re-engaging users, or any content the user did not explicitly request | Promotions, discounts, product recommendations, back-in-stock alerts, newsletters, upsells |
+| **AUTHENTICATION** | Sending one-time passwords or verification codes | Login codes, 2FA, account verification — must use OTP button component |
+
+**Common reclassification triggers (UTILITY → MARKETING):**
+
+- Body text contains promotional language ("Get X% off", "Limited time", "Shop now", "Don't miss")
+- Template includes a call-to-action unrelated to the transaction (e.g., "Check out our new products")
+- Greeting or introduction without referencing a specific user-initiated action
+- Coupon codes or discount offers included alongside transactional content
+- Generic "updates" that aren't tied to a specific order, appointment, or account event
+
+**How to avoid reclassification:**
+
+1. Keep UTILITY templates focused on a single transaction — reference the specific order/appointment/account action
+2. Do NOT mix promotional content into transactional templates — create a separate MARKETING template for promotions
+3. Use explicit transaction references in the body: "Your order #{{1}}", "Your appointment on {{1}}", "Your payment of {{1}}"
+4. If in doubt, use MARKETING — it always works; reclassification only happens UTILITY → MARKETING, never the reverse
+5. Configure [event destinations](configuring-event-destinations.md) to receive `TEMPLATE_STATUS_UPDATE` events that alert you to reclassifications in real-time
+
+**Detecting reclassification after the fact:**
+
+- Via event destinations: `"eventType": "TEMPLATE_STATUS_UPDATE"` with `previousCategory` and `newCategory`
+- Via API: `list-whatsapp-message-templates` — compare `templateCategory` against your expected category
+- **Recovery:** Delete the reclassified template and recreate with corrected content or as MARKETING
+
+## Create from Library
+
+Browse and use pre-approved Meta library templates:
+
+```bash
+aws socialmessaging list-whatsapp-template-library
+
+aws socialmessaging create-whatsapp-message-template-from-library \
+  --id "waba-XXXXXXXXXXXXXXXXXXXX" \
+  --meta-library-template '{"templateName":"my_order_update","libraryTemplateName":"order_status_update","templateCategory":"UTILITY","templateLanguage":"en_US"}'
+
+```
+
+## Check Approval Status
+
+```bash
+aws socialmessaging list-whatsapp-message-templates --id "waba-XXXXXXXXXXXXXXXXXXXX"
+
+```
+
+Response fields are `templateStatus` and `templateCategory` (NOT `status`/`category`):
+
+```json
+{
+  "templates": [{
+    "templateName": "order_shipment_update",
+    "metaTemplateId": "123456789",
+    "templateStatus": "APPROVED",
+    "templateCategory": "UTILITY",
+    "templateLanguage": "en_US"
+  }]
+}
+
+```
+
+- UTILITY: minutes to 24h. MARKETING: hours to 24h.
+- MUST NOT send with PENDING or REJECTED status.
+
+## Get Template Details
+
+```bash
+aws socialmessaging get-whatsapp-message-template \
+  --id "waba-XXXXXXXXXXXXXXXXXXXX" \
+  --meta-template-id "123456789"
+
+```
+
+Use this to retrieve component structure before sending an existing template.
+
+## Update a Template
+
+```bash
+aws socialmessaging update-whatsapp-message-template \
+  --id "waba-XXXXXXXXXXXXXXXXXXXX" \
+  --meta-template-id "123456789" \
+  --template-components "$(printf '%s' '[{"type":"BODY","text":"Your order #{{1}} has shipped. Delivery by: {{2}}","example":{"body_text":[["ORD-12345","July 15"]]}}]' | base64 | tr -d '\n')"
+
+```
+
+The `--template-components` parameter is a blob type — base64-encode the JSON components array. Updated templates go back to PENDING for Meta re-review.
+
+## Delete a Template
+
+⚠️ The delete parameter is `--template-name` (NOT `--meta-template-name`, NOT `--meta-template-id`). There is no `--meta-template-name` parameter — it does not exist.
+
+```bash
+aws socialmessaging delete-whatsapp-message-template \
+  --id "waba-XXXXXXXXXXXXXXXXXXXX" \
+  --template-name "order_shipment_update" \
+  --delete-all-languages
+
+```
+
+Always include `--delete-all-languages` to avoid `InvalidParametersException`.

--- a/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/sending-messages.md
+++ b/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/sending-messages.md
@@ -1,0 +1,130 @@
+# Sending WhatsApp Messages
+
+> **Security:** Avoid sensitive data in template parameters, freeform message text, and all message content — they appear in CloudTrail logs. See [SKILL.md — Security Considerations](../SKILL.md#security-considerations).
+
+## Contents
+
+- [Template Messages](#template-messages)
+- [Freeform Messages (24h Window)](#freeform-messages-24h-window)
+- [Parameters](#parameters)
+- [Expected Output](#expected-output)
+- [Freeform Constraints](#freeform-constraints)
+
+The `--message` parameter is a blob type — base64-encode the JSON.
+
+⚠️ The `"to"` field MUST use E.164 format WITH the `+` prefix (e.g., `"+14155551234"`, NOT `"14155551234"`). Alternatively, recipients can be addressed by Business-Scoped User ID (BSUID) — a username in the format `CC.alphanumeric` (e.g., `US.13491208655302741918`) passed via the `"recipient"` field instead of `"to"`.
+
+**Required JSON body fields (all message types):**
+
+- `"messaging_product": "whatsapp"` — mandatory, always this value
+- `"to"` — recipient in E.164 format with `+` prefix
+- `"type"` — message type (`"template"`, `"text"`, `"image"`, `"document"`, etc.)
+
+**⚠️ API Version:** Before constructing commands, determine the Meta Graph API version to use by checking [Meta's Graph API changelog](https://developers.facebook.com/docs/graph-api/changelog). The examples below use `v{Major}.{Minor}` as a placeholder — substitute the latest supported version in `v{Major}.{Minor}` format (e.g., `v21.0`).
+
+## Template Messages
+
+### Send Utility Template
+
+```bash
+MESSAGE=$(printf '%s' '{"messaging_product":"whatsapp","to":"+14155551234","type":"template","template":{"name":"order_shipment_update","language":{"code":"en_US"},"components":[{"type":"body","parameters":[{"type":"text","text":"ORD-98765"},{"type":"text","text":"https://example.com/track/98765"}]}]}}' | base64 | tr -d '\n')
+
+aws socialmessaging send-whatsapp-message \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX" \
+  --message "$MESSAGE" \
+  --meta-api-version "v{Major}.{Minor}"
+
+```
+
+### Send Marketing Template (with image header)
+
+```bash
+MESSAGE=$(printf '%s' '{"messaging_product":"whatsapp","to":"+14155551234","type":"template","template":{"name":"seasonal_promotion","language":{"code":"en_US"},"components":[{"type":"header","parameters":[{"type":"image","image":{"link":"https://example.com/current-promo.jpg"}}]},{"type":"body","parameters":[{"type":"text","text":"Jane"},{"type":"text","text":"25"},{"type":"text","text":"June 30"}]}]}}' | base64 | tr -d '\n')
+
+aws socialmessaging send-whatsapp-message \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX" \
+  --message "$MESSAGE" \
+  --meta-api-version "v{Major}.{Minor}"
+
+```
+
+### Send Authentication Template
+
+```bash
+MESSAGE=$(printf '%s' '{"messaging_product":"whatsapp","to":"+14155551234","type":"template","template":{"name":"login_verification","language":{"code":"en_US"},"components":[{"type":"body","parameters":[{"type":"text","text":"847293"}]}]}}' | base64 | tr -d '\n')
+
+aws socialmessaging send-whatsapp-message \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX" \
+  --message "$MESSAGE" \
+  --meta-api-version "v{Major}.{Minor}"
+
+```
+
+## Freeform Messages (24h Window)
+
+### Send Text
+
+```bash
+MESSAGE=$(printf '%s' '{"messaging_product":"whatsapp","recipient_type":"individual","to":"+14155551234","type":"text","text":{"body":"Thank you for contacting us. Your issue has been resolved."}}' | base64 | tr -d '\n')
+
+aws socialmessaging send-whatsapp-message \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX" \
+  --message "$MESSAGE" \
+  --meta-api-version "v{Major}.{Minor}"
+
+```
+
+### Send Image (via Media ID — Recommended for Sensitive Content)
+
+```bash
+MESSAGE=$(printf '%s' '{"messaging_product":"whatsapp","recipient_type":"individual","to":"+14155551234","type":"image","image":{"id":"XXXXXXXXXXXXXXXXXXXX","caption":"Your receipt"}}' | base64 | tr -d '\n')
+
+aws socialmessaging send-whatsapp-message \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX" \
+  --message "$MESSAGE" \
+  --meta-api-version "v{Major}.{Minor}"
+
+```
+
+For non-sensitive images, you may use a public URL instead of a media ID — the URL must remain accessible for the full 30-day message availability window:
+
+**Security:** For sensitive content (receipts, invoices, documents with PII), upload via `post-whatsapp-message-media` and reference by media ID instead of using publicly accessible URLs. See [managing-media.md](managing-media.md#usage-in-messages).
+
+### Send Document (via Media ID)
+
+```bash
+MESSAGE=$(printf '%s' '{"messaging_product":"whatsapp","recipient_type":"individual","to":"+14155551234","type":"document","document":{"id":"XXXXXXXXXXXXXXXXXXXX","caption":"Invoice #1234","filename":"invoice-1234.pdf"}}' | base64 | tr -d '\n')
+
+aws socialmessaging send-whatsapp-message \
+  --origination-phone-number-id "phone-number-id-XXXXXXXXXXXXXXXXXXXX" \
+  --message "$MESSAGE" \
+  --meta-api-version "v{Major}.{Minor}"
+
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--origination-phone-number-id` | Yes | Phone number ID (format: `phone-number-id-XXXX`) |
+| `--message` | Yes | Base64-encoded WhatsApp Cloud API message JSON |
+| `--meta-api-version` | Yes | Meta Graph API version (format: `v{Major}.{Minor}`, e.g., `v21.0`). Check [Meta's Graph API changelog](https://developers.facebook.com/docs/graph-api/changelog) for the latest supported version. |
+
+## Expected Output
+
+```json
+{
+  "messageId": "wamid.XXXXXXXXXXXXXXXXXXXX"
+}
+
+```
+
+A `messageId` confirms queued for delivery — not delivered. Configure event destinations for delivery status.
+
+## Freeform Constraints
+
+- MUST be sent within 24h of customer's last inbound message
+- No API to check window status — verify from application logs or event destination history
+- Text length limits per [WhatsApp Cloud API reference](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages)
+- Media limits vary by type — consult [WhatsApp Cloud API media reference](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media) for supported formats and size constraints
+- Media URLs must be publicly accessible via HTTPS and remain available for the full 30-day message availability window — Meta can re-fetch media at any time during this period. For sensitive content (receipts, invoices, PII), upload via `post-whatsapp-message-media` and reference by media ID instead — see [managing-media.md](managing-media.md#usage-in-messages). Note: public URLs are logged in CloudTrail and may be cached by intermediaries. Ensure CloudTrail logs are encrypted with a KMS CMK to protect logged URLs and message metadata.

--- a/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/troubleshooting-delivery.md
+++ b/skills/specialized-skills/messaging-and-streaming-skills/aws-social-messaging/references/troubleshooting-delivery.md
@@ -1,0 +1,111 @@
+# Troubleshooting WhatsApp Message Delivery
+
+> **Security:** See [SKILL.md — Security Considerations](../SKILL.md#security-considerations) for encryption, IAM, and audit logging guidance.
+
+## Diagnostic Flow
+
+### Step 1: Check WABA Status
+
+```bash
+aws socialmessaging get-linked-whatsapp-business-account --id "waba-XXXXXXXXXXXXXXXXXXXX"
+
+```
+
+- Registration status MUST be `COMPLETE`
+- Check `qualityRating` — LOW restricts sending capacity
+- If not COMPLETE, finish registration in the AWS Console (cannot be done via CLI)
+
+### Step 2: Check Phone Number Health
+
+```bash
+aws socialmessaging get-linked-whatsapp-business-account-phone-number \
+  --id "phone-number-id-XXXXXXXXXXXXXXXXXXXX"
+
+```
+
+- Phone must be verified and active
+- Quality rating affects sending limits
+
+### Step 3: Inspect Templates
+
+```bash
+aws socialmessaging list-whatsapp-message-templates --id "waba-XXXXXXXXXXXXXXXXXXXX"
+
+```
+
+Look for:
+
+- `REJECTED` templates — recreate with compliant content
+- `PENDING` > 24h — create a new template
+- Category mismatch (submitted UTILITY, now shows MARKETING) — reclassified by Meta
+
+### Step 4: Verify Event Destinations
+
+```bash
+aws sns list-subscriptions-by-topic \
+  --topic-arn "arn:aws:sns:us-east-1:123456789012:whatsapp-events"
+
+```
+
+- All subscriptions must be `Confirmed`
+- Verify subscription endpoints are authorized personnel/systems; use HTTPS-only endpoints
+- If no event destination configured, delivery failures are invisible
+
+### Step 5: Check Service Quotas
+
+```bash
+aws service-quotas get-service-quota \
+  --service-code social-messaging \
+  --quota-code L-XXXXXXXX
+
+```
+
+Review [service quotas](https://docs.aws.amazon.com/social-messaging/latest/userguide/quotas.html) for quota codes and defaults. New WABAs have lower limits that increase with quality rating.
+
+### Step 6: Check CloudTrail for API Errors
+
+```bash
+aws cloudtrail lookup-events \
+  --lookup-attributes AttributeKey=EventSource,AttributeValue=social-messaging.amazonaws.com \
+  --max-results 20
+
+```
+
+CloudTrail records all `social-messaging` API calls. Look for `SendWhatsAppMessage` events with error details not visible in the CLI response. Verify CloudTrail is enabled for the account/region. Ensure CloudTrail logs are encrypted with a KMS CMK (see [SKILL.md — Security Considerations](../SKILL.md#security-considerations)).
+
+## Common Error Patterns
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Send returns error | Invalid `--origination-phone-number-id` | Use the ID (`phone-number-id-XXXX`), not the phone number |
+| Send returns error | Invalid recipient format | Must be E.164 with `+` prefix (e.g., `+14155551234`) |
+| Send succeeds but not delivered | Recipient not on WhatsApp | Messages silently dropped; no fix |
+| Send succeeds but not delivered | 24h window expired (freeform) | Use template message instead |
+| Send succeeds but not delivered | Rate limited | Check quotas; quality rating must improve |
+| Template REJECTED | Non-compliant content | Recreate with correct category-matching language |
+| Template reclassified | Ambiguous body text | Delete, recreate with clearly transactional language |
+| No delivery callbacks | Event destination missing | Configure via `put-whatsapp-business-account-event-destinations` |
+| No delivery callbacks | SNS subscription pending | Confirm the subscription endpoint |
+
+## Meta Error Codes
+
+Common codes — see [Meta's error reference](https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes) for the full list.
+
+| Code | Meaning |
+|------|---------|
+| 131026 | Recipient phone number not on WhatsApp. Verify E.164 format with `+` prefix, confirm number has active WhatsApp, retry after a brief delay for transient failures, and check if your phone number quality rating has degraded |
+| 131049 | Message failed — requires recent user engagement (marketing templates) |
+| 131047 | Re-engagement message — more than 24h since last reply |
+| 131051 | Unsupported message type |
+| 130472 | Number deregistered from WhatsApp |
+
+## Quick Checklist
+
+1. ✅ WABA registration COMPLETE
+2. ✅ Phone number verified and active
+3. ✅ Template APPROVED (not PENDING/REJECTED)
+4. ✅ Template category matches content (not reclassified)
+5. ✅ Event destinations configured + SNS subscriptions confirmed
+6. ✅ Recipient has WhatsApp on that number
+7. ✅ Within 24h window (freeform only)
+8. ✅ Not exceeding rate limits


### PR DESCRIPTION
## Summary

Adds the `aws-social-messaging` skill for AWS End User Messaging Social. Covers WhatsApp messaging workflows: managing templates (create, update, delete, library), sending messages (utility/marketing/auth templates and freeform), uploading and managing media, configuring event destinations for delivery tracking, and troubleshooting delivery failures.

## Details

- Text-only skill (no executable code)
- Security-reviewed: Guardian PASS
- Tested with: Kiro, Claude Code (via AWS MCP Server gamma)

## Checklist

- [x] Internal-only frontmatter fields removed (`owner_team`, `owner_cti`, `stages`, `metadata`)
- [x] No internal links or references in skill content
- [x] No internal details in commit messages
- [ ] CI checks pass