### PR TITLE
fix(agent-pay): improve OpenClaw onboarding

### DIFF
--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/PUBLISHING.md
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/PUBLISHING.md
@@ -11,6 +11,7 @@ OpenClaw package. The published artifact also contains the canonical
 - Bundled canonical skill and external setup guidance: `1.0.2`
 - Setup discoverability improvements: `1.0.5`
 - AgentCore CLI 0.26.x compat and flag clarity: `1.0.6`
+- Clean-install onboarding and generated-config safety: `1.0.7`
 
 Do not publish until the package has passed the checks below and the publisher
 has given explicit approval.
@@ -69,7 +70,7 @@ Run this before requesting publication approval:
 npx --yes clawhub@0.23.1 package publish . \
   --family code-plugin \
   --name @aws/aws-agents-pay \
-  --version 1.0.6 \
+  --version 1.0.7 \
   --tags latest \
   --source-repo aws/agent-toolkit-for-aws \
   --source-commit <release-commit-sha> \

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/README.md
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/README.md
@@ -35,6 +35,10 @@ The package bundles the canonical `agents-pay` skill. It guides users through
 human-run setup in a separate terminal while the plugin keeps only the two
 runtime payment tools model-visible.
 
+The plugin accepts an unconfigured installation state so OpenClaw can load the
+bundled skill before setup. The payment tools validate the complete trusted
+configuration when invoked and fail closed while it is absent or incomplete.
+
 The plugin keeps policy validation and paid HTTP replay in TypeScript. It uses
 the package-local Python virtual environment created during setup for only
 `GetPaymentSession` and `ProcessPayment`, through a fixed helper path with no
@@ -67,8 +71,9 @@ Required configuration:
   Python `x402_fetch.py` path's `return_body` policy field — set both if you
   run both runtimes and want consistent behavior.
 
-The manifest requires the listed configuration before the plugin can be enabled.
-Both tools fail closed unless every required field is present in trusted plugin
+The manifest accepts either an unconfigured installation or the complete
+configuration listed above. Partial payment configuration is rejected. Both
+tools fail closed unless every required field is present in trusted plugin
 settings or the protected `~/.x402/config.json` file.
 
 `allowAnyRecipient` delegates beneficiary choice to the publisher. It is

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/openclaw.plugin.json
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/openclaw.plugin.json
@@ -8,6 +8,9 @@
       "get_paid_content"
     ]
   },
+  "skills": [
+    "skills/agents-pay"
+  ],
   "activation": {
     "onStartup": true
   },
@@ -36,16 +39,37 @@
         "description": "Opt-in only. When true, get_paid_content returns the actual paid response body (capped, marked untrusted) instead of metadata only. Unsanitized paid content may contain prompt injection; leave unset/false unless you have explicitly accepted that risk."
       }
     },
-    "required": ["paymentManagerArn", "paymentInstrumentId", "userId", "payment_session_id", "maxPaymentAmountAtomic"],
-    "oneOf": [
+    "anyOf": [
       {
-        "required": ["allowedRecipients"],
-        "not": { "required": ["allowAnyRecipient"] }
+        "not": {
+          "anyOf": [
+            { "required": ["paymentManagerArn"] },
+            { "required": ["paymentInstrumentId"] },
+            { "required": ["userId"] },
+            { "required": ["payment_session_id"] },
+            { "required": ["networkPreferences"] },
+            { "required": ["allowedOrigins"] },
+            { "required": ["allowedRecipients"] },
+            { "required": ["allowAnyRecipient"] },
+            { "required": ["allowedAssetsByNetwork"] },
+            { "required": ["maxPaymentAmountAtomic"] },
+            { "required": ["returnBody"] }
+          ]
+        }
       },
       {
-        "required": ["allowAnyRecipient"],
-        "properties": { "allowAnyRecipient": { "const": true } },
-        "not": { "required": ["allowedRecipients"] }
+        "required": ["paymentManagerArn", "paymentInstrumentId", "userId", "payment_session_id", "maxPaymentAmountAtomic"],
+        "oneOf": [
+          {
+            "required": ["allowedRecipients"],
+            "not": { "required": ["allowAnyRecipient"] }
+          },
+          {
+            "required": ["allowAnyRecipient"],
+            "properties": { "allowAnyRecipient": { "const": true } },
+            "not": { "required": ["allowedRecipients"] }
+          }
+        ]
       }
     ]
   }

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/package-lock.json
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/aws-agents-pay",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/aws-agents-pay",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT-0",
       "dependencies": {
         "typebox": "1.1.39"

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/package.json
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aws-agents-pay",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Guarded x402 v2 payments for OpenClaw through AWS AgentCore Payments",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/test/security.test.mjs
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/test/security.test.mjs
@@ -323,12 +323,21 @@ test("model-facing tool inventory excludes setup, session creation, and proof to
   }
 });
 
