### PR TITLE
feat(braket): add amazon-braket skill

### DIFF
--- a/skills/specialized-skills/quantum-computing-skills/amazon-braket/SKILL.md
+++ b/skills/specialized-skills/quantum-computing-skills/amazon-braket/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: amazon-braket
+description: Runs quantum computing workflows on AWS through Amazon Braket — discovering devices (QPUs and simulators) and their availability, building gate-model circuits and analog Hamiltonian programs, submitting quantum tasks, program sets and hybrid jobs, looking up prices, and capping spend with spending limits. Applies to any request about quantum computing, quantum hardware, quantum simulation, AHS, OpenQASM, or running a quantum algorithm on AWS.
+metadata:
+  version: "1"
+---
+
+# Amazon Braket
+
+## Primitives
+
+The vocabulary of a Braket workflow, and which reference to open for each.
+
+| Primitive | What it is | Related References | Open it when the request involves |
+|---|---|---|---|
+| **Device** | A simulator or QPU, identified by a region-scoped ARN | [devices.md](references/devices.md) | anything about a device: what exists, discovering or filtering the fleet, availability and status (online, offline, retired), which region a device lives in, ARNs, choosing a device for a workload, qubit count, connectivity or topology, native gates, fidelities, calibration data, queue depth, shot and gate limits, paradigm (gate-model vs analog Hamiltonian simulation), whether a device supports program sets, pulse-level control, simulators and local emulators |
+| **Program** | The workload/input — one executable (Circuit, AHS, OpenQASM). Which type is legal depends on the device's paradigm | - | - |
+| **Quantum task** | One program + shots, run once (the atomic unit Braket meters) | - | - |
+| **Task batch** | Many *independent* tasks — SDK-only fallback for when a program set does not fit; works on all devices | [program-sets.md](references/program-sets.md) | see the Program set row; also [running multiple programs](https://docs.aws.amazon.com/braket/latest/developerguide/braket-batching-tasks.html) |
+| **Program set** | Many programs in **one service-side task** — preferred way to run multiple programs instead of task batch | [program-sets.md](references/program-sets.md) | running more than one program: parameter sweeps, scanning parameter values, task batches, `run_batch`, several circuits submitted together, attaching observables across programs, and minimizing per-task fees when many programs run, program sets. Also [getting started with program sets](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/braket_features/program_sets/01_Getting_started_with_program_sets.ipynb) |
+| **Hybrid job** | Managed classical-quantum loop that orchestrates many tasks | [hybrid-job.md](references/hybrid-job.md) | hybrid jobs: `@hybrid_job`, algorithm scripts and source modules, `entry_point`, embedded simulators, BYOC and custom container images, CUDA-Q, job execution roles, hyperparameters, checkpoints, and retrieving job results |
+| **Spending limit** | Service-side hard cap that **rejects** QPU tasks — the only true enforcement (not SDK) | [spending-limit.md](references/spending-limit.md) | capping or enforcing spend: spending limits (create, update, delete, search), and cost guardrails |
+| **Cost tracking** | In-session cost *estimate* (not enforcement) | [spending-limit.md](references/spending-limit.md) | in-session cost tracking with `Tracker` |
+
+Each reference carries the domain detail for its own area — field paths, key names, API shapes, and billing models.
+
+Additional notes:
+- **Reservation** — exclusive device access for a booked window. This skill covers reservations at pointer depth only: the billing model is in [pricing.md](references/pricing.md), reservation-specific device limits such as `service.reservationShotsRange` are in [devices.md](references/devices.md), and the full model is in the [reservations developer guide](https://docs.aws.amazon.com/braket/latest/developerguide/braket-reservations.html).
+- **Gate calibrations / pulse control** — access native gate calibrations on QPUs and attach custom pulse sequences at run time. See [devices.md](references/devices.md) for detecting support, and the [pulse control developer guide](https://docs.aws.amazon.com/braket/latest/developerguide/braket-pulse-control.html) for the full model.
+
+## Critical Rules
+
+These rules apply to every Braket request, whatever it involves.
+
+1. **The Amazon Braket Python SDK (`pip install amazon-braket-sdk`, imported as `braket`) is the primary entry point.** Prefer it for every operation including Braket API operations, and understand what it covers by reading the [docs](https://amazon-braket-sdk-python.readthedocs.io/en/stable/) or inspecting the SDK's modules locally.
+    - Use local execution tools for running the Braket SDK, such as `shell` with `python3 -c "<code>"`.
+
+1. **The AWS MCP server is recommended for executing any other AWS API calls in this skill**, especially operations not present in the Python SDK, although not required. Note: the AWS MCP's `run_script` tool executes code in a minimal sandbox without Braket libraries, so prefer using other tools for code execution, especially when using the Braket SDK.
+
+1. **A small set of primitives composes every workflow** — see [Primitives](#primitives) for the vocabulary and the reference for each.
+
+1. **Devices, quantum tasks, and hybrid jobs are region-scoped, so fan out across every Braket region whenever you use the API, CLI, or boto3 to search for resources.** The SDK handles fanout for you where it can — `AwsDevice.get_devices` searches QPUs in all regions.
+Get the list of regions Braket supports from `aws___get_regional_availability` when the AWS MCP server is available, or from the [supported devices and regions documentation](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html).
+Resource ARNs containing a region may only be queried from that same region, otherwise you will see a `ResourceNotFoundException`.
+
+1. **Open the matching reference before you write code or answer.** Use the **Primitives** table to find and read references. Note: A request that asks for several things, e.g. executing a series of circuits and controlling the cost thereof, may require reading multiple reference files.
+
+1. **Verify, never recall.** Device ARNs and statuses, API signatures, supported features, and prices (and other values) all change and may post-date training data.
+
+1. **Confirm an SDK signature before you write code that calls it.** Read it from the [SDK reference docs](https://amazon-braket-sdk-python.readthedocs.io/en/latest/).
+If no available tool can reach them, get it from the installed SDK with `shell`:
+```bash
+PAGER=cat python -c "import braket; help(braket)"       # subpackages: ahs, circuits, pulse, program_sets, ...
+python -c "import braket.ahs; print(dir(braket.ahs))"   # names: DrivingField, AtomArrangement, ...
+python -c "import inspect; from braket.ahs import DrivingField; \
+print(inspect.signature(DrivingField.from_lists)); print(inspect.getdoc(DrivingField.from_lists))"
+```
+
+
+## Guardrail — where this skill's own files live (MCP vs local install)
+
+This skill can be loaded two ways, and they resolve the skill's own bundled files from different places. Determine how the skill was loaded before reading a reference:
+
+- **Loaded through the AWS MCP `retrieve_skill` tool:** The skill is not installed on the local filesystem. You MUST fetch each reference via `retrieve_skill` with the `file` parameter (e.g. `file="references/devices.md"`). Do NOT `file_read` these paths locally — they do not exist on disk.
+- **Installed locally** (e.g. `~/.kiro/skills/amazon-braket/`, `.kiro/skills/amazon-braket/`, or `~/.claude/skills/amazon-braket/`): Read files from the local skill directory using relative paths.
+
+`references/` is a sibling of this `SKILL.md` — resolve reference paths against that directory, not your working directory, and do not search the filesystem for them.
+If a skill tool returns this overview instead of the file you asked for, it did not fetch it: read it from that directory instead, and do not write code from memory because a reference read failed.
+This distinction applies only to the skill's own packaged files. User data and session artifacts are always read from and written to the user's working directory — do not `cd` before running a script that writes a relative artifact path.
+
+
+## Common mistakes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Treats "task", "batch", "job" as interchangeable | Primitive confusion | Task = one run; batch = many parallel tasks; job = managed loop |
+| `Missing required parameter: filters` on `SearchQuantumTasks`, `SearchJobs`, or `SearchDevices` | `filters` is required on all three — only `SearchSpendingLimits` lets you omit it | Pass `filters=[]` (`--filters '[]'`) for an unfiltered search. A populated filter needs `name` and `values`, plus `operator` on tasks and jobs; `SearchDevices` has no `operator` member |
+| `Missing required parameter: clientToken` when using AWS MCP `run_script` tool | `CreateQuantumTask`, `CreateJob`, `CancelQuantumTask`, `CreateSpendingLimit`, `UpdateSpendingLimit` require a `clientToken` for idempotency. The SDK, CLI, and boto3 generate one automatically; the `run_script` tool requires explicit passing | Pass `clientToken=str(uuid.uuid4())` on APIs taking `clientToken` when calling through `run_script`. Otherwise, prefer the SDK for these operations when possible. |
+| Builds program IR as JAQCD | JAQCD is deprecated on Amazon Braket | Use OpenQASM — see [OpenQASM on Braket](https://docs.aws.amazon.com/braket/latest/developerguide/braket-openqasm.html) |
+| Denies a feature or SDK construct exists | Training data outdated | Rule 2 — verify against the docs or `GetDevice` before saying it does not exist |
+| Invents a class, method, or parameter | Writing API names from memory | Confirm the signature first (rule 4). If uncertain, say so rather than inventing |
+
+## Security considerations
+
+Braket workflows touch IAM, S3, and (for hybrid jobs) container execution.
+
+- **Least-privilege IAM.** Scope custom policies to the actions, device ARNs, and buckets a workload actually uses, and avoid broad `braket:*`. Actions are listed at the [Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_braket.html). Prefer a custom policy over `AmazonBraketFullAccess`, which is deliberately broad: S3 on any `amazon-braket-*` bucket or any bucket tagged `AmazonBraket=true` ([if the bucket is enabled for Attribute-Based Access Control](https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging-enable-abac.html)), plus SageMaker and CloudWatch actions a task-submission workflow never needs. See [Managing access to Amazon Braket](https://docs.aws.amazon.com/braket/latest/developerguide/braket-manage-access.html) and [Restricting access to devices](https://docs.aws.amazon.com/braket/latest/developerguide/restrict-access.html).
+  - `braket:UpdateSpendingLimit` and `braket:DeleteSpendingLimit` should be restricted to prevent accidental removal of a spending limit and accidental cost overruns.
+- **Hybrid-job execution role.** Attach only [`AmazonBraketJobsExecutionPolicy`](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonBraketJobsExecutionPolicy.html). Its `iam:PassRole` condition requires the role be named `AmazonBraketJobsExecutionRole*` under the `/service-role/` path, or `create_job` is denied at `PassRole`.
+- **Ephemeral credentials.** Call Braket APIs with IAM roles (instance profiles, ECS/EKS task roles, or assumed roles), not long-lived IAM user access keys.
+- **Encrypt task output.** Enable default encryption (SSE-S3, or SSE-KMS with a customer-managed key for sensitive workloads) on any S3 bucket receiving task results, job source archives, output data, or checkpoints. Add `aws:SourceAccount`/`aws:SourceArn` conditions to the bucket policy where a service principal is granted access, and deny non-TLS access with an `aws:SecureTransport: false` condition.
+- **Auditing.** Enable [CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/view-cloudtrail-events.html) for Braket management events, with log-file validation, KMS encryption, and delivery to an access-restricted bucket — the trail is the primary evidence if a cost guardrail is removed. Encrypt any CloudWatch Logs group receiving task output or hybrid-job logs, since algorithm parameters and results appear there.
+- **Cost guardrail.** Recommend a spending limit before the user's first QPU run, when the user asks what a workload costs, or when one request fans out across several devices or a large shot count. Spending limits may already exist in the customer's account. In general, enforce QPU spend caps with spending limits.
+- **Secrets.** Hyperparameters are stored in job metadata and echoed into the job's
+  CloudWatch log stream at container boot, so never pass a secret as a hyperparameter —
+  fetch it from Secrets Manager or SSM Parameter Store inside the algorithm script.
+  Restrict read access to the job log groups accordingly.
+
+For details, see the [Amazon Braket security documentation](https://docs.aws.amazon.com/braket/latest/developerguide/security.html).
+
+## Reference links
+
+Authoritative sources — prefer these over recalled details, since device ARNs, quotas, prices, and supported features change.
+
+**Official documentation** (stable entry points — navigate/search from here)
+- Developer Guide — https://docs.aws.amazon.com/braket/latest/developerguide/what-is-braket.html
+- Prerequisites & account setup — https://docs.aws.amazon.com/braket/latest/developerguide/braket-get-started.html
+- How Amazon Braket works — https://docs.aws.amazon.com/braket/latest/developerguide/braket-how-it-works.html
+- API Reference — https://docs.aws.amazon.com/braket/latest/APIReference/Welcome.html
+- Python SDK API docs — https://amazon-braket-sdk-python.readthedocs.io/en/latest/
+- Getting started — https://aws.amazon.com/braket/getting-started/
+- OpenQASM 3.0 spec — https://openqasm.com/versions/3.0/index.html
+- OpenQASM on Braket — https://docs.aws.amazon.com/braket/latest/developerguide/braket-openqasm.html
+- Supported OpenQASM features (pragmas, verbatim rules, dynamic circuits) — https://docs.aws.amazon.com/braket/latest/developerguide/braket-openqasm-supported-features.html
+- boto3 `braket` client — https://docs.aws.amazon.com/boto3/latest/reference/services/braket.html
+- Security — https://docs.aws.amazon.com/braket/latest/developerguide/security.html
+
+For anything not covered here, **search the documentation** rather than guessing page slugs or recalling details: if the AWS MCP server is available, its `aws___search_documentation` tool can help; otherwise start from the Developer Guide or API Reference above and navigate.
+
+**GitHub**
+- `amazon-braket-sdk-python` (core SDK) — https://github.com/amazon-braket/amazon-braket-sdk-python
+- `amazon-braket-schemas-python` (schemas and models for public Braket data) — https://github.com/amazon-braket/amazon-braket-schemas-python
+- `amazon-braket-examples` — https://github.com/amazon-braket/amazon-braket-examples

--- a/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/devices.md
+++ b/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/devices.md
@@ -1,0 +1,138 @@
+# Devices
+
+## Related references
+
+For pricing see [pricing.md](pricing.md) — rates differ per device, so a device choice is also a cost choice; for submitting work as a program set (many programs in one task) see [program-sets.md](program-sets.md); for cost guardrails see [spending-limit.md](spending-limit.md).
+
+## Device status
+
+The ONLINE, OFFLINE, and RETIRED statuses have different semantics:
+
+- **ONLINE** — usable now, subject to its availability window.
+- **OFFLINE** — temporarily unusable; task creation is rejected.
+- **RETIRED** — permanently unusable. RETIRED devices will still be returned successfully by `GetDevice` and `SearchDevices`.
+
+## How to query devices
+
+Prefer the SDK — it applies filters client-side, performs region fan-out, and other niceties.
+
+| Task | Braket Python SDK (preferred) | AWS CLI (portable) |
+|---|---|---|
+| Discover and filter devices | `AwsDevice.get_devices(statuses=["ONLINE"], types=["QPU"])` — filters are ANDed; also `arns`, `names`, `provider_names`, `order_by` | `aws braket search-devices --filters '[]' --region <region>` then filter client-side; the API only supports `deviceArn` as filter |
+| One device | `AwsDevice(arn)` | `aws braket get-device --device-arn <arn> --region <region>` |
+| Read a field | `device.name`, `device.status`, `device.type`, `device.is_available` | `aws braket get-device --device-arn <arn> --region <region> --query '{name:deviceName,status:deviceStatus,type:deviceType}'` |
+| Read capabilities | `device.properties` — already a parsed object | `aws braket get-device --device-arn <arn> --region <region> --query 'deviceCapabilities' --output text \| jq '.paradigm.qubitCount, (.action \| keys)'` — a JSON **string**, parse before reading |
+
+Reference docs for correct usage:
+- Braket Python SDK — [`AwsDevice`](https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.aws.aws_device.html) (`AwsDevice.get_devices`, `AwsDevice.properties`)
+- AWS CLI — [`braket search-devices`](https://docs.aws.amazon.com/cli/latest/reference/braket/search-devices.html), [`braket get-device`](https://docs.aws.amazon.com/cli/latest/reference/braket/get-device.html)
+- boto3 `braket` client — [`search_devices`](https://docs.aws.amazon.com/boto3/latest/reference/services/braket/client/search_devices.html), [`get_device`](https://docs.aws.amazon.com/boto3/latest/reference/services/braket/client/get_device.html)
+- API — [SearchDevices](https://docs.aws.amazon.com/braket/latest/APIReference/API_SearchDevices.html), [GetDevice](https://docs.aws.amazon.com/braket/latest/APIReference/API_GetDevice.html)
+
+## Reading GetDevice
+
+Warning: GetDevice responses are large (10–30 KB per device, mostly `deviceCapabilities`). Do NOT dump the full response into your context — extract only the fields you need. Preferred approaches:
+- **SDK:** `device = AwsDevice(arn); device.properties.<path>` (already parsed, access fields directly)
+- **AWS CLI + jq:** `aws braket get-device --device-arn <arn> --region <region> --query 'deviceCapabilities' --output text | jq '<path to fields you need>'`
+
+The `deviceCapabilities` field in GetDevice contains all information about a device, like whether it can run program sets, whether it can run OpenQASM gate model programs, etc.
+`deviceCapabilities` is returned as a **JSON-encoded string** — parse it before reading (the SDK does this for you via `AwsDevice.properties`).
+Inspect `deviceCapabilities` for all relevant fields — action types, `paradigm.qubitCount`, `service.shotsRange`, connectivity, etc. — no matter the device type.
+Simulators and QPUs alike populate these fields (e.g. SV1 reports its qubit cap at `paradigm.qubitCount`).
+Do not skip a field or substitute null based on assumptions about what a device type "has" — read the payload, and only report a field as missing after actually checking it.
+
+For field **meanings, types, and constraints**, consult the `amazon-braket-schemas-python` repository rather than inferring them from memory.
+You can do this by:
+- **Read from the web** — fetch the module source directly from the [GitHub repository](https://github.com/amazon-braket/amazon-braket-schemas-python)
+- **Install the package** — `pip install --upgrade amazon-braket-schemas` (always the latest), then read the module (e.g. `inspect.getsource`).
+
+Resolve the module from the live payload's `braketSchemaHeader`: dots in `name` → folders under `src/braket/`, then append `_v{version}.py`. Example: `braket.device_schema.iqm.iqm_device_capabilities` v1 → `src/braket/device_schema/iqm/iqm_device_capabilities_v1.py`.
+
+## Paradigms
+
+Braket supports two paradigms that are **not mutually compatible**:
+- **Gate model** — quantum circuits (gates + measurements). Most QPUs and all managed simulators.
+- **AHS (Analog Hamiltonian Simulation)** — continuous Hamiltonian evolution on neutral-atom arrays. Verify which devices support AHS via `GetDevice` (`deviceCapabilities.paradigm`) rather than assuming a fixed device.
+
+A device accepts one paradigm. The most reliable discriminator is the **action map**, which names the program types the device will accept and covers every paradigm with one pattern:
+
+```python
+actions = AwsDevice(arn).properties.action        # keyed by DeviceActionType
+"braket.ir.openqasm.program"     in actions      # gate-model OpenQASM
+"braket.ir.openqasm.program_set" in actions      # program sets
+"braket.ir.ahs.program"          in actions      # analog Hamiltonian simulation
+```
+
+`deviceCapabilities.paradigm` carries the physical detail behind that choice — gate-model devices have `nativeGateSet`/`connectivity`, AHS devices have `rydberg`/`lattice`. Submitting a program type absent from the action map causes the program to be rejected.
+
+## Availability windows and maintenance
+
+All information regarding interpreting device availability can be found at https://docs.aws.amazon.com/braket/latest/developerguide/braket-task-when.html.
+When a QPU is online but outside its `executionWindows` (availability window), it shows `deviceStatus=ONLINE` and queues tasks until the next window.
+Unplanned maintenance or other device events shows `deviceStatus=OFFLINE` and attempts to create the quantum task will be rejected.
+
+[Braket device reservations](https://docs.aws.amazon.com/braket/latest/developerguide/braket-reservations.html) may also affect when tasks are able to run against QPUs.
+
+When a target is OFFLINE or RETIRED, suggest an ONLINE alternative that is also within its availability window.
+When a target is outside its availability window, suggest an alternative that is.
+
+## Shot and gate limits
+
+| Field | Present on | SDK access → what it returns |
+|---|---|---|
+| `service.shotsRange` | every device | `AwsDevice(arn).properties.service.shotsRange` → `(shots_lower, shots_upper)` |
+| `service.reservationShotsRange` | devices that support reservations and have different shot ranges | `AwsDevice(arn).properties.service.reservationShotsRange` → `(shots_lower, shots_upper)`, or `None` when absent — a reservation can *lower* the floor, here from 100 shots to 1 |
+
+Some providers apply a further shot minimum when error mitigation is enabled, carried under `provider` rather than `service`. See [error mitigation on IonQ](https://docs.aws.amazon.com/braket/latest/developerguide/error-mitigation-ionq.html).
+
+## Simulators
+
+- **On-demand** (managed by Braket). Duration-billed — see https://docs.aws.amazon.com/braket/latest/developerguide/braket-submit-tasks-simulators.html.
+- **Local** (in the SDK, no ARN, no charge): `LocalSimulator(backend=...)`, documented at https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.devices.local_simulator.html and https://docs.aws.amazon.com/braket/latest/developerguide/braket-send-to-local-simulator.html 
+- **Noise-aware simulation:** applies only to density-matrix backends — `LocalSimulator("braket_dm")` locally, or the managed on-demand DM1. State-vector backends (`braket_sv`, default) cannot express noise models. See the [example notebook](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/braket_features/Simulating_Noise_On_Amazon_Braket.ipynb) and [SDK noise modules](https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.circuits.noise_model.html).
+- `shots=0` has special, simulator-specific behavior (analytical/exact mode): the circuit MUST include explicit result types — e.g. `circuit.probability()`, `circuit.state_vector()`, or `circuit.expectation(observable)` — or the simulator raises an error. QPUs always require `shots > 0`. See https://docs.aws.amazon.com/braket/latest/developerguide/braket-submit-tasks-simulators.html and https://docs.aws.amazon.com/braket/latest/developerguide/braket-result-types.html
+
+
+### Local quantum device emulator
+
+A local quantum device **emulator** is distinct from the local simulator: it applies a real device's validation rules and noise model to a circuit locally, so you can catch a rejection before running on the QPU. 
+Learn how to use local device emulators at https://docs.aws.amazon.com/braket/latest/developerguide/braket-local-emulator.html.
+In the SDK, the emulator obtained from a method on the `AwsDevice` class as [`AwsDevice.emulator()`](https://amazon-braket-sdk-python.readthedocs.io/en/stable/_apidoc/braket.aws.aws_device.html#module-braket.aws.aws_device).
+
+
+### Experimental capabilities
+
+Some devices expose features behind an explicit opt-in, called "Experimental Capabilities" on Braket.
+Learn how to use experimental capabilities at https://docs.aws.amazon.com/braket/latest/developerguide/braket-experimental-capabilities.html.
+See example notebooks for experimental capabilities at https://github.com/amazon-braket/amazon-braket-examples/tree/main/examples/experimental_capabilities
+
+## Pulse-level control and gate calibrations
+
+Some QPUs expose pulse-level access — you can inspect the native gate calibrations the QPU uses and attach custom pulse sequences at run time. Support can be determined from `AwsDevice.properties`.
+Learn more about pulse control on Amazon Braket at https://docs.aws.amazon.com/braket/latest/developerguide/braket-pulse-control.html.
+See example notebooks for pulse control at https://github.com/amazon-braket/amazon-braket-examples/tree/main/examples/pulse_control.
+
+
+## Common mistakes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Context overflow / huge tool output | Dumped full GetDevice JSON into context | Use `jq` or `--query` to extract only needed fields; never dump raw `deviceCapabilities` |
+| Treats "GetDevice succeeded" as "device is available" | Didn't check `deviceStatus` in response | GetDevice returns successfully for RETIRED devices — you MUST check `deviceStatus` in the response is not `RETIRED` (and not `OFFLINE` if you need currently-runnable devices) |
+| Emits an ARN for a device that has since retired | Recall from training data | Verify via `SearchDevices` live |
+| Misses a device | Queried SearchDevices in only one region | Query all Braket regions |
+| `queueSize`/capabilities parse error | Treated string as int / JSON as object | `queueSize` is a string; deviceCapabilities is a json string - `json.loads(deviceCapabilities)` |
+| Wrong availability answer | Looked for a maintenance field | Parse `service.executionWindows` |
+| Recommends a `LocalSimulator` backend name from memory | Backend names and their support status change between SDK releases | Enumerate what the installed SDK actually offers before choosing: `python -c "from braket.devices import LocalSimulator; print(LocalSimulator.registered_backends())"` or read https://docs.aws.amazon.com/braket/latest/developerguide/braket-submit-tasks-simulators.html |
+| Misses a conditional shot minimum (e.g. IonQ error mitigation) | Only read `service.shotsRange` | Check the device's `provider` properties too — a mitigation scheme can raise the minimum above `service.shotsRange` |
+
+## References
+- Amazon Braket Python SDK: https://github.com/amazon-braket/amazon-braket-sdk-python
+- Amazon Braket supported regions and devices: https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html
+- Amazon Braket Python schemas: https://github.com/amazon-braket/amazon-braket-schemas-python
+- Amazon Braket reservations (scheduling, queuing, exclusive access): https://docs.aws.amazon.com/braket/latest/developerguide/braket-reservations.html
+- Restricting access to devices: https://docs.aws.amazon.com/braket/latest/developerguide/restrict-access.html
+- IonQ native gates and error mitigation: https://docs.aws.amazon.com/braket/latest/developerguide/error-mitigation-ionq.html
+- IonQ native gate set (provider docs): https://ionq.com/docs/getting-started-with-native-gates
+- SearchDevices API: https://docs.aws.amazon.com/braket/latest/APIReference/API_SearchDevices.html
+- GetDevice API: https://docs.aws.amazon.com/braket/latest/APIReference/API_GetDevice.html

--- a/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/hybrid-job.md
+++ b/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/hybrid-job.md
@@ -1,0 +1,106 @@
+# Hybrid job
+
+## Key operations
+
+| Operation | Amazon Braket Python SDK | AWS CLI | boto3 `braket` client |
+|---|---|---|---|
+| Create | `AwsQuantumJob.create(...)` or `@hybrid_job` decorator | `aws braket create-job --region <region> --job-name <name> --role-arn <AmazonBraketJobsExecutionRole arn> --device-config '{"device":"<device>"}' --instance-config '{"instanceType":"<instance-type>","volumeSizeInGb":30}' --output-data-config '{"s3Path":"s3://<bucket>/<prefix>"}' --algorithm-specification '{"scriptModeConfig":{"entryPoint":"<module>:<function>","s3Uri":"s3://<bucket>/source.tar.gz","compressionType":"GZIP"}}'` — all six flags are required, and you must package and upload `source.tar.gz` yourself | [`create_job`](https://docs.aws.amazon.com/boto3/latest/reference/services/braket/client/create_job.html) |
+| Status & metadata | `AwsQuantumJob.state()`, `.metadata()` | `aws braket get-job --job-arn <arn> --region <region> --query '{status:status,failureReason:failureReason,spec:algorithmSpecification}'` | [`get_job`](https://docs.aws.amazon.com/boto3/latest/reference/services/braket/client/get_job.html) |
+| Cancel | `AwsQuantumJob.cancel()` | `aws braket cancel-job --job-arn <arn> --region <region>` | [`cancel_job`](https://docs.aws.amazon.com/boto3/latest/reference/services/braket/client/cancel_job.html) |
+| Search / list | — no SDK method | `aws braket search-jobs --filters '[]' --region <region> --query 'jobs[].{name:jobName,status:status,device:device}'` | [`search_jobs`](https://docs.aws.amazon.com/boto3/latest/reference/services/braket/client/search_jobs.html) |
+| Results / metrics / logs | `AwsQuantumJob.result()`, `.metrics()`, `.logs()` | — | — (results in S3, metrics in CloudWatch) |
+
+Learn more about hybrid jobs at https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs.html.
+Choose a current `instanceType` from https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-configure-job-instance-for-script.html.
+
+## Submitting a job
+
+Learn more about creating a hybrid job at https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-first.html.
+
+### `entry_point` MUST be derived from `source_module`
+
+`entry_point` is `<module path inside the archive>:<function>` — a **colon** between module and function, never a dot.
+The SDK archives `source_module` under its **basename only**, stripping every leading path component, so the module path is relative to that basename.
+
+| `source_module` | archive contains | `entry_point` |
+|---|---|---|
+| `a/b/algorithm.py` (a file) | `algorithm.py` at root | `algorithm:main` |
+| `a/b/hj_source` (a directory) | `hj_source/algorithm_script.py` | `hj_source.algorithm_script:main` |
+
+Two failure modes, both `ModuleNotFoundError` at container boot — do NOT do either:
+- ❌ bare module for a directory `source_module`: `entry_point="algorithm_script:main"` (missing the required `hj_source.` prefix)
+- ❌ full path in the module: `entry_point="a.b.hj_source.algorithm_script:main"` (leading `a/b/` is stripped by the SDK)
+
+## Choosing a container
+
+### Embedded simulators
+
+Embedded simulators run inside the job container instead of dispatching to a managed simulator or a QPU.
+Pass `device="local:<provider>/<simulator>"` and a matching `image_uri=retrieve_image(Framework.<VARIANT>, region)`; the provider and simulator names come from the framework variant you select, not from a plugin's device name.
+
+Learn more about embedded simulators at https://docs.aws.amazon.com/braket/latest/developerguide/pennylane-embedded-simulators.html.
+
+### Multi-GPU simulation with CUDA-Q
+
+Whenever a simulation is GPU- or memory-bound — even if the user doesn't say "CUDA-Q" — for example a 30+ qubit state-vector simulation that runs out of memory on one GPU, consider using CUDA-Q with Hybrid Jobs.
+CUDA-Q's `mgpu` target pools the memory of several GPUs to hold one state vector.
+Refer to the notebook [6_Distributed_state_vector_simulations.ipynb](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/nvidia_cuda_q/6_Distributed_state_vector_simulations.ipynb) for examples on how to use CUDA-Q with Hybrid Jobs for large simulations.
+
+Learn more about using CUDA-Q on Amazon Braket at https://docs.aws.amazon.com/braket/latest/developerguide/braket-using-cuda-q.html.
+
+### Bring your own container (BYOC)
+
+**Bring your own container (BYOC)** is the fully-custom path when the base images and framework variants don't fit your dependency stack.
+
+Learn more about bringing your own container at https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-byoc.html and https://docs.aws.amazon.com/braket/latest/developerguide/running-hybrid-jobs-in-own-container.html.
+
+## Writing the algorithm script
+
+Algorithm code MUST NOT hardcode device ARNs, buckets, or credentials — read them from the job environment (`get_job_device_arn()`, `get_hyperparameters()`, `get_results_dir()` from `braket.jobs.environment_variables`) so the same script runs unchanged across devices and regions.
+
+To persist any data from the algorithm script, call `save_job_result` — never write result files by hand:
+
+```python
+from braket.jobs import save_job_result
+save_job_result({"counts": counts})
+```
+
+It writes `results.json` to the managed output directory and uploads it to the job's S3 output; read it back with `load_job_result()`.
+Do NOT `open(...)` a results path yourself or treat a bucket name as a local directory — the container has no such path and it raises `FileNotFoundError`.
+
+Learn more about the algorithm script environment at https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-script-environment.html.
+
+## Debugging a failed job
+
+`@hybrid_job(local=True)` or `LocalQuantumJob.create(...)` runs the container on your machine — use it to reproduce a failure before resubmitting.
+
+Learn more about debugging a hybrid job with local mode at https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-local-mode.html.
+
+### Common mistakes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ModuleNotFoundError` at container boot | `entry_point` uses a dot, or its module path doesn't match the archive layout | Derive it from `source_module` per the procedure above |
+| `ModuleNotFoundError: __path__ attribute not found` | Algorithm script sits flat at the archive root (raw-API path only) | Put it inside a named subdirectory; the SDK packages correctly |
+| Missing dependency, e.g. scipy | Base image lacks the package | Add `requirements.txt` to the source module, or pick an image that includes it |
+| Job fails before your code runs | Source or results bucket is in a different region than the job | Keep both in the job's region |
+| `create` rejects `instance_count`/`instance_type` | Not top-level kwargs | Use `InstanceConfig(instanceType=..., instanceCount=N)`; with `instanceCount > 1` the algorithm must handle multiple hosts |
+| Invented per-hyperparameter env vars | All hyperparameters are one JSON blob at `AMZN_BRAKET_HP_FILE` | Read them with `get_hyperparameters()` |
+| `create_job` denied at `PassRole` | Execution role name doesn't match the required prefix | Name it `AmazonBraketJobsExecutionRole[-suffix]` under `/service-role/` |
+| Tasks lose priority queueing | `create_quantum_task` called through boto3 inside the algorithm script | Pass `AMZN_BRAKET_JOB_TOKEN` as `jobToken` (the SDK does this automatically) |
+
+## References
+- API: [CreateJob](https://docs.aws.amazon.com/braket/latest/APIReference/API_CreateJob.html) · [InstanceConfig](https://docs.aws.amazon.com/braket/latest/APIReference/API_InstanceConfig.html)
+- SDK API:
+  - [`braket.aws.aws_quantum_job`](https://amazon-braket-sdk-python.readthedocs.io/en/stable/_apidoc/braket.aws.aws_quantum_job.html)
+  - [`braket.jobs`](https://amazon-braket-sdk-python.readthedocs.io/en/stable/_apidoc/braket.jobs.html) · [`braket.jobs.hybrid_job`](https://amazon-braket-sdk-python.readthedocs.io/en/stable/_apidoc/braket.jobs.hybrid_job.html)
+  - [`braket.jobs.environment_variables`](https://amazon-braket-sdk-python.readthedocs.io/en/stable/_apidoc/braket.jobs.environment_variables.html) · [`braket.jobs.data_persistence`](https://amazon-braket-sdk-python.readthedocs.io/en/stable/_apidoc/braket.jobs.data_persistence.html)
+  - [`braket.jobs.metrics`](https://amazon-braket-sdk-python.readthedocs.io/en/stable/_apidoc/braket.jobs.metrics.html) · [`braket.jobs.image_uris`](https://amazon-braket-sdk-python.readthedocs.io/en/stable/_apidoc/braket.jobs.image_uris.html)
+- Developer guide:
+  - [Working with hybrid jobs](https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs.html) · [Create a hybrid job](https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-first.html)
+  - [Define the algorithm environment](https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-script-environment.html) · [PennyLane embedded simulators](https://docs.aws.amazon.com/braket/latest/developerguide/pennylane-embedded-simulators.html)
+  - [BYOC](https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-byoc.html) · [Running hybrid jobs in your own container](https://docs.aws.amazon.com/braket/latest/developerguide/running-hybrid-jobs-in-own-container.html) · [Using CUDA-Q](https://docs.aws.amazon.com/braket/latest/developerguide/braket-using-cuda-q.html)
+- Notebooks:
+  - [hybrid_jobs](https://github.com/amazon-braket/amazon-braket-examples/tree/main/examples/hybrid_jobs) — start with [0 — Creating your first hybrid job](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/hybrid_jobs/0_Creating_your_first_Hybrid_Job/0_Creating_your_first_Hybrid_Job.ipynb); [4 — Embedded simulators](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/hybrid_jobs/4_Embedded_simulators_in_Braket_Hybrid_Jobs/Embedded_simulators_in_Braket_Hybrid_Jobs.ipynb); [3 — Bring your own container](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/hybrid_jobs/3_Bring_your_own_container/bring_your_own_container.ipynb)
+  - [nvidia_cuda_q](https://github.com/amazon-braket/amazon-braket-examples/tree/main/examples/nvidia_cuda_q) — [3 — Hybrid jobs with CUDA-Q](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/nvidia_cuda_q/3_Hybrid_jobs_with_CUDA-Q.ipynb) · [5 — Multiple GPU simulations](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/nvidia_cuda_q/5_Multiple_GPU_simulations.ipynb) · [6 — Distributed state vector simulations](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/nvidia_cuda_q/6_Distributed_state_vector_simulations.ipynb)
+- Container source: [`amazon-braket-containers`](https://github.com/amazon-braket/amazon-braket-containers)

--- a/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/pricing.md
+++ b/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/pricing.md
@@ -1,0 +1,87 @@
+# Pricing
+
+## Where rates come from
+
+The [Braket pricing page](https://aws.amazon.com/braket/pricing/), [AWS Pricing API](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/price-changes.html), and the [bulk price list](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBraket/current/index.csv) are the authoritative sources for current rates — either is acceptable.
+See the [AWS Pricing API](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/price-changes.html) for more details about how pricing information is organized with AWS.
+Note that the regions supported by the Pricing API are unrelated to the regions Braket supports.
+
+Quote a specific number only if you have read it this session from one of those sources.
+If you cannot reach any of them, give the link and the pricing model only — never a number, and never a placeholder such as `$0.00` standing in for a rate you did not look up.
+
+## Pricing model by resource
+
+### QPUs - Per task + per shot
+
+QPU used under the per-task and per-shot model charge using two distinct pricing products for every task, and each pricing product has its own `productFamily` value.
+Both must be included when reasoning about task pricing.
+
+- Quantum tasks created outside of a hybrid job use the `"Quantum Task"` (per-task fee) and `"Quantum Task-Shot"` (per-shot fee) `productFamily` values.
+- Quantum tasks created associated with a hybrid job use the `"Braket Managed Jobs QPU Task"` (per-task fee) and `"Braket Managed Jobs QPU Task Shot"` (per-shot fee) `productFamily` values.
+
+CLI examples:
+```bash
+# Fetch names of QPUs
+# QPU names may differ between `SearchDevices` and the Pricing API, so look them up here before getting the corresponding pricing products
+aws pricing get-attribute-values --service-code AmazonBraket \
+    --attribute-name devicename --region us-east-1
+
+# Prices nest under `terms.OnDemand.*.priceDimensions.*.pricePerUnit.USD`
+# Fetch details about pricing products
+aws pricing get-products --service-code AmazonBraket --region us-east-1 \
+    --filters 'Type=TERM_MATCH,Field=devicename,Value=<devicename-from-previous-command>' \
+              'Type=TERM_MATCH,Field=productFamily,Value=Quantum Task-Shot'
+```
+
+The price list contains retired devices, so you should check a device's status before attempting to use it.
+
+### On-demand simulators — by duration
+On-demand simulators bill by **simulation duration** only with a **minimum charge per task**, under a single `productFamily = "Simulator Task"` (per minute).
+Simulators are absent from `devicename` and share that one family, so they are identified by the `usagetype` suffix instead.
+
+CLI examples:
+```bash
+# Fetch simulator usage types
+aws pricing get-attribute-values --service-code AmazonBraket \
+    --attribute-name usagetype --region us-east-1 \
+    --query "AttributeValues[?contains(Value, 'Completed-Task-ExecutionDuration')].Value"
+
+# Fetch details about one simulator's pricing product
+aws pricing get-products --service-code AmazonBraket --region us-east-1 \
+    --filters 'Type=TERM_MATCH,Field=usagetype,Value=<usagetype-from-previous-command>'
+```
+
+### Local simulators — free
+`LocalSimulator` backends in the Braket SDK run on your own machine/instance at no additional charge.
+
+### Hybrid jobs — instance + tasks
+A hybrid job bills **classical instance time** (`productFamily = "Braket Managed Jobs Instance"`, per minute) and job storage (`productFamily = "Braket Managed Jobs Volume"`, GB-month) **plus** any quantum task charges. A task on an on-demand simulator inside a job bills under `productFamily = "Braket Managed Jobs Simulator Task"` (per minute).
+Classical instance rates can be found in the Hybrid Jobs tab of the Braket pricing page.
+An **embedded** simulator inside the job incurs no separate task charge — only the instance time.
+
+### Reservations (Braket Direct) — hourly
+Reserved device access is billed **hourly** (1-hour increments) instead of per-task/per-shot, under `productFamily = "Quantum Reservation"` (per hour).
+During a reservation, tasks and jobs submitted WITH the reservation ARN incur no additional charge.
+Other resources, like S3 buckets, managed notebook compute, or tasks submitted WITHOUT the reservation ARN are billed at on-demand rates.
+Learn more about reservations [here](https://docs.aws.amazon.com/braket/latest/developerguide/braket-reservations.html).
+
+### Managed notebooks — SageMaker-billed
+A Braket managed notebook is a SageMaker notebook instance, so compute and storage are billed by SageMaker.
+Refer to SageMaker documentation for further details.
+
+## Common mistakes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Says simulators bill per task/circuit | Wrong model | On-demand simulators bill by **duration** (per minute, min per task) |
+| Writes a rate of `$0.00`, or reports only one of a QPU's two rates | A QPU has **both** a per-task and a per-shot rate, in separate Pricing API product families | If you found one rate you have not finished looking. Never write a placeholder for a rate you did not read, and heed a pagination warning instead of reporting a truncated result |
+| Uses `deviceCost` from GetDevice as the bill | Not authoritative for billing | Use the pricing page or the AWS Pricing API |
+
+## References
+- Amazon Braket pricing https://aws.amazon.com/braket/pricing/
+- Amazon SageMaker pricing https://aws.amazon.com/sagemaker/pricing/
+- Amazon Braket reservations https://docs.aws.amazon.com/braket/latest/developerguide/braket-reservations.html
+- Amazon Braket developer guide https://docs.aws.amazon.com/braket/latest/developerguide/what-is-braket.html
+- AWS Billing user guide for pricing-related APIs (including regions supported) https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/price-changes.html
+- AWS CLI https://docs.aws.amazon.com/cli/latest/reference/pricing/
+- Boto3 https://docs.aws.amazon.com/boto3/latest/reference/services/pricing.html

--- a/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/program-sets.md
+++ b/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/program-sets.md
@@ -1,0 +1,66 @@
+# Program sets
+
+## Device support
+
+Program sets run on the local simulator and on all gate-based QPUs. Support is one entry in the device's action map — read it, never guess:
+
+```python
+from braket.aws import AwsDevice
+from braket.device_schema import DeviceActionType
+
+device = AwsDevice("<device-arn>")
+supported = DeviceActionType.OPENQASM_PROGRAM_SET in device.properties.action
+```
+
+## Construction
+
+```python
+from braket.circuits import Circuit, FreeParameter, Observable
+from braket.devices import LocalSimulator
+from braket.program_sets import CircuitBinding, ProgramSet
+
+bell = Circuit().h(0).cnot(0, 1)
+rotation = Circuit().rx(0, FreeParameter("a")).cnot(0, 1)
+entangler = Circuit().h(0).cz(0, 1).ry(1, FreeParameter("phi"))
+
+sweep = CircuitBinding(
+    circuit=rotation,
+    input_sets={"a": (0.1, 0.2, 0.3)},
+)
+program_set = ProgramSet([bell, sweep])
+
+# Cartesian product of every circuit under every observable (3 circuits x 2 observables = 6 executables)
+# https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.program_sets.program_set.html#braket.program_sets.program_set.ProgramSet.product
+ProgramSet.product([bell, bell, bell], [Observable.Z() @ Observable.I(), Observable.I() @ Observable.X()])
+
+# zip — the nth circuit in circuits list is bound by the nth input_set and the nth observable
+# https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.program_sets.program_set.html#braket.program_sets.program_set.ProgramSet.zip
+ProgramSet.zip([rotation, entangler], input_sets=[{"a": 0.1}, {"phi": 0.5}],
+               observables=[Observable.Z() @ Observable.I(), Observable.I() @ Observable.X()])
+
+# shots is the TOTAL and must be divisible by program_set.total_executables
+task = LocalSimulator().run(program_set, shots=300)
+counts = [[r.counts for r in entry] for entry in task.result()]  # indexed result[program][executable]
+```
+
+## Contrast with `AwsQuantumTaskBatch`
+- Program sets bundle many programs in **one service-side task**, so the per-task fee is only billed once. Supported on all gate-based QPUs.
+- [`AwsQuantumTaskBatch`](https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.aws.aws_quantum_task_batch.html) (`device.run_batch([...], shots=...)`) — many **independent** tasks dispatched in parallel by the SDK, each billed its own per-task fee. Does not require device support.
+
+Always prefer a program set when the device supports it; fall back to `run_batch` if and only if the device doesn't support program sets, as program sets supersede batches in most cases.
+
+## Related references
+- [devices.md](devices.md) — device discovery and capabilities
+- [pricing.md](pricing.md) — billing models for quantum tasks
+
+## References
+- SDK API: 
+  - [ProgramSet](https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.program_sets.program_set.html)
+  - [CircuitBinding](https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.program_sets.circuit_binding.html)
+  - [ProgramSetQuantumTaskResult](https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.tasks.program_set_quantum_task_result.html)
+  - [Observables](https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.circuits.observables.html)
+- Notebooks: 
+  - [Getting started with program sets](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/braket_features/program_sets/01_Getting_started_with_program_sets.ipynb) · 
+  - [Expectation value calculations with program sets](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/braket_features/program_sets/02_Expectation_value_calculations_with_program_sets.ipynb)
+- [Running multiple programs](https://docs.aws.amazon.com/braket/latest/developerguide/braket-batching-tasks.html)
+- [GetQuantumTask API](https://docs.aws.amazon.com/braket/latest/APIReference/API_GetQuantumTask.html)

--- a/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/spending-limit.md
+++ b/skills/specialized-skills/quantum-computing-skills/amazon-braket/references/spending-limit.md
@@ -1,0 +1,43 @@
+# Spending limits & Cost tracking
+
+## Spending limits
+
+Amazon Braket spending limits provide optional per-device cost controls for quantum processing units (QPUs).
+
+```bash
+# Replace every <placeholder> with a value you looked up or the user supplied.
+aws braket create-spending-limit \
+    --device-arn "arn:aws:braket:<region>::device/qpu/<provider>/<device-name>" \
+    --spending-limit "<amount-usd>" \
+    --time-period startAt=<epoch-seconds-start>,endAt=<epoch-seconds-end>
+
+aws braket search-spending-limits
+aws braket update-spending-limit --spending-limit-arn <arn> --spending-limit "<amount-usd>"
+aws braket delete-spending-limit --spending-limit-arn <arn>
+```
+
+Note that spending limits apply only to quantum tasks that were created during the spending limit's time period and when the spending limit already exists.
+
+## Cost tracking (Tracker)
+
+The Braket SDK also provides near real-time cost tracking with the [`Tracker`](https://amazon-braket-sdk-python.readthedocs.io/en/stable/_apidoc/braket.tracking.tracker.html) class.
+See the [Getting Started notebook](https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/qiskit/0_Getting_Started.ipynb) for an example of how to use the cost tracker.
+
+## Common mistakes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Looks for a spending limit in `amazon-braket-sdk` | Wrong layer | Control-plane only — boto3 `braket` client, CLI, or CloudFormation |
+| Creates one limit and expects it to cap the account | A limit is scoped to one `deviceArn`, and so to that ARN's region | Create one limit per device you want to cap |
+| Targets a simulator | Limits apply to QPU ARNs | Confirm supported device types in the [CreateSpendingLimit reference](https://docs.aws.amazon.com/braket/latest/APIReference/API_CreateSpendingLimit.html) |
+| Raises or deletes a limit to unblock its own task | Treating the guardrail as an obstacle | Report the rejection and stop; a change needs an explicit instruction — see above |
+| Expects `Tracker` to stop a run at a threshold | Estimate ≠ enforcement | Only a spending limit rejects tasks |
+| Reaches for `qml.Tracker` to count Braket shots | Assuming the Braket tracker is cost-only | `quantum_tasks_statistics()` reports per-device shots and task counts |
+| Assumes modifying a spending limit leaves no trace | Limit changes are management events | CloudTrail records `CreateSpendingLimit`, `UpdateSpendingLimit` and `DeleteSpendingLimit` under `braket.amazonaws.com` — read the trail to see who changed a limit |
+
+## References
+- [CreateSpendingLimit](https://docs.aws.amazon.com/braket/latest/APIReference/API_CreateSpendingLimit.html)
+- [UpdateSpendingLimit](https://docs.aws.amazon.com/braket/latest/APIReference/API_UpdateSpendingLimit.html)
+- [SearchSpendingLimits](https://docs.aws.amazon.com/braket/latest/APIReference/API_SearchSpendingLimits.html)
+- [DeleteSpendingLimit](https://docs.aws.amazon.com/braket/latest/APIReference/API_DeleteSpendingLimit.html)
+- Developer Guide: [Cost tracking and spending limits](https://docs.aws.amazon.com/braket/latest/developerguide/braket-pricing.html)


### PR DESCRIPTION
Adds a skill for running quantum computing workflows on Amazon Braket: device discovery, gate-model circuits, analog Hamiltonian programs, quantum tasks, program sets, hybrid jobs, pricing lookups, and spending limits.

## Description

Adding new skill for Amazon Braket 

## Type of Change

- [ ] New plugin
- [x] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
