### PR TITLE
refactor(agents): update get-started for new CLI

### DIFF
--- a/plugins/aws-agents/README.md
+++ b/plugins/aws-agents/README.md
@@ -55,10 +55,23 @@ Discovered automatically from the marketplace manifest.
 
 ## Prerequisites
 
-- AgentCore CLI v0.9.0+ (`npm install -g @aws/agentcore`)
+- AgentCore CLI refactor build with `project`, `harness`, and `runtime`
+  command groups
 - AWS CLI with configured credentials
 - Node.js 20+
 - Python 3.11+ with `uv`
+
+The refactor CLI has no root `--version` flag or command aliases. Project
+lifecycle commands are:
+
+```text
+agentcore project add
+agentcore project remove
+agentcore project dev
+agentcore project deploy
+agentcore project status
+agentcore project build
+```
 
 ## Examples
 

--- a/plugins/aws-agents/skills/agents-get-started/SKILL.md
+++ b/plugins/aws-agents/skills/agents-get-started/SKILL.md
@@ -2,11 +2,12 @@
 name: agents-get-started
 description: >
   Use when a developer wants to create a new agent project or get started
-  with AgentCore. Handles framework selection, project scaffolding, first
-  deploy, and first invocation. Triggers on: "build an agent", "create an
-  agent", "get started", "new project", "agentcore create", "which
+  with AgentCore. Handles Harness-vs-Runtime selection, project scaffolding,
+  local development, deployment, and first invocation. Triggers on: "build an agent",
+  "create an agent", "get started", "new project", "agentcore project
+  create", "which
   framework", "Strands vs LangGraph", "hello world agent", "first agent",
-  "create MCP server", "host MCP server", "agentcore dev", "dev server",
+  "create MCP server", "host MCP server", "local agent server", "dev server",
   "what port", "local development".
   Not for adding capabilities to existing projects — use agents-build
   or agents-connect. Strands vs LangGraph in a migration context routes
@@ -17,19 +18,19 @@ metadata:
   type: skill
   version: "1.0.0"
   author: aws-agentcore
-  requires-cli: ">=0.9.0"
+  cli-surface: refactor
 ---
 
 # get-started
 
-Walk a developer from zero to a running agent on AWS.
+Walk a developer from zero to a managed Harness or a Runtime project.
 
 ## When to use
 
 - Developer wants to build an agent on AWS and doesn't know where to start
 - Developer wants to create a new AgentCore project
-- Developer is choosing between frameworks (Strands, LangGraph, GoogleADK, OpenAI Agents)
-- Developer just ran `agentcore create` and wants to know what to do next
+- Developer is choosing between a managed Harness and custom Runtime code
+- Developer just ran `agentcore project create` and wants to know what to do next
 
 Do NOT use for:
 
@@ -48,22 +49,22 @@ Do NOT use for:
 
 ## Process
 
-### Step 0: Verify CLI version
+### Step 0: Verify the refactor command tree
 
 ```bash
-agentcore --version
+agentcore project create --help
+agentcore harness create --help
+agentcore runtime list --help
 ```
 
-This skill requires v0.9.0 or later.
-
-If the version is older:
-> Your AgentCore CLI is out of date (found vX.Y.Z, need v0.9.0+).
-
-Offer to run the update: `agentcore update`. After the update completes, re-check the version to confirm it's ≥0.9.0 before continuing. Preserve any context the developer already provided (framework preference, project name, what they want to build) so they don't have to repeat themselves.
+There is no root `--version` flag on this branch. If any command above is
+absent, stop and explain that this skill requires the refactor CLI command
+tree. Do not fall back to legacy root commands or aliases.
 
 If `agentcore` is not found:
