### PR TITLE
feat(storage): add aws-storage skill

### DIFF
--- a/skills/core-skills/aws-storage/SKILL.md
+++ b/skills/core-skills/aws-storage/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: aws-storage
+description: "Selects, investigates, and compares AWS object, file, and block storage services, and answers cost, performance, configuration, security, and troubleshooting questions about storage services. Applies when a user asks where to store or archive data based on their usage patterns; which storage service to choose or how two compare; how to migrate data from on-premises or between AWS services; how to protect, replicate, or recover data; how to optimize storage costs; where to deploy shared NFS, SMB, or POSIX file systems; where to store vector embeddings or tabular data; what storage backs enterprise file shares, self-managed databases on EC2, VMware, or stateful containers; or asks what an AWS storage service can do or how it works. Relevant for storage needs for workloads such as AI/ML, analytics, EDA, HPC, media, genomics, or financial trading. Not applicable for SQL query engines (Athena, Spark, Redshift, EMR), ETL (Glue), streaming (Kafka, MSK, Kinesis), or managed database services (RDS, Aurora, DynamoDB)."
+metadata:
+  version: "1"
+---
+## Overview
+
+This skill provides domain expertise for choosing among AWS storage services, selecting storage classes, optimizing cost, and routing to resources for operating storage services. It covers object storage (S3 General Purpose buckets and their storage classes, S3 Express One Zone on directory buckets, S3 Tables, S3 Vectors), file storage (Amazon EFS, S3 Files, FSx for Lustre, FSx for NetApp ONTAP, FSx for OpenZFS, and FSx for Windows File Server), block storage (EBS volume types and EC2 instance store), and the data-movement and protection services that connect them (DataSync, Storage Gateway, Transfer Family, and AWS Backup). It does not advise on databases or analytics query engines. It works with or without the AWS MCP server; when available, the [AWS MCP server](https://docs.aws.amazon.com/agent-toolkit/) is recommended for verifying current specifications and pricing, and all guidance also works with the standard AWS CLI. For deep single-service tasks, route to the specialized skills listed in the Routing section below.
+
+## How to Handle User Queries
+
+When this skill is triggered, classify the user's request and follow the appropriate path.
+
+### Rules
+
+These apply to all responses regardless of path:
+
+1. You MUST verify current numbers. When the AWS MCP server is available, use search_documentation and read_documentation to cross-check before citing specifics. When quoting costs, you MUST include a link to the relevant pricing page. When quoting performance metrics, you MUST include a link to the relevant product page. Otherwise, verify against linked AWS documentation pages or use the AWS CLI to confirm current values. Where a reference file directs you to documentation for a current value, you MUST retrieve that value from the linked page before answering. Do not substitute a remembered figure, and do not offer an approximation or a range in place of a retrieved value. If retrieval is not possible in the current environment, name the value you could not verify rather than citing one from memory.
+2. You MUST retrieve the relevant service reference file from the Routing section below before answering questions about that service. AWS storage specifications, limits, and service capabilities change frequently. You MUST NOT answer from memory alone. You MUST surface relevant troubleshooting guidance and 'gotchas' from reference files in your response. Justify recommendations by workload fit, not by mentioning that a reference file 'explicitly' mentions a workload for a given service.
+3. You MUST include cost implications when recommending services or approaches. Do not wait for the user to ask. Do not compare services on storage charges alone; per-object fees such as metadata charges can materially change TCO. For deep cost analysis, monitoring, or optimization beyond storage selection, route to the [`billing-and-cost-management`](https://github.com/aws/agent-toolkit-for-aws/tree/e2588f4b494416e68c5a991e51b21c2d99038de3/skills/core-skills/aws-billing-and-cost-management) skill.
+4. You MUST have clarity on the user's need when making a recommendation. Match the specificity of your response to the specificity of the request. When the query determines the storage category and the relevant services, retrieve information and recommend directly. When the query is not fully specified, YOU MUST mention the assumptions and limitations of your recommendation and include the additional questions that would confirm or change it. Ask follow up questions in place of a recommendation only when the query does not let you determine the storage category at all. Recommend the best-fit service for the workload even when it falls outside this skill's scope; add relevant in-scope options as alternatives.
+
+---
+
+### Step 1: Classify Intent
+
+Determine what the user needs:
+
+| Intent | Example Triggers | What this means |
+| --- | --- | --- |
+| SELECT | "What should I use?", "Which service?", "Compare Service A vs Service B", "Help me choose", "I want to migrate X to AWS" (workload description without a named service) | User needs help choosing a storage service or approach |
+| INVESTIGATE | "How do I configure Service X?", "Why is Service Y failing?", "What are the limits of Service Z?", "How do I get started with Service X?" (names a specific service and asks an operational question) | User knows what they are using and needs getting started, troubleshooting, or operational help |
+
+You MUST follow the interaction logic in the corresponding path instructions below.
+
+Ambiguous cases: If the user's primary ask is a recommendation, it is SELECT regardless of context. If they need help executing a known plan, it is INVESTIGATE.
+
+---
+
+### Step 2a: SELECT Path
+
+The user needs help choosing. You MUST use the following decision factors to inform your recommendation, asking questions to fill gaps that would change the choice.
+
+Decision Factors:
+
+| # | Decision Factor | What to understand |
+| --- | --- | --- |
+| 1 | Workload Context | Is this a new workload or a migration of an existing workload? If migrating, what is the source system (e.g., NetApp, ZFS, Windows File Server, Lustre, GPFS, etc.)? What application or workload will access this storage? How does it access data (API, file protocol, block device)? What OS or platform are clients running? What is the data model (structured/tabular, vector embeddings, unstructured objects, file system)? |
+| 2 | Capacity and Access Patterns | How much data, how many files or objects, what are the typical sizes? Sequential or random access pattern? Read-heavy, write-heavy, or mixed? |
+| 3 | Performance Requirements | Are there specific latency, throughput, or IOPS requirements? What is the expected concurrency (number of clients or compute nodes accessing simultaneously)? |
+| 4 | Durability and Data Protection | What is the recovery time objective (RTO)? Recovery point objective (RPO)? Compliance retention mandates? Cross-region resilience? Immutability needs? |
+| 5 | Availability | Multi-AZ or Single-AZ acceptable? Co-located with specific compute? |
+
+Use the Storage Options table to identify candidate services, not to cut services; keyword matches against the Common Workloads column are not the only answers. You MUST retrieve the reference files for each of the candidate services using the Routing section below.
+
+Considering these factors, recommend specific AWS storage service(s) and:
+1. You MUST include clear rationale tied to the user's stated requirements.
+2. You MUST present alternatives where the choice is close or dependent on unspecified information, explaining the tradeoff.
+
+---
+
+### Step 2b: INVESTIGATE Path
+
+The user knows their service or approach and needs operational help.
+
+1. Classify the Question Domain based on the table below to identify which context matters.
+
+| Question Domain | Example Triggers | What to clarify |
+| --- | --- | --- |
+| Migration and Data Transfer | "How do I move my data to AWS?", "Set up DataSync", "Sync from on-premises NFS to EFS", source-to-destination questions | Source system and protocol, destination service, data volume, network path to AWS (Direct Connect, VPN, internet) |
+| Data Protection and Resiliency | "Set up backup", "Cross-region replication", "What's my DR strategy?", "RTO under 1 hour", failover, immutability | Failure scenario (deletion, corruption, AZ/region loss, compliance hold), RTO and RPO targets, replication scope (same-region, cross-region, cross-account) |
+| Cost and Lifecycle | "Reduce my storage bill", "Right-size my volumes", "Cost optimize", lifecycle rules, tiering decisions, storage class selection | Current service and configuration, access frequency (daily, weekly, rarely), data volume and growth trajectory |
+| Performance | "My reads are slow", "Throughput bottleneck", "Need more IOPS", sizing | Observed vs. required (latency, IOPS, or throughput), access pattern (random/sequential, read/write mix), whether storage or compute/network is the suspected bottleneck |
+| Security and Compliance | "Encrypt at rest", "Restrict bucket access", "Meet HIPAA", access control, compliance frameworks | Security objective (restrict access, audit access, encrypt, isolate network, meet compliance mandate), compliance framework if any |
+| Configuration and Guidance | "Mount EFS on EKS", "Set up replication", "Does Service X support Y?", deployment steps, best practices | Client environment (OS, compute type, VPC/on-premises), target operation or feature |
+| Troubleshooting | "Getting AccessDenied errors", "Mount is hanging", "Unexpected latency spike", "Why is my lifecycle rule not transitioning?" | Error message or symptom, what changed recently, what they have attempted |
+
+2. Ask scoping questions per the "What to clarify" column for information not already in the query. Where the missing detail would not change the guidance, answer under a stated assumption instead of waiting to ask more questions.
+3. You MUST retrieve the reference files from the Routing section below for all candidate services.
+4. Provide the answer with specific, actionable guidance, gotchas, and documentation links.
+5. When answering Configuration or Security questions, you MUST recommend enabling access logging, CloudTrail data events, and CloudWatch metrics for observability.
+
+## Storage Options
+
+AWS storage services covered by this skill, grouped by storage category. For more information on storage categories, see [Block, file, and object storage compared](https://aws.amazon.com/compare/the-difference-between-block-file-object-storage/).
+
+### Object Storage
+
+| Service | Key Characteristics | Common Workloads |
+| --- | --- | --- |
+| S3 General Purpose | Virtually unlimited-scale object storage with multiple storage classes spanning frequent-access to low-cost archive; lifecycle rules move data to lower-cost storage classes optimized for less-frequently accessed data. Regional availability. Accessed over a REST/HTTP API from anywhere. | Data lakes and analytics, backup and archive targets, ML training data, media storage and content distribution, log and event data, static website and application assets, regulatory and compliance archives |
+| S3 Express One Zone | Single-AZ directory buckets optimized for single-digit millisecond latency on frequently accessed, latency-sensitive data. | large-scale ML training and inference, Spark and EMR shuffle, ML checkpoints, scratch, and model loading, ETL intermediate data, interactive analytics on hot partitions, observability and log analytics (hot tier), Kafka tiered storage, media and video editing, high-frequency transactional access, caching for machine learning inference |
+| S3 Tables | Managed Apache Iceberg tables on S3 with automatic compaction and query optimization. Regional availability. Built for structured, tabular data queried with SQL engines. | Data lake tables, structured analytics data, ETL pipeline outputs, streaming into tables for SQL analysis, migration of open table format data outside of S3 or self-managed Iceberg on S3 |
+| S3 Vectors | Vector storage and similarity search on S3 with native support to cost-effectively store and query vector embeddings. Provides the same elasticity, durability and availability as S3 General Purpose buckets. Regional availability. | RAG pipelines, semantic search, recommendation systems, vector deduplication and matching, anomaly and fraud detection, AI agent memory, cost-effective storage of large vector datasets |
+| S3 Metadata | Queryable object metadata in fully managed, read-only Apache Iceberg tables including system-defined details, user-defined metadata, object tags, and annotations | Business analytics, content cataloging, data governance and compliance, storage optimization, real-time inference applications, AI agents |
+
+### File Storage
+
+When naming a service, you MUST always specify the full name (FSx for Lustre, FSx for Windows File Server, FSx for NetApp ONTAP, or FSx for OpenZFS). EFS and S3 Files can be mounted by Lambda and Fargate. Verify additional services mountable from serverless compute with the latest AWS documentation. FSx for NetApp ONTAP and FSx for OpenZFS data is accessible from serverless compute and S3-based pipelines via S3 Access Points for FSx (exposes file data through the S3 API without copying; surface this when a user needs to read FSx-resident data from S3-native consumers or analytics services).
+
+| Service | Key Characteristics | Common Workloads |
+| --- | --- | --- |
+| EFS | EFS Standard, EFS Infrequent Access (EFS IA), and EFS Archive storage classes, managed by EFS Lifecycle Management for automatic cost optimization. Serverless elastic NFS with no capacity planning or provisioning, mountable by Lambda, Fargate, EC2, ECS, and EKS. Multi-AZ by default (Regional) or One Zone. Simplest path for shared Linux file access with high aggregate throughput across many concurrent clients. | Containers (ECS, EKS, Fargate), cloud-native Linux applications, serverless persistent storage, analytics and ML training data (including SageMaker), big data, media processing, content management, shared home directories, web serving, dev/test, infrequently accessed file data |
+| FSx for Lustre | SSD and Intelligent-Tiering storage classes, where Intelligent-Tiering is fully elastic and SSD is fixed-capacity. Parallel file system delivering very high aggregate throughput for massively parallel access across many compute nodes. | ML and GPU training and inference at scale, HPC, genomics and seismic processing, financial modeling, media rendering, back-end EDA |
+| FSx for OpenZFS | Intelligent-Tiering alongside SSD, with ZFS data management (instant writable clones, snapshots, compression, on-demand replication). Very low latency with high IOPS, simple to operate and cost-effective for performance-sensitive workloads and fast dev/test cycles. Single-AZ and Multi-AZ deployment model. S3-API access via S3 Access Points for FSx. | Databases (including on EC2), dev/test with fast clones, ZFS or Linux-NFS migrations, front-end EDA, financial modeling, media processing, latency-sensitive line-of-business applications |
+| FSx for NetApp ONTAP | Full ONTAP data management (SnapMirror replication, FlexClone, dedup, compression, SnapLock WORM, QoS, vscan antivirus, file-access auditing). Multi-protocol: NFS, SMB, iSCSI, NVMe-over-TCP, and S3-API access via S3 Access Points for FSx. Scales to high aggregate throughput and IOPS. Single-AZ and Multi-AZ deployment model. | Enterprise network-attached storage (NAS) migrations, multi-protocol environments, general-purpose file shares and home directories, business-critical databases including on EC2 (SAP HANA, Oracle, SQL Server), VMware datastores, line-of-business applications (medical imaging, product lifecycle management), front-end EDA (chip design and verification), hybrid and DR |
+| FSx for Windows File Server | Fully managed SMB file storage built on Windows Server with Active Directory identity (Kerberos, NTFS ACLs), DFS namespaces, shadow copies, and FSRM quotas; shares are also accessible from Linux and macOS clients. Single-AZ and Multi-AZ deployment model. | Windows file, home, and department shares, .NET applications, Microsoft SQL Server, Windows Server migrations |
+
+### Block Storage
+
+| Service | Key Characteristics | Common Workloads |
+| --- | --- | --- |
+| EBS | High-performance virtual disk that attaches to an EC2 instance over the network. Durable, resizable SSD or HDD that persists independently of the instance, supports snapshots for backup, time-based snapshot copy, and provisions performance independently of capacity on gp3 (confirm latest volume limits). Supports instant volume clones. AZ-scoped. | Databases, transactional applications and file systems, boot volumes, dev/test environments, sequential batch processing, log and data warehouse scans |
+| EC2 Instance Store | Physically local SSD storage built into the host server, delivering the lowest latency and highest throughput. Ephemeral: data is lost if the instance stops or the hardware fails. | Temporary scratch data, caches, and buffers you can afford to lose |
+
+---
+
+## Cross-Service Overlap
+
+Some storage features cross category boundaries, giving a service from one storage category an interface normally associated with another. Surface these when a workload needs access to shared data from multiple protocols or interfaces.
+
+| Feature | What it enables | What it is | Additional sources |
+| --- | --- | --- | --- |
+| S3 Files | Makes S3 data accessible to file-based applications | Fully managed NFS file access over an S3 bucket, built on EFS infrastructure. Data stays in S3 as the system of record. File locking, POSIX permissions, and full read-write. Choose over EFS when data already lives in S3 and needs file-path access alongside object access. | `references/s3-files-knowledge.md`, `references/efs-knowledge.md` |
+| S3 Access Points for FSx | Makes FSx-resident data accessible to S3-based applications and services | Exposes FSx for NetApp ONTAP or FSx for OpenZFS data through the S3 API without copying it to a bucket. Surface when file data must reach S3-native consumers, or when serverless or S3-based applications need to access data that lives on FSx for NetApp ONTAP or FSx for OpenZFS. | `references/fsx-ontap-knowledge.md`, `references/fsx-openzfs-knowledge.md` |
+
+---
+
+## Security
+
+Cloud security at AWS is the highest priority and is a shared responsibility between AWS and the customer. You MUST include security guidance when recommending or configuring storage resources. You MUST always recommend enabling encryption at rest and encryption in transit. Where encryption at rest is optional or not the default, explicitly advise enabling it at creation time, because it is often immutable after creation. You MUST recommend scoping IAM policies to the authorized principals with least-privileged permissions. You MUST recommend adding condition keys (e.g., aws:SourceArn, aws:SourceAccount, aws:SourceVpc) to resource policies to prevent cross-service confused deputy attacks. You MUST recommend encrypting log destinations: AWS KMS for CloudTrail trails and CloudWatch Logs groups, server-side encryption for server access log buckets, and AWS KMS for SNS topics. Prefer short-lived credentials or IAM-based authentication (e.g., via custom IdP with temporary tokens) over long-lived SSH keys. Where SSH keys are required, enforce rotation policies and store private keys in AWS Secrets Manager for supported services. You MUST recommend restricting security group inbound rules to the narrowest applicable source (specific client security group or minimal CIDR). Service-specific security controls, encryption models, and documentation links are in the Security row of each reference's Service Information table; you MUST read it before advising on that service.
+
+## Routing
+
+When loaded through the AWS MCP server's retrieve_skill tool: the skill is not installed on the local filesystem. You MUST retrieve each reference via retrieve_skill with the file parameter (e.g. file="references/s3-general-purpose-knowledge.md"). Do NOT file_read these paths locally. When loaded outside the AWS MCP server (for example from the local filesystem in the Agent Toolkit), read the reference files directly from their relative paths in the skill directory.
+
+### Reference files
+
+| Topic | Reference |
+| --- | --- |
+| S3 (General Purpose) | `references/s3-general-purpose-knowledge.md` |
+| S3 Metadata | `references/s3-general-purpose-knowledge.md` |
+| S3 Tables | `references/s3-tables-knowledge.md` |
+| S3 Vectors | `references/s3-vectors-knowledge.md` |
+| S3 Express One Zone | `references/s3-express-knowledge.md` |
+| S3 Files | `references/s3-files-knowledge.md` |
+| Amazon EFS | `references/efs-knowledge.md` |
+| FSx for Lustre | `references/fsx-lustre-knowledge.md` |
+| FSx for NetApp ONTAP | `references/fsx-ontap-knowledge.md` |
+| FSx for OpenZFS | `references/fsx-openzfs-knowledge.md` |
+| FSx for Windows File Server | `references/fsx-windows-knowledge.md` |
+| Amazon EBS | `references/ebs-knowledge.md` |
+| Data Movement and Protection (DataSync, Transfer Family, Storage Gateway, AWS Backup) | `references/data-movement-and-protection-knowledge.md` |
+
+### Specialized skills
+
+| Topic | Reference |
+| --- | --- |
+| Security on S3 | [`securing-s3-buckets`](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/storage-skills/securing-s3-buckets) |
+| Using S3 Tables | [`creating-data-lake-table`](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/storage-skills/creating-data-lake-table) |
+| Using S3 Vectors | [`storing-and-querying-vectors`](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/storage-skills/storing-and-querying-vectors) |
+| Troubleshooting S3 Files | [`troubleshooting-s3-files`](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/storage-skills/troubleshooting-s3-files) |
+| Troubleshooting EFS | [`troubleshooting-efs`](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/storage-skills/troubleshooting-efs) |
+| Querying S3 System Tables | [`querying-aws-s3`](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/system-table-skills/querying-aws-s3) |
+| Ingesting data into a data lake | [`ingesting-into-data-lake`](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/analytics-skills/ingesting-into-data-lake) |
+| Finding data lake assets | [`finding-data-lake-assets`](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/analytics-skills/finding-data-lake-assets) |
+| Querying data lakes | [`querying-data-lake`](https://github.com/aws/agent-toolkit-for-aws/tree/main/skills/specialized-skills/analytics-skills/querying-data-lake) |

--- a/skills/core-skills/aws-storage/references/data-movement-and-protection-knowledge.md
+++ b/skills/core-skills/aws-storage/references/data-movement-and-protection-knowledge.md
@@ -1,0 +1,56 @@
+# AWS Data Movement & Protection Services
+
+This reference captures information addressing common gotchas and frequently asked questions for the AWS data movement and protection services (AWS DataSync, AWS Storage Gateway, AWS Transfer Family, and AWS Backup) to support accurate model responses. It is not a complete specification. The authoritative source for latest specifications, limits, quotas, and API behavior is each service's User Guide and API Reference:
+
+| Service | User Guide | API Reference | Product page | FAQs |
+| --- | --- | --- | --- | --- |
+| AWS DataSync | [User Guide](https://docs.aws.amazon.com/datasync/latest/userguide/what-is-datasync.html) | [API Reference](https://docs.aws.amazon.com/datasync/latest/apireference/API_Operations.html) | [Product page](https://aws.amazon.com/datasync/) | [FAQs](https://aws.amazon.com/datasync/faqs/) |
+| AWS Storage Gateway | [User Guide](https://docs.aws.amazon.com/filegateway/latest/files3/what-is-file-s3.html) | [API Reference](https://docs.aws.amazon.com/storagegateway/latest/APIReference/API_Operations.html) | [Product page](https://aws.amazon.com/storagegateway/), [Features](https://aws.amazon.com/storagegateway/features/) | [FAQs](https://aws.amazon.com/storagegateway/faqs/) |
+| AWS Transfer Family | [User Guide](https://docs.aws.amazon.com/transfer/latest/userguide/what-is-aws-transfer-family.html) | [API Reference](https://docs.aws.amazon.com/transfer/latest/APIReference/Welcome.html) | [Product page](https://aws.amazon.com/aws-transfer-family/) | [FAQs](https://aws.amazon.com/aws-transfer-family/faqs/) |
+| AWS Backup | [User Guide](https://docs.aws.amazon.com/aws-backup/latest/devguide/whatisbackup.html) | [API Reference](https://docs.aws.amazon.com/aws-backup/latest/APIReference/Welcome.html) | [Product page](https://aws.amazon.com/backup/) | [FAQs](https://aws.amazon.com/backup/faqs/) |
+
+Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** AWS DataSync, AWS Storage Gateway, AWS Transfer Family, and AWS Backup are the cross-service storage operations layer: they move data between storage systems, bridge on-premises applications to cloud storage, exchange files with external partners over managed protocols, and centralize backup and retention across AWS services. All four support AWS CloudTrail logging and Amazon CloudWatch metrics and alarms to detect unauthorized transfers or anomalous activity.
+
+**Well-suited for:** moving, bridging, exchanging, or protecting data rather than choosing a primary storage target.
+
+Note: AWS Snow Family and Amazon FSx File Gateway are not actively supported for new workloads; for supported data transfer and hybrid storage alternatives, see [Cloud Data Migration](https://aws.amazon.com/cloud-data-migration/).
+
+## 2. Services
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+### AWS DataSync
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| What it does | online transfers and migrations; connects all FSx variants; EFS; S3; non-AWS clouds; agent vs agentless; Enhanced vs Basic mode; continuous replication | [What is AWS DataSync?](https://docs.aws.amazon.com/datasync/latest/userguide/what-is-datasync.html) |
+| Security | scoped IAM roles; TLS in transit | [Security in AWS DataSync](https://docs.aws.amazon.com/datasync/latest/userguide/security.html) |
+| Pricing | per GB transferred (not exhaustive, review pricing page for the full list of pricing dimensions) | [AWS DataSync pricing](https://aws.amazon.com/datasync/pricing/) |
+
+### AWS Storage Gateway
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| What it does | on-premises access via local cache; Amazon S3 File Gateway; Volume Gateway (Cached or Stored); Tape Gateway; bucket-to-file-share mapping; file size limit; no symlink or hard-link | [What is Amazon S3 File Gateway?](https://docs.aws.amazon.com/filegateway/latest/files3/what-is-file-s3.html) |
+| Security | SSL in transit; SSE-S3 or SSE-KMS on the S3 backend; VPC endpoints; IAM roles for activation | [Security in AWS Storage Gateway](https://docs.aws.amazon.com/filegateway/latest/files3/security.html) |
+| Pricing | per GB stored; request charges (not exhaustive, review pricing page for the full list of pricing dimensions) | [AWS Storage Gateway pricing](https://aws.amazon.com/storagegateway/pricing/) |
+
+### AWS Transfer Family
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| What it does | provides managed SFTP; FTPS; FTP; AS2 endpoints on S3 or EFS; public and VPC endpoint types; managed workflows; AS2 MDN; Transfer Family Web Apps | [What is AWS Transfer Family?](https://docs.aws.amazon.com/transfer/latest/userguide/what-is-aws-transfer-family.html) |
+| Security | SFTP and FTPS encrypt in transit; FTP is unencrypted and not for production workloads; FTP and FTPS require a VPC endpoint; ACM certificate for FTPS; managed identity providers; Secrets Manager for keys | [Security in AWS Transfer Family](https://docs.aws.amazon.com/transfer/latest/userguide/security.html) |
+| Pricing | per protocol endpoint provisioned; per GB transferred (not exhaustive, review pricing page for the full list of pricing dimensions) | [AWS Transfer Family pricing](https://aws.amazon.com/aws-transfer-family/pricing/) |
+
+### AWS Backup
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| What it does | policy-based backup across many AWS services; S3 Versioning prerequisite; continuous backup and point-in-time restore; Vault Lock Compliance vs Governance | [What is AWS Backup?](https://docs.aws.amazon.com/aws-backup/latest/devguide/whatisbackup.html) |
+| Security | AWS KMS keys in the vault; Vault Lock WORM immutability | [Security in AWS Backup](https://docs.aws.amazon.com/aws-backup/latest/devguide/security-considerations.html) |
+| Pricing | backup storage; restore; cross-Region and cross-account copy; service-specific tiering (not exhaustive, review pricing page for the full list of pricing dimensions) | [AWS Backup pricing](https://aws.amazon.com/backup/pricing/) |

--- a/skills/core-skills/aws-storage/references/ebs-knowledge.md
+++ b/skills/core-skills/aws-storage/references/ebs-knowledge.md
@@ -1,0 +1,45 @@
+# Amazon Elastic Block Store (EBS)
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon EBS to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon EBS User Guide](https://docs.aws.amazon.com/ebs/latest/userguide/what-is-ebs.html), [Amazon EC2 API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Welcome.html), [Amazon EBS product page](https://aws.amazon.com/ebs/), and [Amazon EBS FAQs](https://aws.amazon.com/ebs/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon EBS is high-performance, durable block storage for Amazon EC2: network-attached volumes that persist independently of the instance and are replicated within an Availability Zone, with a range of SSD and HDD volume types to match performance and cost to the workload.
+
+**Well-suited for:** workloads that need durable, low-latency block storage attached to a single EC2 instance, such as boot volumes, databases, transactional applications and file systems, dev/test environments, sequential batch processing, and log and data warehouse scans.
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | single-instance attachment; Availability Zone scope; Multi-Attach; cross-AZ and cross-Region portability | [Amazon EBS volumes](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volumes.html) |
+| Deployment and availability | Availability Zone scope; in-AZ replication; snapshot portability | [Amazon EBS overview](https://docs.aws.amazon.com/ebs/latest/userguide/what-is-ebs.html) |
+| Volume types | gp3; io2 Block Express; st1; sc1; boot volume requirements | [Amazon EBS volume types](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html) |
+| Data protection and management | snapshots; Volume Clones; Elastic Volumes; Fast Snapshot Restore; Provisioned Rate for Volume Initialization; time-based snapshot copy; snapshot archive; Amazon Data Lifecycle Manager; Recycle Bin | [Amazon EBS snapshots](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-snapshots.html), [Copy an Amazon EBS volume](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-copying-volume.html), [EBS direct APIs](https://docs.aws.amazon.com/ebs/latest/APIReference/API_Operations.html) |
+| Performance | instance EBS bandwidth ceiling; gp3 provisioned performance; lazy-load on first read | [Amazon EBS volume performance](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-performance.html) |
+| Security | encryption by default; encrypted snapshot sharing; least-privilege IAM on destructive actions; tags and descriptions | [Security in Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/security.html) |
+| Health and monitoring | CloudWatch metrics; alarms; CloudTrail | [Monitoring Amazon EBS](https://docs.aws.amazon.com/ebs/latest/userguide/monitoring-overview.html) |
+| Pricing | provisioned capacity; provisioned performance; snapshot storage; snapshot archive; Fast Snapshot Restore; detached-volume charges; gp2-to-gp3 migration (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon EBS pricing](https://aws.amazon.com/ebs/pricing/) |
+
+### Related services and integrations
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related service.
+
+| Example service | Example characteristics and common workloads | Documentation |
+| --- | --- | --- |
+| EC2 instance store | ephemeral local block storage; SSD and HDD variants; data loss on stop, terminate, hibernate, or hardware failure | [Instance store temporary block storage for EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html), [Amazon EC2 FAQs](https://aws.amazon.com/ec2/faqs/) |
+| Amazon EKS (EBS CSI driver) | Kubernetes persistent and ephemeral volumes on EBS | [Use Kubernetes volume storage with Amazon EBS](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Capacity and scaling | resize not reflected in OS; modification limits | extend the OS file system after the volume optimizes | [Extend the file system after resizing](https://docs.aws.amazon.com/ebs/latest/userguide/recognize-expanded-volume-linux.html), [Modify a volume](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modify-volume.html) |
+| Performance | high latency; slow first reads on restored volumes | check the instance bandwidth ceiling; pre-hydrate restored volumes | [Amazon EBS-optimized instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html), [Amazon EBS fast snapshot restore](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-fast-snapshot-restore.html) |
+| Data protection and recovery | root volume deleted on terminate; encrypted snapshot fails to attach | review DeleteOnTermination and KMS permissions | [Preserve data when an instance is terminated](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/preserving-volumes-on-termination.html), [Amazon EBS encryption](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html) |
+| Access and permissions | volume will not attach across AZ | snapshot and restore to move across AZs | [Attach a volume](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-attaching-volume.html) |
+| Cost and billing | unexpected charges; billed size vs restore size | delete or snapshot unused volumes | [View Amazon EBS snapshot information](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-describing-snapshots.html), [Amazon EBS pricing](https://aws.amazon.com/ebs/pricing/) |

--- a/skills/core-skills/aws-storage/references/efs-knowledge.md
+++ b/skills/core-skills/aws-storage/references/efs-knowledge.md
@@ -1,0 +1,34 @@
+# Amazon EFS
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon EFS to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon EFS User Guide](https://docs.aws.amazon.com/efs/latest/ug/whatisefs.html), [Amazon EFS API Reference](https://docs.aws.amazon.com/efs/latest/ug/api-reference.html), [Amazon EFS product page](https://aws.amazon.com/efs/), and [Amazon EFS FAQs](https://aws.amazon.com/efs/faq/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon EFS is a serverless, fully elastic NFS file system for Linux that grows and shrinks automatically with no capacity planning, built for shared file access with high aggregate throughput across many concurrent clients. It is Regional (Multi-AZ) by default, with a lower-cost One Zone option, and is mountable by Lambda, Fargate, EC2, ECS, and EKS.
+
+**Well-suited for:** shared Linux file workloads, such as containers, cloud-native Linux applications, serverless persistent storage, analytics and ML training data (including SageMaker), big data, media processing, web and content management, shared home directories, dev/test, and infrequently accessed file data.
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | NFS on Linux; mounting from Lambda, Fargate, EC2, ECS, EKS; access points; cross-account and cross-VPC mounting; on-premises mount | [Mounting EFS file systems](https://docs.aws.amazon.com/efs/latest/ug/mounting-fs.html) |
+| Deployment and availability | Regional (Multi-AZ); One Zone | [Availability and durability (EFS file system types)](https://docs.aws.amazon.com/efs/latest/ug/features.html) |
+| Storage classes | Standard; Infrequent Access; Archive; One Zone; One Zone-IA; Lifecycle Management | [Managing storage lifecycle](https://docs.aws.amazon.com/efs/latest/ug/lifecycle-management-efs.html) |
+| Data protection and management | cross-Region and cross-account replication; AWS Backup | [Replicating EFS file systems](https://docs.aws.amazon.com/efs/latest/ug/efs-replication.html) |
+| Performance | Elastic, Provisioned, and Bursting throughput modes; General Purpose performance mode; per-client throughput ceiling | [Amazon EFS performance specifications](https://docs.aws.amazon.com/efs/latest/ug/performance.html) |
+| Security | IAM and POSIX authorization; resource-policy condition keys; KMS at rest; TLS in transit | [Securing your data in Amazon EFS](https://docs.aws.amazon.com/efs/latest/ug/security-considerations.html) |
+| Health and monitoring | CloudWatch metrics; alarms; CloudTrail | [Monitoring metrics with Amazon CloudWatch](https://docs.aws.amazon.com/efs/latest/ug/monitoring-cloudwatch.html) |
+| Pricing | per-GB-month by storage class; IA and Archive access charges; Elastic vs Provisioned throughput; replication transfer (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon EFS pricing](https://aws.amazon.com/efs/pricing/) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Performance | per-client throughput capped | spread load across clients; use the higher-ceiling client or CSI driver on Elastic | [Amazon EFS quotas](https://docs.aws.amazon.com/efs/latest/ug/limits.html) |
+| Connectivity and networking | mount timeout; cross-account or cross-VPC DNS resolution fails | verify the security group, a mount target in the client AZ, and cross-VPC DNS | [Troubleshooting mount issues](https://docs.aws.amazon.com/efs/latest/ug/troubleshooting-efs-mounting.html), [Mount from a different VPC](https://docs.aws.amazon.com/efs/latest/ug/efs-different-vpc.html) |
+| Access and permissions | root write denied under IAM authorization | grant the required client actions in either the resource or the identity policy (one ALLOW suffices, no DENY) | [Using IAM to control access to file systems](https://docs.aws.amazon.com/efs/latest/ug/iam-access-control-nfs-efs.html) |

--- a/skills/core-skills/aws-storage/references/fsx-lustre-knowledge.md
+++ b/skills/core-skills/aws-storage/references/fsx-lustre-knowledge.md
@@ -1,0 +1,46 @@
+# Amazon FSx for Lustre
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon FSx for Lustre to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon FSx for Lustre User Guide](https://docs.aws.amazon.com/fsx/latest/LustreGuide/what-is.html), [Amazon FSx API Reference](https://docs.aws.amazon.com/fsx/latest/APIReference/), [Amazon FSx for Lustre product page](https://aws.amazon.com/fsx/lustre/), and [Amazon FSx for Lustre FAQs](https://aws.amazon.com/fsx/lustre/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon FSx for Lustre is a fully managed service that provides high-performance, cost-effective, and scalable storage powered by Lustre, the world's most popular high-performance file system. FSx for Lustre provides the fastest storage performance for GPU instances in the cloud, with up to terabytes per second of throughput, millions of IOPS, sub-millisecond latencies, and virtually unlimited storage capacity.
+
+**Well-suited for:** compute-intensive workloads where storage must keep pace with large fleets of GPU or CPU compute, such as ML training and inference, HPC, genomics, seismic and financial modeling, media rendering, and back-end EDA, with native Amazon S3 integration that makes datasets in S3 transparently accessible as files.
+
+See [When to choose Amazon FSx](https://aws.amazon.com/fsx/when-to-choose-fsx/) and [Amazon FSx for Lustre Features](https://aws.amazon.com/fsx/lustre/features/).
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | Lustre parallel client on Linux; cross-AZ client access; Elastic Fabric Adapter for high-throughput, low-latency inter-node networking | [Accessing file systems](https://docs.aws.amazon.com/fsx/latest/LustreGuide/accessing-fs.html) |
+| Deployment and availability | Persistent 1 and 2; Scratch 2 | [Deployment and storage class options](https://docs.aws.amazon.com/fsx/latest/LustreGuide/using-fsx-lustre.html) |
+| Storage classes | SSD; Intelligent-Tiering | [Lustre storage classes](https://docs.aws.amazon.com/fsx/latest/LustreGuide/using-fsx-lustre.html) |
+| Data protection and management | S3 data repository association; auto-import and auto-export; writes from multiple locations; file release to free local space; capacity increase; backups | [Using data repositories with Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/fsx-data-repositories.html) |
+| Performance | aggregate throughput; sub-millisecond latency; high IOPS; metadata IOPS; NVIDIA GPUDirect Storage (GDS); working-set sizing | [Amazon FSx for Lustre performance](https://docs.aws.amazon.com/fsx/latest/LustreGuide/performance.html) |
+| Security | KMS at rest; in-transit automatic from EC2 instances that support it (Nitro-based) and between file-system hosts; instances that do not support it and on-premises clients do not receive in-transit encryption; POSIX permissions; VPC and security groups | [Security in Amazon FSx for Lustre](https://docs.aws.amazon.com/fsx/latest/LustreGuide/security.html) |
+| Health and monitoring | CloudWatch metrics; alarms; CloudTrail | [Monitoring Amazon FSx for Lustre file systems](https://docs.aws.amazon.com/fsx/latest/LustreGuide/monitoring_overview.html) |
+| Pricing | storage capacity; throughput capacity; metadata IOPS; backup storage; cross-AZ transfer; Intelligent-Tiering (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon FSx for Lustre pricing](https://aws.amazon.com/fsx/lustre/pricing/) |
+
+### Related services and integrations
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related service.
+
+| Example service | Example characteristics and common workloads | Documentation |
+| --- | --- | --- |
+| Amazon EKS (FSx for Lustre CSI driver) | dynamic and static Kubernetes volume provisioning; pod access to shared Lustre | [Amazon FSx for Lustre CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/fsx-csi.html) |
+| Amazon SageMaker | high-throughput training-data input; file-system mount for training jobs | [Setting up training jobs to access datasets](https://docs.aws.amazon.com/sagemaker/latest/dg/model-access-training-data.html) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Connectivity and networking | mount fails; Lustre client missing | install the client matching the OS and kernel | [Installing the Lustre client](https://docs.aws.amazon.com/fsx/latest/LustreGuide/install-lustre-client.html) |
+| Connectivity and networking | mount hangs or times out; security group misconfigured | allow the required Lustre ports between the file-system and client security groups (restrict to the specific client security group IDs); verify VPC routing | [File system access control with Amazon VPC](https://docs.aws.amazon.com/fsx/latest/LustreGuide/limit-access-security-groups.html) |
+| Data protection and recovery | data repository misconfigured; slow first read; conflicting writes; backups only on Persistent non-S3-linked | restore IAM access; pre-stage hot files; write from a single source; use Persistent (not S3-linked) for backups | [Data repository association lifecycle state](https://docs.aws.amazon.com/fsx/latest/LustreGuide/dra-lifecycles.html), [Linking to an S3 bucket](https://docs.aws.amazon.com/fsx/latest/LustreGuide/create-dra-linked-data-repo.html), [Protecting your data with backups](https://docs.aws.amazon.com/fsx/latest/LustreGuide/using-backups-fsx.html) |
+| Capacity and scaling | out of space with a large S3 dataset | release infrequently-accessed files; size to the working set | [Releasing files](https://docs.aws.amazon.com/fsx/latest/LustreGuide/file-release.html), [Increasing storage capacity](https://docs.aws.amazon.com/fsx/latest/LustreGuide/increase-storage-capacity.html) |

--- a/skills/core-skills/aws-storage/references/fsx-ontap-knowledge.md
+++ b/skills/core-skills/aws-storage/references/fsx-ontap-knowledge.md
@@ -1,0 +1,46 @@
+# Amazon FSx for NetApp ONTAP
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon FSx for NetApp ONTAP to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon FSx for NetApp ONTAP User Guide](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/what-is-fsx-ontap.html), [Amazon FSx API Reference](https://docs.aws.amazon.com/fsx/latest/APIReference/), [Amazon FSx for NetApp ONTAP product page](https://aws.amazon.com/fsx/netapp-ontap/), and [Amazon FSx for NetApp ONTAP FAQs](https://aws.amazon.com/fsx/netapp-ontap/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon FSx for NetApp ONTAP provides fully managed shared storage built on NetApp's popular ONTAP file system, bringing the familiar features, performance, and APIs of on-premises NetApp to AWS as a fully managed service. It offers multi-protocol access (NFS, SMB, iSCSI, NVMe-over-TCP, and the Amazon S3 API via S3 Access Points), and is designed to deliver sub-millisecond latencies and tens of GB/s of throughput along with ONTAP's rich data management capabilities (like snapshots, data cloning, SnapMirror replication, deduplication, compression, and automatic tiering).
+
+**Well-suited for:** enterprise NAS migrations, especially from NetApp, and any workload that needs more than one access protocol or the broadest set of enterprise data-management, security, and resiliency features from a single system, such as general-purpose file shares and home directories, multi-protocol shares, business-critical databases (such as SAP HANA, Oracle, and SQL Server), VMware datastores, line-of-business applications (such as medical imaging and product lifecycle management), and hybrid or disaster-recovery workloads.
+
+See [When to choose Amazon FSx](https://aws.amazon.com/fsx/when-to-choose-fsx/) and [How Amazon FSx for NetApp ONTAP works](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/how-it-works-fsx-ontap.html).
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | NFS; SMB; iSCSI and NVMe-over-TCP (block protocols, limited by HA-pair count); S3 Access Points; concurrent NFS and SMB; Storage Virtual Machines; volume security style; Active Directory and LDAP identity | [Accessing your FSx for ONTAP data](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/supported-fsx-clients.html) |
+| Deployment and availability | Single-AZ HA; Multi-AZ | [Availability, durability, and deployment options](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/high-availability-AZ.html) |
+| Storage classes | SSD; capacity pool | [Managing storage capacity (storage tiers)](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/managing-storage-capacity.html) |
+| Data protection and management | tiering policies; snapshots; SnapMirror (ONTAP-to-ONTAP data replication); FlexClone (clones); FlexCache (caching); deduplication; compression; compaction; thin provisioning; SnapLock WORM; backups | [Protecting your data](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/protecting-data.html) |
+| Performance | SSD IOPS baseline and limits; throughput capacity; scale-out with HA pairs; utilization-gated tiering | [Amazon FSx for NetApp ONTAP performance](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/performance.html) |
+| Security | AWS KMS at rest; in-transit via Nitro, Kerberos, IPsec; vscan; SnapLock; file-access auditing; QoS; administrative credentials | [Security in Amazon FSx for NetApp ONTAP](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/security.html) |
+| Health and monitoring | CloudWatch metrics; alarms; ONTAP EMS events; AWS CloudTrail | [Monitoring Amazon FSx for NetApp ONTAP](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/monitoring_overview.html) |
+| Pricing | SSD storage; SSD IOPS; throughput capacity; capacity pool storage and requests; backup storage; S3 Access Points requests; Multi-AZ premium (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon FSx for NetApp ONTAP pricing](https://aws.amazon.com/fsx/netapp-ontap/pricing/) |
+
+### Related services and integrations
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related service.
+
+| Example service | Example characteristics and common workloads | Documentation |
+| --- | --- | --- |
+| S3 Access Points for FSx | S3 API access to file data; per-access-point IAM and POSIX; concurrent NFS and S3 | [Accessing your data via Amazon S3 access points](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/accessing-data-via-s3-access-points.html) |
+| Non-NetApp NAS migration | Dell PowerScale/Isilon, Qumulo, VAST, Pure; rsync, Robocopy, NetApp CloudSync | [Migrating to Amazon FSx for NetApp ONTAP](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/migrating-fsx-ontap.html) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Access and permissions | NFS identities unresolved; SMB fails without AD | join the SVM to Active Directory and configure LDAP | [Enabling multiprotocol workloads](https://aws.amazon.com/blogs/storage/enabling-multiprotocol-workloads-with-amazon-fsx-for-netapp-ontap/), [Active Directory in FSx for ONTAP](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/ad-integration-ontap.html) |
+| Migration | SnapMirror from a non-NetApp source | use AWS DataSync (AWS-native, recommended), rsync, Robocopy, or NetApp CloudSync | [Amazon FSx for NetApp ONTAP FAQs](https://aws.amazon.com/fsx/netapp-ontap/faqs/) |
+| Capacity and scaling | tuning not aligned with SSD utilization; per-volume tiering-policy fine-tuning | keep SSD utilization in range; fine-tune the tiering policy per volume for the workload | [Volume storage capacity](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/volume-storage-capacity.html) |
+| Connectivity and networking | access issues for Multi-AZ file systems from a peered or on-premises network; iSCSI or NVMe LUN unavailable | for Multi-AZ file systems, NFS, SMB, and ONTAP management endpoints use floating IP addresses, so access from a peered VPC or on-premises requires AWS Transit Gateway (VPC Peering, Direct Connect, and Site-to-Site VPN cannot route to floating IPs); Single-AZ endpoints are secondary IPs in the VPC CIDR and do not require Transit Gateway; iSCSI, NVMe, and inter-cluster (SnapMirror) endpoints use VPC-CIDR IPs and work over VPC Peering; for LUNs verify igroup and mapping | [Routing to Multi-AZ file systems](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/configuring-routing-using-AWSTG.html), [Creating an iSCSI LUN](https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/create-iscsi-lun.html) |

--- a/skills/core-skills/aws-storage/references/fsx-openzfs-knowledge.md
+++ b/skills/core-skills/aws-storage/references/fsx-openzfs-knowledge.md
@@ -1,0 +1,44 @@
+# Amazon FSx for OpenZFS
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon FSx for OpenZFS to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon FSx for OpenZFS User Guide](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/what-is-fsx.html), [Amazon FSx API Reference](https://docs.aws.amazon.com/fsx/latest/APIReference/), [Amazon FSx for OpenZFS product page](https://aws.amazon.com/fsx/openzfs/), and [Amazon FSx for OpenZFS FAQs](https://aws.amazon.com/fsx/openzfs/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon FSx for OpenZFS provides fully managed, cost-effective, shared file storage powered by the popular OpenZFS file system, and is designed to deliver latencies as low as a few hundred microseconds and multi-GB/s throughput along with rich ZFS-powered data management capabilities (like snapshots, data cloning, and compression). It is accessible from Linux, Windows, and macOS NFS clients.
+
+**Well-suited for:** Linux and NFS workloads that want the lowest latency and a simple, high-performance NAS, including migrations from ZFS or other Linux file servers, dev/test that benefits from instant writable clones, front-end EDA, financial modeling, media processing, and latency-sensitive line-of-business apps and databases.
+
+See [When to choose Amazon FSx](https://aws.amazon.com/fsx/when-to-choose-fsx/) and [Amazon FSx for OpenZFS features](https://aws.amazon.com/fsx/openzfs/features/).
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | NFS (v3, v4.x); S3 Access Points; POSIX identity | [Accessing your data](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/accessing-your-data.html) |
+| Deployment and availability | Multi-AZ (HA); Single-AZ (HA); Single-AZ (non-HA); max file-system size | [Availability and durability for Amazon FSx for OpenZFS](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/availability-durability.html) |
+| Storage classes | Intelligent-Tiering; SSD | [Choosing a storage class](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/performance.html) |
+| Data protection and management | snapshots; writable clones; LZ4 and Zstandard compression; on-demand replication; backups; child-volume quotas | [Protecting your Amazon FSx for OpenZFS data](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/protecting-data.html) |
+| Performance | latencies as low as a few hundred microseconds for cached data; provisioned throughput and IOPS; record size | [Performance for Amazon FSx for OpenZFS](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/performance.html) |
+| Security | KMS at rest; in-transit automatic on supported EC2 (Nitro-based) instances; VPC, IAM, POSIX | [Security in Amazon FSx for OpenZFS](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/security.html) |
+| Health and monitoring | CloudWatch metrics; alarms; CloudTrail | [Monitoring Amazon FSx for OpenZFS file systems](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/monitoring_overview.html) |
+| Pricing | storage by class and deployment; throughput capacity; SSD IOPS; read cache; backup storage; compression and clones (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon FSx for OpenZFS pricing](https://aws.amazon.com/fsx/openzfs/pricing/) |
+
+### Related services and integrations
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related service.
+
+| Example service | Example characteristics and common workloads | Documentation |
+| --- | --- | --- |
+| S3 Access Points for FSx | S3 API access to file data; per-access-point IAM and POSIX; concurrent NFS and S3 | [Accessing your data using Amazon S3 access points](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/s3accesspoints-for-FSx.html) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Data protection and recovery | snapshot delete blocked by a clone; space not freed; compression not retroactive | delete dependent clones; copy data to apply new settings | [Protecting your data with snapshots](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/snapshots-openzfs.html), [Updating an Amazon FSx for OpenZFS volume](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/updating-volumes.html), [DeleteSnapshot](https://docs.aws.amazon.com/fsx/latest/APIReference/API_DeleteSnapshot.html) |
+| Connectivity and networking | file-system creation fails on security group | allow inbound TCP 2049 from the security group itself or the subnet CIDR so the file-system hosts can reach each other | [Troubleshooting Amazon FSx for OpenZFS issues](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/troubleshooting.html) |
+| Connectivity and networking | mount hangs or times out | allow inbound TCP 2049 from the client (restrict to the specific client security group or narrowest applicable CIDR); verify subnet routing and the volume path | [Troubleshooting Amazon FSx for OpenZFS issues](https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/troubleshooting.html) |

--- a/skills/core-skills/aws-storage/references/fsx-windows-knowledge.md
+++ b/skills/core-skills/aws-storage/references/fsx-windows-knowledge.md
@@ -1,0 +1,43 @@
+# Amazon FSx for Windows File Server
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon FSx for Windows File Server to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon FSx for Windows File Server User Guide](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/what-is.html), [Amazon FSx API Reference](https://docs.aws.amazon.com/fsx/latest/APIReference/), [Amazon FSx for Windows File Server product page](https://aws.amazon.com/fsx/windows/), and [Amazon FSx for Windows File Server FAQs](https://aws.amazon.com/fsx/windows/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon FSx for Windows File Server provides fully managed, highly reliable file storage built on Windows Server and can be accessed via the industry-standard Server Message Block (SMB) protocol. It integrates natively with Microsoft Active Directory and is designed to deliver sub-millisecond latencies along with a rich set of Windows-native data management capabilities (like data deduplication, shadow copies, DFS namespaces, and user quotas). Shares are accessible from Windows, Linux (via cifs-utils), and macOS clients.
+
+**Well-suited for:** workloads where applications and users depend on native Windows and SMB behavior and Active Directory identity, such as Windows file and home or department shares, .NET applications, highly available Microsoft SQL Server, and Windows Server migrations.
+
+See [When to choose Amazon FSx](https://aws.amazon.com/fsx/when-to-choose-fsx/) and [Amazon FSx for Windows File Server Features](https://aws.amazon.com/fsx/windows/features/).
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | SMB; Windows; Active Directory; DFS Namespaces | [Accessing data using file shares](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/using-file-shares.html) |
+| Deployment and availability | Multi-AZ (recommended for production workloads); Single-AZ 2 and Single-AZ 1 (cost-efficient for dev/test); failover timing; Continuously Available shares | [Availability and durability: Single-AZ and Multi-AZ file systems](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/high-availability-multiAZ.html) |
+| Storage classes | SSD; HDD with in-memory cache; in-place HDD-to-SSD; increase-only capacity | [Managing storage (optimizing storage costs)](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/managing-storage-configuration.html) |
+| Data protection and management | incremental backups; cross-Region backup copy; shadow copies; dedup and compression; DFS Replication (Single-AZ 1); FSRM quotas | [Protecting your data with backups](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/using-backups.html) |
+| Performance | throughput capacity; baseline and burst network speeds | [FSx for Windows File Server performance](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/performance.html) |
+| Security | KMS at rest; SMB 3.0+ encryption in transit; Active Directory and Kerberos; IAM and NTFS ACLs; file-access auditing; File Classification (PII tagging); File Screening | [Security in Amazon FSx](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/security.html) |
+| Health and monitoring | CloudWatch metrics; alarms; CloudTrail | [Monitoring FSx for Windows File Server file systems](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/monitoring_overview.html) |
+| Pricing | storage capacity; throughput capacity; backup storage; Multi-AZ premium; dedup and compression; DataSync to S3 (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon FSx for Windows File Server pricing](https://aws.amazon.com/fsx/windows/pricing/) |
+
+### Related services and integrations
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related service.
+
+| Example service | Example characteristics and common workloads | Documentation |
+| --- | --- | --- |
+| AWS DataSync | migrate files preserving NTFS ACLs and SACLs | [Migrating files with DataSync](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/migrate-files-to-fsx-datasync.html) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Data protection and recovery | Robocopy dedup corruption; no native cross-Region replication; shadow copies consume capacity | verify after copy and prefer DataSync; copy backups cross-Region; monitor shadow-copy usage | [Managing storage on FSx for Windows File Server](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/managing-storage-configuration.html), [Protecting your data with backups](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/using-backups.html) |
+| Connectivity and networking | Multi-AZ failover on throughput change; Linux client mount loss | schedule changes in maintenance windows; remount Linux clients after failover | [Availability and durability: Single-AZ and Multi-AZ file systems](https://docs.aws.amazon.com/fsx/latest/WindowsGuide/high-availability-multiAZ.html) |

--- a/skills/core-skills/aws-storage/references/s3-express-knowledge.md
+++ b/skills/core-skills/aws-storage/references/s3-express-knowledge.md
@@ -1,0 +1,35 @@
+# Amazon S3 Express One Zone
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon S3 Express One Zone to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-high-performance.html), [Amazon S3 API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html), [Amazon S3 Express One Zone storage class page](https://aws.amazon.com/s3/storage-classes/express-one-zone/), and [Amazon S3 FAQs](https://aws.amazon.com/s3/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon S3 Express One Zone is an S3 storage class for latency-sensitive, high-request-rate workloads, storing data in directory buckets within a single Availability Zone. It delivers consistent single-digit-millisecond latency at high request rates; offers faster data access with lower request cost than S3 Standard.
+
+**Well-suited for:** latency-sensitive hot data, such as Spark and EMR shuffle, ETL intermediate data, Kafka tiered storage, observability and log analytics (hot tier), interactive analytics on hot partitions, media and video editing, ML training checkpoints, scratch, and model loading, large-scale ML training and inference (including as a primary data tier, not only checkpoints), high-frequency transactional access, and caching for machine learning inference; it especially helps small objects where request latency dominates.
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | Zonal endpoint; s3express namespace; CreateSession session authorization; bucket-name form; zone-ID co-location; gateway VPC endpoint; S3A MagicV2 committer for Spark and EMR | [Networking for directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-networking.html) |
+| Deployment and availability | Single-AZ directory buckets; Dedicated vs other Local Zones | [S3 Express One Zone Availability Zones and Regions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-Endpoints.html) |
+| Data protection and management | limited lifecycle actions; backup or replication to a general purpose bucket | [Differences for directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-differences.html) |
+| Performance | single-digit-millisecond latency; per-second request limits; optional co-location | [Optimizing S3 Express One Zone performance](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-performance.html) |
+| Security | explicit CreateSession grant; scoped s3express policies; condition keys; SSE-S3 and SSE-KMS; Block Public Access; CloudTrail data events | [Security for directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-security.html) |
+| Health and monitoring | CloudWatch metrics; alarms; CloudTrail | [Monitoring metrics with Amazon CloudWatch for directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cloudwatch-monitoring-directory-buckets.html) |
+| Pricing | storage and requests; per-GB upload and retrieval; expiration lifecycle; small-object aggregation (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon S3 pricing](https://aws.amazon.com/s3/pricing/) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Access and permissions | data-plane request rejected without a session; CLI sync failures | use a session-aware SDK or CLI; use recursive copy | [CreateSession](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateSession.html) |
+| Connectivity and networking | 503 Slow Down under rising request rate; throughput capped on a private subnet | retry with exponential backoff while S3 scales; add an s3express gateway VPC endpoint | [Configure a gateway VPC endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-tutorial-endpoints.html) |
+| Data protection and recovery | objects not expiring under a lifecycle rule | grant CreateSession and remove any deny-delete bucket policy; check CloudTrail for AccessDenied | [Troubleshooting S3 Lifecycle issues for directory buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-buckets-lifecycle-troubleshooting.html) |
+| Performance | higher cross-zone latency | co-locate compute with the bucket zone ID | [Optimizing S3 Express One Zone performance](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-performance.html) |
+| Data writes | Spark or Hive write failures on directory buckets; S3 Select and object change-detection incompatibilities with the S3A connector | use the S3A MagicV2 committer rather than the default file output committer; disable S3 Select and object change-detection in the S3A connector | [Upload data to Amazon S3 Express One Zone](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-express-one-zone.html), [S3A MagicV2 Committer](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/s3a-magicv2-committer.html), [Requirements for the EMRFS S3-optimized committer](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-committer-reqs.html) |

--- a/skills/core-skills/aws-storage/references/s3-files-knowledge.md
+++ b/skills/core-skills/aws-storage/references/s3-files-knowledge.md
@@ -1,0 +1,43 @@
+# Amazon S3 Files
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon S3 Files to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files.html), [Amazon S3 Files API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_S3_Files.html), [Amazon S3 Files feature page](https://aws.amazon.com/s3/features/files/), and [Amazon S3 FAQs](https://aws.amazon.com/s3/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon S3 Files is a fully managed shared file system, built on Amazon EFS infrastructure, that provides NFS access to data in an S3 general purpose bucket while the bucket remains the authoritative system of record. Applications read, write, lock, and delete files over NFS while the same data stays reachable through the S3 API, with automatic bidirectional synchronization between the two. It serves small, actively used files from a high-performance layer at low latency while large reads stream directly from S3.
+
+**Well-suited for:** cases where data already lives in an S3 general purpose bucket and file-based applications need NFS read and write access, or where both API and file access to the same data are required without copying.
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | NFS v4.2 and v4.1; s3files mount type; mounting from EC2, ECS, EKS, Lambda, Fargate; bucket prerequisites; file system role | [Mounting your S3 buckets on compute resources](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-attach-compute.html) |
+| Deployment and availability | per-AZ mount target; Multi-AZ durability | [Creating and managing S3 Files resources](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-resources.html) |
+| Data protection and management | bidirectional synchronization; bucket as system of record; lost-and-found; consistency model | [Understanding how synchronization works](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-synchronization.html) |
+| Performance | small-file high-performance layer; large-read streaming from S3 | [Performance specifications](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-performance.html) |
+| Security | API and client access controls; scoped IAM policies; encryption in transit enforced on the mount; encryption at rest on the file system, SSE-S3 (Amazon S3-managed keys) by default or optional customer-managed SSE-KMS; file system policy | [Security for S3 Files](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-security.html) |
+| Health and monitoring | CloudWatch sync and activity metrics; alarms; CloudTrail | [Monitoring and auditing S3 Files](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-monitoring-logging.html) |
+| Pricing | standard S3 storage and requests; high-performance storage; file system access operations (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon S3 pricing](https://aws.amazon.com/s3/pricing/), [How S3 Files is metered](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-metering.html) |
+
+### Related services and integrations
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related service.
+
+| Example service | Example characteristics and common workloads | Documentation |
+| --- | --- | --- |
+| Backing S3 general purpose bucket | system of record; concurrent S3 API access | [Getting started with Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/GetStartedWithS3.html) |
+| Mountpoint for Amazon S3 | read-heavy FUSE client; read-only or append-only vs full read-write | [Mountpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mountpoint.html) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Connectivity and networking | mount fails; command-not-found | install the S3 Files client and use the s3files mount type | [Troubleshooting S3 Files](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-troubleshooting.html) |
+| Rename and move | slow or costly file or directory rename; creation error on a large prefix | expect rename to rewrite objects; pass the bucket-warning flag on large prefixes | [Understanding how synchronization works](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-synchronization.html) |
+| Data protection and recovery | file not visible as an object; lost-and-found; archived-object I/O error | allow export and import to complete; restore archived objects first | [Understanding how synchronization works](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-synchronization.html), [Monitoring S3 Files with Amazon CloudWatch](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-monitoring-cloudwatch.html) |
+| Performance | large reads slower than a direct GET | add the inline S3 read policy; confirm export | [Performance specifications](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files-performance.html) |

--- a/skills/core-skills/aws-storage/references/s3-general-purpose-knowledge.md
+++ b/skills/core-skills/aws-storage/references/s3-general-purpose-knowledge.md
@@ -1,0 +1,39 @@
+# Amazon S3 General Purpose
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon S3 general purpose buckets to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html), [Amazon S3 API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html), [Amazon S3 product page](https://aws.amazon.com/s3/), and [Amazon S3 FAQs](https://aws.amazon.com/s3/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon S3 General Purpose is virtually unlimited object storage accessed over a REST and HTTP API, storing objects redundantly across a minimum of three Availability Zones in a Region for high durability and availability by default. It offers multiple storage classes and Lifecycle Management that optimize cost across access frequencies without application changes.
+
+**Well-suited for:** the default starting point and system of record for unstructured data, such as data lakes and analytics, backups and archive targets, ML training data, media storage and content distribution, log and event data, static website and application assets, and regulatory and compliance archives.
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | REST and HTTP API; strong read-after-write consistency | [Access control in Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-management.html); [Accessing an Amazon S3 general purpose bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html) |
+| Deployment and availability | Multi-AZ redundancy; durability vs backup | [Data protection in Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/DataDurability.html) |
+| Storage classes | S3 Standard; S3 Standard-Infrequent Access (S3 Standard-IA); S3 One Zone-IA; S3 Intelligent-Tiering; S3 Express One Zone; S3 Glacier storage classes (S3 Glacier Instant Retrieval, S3 Glacier Flexible Retrieval, S3 Glacier Deep Archive); Lifecycle transitions | [Understanding and managing Amazon S3 storage classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html) |
+| Data protection and management | Versioning; Object Lock; Replication; Batch Replication; Replication Time Control; Batch Operations | [Data protection in Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/data-protection.html); [Working with objects in Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/uploading-downloading-objects.html); [Retaining multiple versions of objects with S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html) |
+| Performance | prefix partitioning; 503 SlowDown; request-rate pre-warming | [Best practices design patterns: optimizing Amazon S3 performance](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html) |
+| Security | SSE-S3; SSE-KMS; IAM and bucket policies; Block Public Access; ACLs disabled / bucket-owner-enforced; condition keys; explicit deny; checksums; account regional namespace; bucket owner condition; encryption in transit | [Security in Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security.html); [S3 Security Best Practices](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html) |
+| Health and monitoring | CloudWatch metrics; alarms; CloudTrail; Storage Lens | [Logging and monitoring in Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/monitoring-overview.html) |
+| Pricing | storage by class; requests; retrieval; data transfer; Intelligent-Tiering monitoring; lifecycle transitions; Inventory and Analytics; replication (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon S3 pricing](https://aws.amazon.com/s3/pricing/) |
+| Mountpoint for Amazon S3 | local file-system mount; read-heavy sequential workloads | [Mountpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mountpoint.html) |
+| S3 Metadata | queryable object-metadata tables; discovery and governance | [Discovering your data with S3 Metadata tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/metadata-tables-overview.html) |
+| S3 Tables | managed Apache Iceberg tables; automatic compaction, snapshot management, and unreferenced-file removal | [Working with Amazon S3 Tables and table buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) |
+| S3 Vectors | storing and querying vector embeddings | [Working with S3 Vectors and vector buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors.html) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Cost and billing | bill spikes; incomplete multipart uploads; lifecycle transition costs | isolate with Storage Lens and Cost Explorer; abort incomplete uploads | [Understanding your S3 bill](https://docs.aws.amazon.com/AmazonS3/latest/userguide/aws-usage-report-understand.html), [S3 Storage Lens](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens.html), [Aborting incomplete multipart uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpu-abort-incomplete-mpu-lifecycle-config.html) |
+| Data protection and recovery | delete markers on versioned buckets; archive restore expiry; replication gaps | use versioning or Object Lock and Batch Replication; budget minimum durations | [Locking objects with Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html), [Replicating existing objects with Batch Replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-batch-replication-batch.html), [Restoring an archived object](https://docs.aws.amazon.com/AmazonS3/latest/userguide/restoring-objects.html), [Troubleshooting replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-troubleshoot.html), [Troubleshooting versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshooting-versioning.html) |
+| Access and permissions | cross-account AccessDenied; KMS key mismatch | evaluate the full policy chain; explicit deny overrides allows | [Access denied (403)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/troubleshoot-403-errors.html), [Bucket policy examples using condition keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/amazon-s3-policy-keys.html) |
+| Performance | 503 SlowDown on hot prefixes | spread across prefixes; back off with jitter | [Performance design patterns for Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-design-patterns.html) |

--- a/skills/core-skills/aws-storage/references/s3-tables-knowledge.md
+++ b/skills/core-skills/aws-storage/references/s3-tables-knowledge.md
@@ -1,0 +1,45 @@
+# Amazon S3 Tables
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon S3 Tables to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon S3 User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html), [Amazon S3 Tables API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_S3_Tables.html), [Amazon S3 Tables feature page](https://aws.amazon.com/s3/features/tables/), and [Amazon S3 FAQs](https://aws.amazon.com/s3/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon S3 Tables delivers fully managed Apache Iceberg tables in purpose-built table buckets, with S3 running compaction, snapshot management, and unreferenced-file removal automatically. It reduces operational overhead and can deliver higher transactions per second and better query throughput than self-managing Iceberg on general purpose buckets, plus table-native features, like defining tables as resources with Amazon Resource Names (ARNs), Tables replication, and S3 Intelligent-Tiering for tabular datasets. Tables are exposed through the Iceberg REST Catalog API, so any Iceberg-compatible engine (Amazon Athena, Amazon Redshift, Amazon EMR, AWS Glue ETL, Apache Spark, and others) can read and write to S3 Tables.
+
+**Well-suited for:** new Iceberg analytics projects, data lake tables and structured analytics data, ETL pipeline outputs, streaming into tables for SQL analysis, and migrating open table format data outside of S3 or self-managed Iceberg on S3.
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | Iceberg REST Catalog API; concurrent writers; Apache Iceberg supported versions | [Accessing table data](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-access.html) |
+| Iceberg support | Apache Iceberg table format and spec versions, including Apache Iceberg v3 | [Working with Apache Iceberg V3 tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/working-with-apache-iceberg-v3.html) |
+| Deployment and availability | supported Regions; table buckets; per-Region quotas | [Getting started with S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-getting-started.html), [S3 Tables AWS Regions, endpoints, and service quotas](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-regions-quotas.html) |
+| Data protection and management | automatic maintenance; no manual object overwrite or delete; MaximumSnapshotAge and MinimumSnapshots; cross-Region and cross-account replication; noncurrent-version retention | [S3 Tables maintenance](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-maintenance-overview.html); [Replicating S3 tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-replication-tables.html) |
+| Performance | Auto; Binpack; Sort; Z-order compaction | [S3 Tables maintenance](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-maintenance-overview.html) |
+| Security | s3tables namespace; table-bucket, namespace, and table access control; Block Public Access; SSE-S3 and SSE-KMS; maintenance-principal key permissions; condition keys; VPC endpoints | [Security for S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-security-overview.html) |
+| Health and monitoring | CloudWatch metrics; alarms; CloudTrail | [Logging and monitoring for S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-monitoring-overview.html) |
+| Pricing | table storage; per-object monitoring; API requests; automated compaction; cross-Region replication; Intelligent-Tiering (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon S3 pricing](https://aws.amazon.com/s3/pricing/), [Cost optimization for tables with Intelligent-Tiering](https://docs.aws.amazon.com/AmazonS3/latest/userguide/tables-intelligent-tiering.html) |
+
+### Related services and integrations
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related service.
+
+| Example services | Example characteristics and common workloads | Documentation |
+| --- | --- | --- |
+| Amazon Athena, Amazon Redshift, Amazon EMR, AWS Glue ETL, Apache Spark, and other Iceberg-compatible engines | query and process S3 Tables, with AWS Glue Data Catalog integration for AWS analytics services, or access tables directly using the Amazon S3 Tables Iceberg REST endpoint or the Amazon S3 Tables Catalog for Apache Iceberg | [Accessing table data](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-access.html), [Integrating with AWS analytics services](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-integrating-aws.html) |
+| AWS Glue Data Catalog | catalog federation; IAM authentication | [Integrating with Amazon S3 Tables](https://docs.aws.amazon.com/glue/latest/dg/glue-federation-s3tables.html) |
+| AWS Lake Formation | optional fine-grained access control (IAM is the default access model) | [Creating an S3 Tables catalog in Lake Formation](https://docs.aws.amazon.com/lake-formation/latest/dg/create-s3-tables-catalog.html) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Access and permissions | AccessDenied despite broad S3 permissions; IAM vs Lake Formation confusion | grant s3tables actions specifically | [Security for S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-security-overview.html), [Integrating with Amazon S3 Tables](https://docs.aws.amazon.com/glue/latest/dg/glue-federation-s3tables.html), [Integrating Amazon S3 Tables with AWS analytics services](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-integrating-aws.html) |
+| Capacity and scaling | quota reached; throttling during ingestion | request a quota increase through Support; back off and spread writes | [S3 Tables AWS Regions, endpoints, and service quotas](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-regions-quotas.html) |
+| Data protection and recovery | replicas reject writes; deleted noncurrent objects unrecoverable | write to the source; enable noncurrent-version retention | [Replicating S3 tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-replication-tables.html) |
+| Maintenance | table name rejected; Sort or Z-order not applied; manual overwrite blocked | define a sort order; rely on automatic maintenance | [Maintenance for tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-maintenance.html), [Naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-buckets-naming.html) |

--- a/skills/core-skills/aws-storage/references/s3-vectors-knowledge.md
+++ b/skills/core-skills/aws-storage/references/s3-vectors-knowledge.md
@@ -1,0 +1,43 @@
+# Amazon S3 Vectors
+
+This reference captures information addressing common gotchas and frequently asked questions for Amazon S3 Vectors to support accurate model responses. It is not a complete specification. The authoritative source for current specifications, limits, quotas, and API behavior is the [Amazon S3 User Guide (S3 Vectors)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors.html), [Amazon S3 Vectors API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_S3_Vectors.html), [Amazon S3 Vectors feature page](https://aws.amazon.com/s3/features/vectors/), and [Amazon S3 FAQs](https://aws.amazon.com/s3/faqs/). Retrieve current specifications, limits, and quotas from those pages before citing specifics; cite figures only from those pages.
+
+## 1. Overview
+
+**What it is:** Amazon S3 Vectors is object storage with native support for storing and querying vector embeddings. It delivers the elasticity, durability, and availability of Amazon S3, and is cost-optimized for infrequent to moderately frequent similarity queries.
+
+**Well-suited for:** cost-sensitive retrieval augmented generation (RAG) pipelines, semantic search, recommendation systems, vector deduplication and matching, anomaly and fraud detection, AI agent memory, and cost-effective storage of large vector datasets.
+
+Choose Amazon OpenSearch Service or another dedicated vector database when the workload needs very low latency, very high sustained query throughput, or capabilities beyond what S3 Vectors supports; see [Vector database options](https://docs.aws.amazon.com/prescriptive-guidance/latest/choosing-an-aws-vector-database-for-rag-use-cases/vector-db-options.html).
+
+## 2. Service Information
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related topic.
+
+| Topic | Example service characteristics, features, and actions | Documentation |
+| --- | --- | --- |
+| Access and protocols | s3vectors namespace and API | [Identity and Access management in S3 Vectors](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-access-management.html) |
+| Deployment and availability | supported Regions and endpoints | [AWS Regions, endpoints, and quotas for S3 Vectors](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-regions-quotas.html) |
+| Data protection and management | 11 9's durability inherited from Amazon S3 | [Working with S3 Vectors and vector buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors.html) |
+| Performance | latency for cold vs. warm queries; queries per second throughput; batching; index sharding | [S3 Vectors best practices](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-best-practices.html) |
+| Security | SSE-S3 and SSE-KMS; S3 Block Public Access; AWS PrivateLink; condition keys | [Security in S3 Vectors](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-security.html) |
+| Health and monitoring | CloudTrail management and data events (including QueryVectors) | [Logging with AWS CloudTrail for S3 Vectors](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-logging.html) |
+| Pricing | storage; PUT; queries; data processed and returned; index partitioning (not exhaustive, review pricing page for the full list of pricing dimensions) | [Amazon S3 pricing](https://aws.amazon.com/s3/pricing/) |
+
+### Related services and integrations
+
+You MUST retrieve information from the linked documentation in the below table before answering any user question on the related service.
+
+| Example service | Example characteristics and common workloads | Documentation |
+| --- | --- | --- |
+| Amazon Bedrock Knowledge Bases | integration provides S3 Vectors as managed vector store for RAG with characteristics such as metadata filtering; storing large text chunks via non-filterable metadata keys, etc. | [Using S3 Vectors with Amazon Bedrock Knowledge Bases](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-bedrock-kb.html), [Metadata filtering](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-metadata-filtering.html) |
+| Amazon OpenSearch Service | Integration with S3 Vectors provides two distinct architectural paths: a low-cost vector storage engine for managed OpenSearch Service clusters, and an automated export pipeline to OpenSearch Serverless for high-performance search workloads. | [Using S3 Vectors with OpenSearch Service](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-opensearch.html) |
+
+## 3. Troubleshooting
+
+You MUST retrieve information from the linked documentation in the below table before providing the user with any guidance on the related area.
+
+| Example area | Example errors | Example fixes | Documentation |
+| --- | --- | --- | --- |
+| Access and permissions | AccessDenied on s3vectors query or get actions | use s3vectors actions; grant query and get actions | [Identity and Access management in S3 Vectors](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-access-management.html), [QueryVectors](https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_QueryVectors.html), [GetVectors](https://docs.aws.amazon.com/AmazonS3/latest/API/API_S3VectorBuckets_GetVectors.html) |
+| Capacity and scaling | TooManyRequestsException under high request rates | S3 Vectors is fully serverless and scales automatically; use client-side backoff and rate limiting, and batch writes | [Limitations and restrictions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-limitations.html), [S3 Vectors best practices](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-best-practices.html) |


### PR DESCRIPTION
## Summary

Adds the `aws-storage` skill under skills/core-skills/aws-storage/. Covers selecting, comparing, and operating AWS object, file, and block storage — S3, EFS, FSx, and EBS — and the services that move data between them.

## Details

- Text-only skill (no executable code)
- Security-reviewed: Guardian PASS
- Tested with: Claude Code, Kiro (against AWS MCP preprod endpoint)

## Checklist

- [x] Internal-only frontmatter fields removed (`owner_team`, `owner_cti`, `stages`, `metadata`, `categories`)
- [x] No internal links or references in skill content
- [x] No internal details in commit messages
- [x] CI checks pass
