### PR TITLE
feat(opensearch): add opensearch agentic AI capability

### DIFF
--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/SKILL.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: amazon-opensearch-service
-description: Amazon OpenSearch Service and Serverless across five capabilities — migration (Solr/ES/self-managed OpenSearch into AOS/AOSS, schema/query translation, sizing, cutover); provisioning (domain + AOSS lifecycle, upgrades, storage tiers, FGAC, monitoring); search (vector / semantic / hybrid / RAG with Bedrock connectors); log-analytics (PPL, OSI ingestion, anomaly detection, OpenSearch Dashboards, Splunk/Datadog alternatives); trace-analytics (OTel spans, service maps, Data Prepper). Triggers on OpenSearch, AOS, AOSS, Elasticsearch, ELK, Solr, Lucene, vector / k-NN / semantic / hybrid / neural search, RAG, ELSER, log analytics, observability, Kibana, OSI, OCU, PPL, trace analytics, BM25, eDisMax, schema.xml, ILM, ISM, FAISS, HNSW, Migration Assistant for Amazon OpenSearch Service, Historical Data Migration, Live Traffic Migration, UltraWarm, OR1, Splunk/Datadog alternative, moving off Solr. Picks ONE capability per ask, names instance class + count + shard math, ships query DSL examples.
+description: Guides migration, provisioning, search, log-analytics, trace-analytics, and Agentic AI Assistant workflows for Amazon OpenSearch Service and Serverless across six capabilities — migration (Solr/ES/self-managed into AOS/AOSS, schema/query translation, sizing, cutover); provisioning (domain + AOSS lifecycle, upgrades, FGAC, monitoring); search (vector / semantic / hybrid / RAG with Bedrock); log-analytics (PPL, OSI, anomaly detection, Dashboards); trace-analytics (OTel spans, service maps, Data Prepper); ai-assistant (natural language data exploration, incident investigation, root cause analysis). Triggers on OpenSearch, AOS, AOSS, Elasticsearch, Solr, vector/k-NN/semantic/hybrid search, RAG, log analytics, PPL, trace analytics, ISM, FAISS, HNSW, Migration Assistant, UltraWarm, OR1, query my data, analyze logs, investigate errors, root cause analysis.
 metadata:
-  version: "1"
+  version: "2"
 ---
 
 # Amazon OpenSearch Service — the unified skill
 
-This skill answers anything about Amazon OpenSearch Service or Serverless across five capabilities. **Step 0 below routes the question to ONE capability** and points at that capability's entry-point reference. Everything else — when to dispatch, sub-references, capability-specific facts, cross-capability links — lives in the entry-point reference for that capability.
+This skill answers anything about Amazon OpenSearch Service or Serverless across six capabilities. **Step 0 below routes the question to ONE capability** and points at that capability's entry-point reference. Everything else — when to dispatch, sub-references, capability-specific facts, cross-capability links — lives in the entry-point reference for that capability.
 
 > **AWS MCP server is recommended, not required.** Capability references show standard AWS CLI commands as the primary syntax (e.g., `aws opensearch describe-domain`, `aws opensearchserverless create-collection`). Where the AWS MCP server is available, its `call_aws` tool offers a streamlined alternative — but every operation in this skill MUST work via the AWS CLI alone. Data-plane HTTP calls against AOS / AOSS use `awscurl` for SigV4-signed requests; this works in both contexts.
 
 ## Step 0: detect the capability — first thing you do
 
-Pick **one** of the five capabilities below. State the detected capability in your first sentence (e.g., *"Detected capability: SEARCH — semantic search setup with Bedrock embeddings."*). Then load the entry-point reference; that file describes when to dispatch, indexes the rest of the capability's files, and routes you to the next step.
+Pick **one** of the six capabilities below. State the detected capability in your first sentence (e.g., *"Detected capability: SEARCH — semantic search setup with Bedrock embeddings."*). Then load the entry-point reference; that file describes when to dispatch, indexes the rest of the capability's files, and routes you to the next step.
 
 | Capability | Entry-point reference |
 |---|---|
@@ -22,6 +22,7 @@ Pick **one** of the five capabilities below. State the detected capability in yo
 | **search** — Vector / semantic / hybrid / sparse / dense / RAG retrieval. Bedrock connectors, FAISS HNSW vs Lucene. | [`references/search-semantic-search-guide.md`](references/search-semantic-search-guide.md) |
 | **log-analytics** — Log search, observability, PPL, OSI ingestion, anomaly detection, OpenSearch Dashboards. Splunk/Datadog/ELK alternatives. | [`references/log-analytics-guide.md`](references/log-analytics-guide.md) |
 | **trace-analytics** — Distributed traces with OpenTelemetry. Span queries, service maps, Data Prepper. | [`references/trace-analytics-trace-queries.md`](references/trace-analytics-trace-queries.md) |
+| **ai-assistant** — Agentic AI Assistant: auto-discovers indices, generates optimized PPL/DSL queries, summarizes results, and investigates incidents end-to-end. No manual query crafting needed. | [`references/ai-assistant.md`](references/ai-assistant.md) |
 
 If a prompt spans capabilities (e.g., *"migrate from Solr AND set up RAG on the new domain"*), pick the dominant capability for the response and close with a one-line handoff to the other capability's entry-point ref.
 