-> The AgentCore CLI isn't installed. Run `npm install -g @aws/agentcore` (requires Node.js 20+).
-> If you're having trouble with installation, I can run the `agents-debug` skill (which loads [`references/doctor.md`](../agents-debug/references/doctor.md)) to diagnose your environment.
+> The AgentCore CLI refactor build is not installed. Follow the installation
+> instructions for that build. If installation is failing, use
+> `agents-debug`.
 
 ### Step 1: Determine intent — exploring or ready to create?
 
@@ -73,28 +74,41 @@ Before jumping into framework selection, figure out where the developer is:
 
 - **Exploring** → Go to Step 2 (framework comparison). Present the options, answer questions, and wait. Do not construct a `create` command until they signal they're ready.
 - **Ready to create** → Skip to Step 3 (create the project). If they already specified a framework, skip Step 2 entirely.
-- **Already has a project** → Look for `agentcore/agentcore.json` in the current directory. If found, read it and skip to Step 5 (what to do next). Don't re-scaffold.
+- **Already has a project** → Inspect the current directory for generated
+  project files. If found, read them and skip to Step 5. Do not re-scaffold.
 
 If the developer's intent is clear from `$ARGUMENTS` (e.g., "create a Strands agent called MyBot"), skip straight to Step 3.
 
-### Step 2: Framework selection
+### Step 2: Choose Harness or Runtime
+
+| Need | Choose |
+|---|---|
+| Managed agent loop configured with model, prompt, tools, skills, and memory | Harness |
+| Custom framework, graph/workflow, protocol handling, or full loop control | Runtime project |
+
+Create a Harness directly with `agentcore harness create`. A project is not
+required. For Runtime code, `agentcore project create` scaffolds a supported
+template; framework selection happens in application code.
+
+#### Runtime framework selection
 
 **Check conversation context first.** If the developer already discussed frameworks earlier in this conversation (e.g., from a previous skill invocation), don't re-present the full table. Summarize what was discussed and ask if they've decided, or if anything changed.
 
 If this is the first time discussing frameworks, present the options:
 
-**Supported frameworks (CLI-scaffolded, Python):**
+**Common Python frameworks:**
 
-| Framework | CLI value | Best for |
-|---|---|---|
-| Strands | `Strands` | AWS-native, simplest path, best AgentCore integration |
-| LangGraph | `LangChain_LangGraph` | Complex graph-based workflows, existing LangChain investment |
-| Google ADK | `GoogleADK` | Teams already using Google's agent toolkit |
-| OpenAI Agents | `OpenAIAgents` | Teams already using OpenAI's agent SDK |
+| Framework | Best for |
+|---|---|
+| Strands | AWS-native, simplest path, best AgentCore integration |
+| LangGraph | Complex graph-based workflows, existing LangChain investment |
+| Google ADK | Teams already using Google's agent toolkit |
+| OpenAI Agents | Teams already using OpenAI's agent SDK |
 
 **Ask the developer to choose.** Present the options and wait for their selection. Don't assume a default unless they explicitly say they have no preference.
 
-> **Note on naming:** The CLI flag value is the exact string to pass to `--framework`. In prose use the shorter names.
+> **Note:** The refactor CLI does not expose a `--framework` flag. Install and
+> configure the chosen framework in the scaffolded Runtime project.
 
 **Default recommendation** (only when the developer says "no preference" or "you pick"): Strands — AWS-native framework with the tightest AgentCore integration and the most samples/docs.
 
@@ -110,30 +124,33 @@ If the developer asks about a framework not in the table above, handle it:
 
 | They ask about | What to say |
 |---|---|
-| **CrewAI, AutoGen, Semantic Kernel** | Not scaffolded by the CLI, but you can use them via the BYO Container path (below). AgentCore Runtime is framework-agnostic — any code that implements the HTTP contract works. |
+| **CrewAI, AutoGen, Semantic Kernel** | Use the container project path below. AgentCore Runtime is framework-agnostic — any code that implements the HTTP contract works. |
 | **Anthropic SDK / Claude Agent SDK** | This is a model SDK, not an agent framework. You can use it inside any framework (Strands, LangGraph, etc.) or standalone. For standalone use, wrap it in a container with the Runtime contract. |
 | **Claude Code / Cursor / Copilot** | These are IDE tools, not agent frameworks. They're where you *write* agent code, not what you deploy. Pick a framework from the table above for the agent itself. |
