### PR TITLE
docs(aws-serverless): add Function URL 403 entry to troubleshooting.md

### DIFF
--- a/plugins/aws-core/skills/aws-serverless/references/troubleshooting.md
+++ b/plugins/aws-core/skills/aws-serverless/references/troubleshooting.md
@@ -14,6 +14,26 @@ Error → cause → fix, focused on non-obvious gotchas and exact CLI commands. 
 
 ## Lambda errors (gotchas)
 
+### Function URL 403 Forbidden (`AuthType=NONE`)
+
+A public Function URL returns **403 Forbidden** even with `AuthType=NONE` when the resource-based policy grants only `lambda:InvokeFunctionUrl`. Invoking a Function URL **always requires both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`** — the console and SAM add both statements automatically, but with the CLI/API you must add each yourself (two separate `add-permission` calls):
+
+```bash
+# Statement 1: allow invoking via the Function URL (public)
+aws lambda add-permission --function-name my-function \
+  --statement-id FunctionURLAllowPublicAccess \
+  --action lambda:InvokeFunctionUrl --principal '*' \
+  --function-url-auth-type NONE
+
+# Statement 2: REQUIRED — allow the underlying invoke, scoped to URL calls
+aws lambda add-permission --function-name my-function \
+  --statement-id FunctionURLInvokeAllowPublicAccess \
+  --action lambda:InvokeFunction --principal '*' \
+  --invoked-via-function-url
+```
+
+The `--invoked-via-function-url` flag sets the `lambda:InvokedViaFunctionUrl` condition on statement 2, scoping it to Function URL calls so it does not open direct `Invoke` access. This 403 is **not** an org SCP/RCP block — Lambda does not support RCPs, so don't chase that path. See [Function URLs](lambda.md#function-urls) and [Lambda function URL auth](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html).
+
 ### RecursiveInvocationException
 
 A function writes to a resource that re-triggers it (Lambda halts after ~16 loops).

--- a/skills/core-skills/aws-serverless/references/troubleshooting.md
+++ b/skills/core-skills/aws-serverless/references/troubleshooting.md
@@ -14,6 +14,26 @@ Error → cause → fix, focused on non-obvious gotchas and exact CLI commands. 
 
 ## Lambda errors (gotchas)
 
+### Function URL 403 Forbidden (`AuthType=NONE`)
+
+A public Function URL returns **403 Forbidden** even with `AuthType=NONE` when the resource-based policy grants only `lambda:InvokeFunctionUrl`. Invoking a Function URL **always requires both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction`** — the console and SAM add both statements automatically, but with the CLI/API you must add each yourself (two separate `add-permission` calls):
+
+```bash
+# Statement 1: allow invoking via the Function URL (public)
+aws lambda add-permission --function-name my-function \
+  --statement-id FunctionURLAllowPublicAccess \
+  --action lambda:InvokeFunctionUrl --principal '*' \
+  --function-url-auth-type NONE
+
+# Statement 2: REQUIRED — allow the underlying invoke, scoped to URL calls
+aws lambda add-permission --function-name my-function \
+  --statement-id FunctionURLInvokeAllowPublicAccess \
+  --action lambda:InvokeFunction --principal '*' \
+  --invoked-via-function-url
+```
+
+The `--invoked-via-function-url` flag sets the `lambda:InvokedViaFunctionUrl` condition on statement 2, scoping it to Function URL calls so it does not open direct `Invoke` access. This 403 is **not** an org SCP/RCP block — Lambda does not support RCPs, so don't chase that path. See [Function URLs](lambda.md#function-urls) and [Lambda function URL auth](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html).
+
 ### RecursiveInvocationException
 
 A function writes to a resource that re-triggers it (Lambda halts after ~16 loops).


### PR DESCRIPTION
## What

Adds a **Function URL 403 Forbidden** entry to the `aws-serverless` skill's `references/troubleshooting.md` (both the `skills/` and `plugins/aws-core/` copies), documenting the two permissions a public Lambda Function URL requires: `lambda:InvokeFunctionUrl` **and** `lambda:InvokeFunction`.

## Why

The guidance already lived in the same skill under [`references/lambda.md#function-urls`](https://github.com/aws/agent-toolkit-for-aws/blob/main/skills/core-skills/aws-serverless/references/lambda.md#function-urls), but not in `troubleshooting.md`. When an agent hit a `403 Forbidden` on a public Function URL (`AuthType=NONE`), it checked `troubleshooting.md`, didn't find the answer, and misdiagnosed the failure as an org-level RCP block (Lambda doesn't support RCPs) — then built an unnecessary CloudFront + OAC workaround. Since Oct 2025, new Function URLs require *both* permissions; granting only `InvokeFunctionUrl` returns 403 even with `AuthType=NONE`.

This duplicates the fix into the troubleshooting reference where a debugging agent naturally looks.

## Change

New `### Function URL 403 Forbidden (AuthType=NONE)` entry as the first item under "Lambda errors (gotchas)": both `add-permission` commands, a note that the console/SAM add both statements automatically while the CLI/API do not, and an explicit callout that this is not an SCP/RCP issue.

Kept the `skills/` and `plugins/aws-core/` copies identical.