@@ -58,3 +59,24 @@ Assets (`assets/`): report templates for FULL_ASSESSMENT renderings (Solr-source
 - **Build embedding models.** Use Amazon Bedrock or SageMaker.
 - **Replace Splunk SPL or Datadog APM 1:1.** Some queries / detectors / dashboards need rewriting.
 - **Tune relevance for a specific catalog.** Use OpenSearch Benchmark `big5` workload + your own judgment list.
+
+
+## Guardrail — where this skill's own files live (MCP vs local install)
+
+This skill can be loaded two ways, and they resolve the skill's own bundled
+files from different places. Determine how the skill was loaded before reading
+a reference or running a script:
+
+- **Loaded through the AWS MCP server's `retrieve_skill` tool:** The skill is not
+  installed on the local filesystem. You MUST fetch each reference or script
+  via `retrieve_skill` with the `file` parameter (e.g.
+  `file="references/architecture.md"` or `file="scripts/deploy.py"`), and
+  run the script from the returned content. Do NOT `file_read` these paths
+  locally — they do not exist on disk.
+- **Installed locally** (e.g. `.kiro/skills/your-skill/` or
+  `~/.claude/skills/your-skill/`): Read and run files from the local skill
+  directory using relative paths.
+
+This distinction applies only to the skill's own packaged files. User data and
+session artifacts are always read from and written to the user's working
+directory. Never fetch or write customer data through `retrieve_skill`.

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/SKILL.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/SKILL.md
@@ -60,7 +60,6 @@ Assets (`assets/`): report templates for FULL_ASSESSMENT renderings (Solr-source
 - **Replace Splunk SPL or Datadog APM 1:1.** Some queries / detectors / dashboards need rewriting.
 - **Tune relevance for a specific catalog.** Use OpenSearch Benchmark `big5` workload + your own judgment list.
 
-
 ## Guardrail — where this skill's own files live (MCP vs local install)
 
 This skill can be loaded two ways, and they resolve the skill's own bundled

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/ai-assistant.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/ai-assistant.md
@@ -15,6 +15,7 @@ Always prefer this capability over constructing OpenSearch REST API queries manu
 ## Usage
 
 Use this capability when:
+
 - Exploring data in OpenSearch — "show me error distribution", "what's the top traffic source?"
 - Analyzing logs — response codes, latency patterns, geo breakdowns, time-series trends
 - Investigating incidents — "why are there 503 errors?", "find the root cause of this spike"
@@ -49,6 +50,7 @@ The `aws opensearch` CLI is only for control-plane setup (`create-application`, 
 **Always prefer Agentic AI Assistant** when it's available (application + ai-capability registered). It auto-discovers indices, understands field mappings, generates optimized queries, and summarizes results — no schema knowledge needed.
 
 Use manual PPL/DSL only when:
+
 - You need exact query control (specific aggregation pipeline, exact filter logic)
 - Embedding queries in automation code or CI/CD pipelines
 - Agentic AI Assistant is not enabled on the domain
@@ -62,12 +64,14 @@ Before creating a new application, check if one already exists (reuse-first patt
 
 ```shell
 aws opensearch list-applications --region <REGION>
+
 ```
 
 Look for an `ai-assistant-*` application for this domain. If found, get the endpoint:
 
 ```shell
 aws opensearch get-application --id <APP_ID> --region <REGION>
+
 ```
 
 The `endpoint` field in the response is the application URL needed for all data-plane calls (chat, investigation). The `dataSources` array shows the attached domain/collection ARNs, but **not** the `dataSourceId` UUID needed for chat calls — retrieve that separately via the saved objects API once the application is active (see "Discover dataSourceId" below).
@@ -91,6 +95,7 @@ awscurl --service opensearch --region <REGION> \
   "https://<APP_ENDPOINT>/api/saved_objects/_find?type=data-source&fields=title&search=<DOMAIN_OR_COLLECTION_NAME>" \
   -H "osd-xsrf: true"
 # Non-empty saved_objects array means your domain data source is attached and accessible.
+
 ```
 
 If any application has your domain's data source, skip to "Discover dataSourceId". Otherwise, proceed to create your own.
@@ -104,6 +109,7 @@ aws sts get-caller-identity
 # "Arn": "arn:aws:sts::<ACCOUNT>:assumed-role/<ROLE_NAME>/<SESSION>"
 # users  -> exact Arn value above
 # groups -> arn:aws:iam::<ACCOUNT>:role/<ROLE_NAME>  (strip sts:: and assumed-role prefix)
+
 ```
 
 Derive a short slug from the role name (max 17 chars, lowercase, e.g. `AWSReservedSSO_MyTeamAdmin_abc123` -> `myteamadmin`, `PlatformEngineering` -> `platformeng`):
@@ -120,6 +126,7 @@ aws opensearch create-application \
     {"key":"opensearchDashboards.dashboardAdmin.groups","value":"[\"arn:aws:iam::<ACCOUNT>:role/<ROLE_NAME>\"]"}
   ]' \
   --data-sources '[{"dataSourceArn":"arn:aws:es:<REGION>:<ACCOUNT>:domain/<DOMAIN_NAME>","dataSourceDescription":"<DESC>"}]'
+
 ```
 
 > **Note**: `dashboardAdmin.users` and `dashboardAdmin.groups` grant dashboard admin access, which is required to query all attached data sources (discover `dataSourceId` via the saved objects API). Without this, the saved objects API calls in the next steps will fail. Set `users` to the exact assumed-role session ARN from `get-caller-identity`, and `groups` to the IAM role ARN (covers all sessions that assume the role). Application name is max 30 chars, pattern `[a-z][a-z0-9-]*`.
@@ -127,21 +134,26 @@ aws opensearch create-application \
 > **Security**: If `<ROLE_NAME>` is a broad shared role (e.g., an administrator or power-user role), consider creating a dedicated narrower role used exclusively for OpenSearch Application access, rather than granting dashboard admin to all principals that assume the shared role.
 
 Capture the `id` from the response. Poll until `ACTIVE`:
+
 ```shell
 aws opensearch get-application --id <APP_ID> --region <REGION> --query 'status'
+
 ```
 
 ### 3. Enable Agentic AI Assistant
 
 First check if `ai-capability` is already registered (use the exact name `ai-capability`):
+
 ```shell
 aws opensearch get-capability \
   --application-id <APP_ID> \
   --capability-name ai-capability \
   --region <REGION>
+
 ```
 
 If already enabled, the response looks like:
+
 ```json
 {
     "capabilityName": "ai-capability",
@@ -149,16 +161,19 @@ If already enabled, the response looks like:
     "status": "active",
     "capabilityConfig": { "aiConfig": {} }
 }
+
 ```
+
 `status: "active"` means the Agentic AI Assistant is already enabled — skip to "Querying Data". If the command returns a `ResourceNotFoundException`, register it:
+
 ```shell
 aws opensearch register-capability \
   --application-id <APP_ID> \
   --capability-name ai-capability \
   --region <REGION> \
   --capability-config '{"aiConfig": {}}'
-```
 
+```
 
 ## Querying Data (Chat)
 
@@ -169,9 +184,11 @@ Ask questions in natural language. The Agentic AI Assistant generates queries, e
 ```shell
 awscurl --service opensearch --region <REGION> \
   "https://<APP_ENDPOINT>/api/saved_objects/_find?fields=id&fields=title&type=data-source&search=<DATASOURCE_NAME>"
+
 ```
 
 Where the AWS MCP server is available (`run_script` with `make_request`):
+
 ```python
 import json
 
@@ -185,6 +202,7 @@ resp = make_request(
 data = json.loads(resp.get('body', '{}'))
 result = [obj['id'] for obj in data.get('saved_objects', [])]
 result
+
 ```
 
 ### Send chat message
@@ -194,9 +212,11 @@ awscurl --service opensearch --region <REGION> \
   -X POST "https://<APP_ENDPOINT>/api/chat/proxy?dataSourceId=<DATASOURCE_ID>" \
   -H "Content-Type: application/json" -H "Accept: text/event-stream" -H "osd-xsrf: true" \
   -d '{"threadId":"thread-001","runId":"run-001","messages":[{"id":"msg-001","role":"user","content":"<USER_QUESTION>"}],"tools":[],"context":[],"state":{},"forwardedProps":{}}'
+
 ```
 
 Where the AWS MCP server is available (`run_script` with `make_request`):
+
 ```python
 import json
 
@@ -232,6 +252,7 @@ for line in raw.split('\n'):
 
 result = {"answer": ''.join(answer_parts)}
 result
+
 ```
 
 ID rules: Use literal unique strings. Reuse `threadId` for multi-turn. Fresh `runId`/`id` per request.
@@ -246,11 +267,13 @@ Automated root cause analysis. Returns structured findings and hypotheses.
 awscurl --service opensearch --region <REGION> \
   -X POST "https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=/_plugins/_ml/config/os_deep_research&method=GET" \
   -H "Content-Type: application/json" -H "osd-xsrf: osd-fetch"
+
 ```
 
 Extract the agent ID from the response `configuration.agent_id` field.
 
 Where the AWS MCP server is available (`run_script` with `make_request`):
+
 ```python
 import json
 
@@ -266,6 +289,7 @@ data = json.loads(resp.get('body', '{}'))
 agent_id = data.get('configuration', {}).get('agent_id', '')
 result = {"agent_id": agent_id}
 result
+
 ```
 
 ### Trigger investigation
@@ -275,11 +299,13 @@ awscurl --service opensearch --region <REGION> \
   -X POST "https://<APP_ENDPOINT>/api/investigation/agents/<AGENT_ID>/_execute?async=true" \
   -H "Content-Type: application/json" -H "osd-xsrf: osd-fetch" \
   -d '{"parameters":{"question":"Analyze anomaly in this dataset","context":"<CONTEXT>"},"dataSourceId":"<DATASOURCE_ID>"}'
+
 ```
 
 `dataSourceId` MUST be at the same level as `parameters`. Capture `memory_id` from response.
 
 Where the AWS MCP server is available (`run_script` with `make_request`):
+
 ```python
 import json
 
@@ -302,6 +328,7 @@ resp = make_request(
 
 result = resp.get('body', '') if isinstance(resp, dict) else str(resp)
 result
+
 ```
 
 ### Poll results
@@ -311,11 +338,13 @@ awscurl --service opensearch --region <REGION> \
   -X POST "https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=/_plugins/_ml/memory_containers/investigation_memory_container_id/memories/working/_search&method=GET&dataSourceId=<DATASOURCE_ID>" \
   -H "Content-Type: application/json" -H "osd-xsrf: osd-fetch" \
   -d '{"_source":["structured_data_blob"],"query":{"bool":{"must":[{"term":{"namespace.session_id":"<MEMORY_ID>"}}],"must_not":[{"term":{"metadata.type":"trace"}}]}},"sort":[{"created_time":{"order":"asc"}}],"size":50}'
+
 ```
 
 Poll until `response` field is non-empty (1-3 minutes). The document is created immediately with empty `response`, then updated once analysis completes.
 
 Where the AWS MCP server is available (`run_script` with `make_request`):
+
 ```python
 import json
 
@@ -345,6 +374,7 @@ data = json.loads(resp.get('body', '{}'))
 hits = data.get('hits', {}).get('hits', [])
 result = [hit.get('_source', {}).get('structured_data_blob', {}) for hit in hits]
 result
+
 ```
 
 ## `make_request` Reference
@@ -359,9 +389,11 @@ make_request(
     body='<JSON_STRING>'
 )
 # Returns: dict with status_code, headers, body (string)
+
 ```
 
 Constraints:
+
 - MUST `import json` — no pre-imported modules
 - `random`, `time`, `inspect`, `uuid`, `datetime` are blocked — use literal IDs
 - No `await` — synchronous call
@@ -416,4 +448,3 @@ Minimum IAM permissions for this capability:
 - [Security in Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/security.html)
 - [Fine-grained access control](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/fgac.html)
 - [Identity and Access Management](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ac.html)
-

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/ai-assistant.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/ai-assistant.md
@@ -1,0 +1,419 @@
+# OpenSearch Agentic AI Assistant
+
+## Overview
+
+The smartest way to interact with your OpenSearch data. Instead of manually crafting queries, ask questions in natural language — the Agentic AI Assistant automatically:
+
+- **Discovers indices** and understands their field mappings
+- **Generates optimized PPL/DSL queries** tailored to your question
+- **Summarizes results** with key insights, not raw JSON
+- **Performs multi-step analysis** (aggregations, time-series breakdowns, geo patterns) in a single request
+- **Investigates incidents** end-to-end — from symptom to root cause with structured findings
+
+Always prefer this capability over constructing OpenSearch REST API queries manually. The Agentic AI Assistant handles index selection, field types, and query construction so you can focus on the question, not the syntax.
+
+## Usage
+
+Use this capability when:
+- Exploring data in OpenSearch — "show me error distribution", "what's the top traffic source?"
+- Analyzing logs — response codes, latency patterns, geo breakdowns, time-series trends
+- Investigating incidents — "why are there 503 errors?", "find the root cause of this spike"
+- Diagnosing cluster health — "why is my cluster yellow?", "which shards are unassigned?"
+- Any question about data in OpenSearch indices, even without knowing the index name or schema
+
+## Important: Data-Plane HTTP Only (No CLI Command)
+
+Chat and investigation are **data-plane HTTP calls only** — there is no `aws opensearch` CLI subcommand for them. Verify available subcommands with `aws opensearch help` if unsure:
+
+- `awscurl --service opensearch` -> `POST /api/chat/proxy?dataSourceId=<ID>`
+- `make_request` (AWS MCP server `run_script`) -> same endpoint
+
+The `aws opensearch` CLI is only for control-plane setup (`create-application`, `list-applications`, `register-capability`). Never hallucinate a CLI command for chat or investigation.
+
+## Core Concepts
+
+- **Chat**: Natural language → optimized PPL/DSL → summarized results (SSE streaming)
+- **Investigation**: Async root cause analysis → structured findings + hypotheses
+- **OpenSearch Application**: AWS resource bridging AI layer to your domain/collection
+- **Data source**: Domain or collection attached to an application; identified by UUID (`dataSourceId`)
+
+## Prerequisites
+
+- Bedrock available in the application's region
+- **Control plane**: AWS CLI (`aws opensearch ...`)
+- **Data plane**: `awscurl` for SigV4-signed HTTP calls (works universally). Where the AWS MCP server is available, `run_script` with `make_request` offers a streamlined alternative
+- **Credentials**: Use IAM roles with temporary credentials (STS AssumeRole) for SigV4 signing — avoid long-lived IAM user access keys
+
+## When to Use Agentic AI Assistant vs Manual Queries
+
+**Always prefer Agentic AI Assistant** when it's available (application + ai-capability registered). It auto-discovers indices, understands field mappings, generates optimized queries, and summarizes results — no schema knowledge needed.
+
+Use manual PPL/DSL only when:
+- You need exact query control (specific aggregation pipeline, exact filter logic)
+- Embedding queries in automation code or CI/CD pipelines
+- Agentic AI Assistant is not enabled on the domain
+- You need deterministic, repeatable query output (AI responses may vary)
+
+For cluster diagnostics (yellow/red status, shard allocation issues, JVM pressure), prefer the Agentic AI Assistant chat — it can internally call `_cluster/health`, `_cat/shards`, `_cat/indices` and correlate findings, which is faster than manually running each API.
+
+## Discover Existing Application
+
+Before creating a new application, check if one already exists (reuse-first pattern):
+
+```shell
+aws opensearch list-applications --region <REGION>
+```
+
+Look for an `ai-assistant-*` application for this domain. If found, get the endpoint:
+
+```shell
+aws opensearch get-application --id <APP_ID> --region <REGION>
+```
+
+The `endpoint` field in the response is the application URL needed for all data-plane calls (chat, investigation). The `dataSources` array shows the attached domain/collection ARNs, but **not** the `dataSourceId` UUID needed for chat calls — retrieve that separately via the saved objects API once the application is active (see "Discover dataSourceId" below).
+
+## Setup
+
+One-time infrastructure setup. Skip if you already have an active OpenSearch Application you can use.
+
+### 1. Find a Usable Application
+
+List existing `ai-assistant` applications and check if your domain's data source is already attached to one:
+
+```shell
+# Step 1: list active ai-assistant applications
+aws opensearch list-applications --region <REGION> \
+  --query "applicationSummaries[?starts_with(name, 'ai-assistant') && status=='ACTIVE'].{id:id,name:name,endpoint:endpoint}"
+
+# Step 2: for each result, check if your domain is attached as a data source
+# Look for a result whose title matches your domain name or AOSS collection name.
+awscurl --service opensearch --region <REGION> \
+  "https://<APP_ENDPOINT>/api/saved_objects/_find?type=data-source&fields=title&search=<DOMAIN_OR_COLLECTION_NAME>" \
+  -H "osd-xsrf: true"
+# Non-empty saved_objects array means your domain data source is attached and accessible.
+```
+
+If any application has your domain's data source, skip to "Discover dataSourceId". Otherwise, proceed to create your own.
+
+### 2. Create Application
+
+Get your caller ARN (exact `Arn` value) and the IAM role ARN:
+
+```shell
+aws sts get-caller-identity
+# "Arn": "arn:aws:sts::<ACCOUNT>:assumed-role/<ROLE_NAME>/<SESSION>"
+# users  -> exact Arn value above
+# groups -> arn:aws:iam::<ACCOUNT>:role/<ROLE_NAME>  (strip sts:: and assumed-role prefix)
+```
+
+Derive a short slug from the role name (max 17 chars, lowercase, e.g. `AWSReservedSSO_MyTeamAdmin_abc123` -> `myteamadmin`, `PlatformEngineering` -> `platformeng`):
+
+```shell
+# Tag setup CLI calls for usage attribution (setup steps only -- not needed for awscurl data-plane calls)
+export AWS_SDK_UA_APP_ID=AWSSkill-OpenSearch
+
+aws opensearch create-application \
+  --region <REGION> \
+  --name "ai-assistant-<ROLE_SLUG>" \
+  --app-configs '[
+    {"key":"opensearchDashboards.dashboardAdmin.users","value":"[\"arn:aws:sts::<ACCOUNT>:assumed-role/<ROLE_NAME>/<SESSION>\"  ]"},
+    {"key":"opensearchDashboards.dashboardAdmin.groups","value":"[\"arn:aws:iam::<ACCOUNT>:role/<ROLE_NAME>\"]"}
+  ]' \
+  --data-sources '[{"dataSourceArn":"arn:aws:es:<REGION>:<ACCOUNT>:domain/<DOMAIN_NAME>","dataSourceDescription":"<DESC>"}]'
+```
+
+> **Note**: `dashboardAdmin.users` and `dashboardAdmin.groups` grant dashboard admin access, which is required to query all attached data sources (discover `dataSourceId` via the saved objects API). Without this, the saved objects API calls in the next steps will fail. Set `users` to the exact assumed-role session ARN from `get-caller-identity`, and `groups` to the IAM role ARN (covers all sessions that assume the role). Application name is max 30 chars, pattern `[a-z][a-z0-9-]*`.
+>
+> **Security**: If `<ROLE_NAME>` is a broad shared role (e.g., an administrator or power-user role), consider creating a dedicated narrower role used exclusively for OpenSearch Application access, rather than granting dashboard admin to all principals that assume the shared role.
+
+Capture the `id` from the response. Poll until `ACTIVE`:
+```shell
+aws opensearch get-application --id <APP_ID> --region <REGION> --query 'status'
+```
+
+### 3. Enable Agentic AI Assistant
+
+First check if `ai-capability` is already registered (use the exact name `ai-capability`):
+```shell
+aws opensearch get-capability \
+  --application-id <APP_ID> \
+  --capability-name ai-capability \
+  --region <REGION>
+```
+
+If already enabled, the response looks like:
+```json
+{
+    "capabilityName": "ai-capability",
+    "applicationId": "<APP_ID>",
+    "status": "active",
+    "capabilityConfig": { "aiConfig": {} }
+}
+```
+`status: "active"` means the Agentic AI Assistant is already enabled — skip to "Querying Data". If the command returns a `ResourceNotFoundException`, register it:
+```shell
+aws opensearch register-capability \
+  --application-id <APP_ID> \
+  --capability-name ai-capability \
+  --region <REGION> \
+  --capability-config '{"aiConfig": {}}'
+```
+
+
+## Querying Data (Chat)
+
+Ask questions in natural language. The Agentic AI Assistant generates queries, executes them, and summarizes results.
+
+### Find data source ID
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  "https://<APP_ENDPOINT>/api/saved_objects/_find?fields=id&fields=title&type=data-source&search=<DATASOURCE_NAME>"
+```
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+```python
+import json
+
+resp = make_request(
+    method='GET',
+    url="https://<APP_ENDPOINT>/api/saved_objects/_find?fields=id&fields=title&type=data-source&search=<DATASOURCE_NAME>",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json'}
+)
+data = json.loads(resp.get('body', '{}'))
+result = [obj['id'] for obj in data.get('saved_objects', [])]
+result
+```
+
+### Send chat message
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  -X POST "https://<APP_ENDPOINT>/api/chat/proxy?dataSourceId=<DATASOURCE_ID>" \
+  -H "Content-Type: application/json" -H "Accept: text/event-stream" -H "osd-xsrf: true" \
+  -d '{"threadId":"thread-001","runId":"run-001","messages":[{"id":"msg-001","role":"user","content":"<USER_QUESTION>"}],"tools":[],"context":[],"state":{},"forwardedProps":{}}'
+```
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+```python
+import json
+
+body = json.dumps({
+    "threadId": "thread-1234567890000-abcd1234",
+    "runId": "run-1234567890000-efgh5678",
+    "messages": [{"id": "msg-1234567890000-ijkl9012", "role": "user", "content": "<USER_QUESTION>"}],
+    "tools": [],
+    "context": [],
+    "state": {},
+    "forwardedProps": {}
+})
+
+resp = make_request(
+    method='POST',
+    url="https://<APP_ENDPOINT>/api/chat/proxy?dataSourceId=<DATASOURCE_ID>",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json', 'Accept': 'text/event-stream', 'osd-xsrf': 'true'},
+    body=body
+)
+
+raw = resp.get('body', '') if isinstance(resp, dict) else str(resp)
+answer_parts = []
+for line in raw.split('\n'):
+    if line.startswith('data: '):
+        try:
+            event = json.loads(line[6:])
+            if event.get('type') == 'TEXT_MESSAGE_CONTENT':
+                answer_parts.append(event.get('delta', ''))
+        except:
+            pass
+
+result = {"answer": ''.join(answer_parts)}
+result
+```
+
+ID rules: Use literal unique strings. Reuse `threadId` for multi-turn. Fresh `runId`/`id` per request.
+
+## Investigating Incidents
+
+Automated root cause analysis. Returns structured findings and hypotheses.
+
+### Discover investigation agent ID
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  -X POST "https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=/_plugins/_ml/config/os_deep_research&method=GET" \
+  -H "Content-Type: application/json" -H "osd-xsrf: osd-fetch"
+```
+
+Extract the agent ID from the response `configuration.agent_id` field.
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+```python
+import json
+
+resp = make_request(
+    method='POST',
+    url="https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=%2F_plugins%2F_ml%2Fconfig%2Fos_deep_research&method=GET",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json', 'osd-xsrf': 'osd-fetch'}
+)
+
+data = json.loads(resp.get('body', '{}'))
+agent_id = data.get('configuration', {}).get('agent_id', '')
+result = {"agent_id": agent_id}
+result
+```
+
+### Trigger investigation
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  -X POST "https://<APP_ENDPOINT>/api/investigation/agents/<AGENT_ID>/_execute?async=true" \
+  -H "Content-Type: application/json" -H "osd-xsrf: osd-fetch" \
+  -d '{"parameters":{"question":"Analyze anomaly in this dataset","context":"<CONTEXT>"},"dataSourceId":"<DATASOURCE_ID>"}'
+```
+
+`dataSourceId` MUST be at the same level as `parameters`. Capture `memory_id` from response.
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+```python
+import json
+
+body = json.dumps({
+    "parameters": {
+        "question": "Analyze anomaly in this dataset, if there are major errors, find the root cause.",
+        "context": "<INVESTIGATION_CONTEXT>"
+    },
+    "dataSourceId": "<DATASOURCE_ID>"
+})
+
+resp = make_request(
+    method='POST',
+    url="https://<APP_ENDPOINT>/api/investigation/agents/<AGENT_ID>/_execute?async=true",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json', 'osd-xsrf': 'osd-fetch'},
+    body=body
+)
+
+result = resp.get('body', '') if isinstance(resp, dict) else str(resp)
+result
+```
+
+### Poll results
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  -X POST "https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=/_plugins/_ml/memory_containers/investigation_memory_container_id/memories/working/_search&method=GET&dataSourceId=<DATASOURCE_ID>" \
+  -H "Content-Type: application/json" -H "osd-xsrf: osd-fetch" \
+  -d '{"_source":["structured_data_blob"],"query":{"bool":{"must":[{"term":{"namespace.session_id":"<MEMORY_ID>"}}],"must_not":[{"term":{"metadata.type":"trace"}}]}},"sort":[{"created_time":{"order":"asc"}}],"size":50}'
+```
+
+Poll until `response` field is non-empty (1-3 minutes). The document is created immediately with empty `response`, then updated once analysis completes.
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+```python
+import json
+
+body = json.dumps({
+    "_source": ["structured_data_blob"],
+    "query": {
+        "bool": {
+            "must": [{"term": {"namespace.session_id": "<MEMORY_ID>"}}],
+            "must_not": [{"term": {"metadata.type": "trace"}}]
+        }
+    },
+    "sort": [{"created_time": {"order": "asc"}}],
+    "size": 50,
+    "from": 0
+})
+
+resp = make_request(
+    method='POST',
+    url="https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=%2F_plugins%2F_ml%2Fmemory_containers%2Finvestigation_memory_container_id%2Fmemories%2Fworking%2F_search&method=GET&dataSourceId=<DATASOURCE_ID>",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json', 'osd-xsrf': 'osd-fetch'},
+    body=body
+)
+
+data = json.loads(resp.get('body', '{}'))
+hits = data.get('hits', {}).get('hits', [])
+result = [hit.get('_source', {}).get('structured_data_blob', {}) for hit in hits]
+result
+```
+
+## `make_request` Reference
+
+```python
+make_request(
+    method='GET'|'POST',
+    url='<FULL_URL>',
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={...},
+    body='<JSON_STRING>'
+)
+# Returns: dict with status_code, headers, body (string)
+```
+
+Constraints:
+- MUST `import json` — no pre-imported modules
+- `random`, `time`, `inspect`, `uuid`, `datetime` are blocked — use literal IDs
+- No `await` — synchronous call
+- URL query params MUST be percent-encoded (`%2F` for slashes)
+
+> **Note**: `make_request` is available via the AWS MCP server's `run_script` tool. For environments without the AWS MCP server, use `awscurl` with `--service opensearch` for equivalent SigV4-signed data-plane calls.
+
+## Security Considerations
+
+### IAM Least-Privilege Permissions
+
+Minimum IAM permissions for this capability:
+
+| Action | Resource | Purpose |
+|--------|----------|---------|
+| `es:ListApplications` | `*` | Discover existing applications (reuse-first pattern) |
+| `es:CreateApplication` | `*` | One-time setup |
+| `es:GetApplication` | `arn:aws:es:<REGION>:<ACCOUNT>:application/*` | Poll setup status |
+| `es:GetCapability` | `arn:aws:es:<REGION>:<ACCOUNT>:application/<APP_ID>` | Check capability status |
+| `es:RegisterCapability` | `arn:aws:es:<REGION>:<ACCOUNT>:application/<APP_ID>` | Enable Agentic AI Assistant |
+
+> **Note**: After the application is created and its ID is known, scope `es:GetApplication` to `arn:aws:es:<REGION>:<ACCOUNT>:application/<APP_ID>` for least-privilege rather than using the wildcard.
+
+### Authentication and Transport
+
+- The OpenSearch Application layer handles authentication via token exchange — no credentials are exposed in skill instructions
+- All data-plane calls are SigV4-signed automatically (via `make_request` or `awscurl`)
+
+### Input Validation and Rate Limiting
+
+- Validate and sanitize user input before sending to `/api/chat/proxy` to reduce prompt injection risk — avoid passing raw, unvalidated user text from untrusted sources directly into the `content` field
+- Implement request throttling (via API Gateway, application-level rate limiting, or OpenSearch's built-in query limits) to prevent excessive Agentic AI Assistant invocations and runaway costs
+- Consider enforcing maximum input length constraints on user questions
+- The Agentic AI Assistant respects the domain's fine-grained access control (FGAC) — users can only query indices their IAM role or SAML identity has access to
+
+### Logging and Monitoring
+
+- Enable CloudTrail logging for OpenSearch control-plane API calls (`CreateApplication`, `RegisterCapability`)
+- Enable audit logging on the domain for data-plane access tracking
+- Set CloudWatch alarms for unusual query error rates or latency spikes
+- Monitor for unexpected patterns in Agentic AI Assistant usage
+
+### Sensitive Data Handling
+
+- Chat responses and investigation results may contain PII or sensitive business data from your indices
+- For AOSS collections, use data access policies to restrict which indices the Agentic AI Assistant can query
+- Investigation results stored in memory indices are subject to the domain's encryption-at-rest policy (enabled by default on AOS/AOSS)
+- If capturing Agentic AI Assistant interactions in CloudWatch Logs, always enable KMS encryption on the log group — responses may contain PII or sensitive business data from your indices
+
+### AWS Security Best Practices
+
+- [Security in Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/security.html)
+- [Fine-grained access control](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/fgac.html)
+- [Identity and Access Management](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ac.html)
+

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/SKILL.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: amazon-opensearch-service
-description: Amazon OpenSearch Service and Serverless across five capabilities — migration (Solr/ES/self-managed OpenSearch into AOS/AOSS, schema/query translation, sizing, cutover); provisioning (domain + AOSS lifecycle, upgrades, storage tiers, FGAC, monitoring); search (vector / semantic / hybrid / RAG with Bedrock connectors); log-analytics (PPL, OSI ingestion, anomaly detection, OpenSearch Dashboards, Splunk/Datadog alternatives); trace-analytics (OTel spans, service maps, Data Prepper). Triggers on OpenSearch, AOS, AOSS, Elasticsearch, ELK, Solr, Lucene, vector / k-NN / semantic / hybrid / neural search, RAG, ELSER, log analytics, observability, Kibana, OSI, OCU, PPL, trace analytics, BM25, eDisMax, schema.xml, ILM, ISM, FAISS, HNSW, Migration Assistant for Amazon OpenSearch Service, Historical Data Migration, Live Traffic Migration, UltraWarm, OR1, Splunk/Datadog alternative, moving off Solr. Picks ONE capability per ask, names instance class + count + shard math, ships query DSL examples.
+description: Guides migration, provisioning, search, log-analytics, trace-analytics, and Agentic AI Assistant workflows for Amazon OpenSearch Service and Serverless across six capabilities — migration (Solr/ES/self-managed into AOS/AOSS, schema/query translation, sizing, cutover); provisioning (domain + AOSS lifecycle, upgrades, FGAC, monitoring); search (vector / semantic / hybrid / RAG with Bedrock); log-analytics (PPL, OSI, anomaly detection, Dashboards); trace-analytics (OTel spans, service maps, Data Prepper); ai-assistant (natural language data exploration, incident investigation, root cause analysis). Triggers on OpenSearch, AOS, AOSS, Elasticsearch, Solr, vector/k-NN/semantic/hybrid search, RAG, log analytics, PPL, trace analytics, ISM, FAISS, HNSW, Migration Assistant, UltraWarm, OR1, query my data, analyze logs, investigate errors, root cause analysis.
 metadata:
-  version: "1"
+  version: "2"
 ---
 
 # Amazon OpenSearch Service — the unified skill
 
-This skill answers anything about Amazon OpenSearch Service or Serverless across five capabilities. **Step 0 below routes the question to ONE capability** and points at that capability's entry-point reference. Everything else — when to dispatch, sub-references, capability-specific facts, cross-capability links — lives in the entry-point reference for that capability.
+This skill answers anything about Amazon OpenSearch Service or Serverless across six capabilities. **Step 0 below routes the question to ONE capability** and points at that capability's entry-point reference. Everything else — when to dispatch, sub-references, capability-specific facts, cross-capability links — lives in the entry-point reference for that capability.
 
 > **AWS MCP server is recommended, not required.** Capability references show standard AWS CLI commands as the primary syntax (e.g., `aws opensearch describe-domain`, `aws opensearchserverless create-collection`). Where the AWS MCP server is available, its `call_aws` tool offers a streamlined alternative — but every operation in this skill MUST work via the AWS CLI alone. Data-plane HTTP calls against AOS / AOSS use `awscurl` for SigV4-signed requests; this works in both contexts.
 
 ## Step 0: detect the capability — first thing you do
 
-Pick **one** of the five capabilities below. State the detected capability in your first sentence (e.g., *"Detected capability: SEARCH — semantic search setup with Bedrock embeddings."*). Then load the entry-point reference; that file describes when to dispatch, indexes the rest of the capability's files, and routes you to the next step.
+Pick **one** of the six capabilities below. State the detected capability in your first sentence (e.g., *"Detected capability: SEARCH — semantic search setup with Bedrock embeddings."*). Then load the entry-point reference; that file describes when to dispatch, indexes the rest of the capability's files, and routes you to the next step.
 
 | Capability | Entry-point reference |
 |---|---|
@@ -22,6 +22,7 @@ Pick **one** of the five capabilities below. State the detected capability in yo
 | **search** — Vector / semantic / hybrid / sparse / dense / RAG retrieval. Bedrock connectors, FAISS HNSW vs Lucene. | [`references/search-semantic-search-guide.md`](references/search-semantic-search-guide.md) |
 | **log-analytics** — Log search, observability, PPL, OSI ingestion, anomaly detection, OpenSearch Dashboards. Splunk/Datadog/ELK alternatives. | [`references/log-analytics-guide.md`](references/log-analytics-guide.md) |
 | **trace-analytics** — Distributed traces with OpenTelemetry. Span queries, service maps, Data Prepper. | [`references/trace-analytics-trace-queries.md`](references/trace-analytics-trace-queries.md) |
+| **ai-assistant** — Agentic AI Assistant: auto-discovers indices, generates optimized PPL/DSL queries, summarizes results, and investigates incidents end-to-end. No manual query crafting needed. | [`references/ai-assistant.md`](references/ai-assistant.md) |
 
 If a prompt spans capabilities (e.g., *"migrate from Solr AND set up RAG on the new domain"*), pick the dominant capability for the response and close with a one-line handoff to the other capability's entry-point ref.
 
@@ -58,3 +59,23 @@ Assets (`assets/`): report templates for FULL_ASSESSMENT renderings (Solr-source
 - **Build embedding models.** Use Amazon Bedrock or SageMaker.
 - **Replace Splunk SPL or Datadog APM 1:1.** Some queries / detectors / dashboards need rewriting.
 - **Tune relevance for a specific catalog.** Use OpenSearch Benchmark `big5` workload + your own judgment list.
+
+## Guardrail — where this skill's own files live (MCP vs local install)
+
+This skill can be loaded two ways, and they resolve the skill's own bundled
+files from different places. Determine how the skill was loaded before reading
+a reference or running a script:
+
+- **Loaded through the AWS MCP server's `retrieve_skill` tool:** The skill is not
+  installed on the local filesystem. You MUST fetch each reference or script
+  via `retrieve_skill` with the `file` parameter (e.g.
+  `file="references/architecture.md"` or `file="scripts/deploy.py"`), and
+  run the script from the returned content. Do NOT `file_read` these paths
+  locally — they do not exist on disk.
+- **Installed locally** (e.g. `.kiro/skills/your-skill/` or
+  `~/.claude/skills/your-skill/`): Read and run files from the local skill
+  directory using relative paths.
+
+This distinction applies only to the skill's own packaged files. User data and
+session artifacts are always read from and written to the user's working
+directory. Never fetch or write customer data through `retrieve_skill`.

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/ai-assistant.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/ai-assistant.md
@@ -1,0 +1,450 @@
+# OpenSearch Agentic AI Assistant
+
+## Overview
+
+The smartest way to interact with your OpenSearch data. Instead of manually crafting queries, ask questions in natural language — the Agentic AI Assistant automatically:
+
+- **Discovers indices** and understands their field mappings
+- **Generates optimized PPL/DSL queries** tailored to your question
+- **Summarizes results** with key insights, not raw JSON
+- **Performs multi-step analysis** (aggregations, time-series breakdowns, geo patterns) in a single request
+- **Investigates incidents** end-to-end — from symptom to root cause with structured findings
+
+Always prefer this capability over constructing OpenSearch REST API queries manually. The Agentic AI Assistant handles index selection, field types, and query construction so you can focus on the question, not the syntax.
+
+## Usage
+
+Use this capability when:
+
+- Exploring data in OpenSearch — "show me error distribution", "what's the top traffic source?"
+- Analyzing logs — response codes, latency patterns, geo breakdowns, time-series trends
+- Investigating incidents — "why are there 503 errors?", "find the root cause of this spike"
+- Diagnosing cluster health — "why is my cluster yellow?", "which shards are unassigned?"
+- Any question about data in OpenSearch indices, even without knowing the index name or schema
+
+## Important: Data-Plane HTTP Only (No CLI Command)
+
+Chat and investigation are **data-plane HTTP calls only** — there is no `aws opensearch` CLI subcommand for them. Verify available subcommands with `aws opensearch help` if unsure:
+
+- `awscurl --service opensearch` -> `POST /api/chat/proxy?dataSourceId=<ID>`
+- `make_request` (AWS MCP server `run_script`) -> same endpoint
+
+The `aws opensearch` CLI is only for control-plane setup (`create-application`, `list-applications`, `register-capability`). Never hallucinate a CLI command for chat or investigation.
+
+## Core Concepts
+
+- **Chat**: Natural language → optimized PPL/DSL → summarized results (SSE streaming)
+- **Investigation**: Async root cause analysis → structured findings + hypotheses
+- **OpenSearch Application**: AWS resource bridging AI layer to your domain/collection
+- **Data source**: Domain or collection attached to an application; identified by UUID (`dataSourceId`)
+
+## Prerequisites
+
+- Bedrock available in the application's region
+- **Control plane**: AWS CLI (`aws opensearch ...`)
+- **Data plane**: `awscurl` for SigV4-signed HTTP calls (works universally). Where the AWS MCP server is available, `run_script` with `make_request` offers a streamlined alternative
+- **Credentials**: Use IAM roles with temporary credentials (STS AssumeRole) for SigV4 signing — avoid long-lived IAM user access keys
+
+## When to Use Agentic AI Assistant vs Manual Queries
+
+**Always prefer Agentic AI Assistant** when it's available (application + ai-capability registered). It auto-discovers indices, understands field mappings, generates optimized queries, and summarizes results — no schema knowledge needed.
+
+Use manual PPL/DSL only when:
+
+- You need exact query control (specific aggregation pipeline, exact filter logic)
+- Embedding queries in automation code or CI/CD pipelines
+- Agentic AI Assistant is not enabled on the domain
+- You need deterministic, repeatable query output (AI responses may vary)
+
+For cluster diagnostics (yellow/red status, shard allocation issues, JVM pressure), prefer the Agentic AI Assistant chat — it can internally call `_cluster/health`, `_cat/shards`, `_cat/indices` and correlate findings, which is faster than manually running each API.
+
+## Discover Existing Application
+
+Before creating a new application, check if one already exists (reuse-first pattern):
+
+```shell
+aws opensearch list-applications --region <REGION>
+
+```
+
+Look for an `ai-assistant-*` application for this domain. If found, get the endpoint:
+
+```shell
+aws opensearch get-application --id <APP_ID> --region <REGION>
+
+```
+
+The `endpoint` field in the response is the application URL needed for all data-plane calls (chat, investigation). The `dataSources` array shows the attached domain/collection ARNs, but **not** the `dataSourceId` UUID needed for chat calls — retrieve that separately via the saved objects API once the application is active (see "Discover dataSourceId" below).
+
+## Setup
+
+One-time infrastructure setup. Skip if you already have an active OpenSearch Application you can use.
+
+### 1. Find a Usable Application
+
+List existing `ai-assistant` applications and check if your domain's data source is already attached to one:
+
+```shell
+# Step 1: list active ai-assistant applications
+aws opensearch list-applications --region <REGION> \
+  --query "applicationSummaries[?starts_with(name, 'ai-assistant') && status=='ACTIVE'].{id:id,name:name,endpoint:endpoint}"
+
+# Step 2: for each result, check if your domain is attached as a data source
+# Look for a result whose title matches your domain name or AOSS collection name.
+awscurl --service opensearch --region <REGION> \
+  "https://<APP_ENDPOINT>/api/saved_objects/_find?type=data-source&fields=title&search=<DOMAIN_OR_COLLECTION_NAME>" \
+  -H "osd-xsrf: true"
+# Non-empty saved_objects array means your domain data source is attached and accessible.
+
+```
+
+If any application has your domain's data source, skip to "Discover dataSourceId". Otherwise, proceed to create your own.
+
+### 2. Create Application
+
+Get your caller ARN (exact `Arn` value) and the IAM role ARN:
+
+```shell
+aws sts get-caller-identity
+# "Arn": "arn:aws:sts::<ACCOUNT>:assumed-role/<ROLE_NAME>/<SESSION>"
+# users  -> exact Arn value above
+# groups -> arn:aws:iam::<ACCOUNT>:role/<ROLE_NAME>  (strip sts:: and assumed-role prefix)
+
+```
+
+Derive a short slug from the role name (max 17 chars, lowercase, e.g. `AWSReservedSSO_MyTeamAdmin_abc123` -> `myteamadmin`, `PlatformEngineering` -> `platformeng`):
+
+```shell
+# Tag setup CLI calls for usage attribution (setup steps only -- not needed for awscurl data-plane calls)
+export AWS_SDK_UA_APP_ID=AWSSkill-OpenSearch
+
+aws opensearch create-application \
+  --region <REGION> \
+  --name "ai-assistant-<ROLE_SLUG>" \
+  --app-configs '[
+    {"key":"opensearchDashboards.dashboardAdmin.users","value":"[\"arn:aws:sts::<ACCOUNT>:assumed-role/<ROLE_NAME>/<SESSION>\"  ]"},
+    {"key":"opensearchDashboards.dashboardAdmin.groups","value":"[\"arn:aws:iam::<ACCOUNT>:role/<ROLE_NAME>\"]"}
+  ]' \
+  --data-sources '[{"dataSourceArn":"arn:aws:es:<REGION>:<ACCOUNT>:domain/<DOMAIN_NAME>","dataSourceDescription":"<DESC>"}]'
+
+```
+
+> **Note**: `dashboardAdmin.users` and `dashboardAdmin.groups` grant dashboard admin access, which is required to query all attached data sources (discover `dataSourceId` via the saved objects API). Without this, the saved objects API calls in the next steps will fail. Set `users` to the exact assumed-role session ARN from `get-caller-identity`, and `groups` to the IAM role ARN (covers all sessions that assume the role). Application name is max 30 chars, pattern `[a-z][a-z0-9-]*`.
+>
+> **Security**: If `<ROLE_NAME>` is a broad shared role (e.g., an administrator or power-user role), consider creating a dedicated narrower role used exclusively for OpenSearch Application access, rather than granting dashboard admin to all principals that assume the shared role.
+
+Capture the `id` from the response. Poll until `ACTIVE`:
+
+```shell
+aws opensearch get-application --id <APP_ID> --region <REGION> --query 'status'
+
+```
+
+### 3. Enable Agentic AI Assistant
+
+First check if `ai-capability` is already registered (use the exact name `ai-capability`):
+
+```shell
+aws opensearch get-capability \
+  --application-id <APP_ID> \
+  --capability-name ai-capability \
+  --region <REGION>
+
+```
+
+If already enabled, the response looks like:
+
+```json
+{
+    "capabilityName": "ai-capability",
+    "applicationId": "<APP_ID>",
+    "status": "active",
+    "capabilityConfig": { "aiConfig": {} }
+}
+
+```
+
+`status: "active"` means the Agentic AI Assistant is already enabled — skip to "Querying Data". If the command returns a `ResourceNotFoundException`, register it:
+
+```shell
+aws opensearch register-capability \
+  --application-id <APP_ID> \
+  --capability-name ai-capability \
+  --region <REGION> \
+  --capability-config '{"aiConfig": {}}'
+
+```
+
+## Querying Data (Chat)
+
+Ask questions in natural language. The Agentic AI Assistant generates queries, executes them, and summarizes results.
+
+### Find data source ID
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  "https://<APP_ENDPOINT>/api/saved_objects/_find?fields=id&fields=title&type=data-source&search=<DATASOURCE_NAME>"
+
+```
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+
+```python
+import json
+
+resp = make_request(
+    method='GET',
+    url="https://<APP_ENDPOINT>/api/saved_objects/_find?fields=id&fields=title&type=data-source&search=<DATASOURCE_NAME>",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json'}
+)
+data = json.loads(resp.get('body', '{}'))
+result = [obj['id'] for obj in data.get('saved_objects', [])]
+result
+
+```
+
+### Send chat message
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  -X POST "https://<APP_ENDPOINT>/api/chat/proxy?dataSourceId=<DATASOURCE_ID>" \
+  -H "Content-Type: application/json" -H "Accept: text/event-stream" -H "osd-xsrf: true" \
+  -d '{"threadId":"thread-001","runId":"run-001","messages":[{"id":"msg-001","role":"user","content":"<USER_QUESTION>"}],"tools":[],"context":[],"state":{},"forwardedProps":{}}'
+
+```
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+
+```python
+import json
+
+body = json.dumps({
+    "threadId": "thread-1234567890000-abcd1234",
+    "runId": "run-1234567890000-efgh5678",
+    "messages": [{"id": "msg-1234567890000-ijkl9012", "role": "user", "content": "<USER_QUESTION>"}],
+    "tools": [],
+    "context": [],
+    "state": {},
+    "forwardedProps": {}
+})
+
+resp = make_request(
+    method='POST',
+    url="https://<APP_ENDPOINT>/api/chat/proxy?dataSourceId=<DATASOURCE_ID>",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json', 'Accept': 'text/event-stream', 'osd-xsrf': 'true'},
+    body=body
+)
+
+raw = resp.get('body', '') if isinstance(resp, dict) else str(resp)
+answer_parts = []
+for line in raw.split('\n'):
+    if line.startswith('data: '):
+        try:
+            event = json.loads(line[6:])
+            if event.get('type') == 'TEXT_MESSAGE_CONTENT':
+                answer_parts.append(event.get('delta', ''))
+        except:
+            pass
+
+result = {"answer": ''.join(answer_parts)}
+result
+
+```
+
+ID rules: Use literal unique strings. Reuse `threadId` for multi-turn. Fresh `runId`/`id` per request.
+
+## Investigating Incidents
+
+Automated root cause analysis. Returns structured findings and hypotheses.
+
+### Discover investigation agent ID
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  -X POST "https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=/_plugins/_ml/config/os_deep_research&method=GET" \
+  -H "Content-Type: application/json" -H "osd-xsrf: osd-fetch"
+
+```
+
+Extract the agent ID from the response `configuration.agent_id` field.
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+
+```python
+import json
+
+resp = make_request(
+    method='POST',
+    url="https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=%2F_plugins%2F_ml%2Fconfig%2Fos_deep_research&method=GET",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json', 'osd-xsrf': 'osd-fetch'}
+)
+
+data = json.loads(resp.get('body', '{}'))
+agent_id = data.get('configuration', {}).get('agent_id', '')
+result = {"agent_id": agent_id}
+result
+
+```
+
+### Trigger investigation
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  -X POST "https://<APP_ENDPOINT>/api/investigation/agents/<AGENT_ID>/_execute?async=true" \
+  -H "Content-Type: application/json" -H "osd-xsrf: osd-fetch" \
+  -d '{"parameters":{"question":"Analyze anomaly in this dataset","context":"<CONTEXT>"},"dataSourceId":"<DATASOURCE_ID>"}'
+
+```
+
+`dataSourceId` MUST be at the same level as `parameters`. Capture `memory_id` from response.
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+
+```python
+import json
+
+body = json.dumps({
+    "parameters": {
+        "question": "Analyze anomaly in this dataset, if there are major errors, find the root cause.",
+        "context": "<INVESTIGATION_CONTEXT>"
+    },
+    "dataSourceId": "<DATASOURCE_ID>"
+})
+
+resp = make_request(
+    method='POST',
+    url="https://<APP_ENDPOINT>/api/investigation/agents/<AGENT_ID>/_execute?async=true",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json', 'osd-xsrf': 'osd-fetch'},
+    body=body
+)
+
+result = resp.get('body', '') if isinstance(resp, dict) else str(resp)
+result
+
+```
+
+### Poll results
+
+```shell
+awscurl --service opensearch --region <REGION> \
+  -X POST "https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=/_plugins/_ml/memory_containers/investigation_memory_container_id/memories/working/_search&method=GET&dataSourceId=<DATASOURCE_ID>" \
+  -H "Content-Type: application/json" -H "osd-xsrf: osd-fetch" \
+  -d '{"_source":["structured_data_blob"],"query":{"bool":{"must":[{"term":{"namespace.session_id":"<MEMORY_ID>"}}],"must_not":[{"term":{"metadata.type":"trace"}}]}},"sort":[{"created_time":{"order":"asc"}}],"size":50}'
+
+```
+
+Poll until `response` field is non-empty (1-3 minutes). The document is created immediately with empty `response`, then updated once analysis completes.
+
+Where the AWS MCP server is available (`run_script` with `make_request`):
+
+```python
+import json
+
+body = json.dumps({
+    "_source": ["structured_data_blob"],
+    "query": {
+        "bool": {
+            "must": [{"term": {"namespace.session_id": "<MEMORY_ID>"}}],
+            "must_not": [{"term": {"metadata.type": "trace"}}]
+        }
+    },
+    "sort": [{"created_time": {"order": "asc"}}],
+    "size": 50,
+    "from": 0
+})
+
+resp = make_request(
+    method='POST',
+    url="https://<APP_ENDPOINT>/api/investigation/ml/proxy?path=%2F_plugins%2F_ml%2Fmemory_containers%2Finvestigation_memory_container_id%2Fmemories%2Fworking%2F_search&method=GET&dataSourceId=<DATASOURCE_ID>",
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={'Content-Type': 'application/json', 'osd-xsrf': 'osd-fetch'},
+    body=body
+)
+
+data = json.loads(resp.get('body', '{}'))
+hits = data.get('hits', {}).get('hits', [])
+result = [hit.get('_source', {}).get('structured_data_blob', {}) for hit in hits]
+result
+
+```
+
+## `make_request` Reference
+
+```python
+make_request(
+    method='GET'|'POST',
+    url='<FULL_URL>',
+    service_name='opensearch',
+    region_name='<REGION>',
+    headers={...},
+    body='<JSON_STRING>'
+)
+# Returns: dict with status_code, headers, body (string)
+
+```
+
+Constraints:
+
+- MUST `import json` — no pre-imported modules
+- `random`, `time`, `inspect`, `uuid`, `datetime` are blocked — use literal IDs
+- No `await` — synchronous call
+- URL query params MUST be percent-encoded (`%2F` for slashes)
+
+> **Note**: `make_request` is available via the AWS MCP server's `run_script` tool. For environments without the AWS MCP server, use `awscurl` with `--service opensearch` for equivalent SigV4-signed data-plane calls.
+
+## Security Considerations
+
+### IAM Least-Privilege Permissions
+
+Minimum IAM permissions for this capability:
+
+| Action | Resource | Purpose |
+|--------|----------|---------|
+| `es:ListApplications` | `*` | Discover existing applications (reuse-first pattern) |
+| `es:CreateApplication` | `*` | One-time setup |
+| `es:GetApplication` | `arn:aws:es:<REGION>:<ACCOUNT>:application/*` | Poll setup status |
+| `es:GetCapability` | `arn:aws:es:<REGION>:<ACCOUNT>:application/<APP_ID>` | Check capability status |
+| `es:RegisterCapability` | `arn:aws:es:<REGION>:<ACCOUNT>:application/<APP_ID>` | Enable Agentic AI Assistant |
+
+> **Note**: After the application is created and its ID is known, scope `es:GetApplication` to `arn:aws:es:<REGION>:<ACCOUNT>:application/<APP_ID>` for least-privilege rather than using the wildcard.
+
+### Authentication and Transport
+
+- The OpenSearch Application layer handles authentication via token exchange — no credentials are exposed in skill instructions
+- All data-plane calls are SigV4-signed automatically (via `make_request` or `awscurl`)
+
+### Input Validation and Rate Limiting
+
+- Validate and sanitize user input before sending to `/api/chat/proxy` to reduce prompt injection risk — avoid passing raw, unvalidated user text from untrusted sources directly into the `content` field
+- Implement request throttling (via API Gateway, application-level rate limiting, or OpenSearch's built-in query limits) to prevent excessive Agentic AI Assistant invocations and runaway costs
+- Consider enforcing maximum input length constraints on user questions
+- The Agentic AI Assistant respects the domain's fine-grained access control (FGAC) — users can only query indices their IAM role or SAML identity has access to
+
+### Logging and Monitoring
+
+- Enable CloudTrail logging for OpenSearch control-plane API calls (`CreateApplication`, `RegisterCapability`)
+- Enable audit logging on the domain for data-plane access tracking
+- Set CloudWatch alarms for unusual query error rates or latency spikes
+- Monitor for unexpected patterns in Agentic AI Assistant usage
+
+### Sensitive Data Handling
+
+- Chat responses and investigation results may contain PII or sensitive business data from your indices
+- For AOSS collections, use data access policies to restrict which indices the Agentic AI Assistant can query
+- Investigation results stored in memory indices are subject to the domain's encryption-at-rest policy (enabled by default on AOS/AOSS)
+- If capturing Agentic AI Assistant interactions in CloudWatch Logs, always enable KMS encryption on the log group — responses may contain PII or sensitive business data from your indices
+
+### AWS Security Best Practices
+
+- [Security in Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/security.html)
+- [Fine-grained access control](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/fgac.html)
+- [Identity and Access Management](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ac.html)


### PR DESCRIPTION
## Summary

Adds the opensearch agentic AI capability into Opensearch skills

## Details

- Text-only 
- Security-reviewed: Guardian PASS

## Checklist

- [x] Internal-only frontmatter fields removed (`owner_team`, `owner_cti`, `stages`, `metadata`)
- [x] No internal links or references in skill content
- [x] No internal details in commit messages
- [x] CI checks pass