-| **LangChain (without LangGraph)** | LangChain is a library, LangGraph is the agent framework built on it. The CLI scaffolds LangGraph. If you're using plain LangChain chains, the BYO Container path works. |
+| **LangChain (without LangGraph)** | LangChain is a library, LangGraph is the agent framework built on it. Configure either in the scaffolded application code. |
 | **Custom / homegrown framework** | BYO Container path — see below. |
 
-**BYO Container path (any framework, any language):**
+**Container project path (any framework, any language):**
 
-For frameworks or languages not scaffolded by the CLI, AgentCore Runtime accepts any container that implements the HTTP contract (`POST /invocations`, `GET /ping`). The workflow:
+For custom frameworks or languages, scaffold the container template and
+implement the Runtime HTTP contract (`POST /invocations`, `GET /ping`):
 
-1. `agentcore create --name <ProjectName> --defaults` to scaffold the project structure
-2. `agentcore add agent --type byo --build Container --language <Language> --code-location <path>` to register your code
-3. Write a `Dockerfile` that builds and runs your agent
-4. `agentcore deploy` handles ECR push, CDK infra, and runtime creation
+```bash
+agentcore project create \
+  --name <ProjectName> \
+  --template hello-world-python-container
+```
+
+Replace the starter application with the chosen framework and container
+entrypoint. Use the project lifecycle commands to build and deploy it.
 
 **Language-specific notes:**
 
 | Language | Recommended path |
 |---|---|
