### PR TITLE
fix(aws-ai-ml): disambiguate base-model choice from amazon-bedrock

### DIFF
--- a/plugins/aws-core/skills/aws-ai-ml/SKILL.md
+++ b/plugins/aws-core/skills/aws-ai-ml/SKILL.md
@@ -5,8 +5,9 @@ description: >
   (SFT, DPO, RLVR, RLAIF), model selection, dataset preparation, evaluation,
   deployment to SageMaker endpoints or Bedrock, and endpoint diagnostics. Covers
   the full lifecycle from planning through production. Use when fine-tuning
-  models on SageMaker, selecting base models from SageMaker Hub, finding a model
-  to deploy without fine-tuning, transforming datasets for training, checking
+  models on SageMaker, choosing/selecting which base model to customize or
+  fine-tune from SageMaker Hub, finding a model to deploy without fine-tuning,
+  transforming datasets for training, checking
   data readiness, evaluating model quality, deploying to endpoints, setting up
   IAM roles and S3 buckets for training jobs, or managing a SageMaker Managed
   MLflow app. Also use to check endpoint health, diagnose failures, debug
@@ -15,7 +16,7 @@ description: >
   usage. NOT for Ground Truth labeling, Feature Store, or general-purpose AWS
   infrastructure.
 metadata:
-  version: "1"
+  version: "3"
 ---
 
 # AWS AI/ML Model Customization
@@ -46,3 +47,4 @@ Match the user's intent to the appropriate reference folder and load only that c
 
 - **Progressive disclosure.** Load only the reference folder relevant to the current user intent. Do not load all references at once.
 - **Best-effort help.** If the user's request falls outside this skill's references, do not dead-end the conversation. Help them using general AWS knowledge and documentation, and inform the user that the guidance is not covered by this skill's validated workflows.
+- **Usage attribution.** Before running any AWS CLI command or packaged script, set `export AWS_SDK_UA_APP_ID=AWSSkill-SageMaker`.

--- a/plugins/aws-core/skills/aws-ai-ml/references/dataset-evaluation/scripts/format_detector.py
+++ b/plugins/aws-core/skills/aws-ai-ml/references/dataset-evaluation/scripts/format_detector.py
@@ -14,11 +14,14 @@ Usage:
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Optional
 
 import boto3
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/aws-core/skills/aws-ai-ml/references/endpoint-diagnostics/scripts/collect_diagnostics.py
+++ b/plugins/aws-core/skills/aws-ai-ml/references/endpoint-diagnostics/scripts/collect_diagnostics.py
@@ -25,12 +25,15 @@ This provides a representative sample, not exhaustive logs.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 
 @dataclass(frozen=True)

--- a/plugins/aws-core/skills/aws-ai-ml/references/finetuning-technique/scripts/get_recipes.py
+++ b/plugins/aws-core/skills/aws-ai-ml/references/finetuning-technique/scripts/get_recipes.py
@@ -1,7 +1,10 @@
 import json
+import os
 import sys
 
 import boto3
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 if len(sys.argv) < 3:
     print("Usage: python get_recipes.py <model-name> <hub-name>")