-test("manifest declares all required fields for safe startup", async () => {
+test("manifest supports setup before enforcing complete payment config", async () => {
   const manifest = JSON.parse(
     await readFile(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
   );
-  const required = manifest.configSchema.required;
-  // Every field the plugin refuses to start without must be declared here.
+  assert.deepEqual(manifest.skills, ["skills/agents-pay"]);
+  assert.equal(manifest.configSchema.required, undefined);
+  const [unconfigured, configured] = manifest.configSchema.anyOf;
+  const preconfigurationFields = unconfigured.not.anyOf.map(
+    (branch) => branch.required[0],
+  );
+  assert.ok(preconfigurationFields.includes("paymentManagerArn"));
+  assert.ok(preconfigurationFields.includes("allowedRecipients"));
+  assert.ok(preconfigurationFields.includes("returnBody"));
+
+  const required = configured.required;
   assert.ok(required.includes("paymentManagerArn"));
   assert.ok(required.includes("paymentInstrumentId"));
   assert.ok(required.includes("userId"));
@@ -336,7 +345,7 @@ test("manifest declares all required fields for safe startup", async () => {
   assert.ok(!required.includes("allowedRecipients"));
   assert.ok(required.includes("maxPaymentAmountAtomic"));
   assert.deepEqual(
-    manifest.configSchema.oneOf.map((branch) => branch.required),
+    configured.oneOf.map((branch) => branch.required),
     [["allowedRecipients"], ["allowAnyRecipient"]],
   );
   const amount = manifest.configSchema.properties.maxPaymentAmountAtomic;
@@ -355,9 +364,10 @@ test("public package and runtime identities stay aligned", async () => {
     readFile(new URL("../README.md", import.meta.url), "utf8"),
   ]);
   assert.equal(packageJson.name, "@aws/aws-agents-pay");
-  assert.equal(packageJson.version, "1.0.6");
+  assert.equal(packageJson.version, "1.0.7");
   assert.equal(manifest.id, "aws-agents-pay");
   assert.equal(manifest.name, "AWS Agents Pay");
+  assert.deepEqual(manifest.skills, ["skills/agents-pay"]);
   assert.ok(packageJson.files.includes("skills"));
   assert.ok(packageJson.files.includes("runtime/agentcore_bridge.py"));
   assert.equal(packageJson.dependencies["@aws-sdk/client-bedrock-agentcore"], undefined);
@@ -405,6 +415,10 @@ test("bundled skill is exact and excludes nested packages", async () => {
     );
   }
   await assert.rejects(access(path.join(bundledRoot, "packages")));
+  assert.match(
+    await readFile(path.join(bundledRoot, "requirements.txt"), "utf8"),
+    /^bedrock-agentcore==1\.19\.0$/m,
+  );
 });
 
 test("runtime dependency graph excludes Bowser", async () => {

--- a/plugins/aws-agents/skills/agents-pay/packages/openclaw/test/test_setup_openclaw.py
+++ b/plugins/aws-agents/skills/agents-pay/packages/openclaw/test/test_setup_openclaw.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from decimal import Decimal
+from pathlib import Path
+
+
+ADMIN_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "agents-pay"
+    / "scripts"
+    / "agents_pay_admin.py"
+)
+sys.dont_write_bytecode = True
+SPEC = importlib.util.spec_from_file_location("agents_pay_admin", ADMIN_PATH)
+assert SPEC and SPEC.loader
+admin = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(admin)
+
+
+class OpenClawSetupTests(unittest.TestCase):
+    def test_usd_to_atomic_is_exact_and_rejects_excess_precision(self) -> None:
+        self.assertEqual(admin.usd_to_atomic(Decimal("0.10")), "100000")
+        self.assertEqual(admin.usd_to_atomic(Decimal("0.000001")), "1")
+        with self.assertRaisesRegex(ValueError, "at most 6 decimal places"):
+            admin.usd_to_atomic(Decimal("0.0000001"))
+
+    def test_generated_config_preserves_policy_inputs(self) -> None:
+        config = admin.build_openclaw_config(
+            region="us-east-1",
+            manager_arn="arn:manager",
+            instrument_id="instrument-1",
+            session_id="session-1",
+            user_id="user-1",
+            network="eip155:84532",
+            asset="0xasset",
+            max_payment_atomic="100000",
+            recipients=["0xmerchant"],
+            allow_any=False,
+            origins=["https://sandbox.example"],
+            return_body=True,
+        )
+
+        plugin = config["plugins"]["entries"]["aws-agents-pay"]["config"]
+        self.assertEqual(plugin["maxPaymentAmountAtomic"], "100000")
+        self.assertEqual(plugin["allowedOrigins"], ["https://sandbox.example"])
+        self.assertEqual(plugin["allowedRecipients"], ["0xmerchant"])
+        self.assertTrue(plugin["returnBody"])
+        self.assertNotIn("allowAnyRecipient", plugin)
+
+    def test_explicit_project_dir_finds_agentcore_deployment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            state = project / "agentcore" / ".cli" / "deployed-state.json"
+            state.parent.mkdir(parents=True)
+            state.write_text(
+                json.dumps(
+                    {
+                        "targets": {
+                            "default": {
+                                "resources": {
+                                    "payments": {
+                                        "payments": {
+                                            "managerArn": "arn:manager",
+                                            "connectors": {
+                                                "connector": {
+                                                    "connectorId": "connector-1"
+                                                }
+                                            },
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
+            )
+
+            self.assertEqual(
+                admin.discover_deployed(project),
+                {
+                    "manager_arn": "arn:manager",
+                    "connector_id": "connector-1",
+                    "role_arn": None,
+                },
+            )
+
+    def test_duration_review_includes_hours_for_full_hours(self) -> None:
+        self.assertEqual(admin.format_duration(1440), "1440 minutes (24 hours)")
+        self.assertEqual(admin.format_duration(90), "90 minutes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/aws-agents/skills/agents-pay/references/openclaw-setup.md
+++ b/plugins/aws-agents/skills/agents-pay/references/openclaw-setup.md
@@ -27,16 +27,41 @@ first (which generates and stores one in `~/.agents-pay/config.json` for you).
 openclaw plugins install clawhub:@aws/aws-agents-pay
 ```
 
+The plugin can load before payment resources are configured so the bundled
+setup skill remains discoverable. Both payment tools still fail closed until a
+complete trusted configuration exists.
+
+## Provision the AgentCore project
+
+Create an AgentCore project before adding and deploying the payment resources:
+
+```bash
+npm install -g @aws/agentcore
+PROJECT_NAME=openclaw-payments
+agentcore create --project-name "$PROJECT_NAME" --no-agent
+cd "$PROJECT_NAME"
+agentcore add payment-manager
+agentcore add payment-connector
+agentcore deploy
+export AGENTCORE_PROJECT_DIR="$PWD"
+```
+
+Run both `agentcore add` commands without flags so credentials remain in the
+interactive terminal. Keep `AGENTCORE_PROJECT_DIR` set while running the setup
+wizard from the plugin directory.
+
 ## Quick Setup (Recommended)
 
-Run the interactive wizard — it handles all steps in one flow:
+After deploying the AgentCore project, run the interactive wizard. It creates
+the payment instrument and session, then generates the OpenClaw configuration:
 
 ```bash
 cd ~/.openclaw/extensions/aws-agents-pay/skills/agents-pay
-python3 -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
 python -m pip install -r requirements.txt
-python3 scripts/agents_pay_admin.py setup-openclaw
+python scripts/agents_pay_admin.py setup-openclaw \
+  --project-dir "$AGENTCORE_PROJECT_DIR"
 ```
 
 The wizard walks through: user identity → network → recipients → spend limits →
@@ -53,11 +78,7 @@ Open a separate terminal and run the human setup from the bundled skill:
 
 ```bash
 cd ~/.openclaw/extensions/aws-agents-pay/skills/agents-pay
-npm install -g @aws/agentcore
-agentcore add payment-manager
-agentcore add payment-connector
-agentcore deploy
-python3 -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
 python -m pip install -r requirements.txt
 python scripts/agents_pay_admin.py init-config \

--- a/plugins/aws-agents/skills/agents-pay/scripts/agents_pay_admin.py
+++ b/plugins/aws-agents/skills/agents-pay/scripts/agents_pay_admin.py
@@ -41,6 +41,7 @@ import secrets
 import stat
 import sys
 import tempfile
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
 
@@ -78,14 +79,7 @@ def _check_aws_credentials(region: str | None = None) -> bool:
 DEFAULT_DIR = Path.home() / ".agents-pay"
 DEFAULT_CONFIG = DEFAULT_DIR / "config.json"
 AGENT_NAME = "aws-agents-pay"
-
-# Where the AgentCore CLI records what `agentcore deploy` created. Read so the
-# operator never has to copy a manager ARN or connector ID by hand.
-DEPLOYED_STATE_CANDIDATES = [
-    Path("agentcore/.cli/deployed-state.json"),   # from project root (parent of agentcore/)
-    Path(".cli/deployed-state.json"),              # from inside the agentcore/ directory
-    Path("../.cli/deployed-state.json"),           # from a subdirectory of agentcore/
-]
+USDC_DECIMALS = 6
 
 
 def admin_config_path(explicit: str | None) -> Path:
@@ -93,15 +87,31 @@ def admin_config_path(explicit: str | None) -> Path:
     return Path(explicit or os.environ.get("AGENTS_PAY_CONFIG") or DEFAULT_CONFIG)
 
 
-def _find_deployed_state() -> Path | None:
+def deployed_state_candidates(project_dir: str | Path | None = None) -> list[Path]:
+    """Paths where the AgentCore CLI may record deployed payment resources."""
+    explicit = project_dir or os.environ.get("AGENTCORE_PROJECT_DIR")
+    if explicit:
+        root = Path(explicit).expanduser().resolve()
+        return [
+            root / "agentcore/.cli/deployed-state.json",
+            root / ".cli/deployed-state.json",
+        ]
+    return [
+        Path("agentcore/.cli/deployed-state.json"),  # project root
+        Path(".cli/deployed-state.json"),             # inside agentcore/
+        Path("../.cli/deployed-state.json"),          # child of agentcore/
+    ]
+
+
+def _find_deployed_state(project_dir: str | Path | None = None) -> Path | None:
     """Return the first existing deployed-state.json candidate, or None."""
-    for candidate in DEPLOYED_STATE_CANDIDATES:
+    for candidate in deployed_state_candidates(project_dir):
         if candidate.exists():
             return candidate
     return None
 
 
-def discover_deployed() -> dict[str, str | None]:
+def discover_deployed(project_dir: str | Path | None = None) -> dict[str, str | None]:
     """Best-effort read of manager ARN / connector ID from the CLI's deploy record.
 
     Returns a dict with possibly-None values; callers fall back to flags or env.
@@ -116,7 +126,7 @@ def discover_deployed() -> dict[str, str | None]:
     All three are handled.
     """
     out: dict[str, str | None] = {"manager_arn": None, "connector_id": None, "role_arn": None}
-    state_path = _find_deployed_state()
+    state_path = _find_deployed_state(project_dir)
     if state_path is None:
         return out
     try:
@@ -434,7 +444,7 @@ def cmd_create_instrument(args: argparse.Namespace) -> int:
     connector_id = args.connector_id or os.environ.get("PAYMENT_CONNECTOR_ID") or discovered["connector_id"]
 
     if not manager_arn or not connector_id:
-        checked = ", ".join(str(p) for p in DEPLOYED_STATE_CANDIDATES)
+        checked = ", ".join(str(p) for p in deployed_state_candidates())
         print(
             f"Could not find deployed-state.json (checked: {checked}).\n\n"
             "This file is created by `agentcore deploy`. To resolve:\n"
@@ -542,7 +552,7 @@ def cmd_new_session(args: argparse.Namespace) -> int:
 
     manager_arn = resolve_manager_arn(args.manager_arn, config_path)
     if not manager_arn:
-        checked = ", ".join(str(p) for p in DEPLOYED_STATE_CANDIDATES)
+        checked = ", ".join(str(p) for p in deployed_state_candidates())
         print(
             f"Could not determine the payment manager ARN.\n\n"
             f"Searched for deployed-state.json at: {checked}\n\n"
@@ -598,10 +608,94 @@ def _prompt(question: str, default: str = "") -> str:
     return answer or default
 
 
+def parse_positive_decimal(value: str, label: str) -> Decimal:
+    """Parse a human-entered positive decimal without float rounding."""
+    try:
+        amount = Decimal(value)
+    except InvalidOperation as exc:
+        raise ValueError(f"{label} must be a decimal number.") from exc
+    if not amount.is_finite() or amount <= 0:
+        raise ValueError(f"{label} must be greater than zero.")
+    return amount
+
+
+def usd_to_atomic(value: Decimal, decimals: int = USDC_DECIMALS) -> str:
+    """Convert a decimal stablecoin amount to exact atomic units."""
+    atomic = value * (Decimal(10) ** decimals)
+    if atomic != atomic.to_integral_value():
+        raise ValueError(
+            f"Max per-payment USD supports at most {decimals} decimal places."
+        )
+    return str(int(atomic))
+
+
+def format_duration(minutes: int) -> str:
+    """Render minutes with a compact hours hint for human review."""
+    if minutes % 60 == 0:
+        hours = minutes // 60
+        return f"{minutes} minutes ({hours} hour{'s' if hours != 1 else ''})"
+    return f"{minutes} minutes"
+
+
+def build_openclaw_config(
+    *,
+    region: str,
+    manager_arn: str,
+    instrument_id: str,
+    session_id: str,
+    user_id: str,
+    network: str,
+    asset: str,
+    max_payment_atomic: str,
+    recipients: list[str],
+    allow_any: bool,
+    origins: list[str],
+    return_body: bool,
+) -> dict:
+    """Build the final OpenClaw configuration from validated wizard inputs."""
+    plugin_config = {
+        "region": region,
+        "paymentManagerArn": manager_arn,
+        "paymentInstrumentId": instrument_id,
+        "payment_session_id": session_id,
+        "userId": user_id,
+        "networkPreferences": [network],
+        "allowedAssetsByNetwork": {network: [asset]},
+        "maxPaymentAmountAtomic": max_payment_atomic,
+        "returnBody": return_body,
+    }
+    if allow_any:
+        plugin_config["allowAnyRecipient"] = True
+    else:
+        plugin_config["allowedRecipients"] = recipients
+    if origins:
+        plugin_config["allowedOrigins"] = origins
+
+    return {
+        "plugins": {
+            "allow": ["aws-agents-pay"],
+            "entries": {
+                "aws-agents-pay": {
+                    "enabled": True,
+                    "config": plugin_config,
+                },
+            },
+        }
+    }
+
+
 def cmd_setup_openclaw(args: argparse.Namespace) -> int:
     """Interactive guided setup for OpenClaw — collects inputs once and threads through."""
     if not sys.stdin.isatty():
         print("setup-openclaw requires an interactive terminal.", file=sys.stderr)
+        return 1
+    project_dir = (
+        Path(args.project_dir).expanduser().resolve()
+        if args.project_dir
+        else None
+    )
+    if project_dir and not project_dir.is_dir():
+        print(f"AgentCore project directory does not exist: {project_dir}", file=sys.stderr)
         return 1
 
     print("\n" + "=" * 60)
@@ -612,6 +706,8 @@ def cmd_setup_openclaw(args: argparse.Namespace) -> int:
     print("  • agentcore CLI installed and deployed (agentcore deploy)")
     print("  • bedrock-agentcore Python package (>=1.19.0)")
     print("  • AWS credentials with the ManagementRole")
+    if project_dir:
+        print(f"  • AgentCore project: {project_dir}")
     print()
 
     # --- Prerequisites check ---
@@ -671,7 +767,35 @@ def cmd_setup_openclaw(args: argparse.Namespace) -> int:
 
     # --- Step 5: Per-payment cap ---
     print("\n--- Step 4: Spend Limits ---")
-    max_usd = _prompt("Max per-payment USD", "0.05")
+    max_usd_text = _prompt(
+        "Max per-payment USD (for example 0.10, not atomic units)",
+        "0.05",
+    )
+    try:
+        max_usd = parse_positive_decimal(max_usd_text, "Max per-payment USD")
+        max_payment_atomic = usd_to_atomic(max_usd)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(
+        f"  ${format(max_usd, 'f')} USD = {max_payment_atomic} atomic units "
+        f"(USDC, {USDC_DECIMALS} decimals)"
+    )
+    budget_text = _prompt("Cumulative session budget USD", "5.00")
+    expiry_text = _prompt("Session expiry in minutes (1440 = 24 hours)", "120")
+    try:
+        budget = parse_positive_decimal(budget_text, "Session budget USD")
+        expiry = int(expiry_text)
+        if expiry <= 0:
+            raise ValueError("Expiry minutes must be greater than zero.")
+        if max_usd > budget:
+            raise ValueError(
+                "Max per-payment USD cannot exceed the cumulative session budget. "
+                "Enter decimal USD values, not atomic units."
+            )
+    except (ValueError, TypeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
     # --- Step 6: Origins ---
     print("\nAllowed origins (blank to allow any public HTTPS site):")
@@ -698,7 +822,7 @@ def cmd_setup_openclaw(args: argparse.Namespace) -> int:
     config["resources"]["user_id"] = user_id
     config["resources"]["region"] = region
     config["policy"] = {
-        "max_per_payment_usd": max_usd,
+        "max_per_payment_usd": format(max_usd, "f"),
         "allowed_networks": [network],
         "allowed_assets": {network: [asset]},
         "allowed_schemes": ["exact"],
@@ -712,11 +836,15 @@ def cmd_setup_openclaw(args: argparse.Namespace) -> int:
         config["policy"]["allowed_origins"] = origins
 
     # Discover manager ARN
-    discovered = discover_deployed()
+    discovered = discover_deployed(project_dir)
     manager_arn = discovered["manager_arn"]
     connector_id = discovered["connector_id"]
     if not manager_arn:
-        print("\nCould not auto-discover payment manager ARN from deployed-state.json.")
+        checked = ", ".join(str(p) for p in deployed_state_candidates(project_dir))
+        print(
+            "\nCould not auto-discover payment manager ARN from deployed-state.json.\n"
+            f"Checked: {checked}"
+        )
         manager_arn = _prompt("Payment Manager ARN", "")
         if not manager_arn:
             print("Manager ARN is required.", file=sys.stderr)
@@ -787,21 +915,27 @@ def cmd_setup_openclaw(args: argparse.Namespace) -> int:
 
     # --- Create session ---
     print("\n--- Step 8: Create Payment Session ---")
-    budget = _prompt("Session budget USD", "5.00")
-    expiry = _prompt("Expiry minutes", "120")
-
     print(f"\n  About to create session:")
-    print(f"    Budget:  ${budget} USD")
-    print(f"    Expiry:  {expiry} minutes")
-    print(f"    User:    {user_id}")
+    print(f"    Budget:          ${format(budget, 'f')} USD cumulative")
+    print(
+        f"    Per-payment cap: ${format(max_usd, 'f')} USD "
+        f"({max_payment_atomic} atomic units)"
+    )
+    print(f"    Expiry:          {format_duration(expiry)}")
+    print(f"    User:            {user_id}")
     if input("  Type 'approve' to continue: ").strip() != "approve":
         print("Aborted. No session created.")
         return 1
 
     session = manager.create_payment_session(
         user_id=user_id,
-        expiry_time_in_minutes=int(expiry),
-        limits={"maxSpendAmount": {"value": budget, "currency": "USD"}},
+        expiry_time_in_minutes=expiry,
+        limits={
+            "maxSpendAmount": {
+                "value": format(budget, "f"),
+                "currency": "USD",
+            }
+        },
     )
     session_id = session["paymentSessionId"]
     update_resources(config_path, payment_session_id=session_id)
@@ -813,34 +947,20 @@ def cmd_setup_openclaw(args: argparse.Namespace) -> int:
     print("=" * 60)
     print("\nAdd this to your OpenClaw config (~/.openclaw/openclaw.json):")
     print()
-    openclaw_config = {
-        "plugins": {
-            "allow": ["aws-agents-pay"],
-            "entries": {
-                "aws-agents-pay": {
-                    "enabled": True,
-                    "config": {
-                        "region": region,
-                        "paymentManagerArn": manager_arn,
-                        "paymentInstrumentId": instrument_id,
-                        "payment_session_id": session_id,
-                        "userId": user_id,
-                        "networkPreferences": [network],
-                        "allowedAssetsByNetwork": {network: [asset]},
-                        "maxPaymentAmountAtomic": str(int(float(max_usd) * 1_000_000)),
-                    },
-                },
-            },
-        }
-    }
-    # Add recipient mode
-    plugin_cfg = openclaw_config["plugins"]["entries"]["aws-agents-pay"]["config"]
-    if allow_any:
-        plugin_cfg["allowAnyRecipient"] = True
-    else:
-        plugin_cfg["allowedRecipients"] = recipients
-    if origins:
-        plugin_cfg["allowedOrigins"] = origins
+    openclaw_config = build_openclaw_config(
+        region=region,
+        manager_arn=manager_arn,
+        instrument_id=instrument_id,
+        session_id=session_id,
+        user_id=user_id,
+        network=network,
+        asset=asset,
+        max_payment_atomic=max_payment_atomic,
+        recipients=recipients,
+        allow_any=allow_any,
+        origins=origins,
+        return_body=return_body,
+    )
 
     print(json.dumps(openclaw_config, indent=2))
     print("\nThen restart OpenClaw to activate the plugin.")
@@ -874,7 +994,10 @@ def cmd_preflight(args: argparse.Namespace) -> int:
             print(f"\n       Found in {state_path}: run this to fix the above ->")
             print(f"         export PAYMENT_MANAGER_ARN={discovered['manager_arn']}")
         else:
-            print(f"\n       deployed-state.json not found (checked: {', '.join(str(p) for p in DEPLOYED_STATE_CANDIDATES)}).")
+            print(
+                "\n       deployed-state.json not found "
+                f"(checked: {', '.join(str(p) for p in deployed_state_candidates())})."
+            )
             print("       Run from the directory that CONTAINS the agentcore/ folder,")
             print("       from inside it, or set the variables by hand.")
 
@@ -966,6 +1089,14 @@ def main() -> int:
 
     p = sub.add_parser("setup-openclaw", help="Interactive guided setup for OpenClaw (all steps in one flow)")
     p.add_argument("--path", default=None, help="Config path (default ~/.agents-pay/config.json)")
+    p.add_argument(
+        "--project-dir",
+        default=None,
+        help=(
+            "AgentCore project directory used to locate deployed-state.json "
+            "(or set AGENTCORE_PROJECT_DIR)"
+        ),
+    )
     p.set_defaults(func=cmd_setup_openclaw)
 
     args = ap.parse_args()


### PR DESCRIPTION
## Summary
- let OpenClaw load the bundled `agents-pay` skill before payment configuration exists while keeping runtime tools fail-closed
- make AgentCore deployment discovery explicit through `--project-dir` and `AGENTCORE_PROJECT_DIR`
- generate safer OpenClaw configuration with exact USD-to-atomic conversion, budget validation, origin preservation, and `returnBody`
- update setup guidance and bump `@aws/aws-agents-pay` to `1.0.7`

## Validation
- `npm test` (9 Python tests, 20 Node tests)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- Python 3.11: `test_x402_policy.py` (119 tests), `test_portability.py`, `test_resource_resolution.py`
- ClawHub runtime validation and package verification with `clawhub@0.23.1`
- packed artifact inspection: version, requirements, built `dist`, and no Python cache files
- fresh-home OpenClaw `2026.3.24` install, plugin inspection, and bundled skill discovery