-| Java (Spring Boot) | [Spring AI SDK for AgentCore](https://aws.amazon.com/blogs/machine-learning/spring-ai-sdk-for-amazon-bedrock-agentcore-is-now-generally-available) — handles the Runtime contract, SSE streaming, and health checks. Use `--language Other --build Container`. |
-| JavaScript / TypeScript | Implement the Runtime contract in Express/Fastify/etc. Use `--language TypeScript --build Container`. |
-| Go, Rust, .NET, other | Implement the Runtime HTTP contract. Use `--language Other --build Container`. |
-
-The rest of this skill (deploy, status, logs, invoke) applies once the container builds correctly.
+| Java (Spring Boot) | [Spring AI SDK for AgentCore](https://aws.amazon.com/blogs/machine-learning/spring-ai-sdk-for-amazon-bedrock-agentcore-is-now-generally-available) — handles the Runtime contract, SSE streaming, and health checks. |
+| JavaScript / TypeScript | Implement the Runtime contract in Express/Fastify/etc. |
+| Go, Rust, .NET, other | Implement the Runtime HTTP contract. |
 
 #### Framework vs. model provider — a common confusion
 
@@ -146,11 +163,30 @@ The framework is how your agent orchestrates (Strands, LangGraph, etc.). The mod
 
 If the developer says "I want to use Claude" they mean the model provider (Bedrock or Anthropic), not the framework. If they say "I want to use LangGraph" they mean the framework.
 
-### Step 3: Create the project
+### Step 3: Create the Harness or project
 
-Build the `agentcore create` command based on the developer's choices.
+For a Harness, validate the name against
+`[a-zA-Z][a-zA-Z0-9_]{0,39}` and create it directly:
 
-**Before constructing the command — validate the project name.** The CLI fails late: if the name is invalid, you'll see the error *after* walking through prompts or building the full command. Save the round-trip and check these rules up front. Reject the name and ask for a new one if any rule fails:
+```bash
+agentcore harness create \
+  --name <HarnessName> \
+  --system-prompt "You are a helpful assistant" \
+  --model '{"bedrockModelConfig":{"modelId":"<MODEL_ID>"}}' \
+  --max-iterations 50 \
+  --timeout-seconds 300
+```
+
+Invoke it after creation:
+
+```bash
+agentcore harness invoke \
+  --id <HARNESS_ID> \
+  --prompt "Hello, what can you do?"
+```
+
+For a Runtime project, validate the project name before constructing the
+command:
 
 - **Length ≤ 23 characters** (this is shorter than most developers assume — `MyCustomerSupportAgent` is 22 chars and fits; `CustomerSupportChatbot` is 22 and fits; `MyCustomerSupportBotApp` is 23 and just fits; `MyCustomerSupportChatBot` is 24 and **fails**)
 - **Alphanumeric only** — no hyphens, underscores, dots, or spaces
@@ -158,158 +194,98 @@ Build the `agentcore create` command based on the developer's choices.
 
 Say the count back out loud when close to the limit: "That name is 24 characters — the CLI caps project names at 23. Want to shorten it to `<suggestion>`?" Do not run the command with an invalid name on the assumption that the CLI error message will be clear — it isn't always, and the developer's mental model will be wrong for subsequent commands.
 
-**Construct the command, then present it for confirmation before the developer runs it.** Show the full command with all flags and explain what each choice means. Wait for the developer to confirm or adjust before proceeding.
+Present the command for confirmation before the developer runs it:
 
-Example presentation:
-
-> Here's the command I'd recommend based on what you've told me:
->
-> ```bash
-> agentcore create --name MyAgent --framework Strands --model-provider Bedrock --build CodeZip --memory none
-> ```
->
-> This creates a Strands agent using Bedrock models, deployed as a code zip (no Docker needed). Memory can be added later.
->
-> Want to run this, or change anything?
-
-Do NOT execute the command automatically — present it and wait.
-
-**Minimal (defaults — Strands, Bedrock, CodeZip, no memory):**
+**Default Python template:**
 
 ```bash
-agentcore create --name <ProjectName> --defaults
+agentcore project create --name <ProjectName>
 ```
 
-**With specific options:**
+**Container template:**
 
 ```bash
-agentcore create \
+agentcore project create \
   --name <ProjectName> \
-  --framework <Framework> \
-  --model-provider Bedrock \
-  --build CodeZip \
-  --memory none
+  --template hello-world-python-container
 ```
 
-**Flag reference:**
-
-| Flag | Values | Default |
-|---|---|---|
-| `--name` | alphanumeric, max 23 chars | prompted |
-| `--framework` | `Strands`, `LangChain_LangGraph`, `GoogleADK`, `OpenAIAgents` | prompted |
-| `--protocol` | `HTTP`, `MCP`, `A2A` | `HTTP` |
-| `--build` | `CodeZip`, `Container` | `CodeZip` |
-| `--model-provider` | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini` | prompted |
-| `--memory` | `none`, `shortTerm`, `longAndShortTerm` | prompted |
-| `--network-mode` | `PUBLIC`, `VPC` | `PUBLIC` |
-| `--dry-run` | — | preview without creating |
-
-**Guidance on choices:**
-
-- **Protocol:** Use `HTTP` unless the developer specifically needs MCP tool serving or A2A agent-to-agent communication
-- **Build:** Use `CodeZip` unless the developer needs custom system dependencies (CodeZip is faster to deploy and doesn't require Docker locally)
-- **Model provider:** Use `Bedrock` unless the developer has a specific reason for another provider (Bedrock doesn't require managing API keys)
-- **Memory:** Start with `none` — memory can be added later via `agents-build` (loads [`references/memory.md`](../agents-build/references/memory.md)) when the developer needs it
+The only project templates on this branch are `hello-world-python` (default)
+and `hello-world-python-container`. Do not generate legacy framework,
+protocol, build, model-provider, memory, network, or dry-run flags.
 
 ### Step 4: Explain what was created
 
-After the project exists, read `agentcore/agentcore.json` and the generated code to explain the project structure.
+After the project exists, inspect the generated code and explain the actual
+template structure:
 
-The layout below reflects CLI v0.9.x. If the CLI version is different, run `tree <ProjectName>/ -L 3` to see the actual generated structure and explain from there.
+```bash
+tree <ProjectName>/ -L 3
+```
 
-```
-<ProjectName>/
-├── agentcore/
-│   ├── agentcore.json      ← Project config (agents, resources)
-│   ├── aws-targets.json    ← AWS account + region
-│   ├── .env.local          ← Local environment variables (gitignored)
-│   └── cdk/                ← CDK infrastructure (auto-managed, don't edit)
-└── app/
-    └── <AgentName>/
-        ├── main.py          ← Your agent code — this is where you build
-        ├── mcp_client/      ← Pre-wired example MCP client (see note below)
-        └── pyproject.toml   ← Python dependencies
-```
+Do not assume the legacy `agentcore/agentcore.json` layout. The refactor
+templates own their generated structure.
 
 **Key files to highlight:**
 
 - `app/<AgentName>/main.py` — the agent's entry point. This is where the developer adds tools, system prompts, and logic.
-- `agentcore/agentcore.json` — the project config. Resources are added here via `agentcore add` commands.
-- `agentcore/.env.local` — local environment variables. After deploy, resource IDs are written here for local dev.
+- The generated dependency file — framework and model dependencies.
+- The generated environment/config files — non-secret local configuration.
 
-**Heads-up on the scaffolded MCP client.** `main.py` imports `get_streamable_http_mcp_client()` from `mcp_client/client.py` and appends it to `tools`. In a fresh project, this client points at a public example MCP endpoint — so `agentcore dev` works immediately. Two things to flag:
+**If the scaffold includes an MCP client,** inspect its endpoint and tool
+wiring rather than assuming it is available locally. Two things to flag:
 
-1. **It will become a silent no-op if you repoint it at a gateway that isn't deployed yet.** The common path is to swap the example endpoint for `os.getenv("AGENTCORE_GATEWAY_<NAME>_URL")`. That env var is only populated after `agentcore deploy`. If the developer repoints and runs `agentcore dev` before deploying, `get_streamable_http_mcp_client()` returns a client with a `None` URL and the agent starts with zero MCP tools — no error, no warning. See the "Local dev gap" section in `agents-connect` for the guard pattern: `if not GATEWAY_URL: tools = []`.
+1. **A Gateway endpoint is an AWS resource.** If the endpoint is absent, use
+   the guard pattern from `agents-connect`: `if not GATEWAY_URL: tools = []`.
 2. **If the developer doesn't need MCP tools at all**, remove the `mcp_clients` list and the loop that appends it to `tools`. The scaffold includes it as a convenience, not a requirement.
 
-The reference client code in `agents-connect` (Path A) shows the correct pattern for gateway-backed MCP clients once deploy has run.
+The reference client code in `agents-connect` (Path A) shows the correct
+pattern for gateway-backed MCP clients after the Gateway exists.
 
 ### Step 5: Local development
 
+Start local development:
+
 ```bash
-agentcore dev
+agentcore project dev
 ```
 
-This starts a local dev server. The developer can interact with their agent immediately.
-
-**Port the dev server binds to** (important if you're scripting `curl` calls or testing from another process):
-
-| Protocol | Default port |
-|---|---|
-| HTTP | `8080` |
-| MCP | `8000` |
-| A2A | `9000` |
-
-The CLI prints the bound port and URL on startup — always read the actual value from the CLI output rather than hardcoding. **If the default port is already in use**, the CLI auto-increments (e.g., 8080 → 8081 → 8082), so a second dev session or a lingering process from a previous run can shift your port without warning. Use `agentcore dev --port <N>` to pin it, or grep `ps` / check the CLI banner if invocations start failing with connection-refused or exit-code-7 errors.
-
-**Important limitations to mention:**
-
-- Memory is not available in `agentcore dev` — it requires a deploy
-- Gateway URLs are not available locally — they require a deploy
-- The local server uses the model provider configured in the project
+Use the URL printed by the command to test the generated application.
 
 ### Step 6: First deploy
 
-When the developer is ready to deploy:
+Deploy the project and inspect its resource status:
 
 ```bash
-agentcore deploy
+agentcore project deploy
+agentcore project status
 ```
 
-This will:
-
-1. Show a preview of AWS resources to be created
-2. Ask for confirmation
-3. Build and deploy via CDK
-
-**First deploy takes 3-5 minutes.** Subsequent deploys are faster.
-
-After deploy, show them how to invoke:
+The reference does not define flags for these commands, so keep them bare.
+Once the Runtime exists, inspect and invoke it directly:
 
 ```bash
-agentcore invoke "Hello, what can you do?"
-```
-
-And how to check status:
-
-```bash
-agentcore status
+agentcore runtime get --id <RUNTIME_ID> --json
+agentcore runtime invoke \
+  --id <RUNTIME_ID> \
+  --payload '{"prompt":"Hello, what can you do?"}' \
+  --json
 ```
 
 ### Step 7: What's next
 
 Based on what the developer said they want to build, suggest the logical next skill:
 
-| Developer intent | Next skill | Command hint |
-|---|---|---|
-| "How do I call it from my app?" | `agents-build` | `agentcore fetch access` |
-| "I want it to remember things" | `agents-build` | `agentcore add memory` |
-| "I want it to call external APIs" | `agents-connect` | `agentcore add gateway` |
-| "I want to restrict what it can do" | `agents-connect` | `agentcore add policy-engine` |
-| "I want to measure quality" | `agents-optimize` | `agentcore add evaluator` |
-| "I want to go to production" | `agents-harden` | production readiness checklist |
-| "I want multiple agents working together" | `agents-build` | `agentcore create --protocol A2A` |
-| "I need it in a VPC" | `agents-build` | `agentcore create --network-mode VPC` |
+| Developer intent | Next skill |
+|---|---|
+| "How do I call it from my app?" | `agents-build` |
+| "I want it to remember things" | `agents-build` |
+| "I want it to call external APIs" | `agents-connect` |
+| "I want to restrict what it can do" | `agents-connect` |
+| "I want to measure quality" | `agents-optimize` |
+| "I want to go to production" | `agents-harden` |
+| "I want multiple agents working together" | `agents-build` |
+| "I need it in a VPC" | `agents-build` |
 
 Don't overwhelm — suggest one or two next steps based on what the developer actually asked for.
 
@@ -325,14 +301,16 @@ More examples can be added to this skill's references directory as common patter
 
 ## Output
 
-- A clear path from "I want to build an agent" to a running deployed agent
-- The `agentcore create` command tailored to their choices
+- A clear Harness-versus-Runtime recommendation
+- A valid `agentcore harness create` or `agentcore project create` command
 - An explanation of the generated project structure
+- Project development, deployment, status, and Runtime invocation steps
 - Concrete next steps based on their intent
 
 ## Quality criteria
 
-- The `agentcore create` command uses only valid flags from CLI v0.9.1
+- Commands use only the refactor CLI command tree
+- Project lifecycle commands have no invented flags
 - Framework recommendation is based on the developer's context, not a generic default
 - The developer understands what each generated file does
 - Next steps are specific to what the developer wants to build, not a generic list of all features

--- a/plugins/aws-agents/skills/agents-get-started/references/example-support-agent.md
+++ b/plugins/aws-agents/skills/agents-get-started/references/example-support-agent.md
@@ -1,6 +1,7 @@
 # Example: Customer Support Agent
 
-A complete, realistic example of a customer support agent scaffolded with `agentcore create`. Use this as a reference when the developer asks to "build a customer support agent" or similar task-framed prompts.
+A complete customer support Runtime project scaffolded with `agentcore project
+create`. Use this when the developer asks to build a customer support agent.
 
 ## What this agent does
 
@@ -9,13 +10,9 @@ Answers customer questions about product policies, shipping, and returns. Uses S
 ## Scaffold command
 
 ```bash
-agentcore create \
+agentcore project create \
   --name SupportAgent \
-  --framework Strands \
-  --protocol HTTP \
-  --build CodeZip \
-  --model-provider Bedrock \
-  --memory none
+  --template hello-world-python
 ```
 
 ## Generated `main.py` (annotated)
@@ -25,7 +22,7 @@ After scaffolding, `app/SupportAgent/main.py` looks something like:
 ```python
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from strands import Agent
-from model.load import load_model  # scaffolded by `agentcore create` in model/load.py
+from model.load import load_model
 
 app = BedrockAgentCoreApp()
 
@@ -56,10 +53,11 @@ if __name__ == "__main__":
 ## Try it locally
 
 ```bash
-agentcore dev
+agentcore project dev
 ```
 
-In another terminal:
+Use the URL printed by the command. If it exposes the Runtime HTTP contract on
+port 8080, invoke it with:
 
 ```bash
 curl -X POST http://localhost:8080/invocations \
@@ -70,7 +68,16 @@ curl -X POST http://localhost:8080/invocations \
 ## Deploy it
 
 ```bash
-agentcore deploy
+agentcore project deploy
+```
+
+Once the Runtime exists:
+
+```bash
+agentcore runtime invoke \
+  --id <RUNTIME_ID> \
+  --payload '{"prompt":"What is your return policy?"}' \
+  --json
 ```
 
 ## Natural next steps
@@ -89,11 +96,8 @@ After the basic agent is working, the developer typically asks for one of these 
 
 ### LangGraph variant
 
-```bash
-agentcore create --name SupportAgent --framework LangChain_LangGraph --model-provider Bedrock --memory none
-```
-
-Generated `main.py` uses `create_react_agent` and `langchain_aws`:
+Use the same project scaffold, install LangGraph dependencies, and implement
+`main.py` with `create_react_agent` and `langchain_aws`:
 
 ```python
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -121,9 +125,8 @@ if __name__ == "__main__":
 
 ### OpenAI Agents SDK variant
 
-```bash
-agentcore create --name SupportAgent --framework OpenAIAgents --model-provider OpenAI --memory none
-```
+Use the same project scaffold, install the OpenAI Agents SDK, and replace the
+application code:
 
 ```python
 from agents import Agent, Runner
@@ -146,9 +149,8 @@ if __name__ == "__main__":
 
 ### Google ADK variant
 
-```bash
-agentcore create --name SupportAgent --framework GoogleADK --model-provider Gemini --memory none
-```
+Use the same project scaffold, install Google ADK, and replace the application
+code:
 
 ```python
 from google.adk.agents import Agent
@@ -186,7 +188,7 @@ if __name__ == "__main__":
 
 ### Model provider options
 
-The CLI supports four model providers:
+The application can use these model providers:
 
 | Provider | Best for | Notes |
 |---|---|---|
@@ -197,4 +199,6 @@ The CLI supports four model providers:
 
 For cost-sensitive use cases, consider Bedrock Nova models (e.g., `amazon.nova-micro-v1:0`, `amazon.nova-lite-v1:0`) — significantly cheaper than Claude for simpler extractive tasks. See [`agents-optimize/references/cost.md`](../../agents-optimize/references/cost.md) for model selection guidance.
 
-For a chatbot that remembers conversations, add `--memory longAndShortTerm` during scaffolding. Memory can also be added later — see [`agents-build/references/memory.md`](../../agents-build/references/memory.md).
+For a chatbot that remembers conversations, add Memory with `agentcore project
+add`; see
+[`agents-build/references/memory.md`](../../agents-build/references/memory.md).

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -17,6 +17,20 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 KEBAB_RE = re.compile(r"^[a-z][a-z0-9]+(-[a-z0-9]+)*$")
+LEGACY_AGENTCORE_RE = re.compile(
+    r"\bagentcore "
+    r"(?:--version|create|add|remove|dev|deploy|status|invoke|fetch|logs|"
+    r"traces|run|evals|pause|resume|validate|update|import|init|dp)"
+    r"(?=[\s`]|$)"
+)
+PROJECT_LIFECYCLE_ARGS_RE = re.compile(
+    r"\bagentcore project (?:add|remove|dev|deploy|status|build)\s+"
+    r"(?:--|[a-zA-Z0-9_<])"
+)
+MIGRATED_AGENTCORE_DOCS = (
+    Path("plugins/aws-agents/README.md"),
+    Path("plugins/aws-agents/skills/agents-get-started"),
+)
 
 errors: list[str] = []
 
@@ -171,6 +185,36 @@ def validate_top_level_skills() -> None:
         validate_skill_frontmatter(skill_md)
 
 
+def validate_migrated_agentcore_docs() -> None:
+    """Validate AgentCore commands in skill families migrated to the new CLI."""
+    print("Validating migrated AgentCore CLI references")
+    markdown_files: set[Path] = set()
+    for relative_path in MIGRATED_AGENTCORE_DOCS:
+        path = REPO_ROOT / relative_path
+        if path.is_file():
+            markdown_files.add(path)
+        elif path.is_dir():
+            markdown_files.update(path.rglob("*.md"))
+
+    for path in sorted(markdown_files):
+        relative = path.relative_to(REPO_ROOT)
+        lines = path.read_text().splitlines()
+        for line_number, line in enumerate(lines, start=1):
+            legacy = LEGACY_AGENTCORE_RE.search(line)
+            if legacy:
+                error(
+                    f"Legacy AgentCore command '{legacy.group(0)}' in "
+                    f"{relative}:{line_number}"
+                )
+
+            if PROJECT_LIFECYCLE_ARGS_RE.search(line):
+                error(
+                    "Project lifecycle commands must not have undocumented "
+                    "arguments "
+                    f"or flags in {relative}:{line_number}"
+                )
+
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Validate repo manifests and skills")
@@ -185,6 +229,8 @@ def main() -> None:
             print(f"Plugin not found: {args.plugin}", file=sys.stderr)
             sys.exit(1)
         validate_plugin(plugin_dir)
+        if args.plugin == "aws-agents":
+            validate_migrated_agentcore_docs()
     else:
         # Marketplace manifests
         validate_marketplace(
@@ -205,6 +251,7 @@ def main() -> None:
 
         # Top-level skills
         validate_top_level_skills()
+        validate_migrated_agentcore_docs()
 
     if errors:
         print(f"\nValidation failed with {len(errors)} error(s).", file=sys.stderr)


### PR DESCRIPTION
## Description

First reviewable slice of the AgentCore CLI skill migration:

- document the refactor CLI contract in the aws-agents README
- update `agents-get-started` to choose between managed Harness and Runtime
  projects
- replace legacy project creation flags with the supported templates
- document project dev/deploy/status as the intended bare lifecycle commands
- update the customer-support example while preserving its framework examples
- validate migrated AgentCore docs against legacy commands and undocumented
  project lifecycle flags

This PR intentionally leaves the other skill families unchanged. They will be
migrated in follow-up PRs.

No AWS resources were created or modified.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [x] Bug fix
- [x] Documentation update
- [x] CI/CD change
- [ ] Other

## Validation

- `python3 tools/validate.py`
- `python3 tools/validate_spec.py`
- `quick_validate.py plugins/aws-agents/skills/agents-get-started`
- `npx markdownlint-cli2` on the three changed Markdown files
- get-started forward test for a LangGraph Runtime project

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