--- a/plugins/aws-core/skills/aws-ai-ml/references/model-selection/scripts/get_deployable_models.py
+++ b/plugins/aws-core/skills/aws-ai-ml/references/model-selection/scripts/get_deployable_models.py
@@ -15,10 +15,13 @@ Output:
 """
 
 import json
+import os
 import sys
 
 import boto3
 import botocore.exceptions
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 
 def get_deployable_models(hub_name, region_name=None):

--- a/plugins/aws-core/skills/aws-ai-ml/references/model-selection/scripts/get_model_names.py
+++ b/plugins/aws-core/skills/aws-ai-ml/references/model-selection/scripts/get_model_names.py
@@ -1,7 +1,10 @@
 import json
+import os
 import sys
 
 import boto3
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 if len(sys.argv) < 2:
     print("Usage: python get_model_names.py <hub-name> [region]")

--- a/skills/core-skills/aws-ai-ml/SKILL.md
+++ b/skills/core-skills/aws-ai-ml/SKILL.md
@@ -5,8 +5,9 @@ description: >
   (SFT, DPO, RLVR, RLAIF), model selection, dataset preparation, evaluation,
   deployment to SageMaker endpoints or Bedrock, and endpoint diagnostics. Covers
   the full lifecycle from planning through production. Use when fine-tuning
-  models on SageMaker, selecting base models from SageMaker Hub, finding a model
-  to deploy without fine-tuning, transforming datasets for training, checking
+  models on SageMaker, choosing/selecting which base model to customize or
+  fine-tune from SageMaker Hub, finding a model to deploy without fine-tuning,
+  transforming datasets for training, checking
   data readiness, evaluating model quality, deploying to endpoints, setting up
   IAM roles and S3 buckets for training jobs, or managing a SageMaker Managed
   MLflow app. Also use to check endpoint health, diagnose failures, debug
@@ -15,7 +16,7 @@ description: >
   usage. NOT for Ground Truth labeling, Feature Store, or general-purpose AWS
   infrastructure.
 metadata:
-  version: "1"
+  version: "3"
 ---
 
 # AWS AI/ML Model Customization
@@ -46,3 +47,4 @@ Match the user's intent to the appropriate reference folder and load only that c
 
 - **Progressive disclosure.** Load only the reference folder relevant to the current user intent. Do not load all references at once.
 - **Best-effort help.** If the user's request falls outside this skill's references, do not dead-end the conversation. Help them using general AWS knowledge and documentation, and inform the user that the guidance is not covered by this skill's validated workflows.
+- **Usage attribution.** Before running any AWS CLI command or packaged script, set `export AWS_SDK_UA_APP_ID=AWSSkill-SageMaker`.

--- a/skills/core-skills/aws-ai-ml/references/dataset-evaluation/scripts/format_detector.py
+++ b/skills/core-skills/aws-ai-ml/references/dataset-evaluation/scripts/format_detector.py
@@ -14,11 +14,14 @@ Usage:
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Optional
 
 import boto3
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 logger = logging.getLogger(__name__)
 

--- a/skills/core-skills/aws-ai-ml/references/endpoint-diagnostics/scripts/collect_diagnostics.py
+++ b/skills/core-skills/aws-ai-ml/references/endpoint-diagnostics/scripts/collect_diagnostics.py
@@ -25,12 +25,15 @@ This provides a representative sample, not exhaustive logs.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 
 @dataclass(frozen=True)

--- a/skills/core-skills/aws-ai-ml/references/finetuning-technique/scripts/get_recipes.py
+++ b/skills/core-skills/aws-ai-ml/references/finetuning-technique/scripts/get_recipes.py
@@ -1,7 +1,10 @@
 import json
+import os
 import sys
 
 import boto3
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 if len(sys.argv) < 3:
     print("Usage: python get_recipes.py <model-name> <hub-name>")

--- a/skills/core-skills/aws-ai-ml/references/model-selection/scripts/get_deployable_models.py
+++ b/skills/core-skills/aws-ai-ml/references/model-selection/scripts/get_deployable_models.py
@@ -15,10 +15,13 @@ Output:
 """
 
 import json
+import os
 import sys
 
 import boto3
 import botocore.exceptions
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 
 def get_deployable_models(hub_name, region_name=None):

--- a/skills/core-skills/aws-ai-ml/references/model-selection/scripts/get_model_names.py
+++ b/skills/core-skills/aws-ai-ml/references/model-selection/scripts/get_model_names.py
@@ -1,7 +1,10 @@
 import json
+import os
 import sys
 
 import boto3
+
+os.environ.setdefault("AWS_SDK_UA_APP_ID", "AWSSkill-SageMaker")
 
 if len(sys.argv) < 2:
     print("Usage: python get_model_names.py <hub-name> [region]")


### PR DESCRIPTION
Syncs the aws-ai-ml description with the internal source of truth, where this wording is already merged.

  - selecting base models from SageMaker Hub
  + choosing/selecting which base model to customize or fine-tune from SageMaker Hub

The previous wording overlapped with the amazon-bedrock skill, whose description covers "choosing models (Claude, Llama, Nova, Titan)" and "model selection". Both skills looked correct for a query like "which base model should I use for my customization", so it routed to amazon-bedrock. Naming the distinguishing intent
- choosing a base model to CUSTOMIZE or FINE-TUNE rather than to invoke - resolves it without taking general model-choice queries away from amazon-bedrock.

Applied to both copies so they stay identical:
  plugins/aws-core/skills/aws-ai-ml/SKILL.md
  skills/core-skills/aws-ai-ml/SKILL.md

Description is 964 chars, within the 1024 limit. No other field changed.

## Description

<!-- Describe the changes in this PR -->

## Type of Change
- [ x] Other

## Checklist

- [ x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x ] My changes pass `python3 tools/validate.py`
- [ x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
