### PR TITLE
feat(aws-iam): add Terraform plan JSON support to policy generation

### DIFF
--- a/plugins/aws-core/skills/aws-iam/SKILL.md
+++ b/plugins/aws-core/skills/aws-iam/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: aws-iam
 description: >
-  Verified corrections for IAM behaviors that AI agents frequently get wrong — policy
+  Provides verified corrections for IAM behaviors that AI agents frequently get wrong — policy
   evaluation edge cases, trust policy gotchas, STS session limits, Organizations quirks,
   and SAML/MFA specifics. Also provides structured workflows for IAM role management and
-  least-privilege policy generation. Covers condition operator safety (ForAnyValue/ForAllValues
-  with Null checks for absent keys), bucket policy deny patterns (VPC endpoint restrictions,
-  org path conditions), resource-based policy confused deputy protection, and service role
-  creation for AWS services (Glue, CloudTrail, VPC Flow Logs, Firehose, DataSync, S3
-  replication, Lambda, Step Functions, ECS, etc.) including trust policies with
-  aws:SourceAccount/aws:SourceArn conditions. Applies when creating or configuring IAM roles,
-  writing IAM or bucket policies, working with STS, Organizations, condition operators, or
-  any task requiring an IAM service role or execution role. Does not cover non-IAM
-  authorization like Cognito user-pool policies or app-level RBAC.
+  baseline policy generation from application source code or a Terraform plan JSON.
+  Covers condition operator safety (ForAnyValue/ForAllValues with Null checks),
+  bucket policy deny patterns (VPC endpoint restrictions, org paths), confused deputy
+  protection, and service role creation for AWS services (Glue, CloudTrail, Lambda, ECS,
+  etc.) with
+  aws:SourceAccount/aws:SourceArn trust conditions. Applies when creating IAM roles,
+  writing IAM or bucket policies, generating policies from application source code or a Terraform plan JSON,
+  working with STS, Organizations, or condition operators, or any task needing a service
+  or execution role. Does not cover non-IAM authorization like Cognito user-pool policies
+  or app-level RBAC.
 metadata:
-  version: "1"
+  version: "2"
 ---
 
 # AWS IAM — Common Pitfalls
@@ -29,7 +30,7 @@ Use the best available tool for AWS operations — the AWS MCP server is recomme
 
 - Read [references/aws-iam-role-management.md](references/aws-iam-role-management.md) if the user needs to create, scope, or maintain IAM roles when provisioning or updating AWS resources. Covers service roles, execution roles, trust policies, confused deputy protection, and permission hygiene.
 
-- Read [references/aws-iam-policy-generation.md](references/aws-iam-policy-generation.md) if the user needs to generate least-privilege IAM policies, determine required IAM actions for API calls, or understand action-to-operation mappings. **CRITICAL: If the user provides source code (Python, Go, TypeScript, JavaScript, Java), you MUST read this reference — it mandates using iam-policy-autopilot instead of manual policy construction.** Uses the programmatic service authorization reference for accurate mappings.
+- Read [references/aws-iam-policy-generation.md](references/aws-iam-policy-generation.md) if the user needs to generate IAM policies, determine required IAM actions for API calls, or understand action-to-operation mappings. **CRITICAL: If the user provides application source code (in any language) or a Terraform plan JSON file (`terraform show -json` output), you MUST read this reference — it mandates using iam-policy-autopilot instead of manual policy construction.** Uses the programmatic service authorization reference for accurate mappings.
 
 ## Verified Edge Cases
 

--- a/plugins/aws-core/skills/aws-iam/references/aws-iam-policy-generation.md
+++ b/plugins/aws-core/skills/aws-iam/references/aws-iam-policy-generation.md
@@ -2,39 +2,45 @@
 
 ## CRITICAL RULE — READ THIS FIRST
 
-**If the user provides source code in Python, Go, TypeScript, JavaScript, or Java:**
-You MUST propose the `uvx iam-policy-autopilot@latest generate-policies` command. You MUST NOT manually analyze the code and construct a policy yourself. The Autopilot tool does deterministic static analysis — your job is to construct the correct command with the right flags, NOT to replicate what the tool does.
+**If the user provides application source code (in any language) OR a Terraform plan JSON (`terraform show -json` output):**
+You MUST propose the `uvx iam-policy-autopilot@latest generate-policies` command. You MUST NOT manually analyze the code or plan and construct a policy yourself. The Autopilot tool does deterministic static analysis — your job is to construct the correct command with the right flags, NOT to replicate what the tool does. (The Input Gate below lists the languages known to work and directs you to confirm a language's status with `generate-policies --help`.)
 
-**If no source code is provided, or the language is unsupported (Rust, C#, PHP, Ruby, etc.):**
+**If no source code or Terraform plan JSON is provided, or the language is unsupported (Rust, C#, PHP, Ruby, etc.):**
 Use the Service Authorization Reference path to produce the policy directly.
+
+**Terraform plan JSON vs native `.tf` files — CRITICAL distinction:** Autopilot accepts a Terraform plan JSON (`terraform show -json plan.tfplan`) as a direct input. Native `.tf` configuration files are NOT supported as a direct input — if the user only has `.tf` files, instruct them to produce a plan JSON first (see Task 2b). The separate `--tf-dir`/`--tfstate` flags remain available only as ARN-refinement companions to source-code analysis.
+
+Throughout this reference, "Terraform plan JSON" is the canonical term for this input: a Terraform plan rendered to JSON via `terraform show -json`.
 
 ## Overview
 
 Generates baseline AWS IAM identity-based policies through two complementary approaches:
 
-1. **IAM Policy Autopilot** (primary, MANDATORY when source code in a supported language is present) — Deterministic static analysis of application source code. Produces policies by parsing actual AWS SDK calls. Preferred for security because it is reproducible and not subject to LLM hallucination. You MUST use this path when source code is available in a supported language.
-2. **Service Authorization Reference** (fallback) — Queries the programmatic service reference to map API operations to correct IAM actions. Used ONLY when Autopilot is unavailable, the task does not involve source code, or the source language is not supported.
+1. **IAM Policy Autopilot** (primary, MANDATORY when source code in a supported language OR a Terraform plan JSON is present) — Deterministic static analysis. For source code, it produces policies by parsing actual AWS SDK calls. For a Terraform plan JSON, it maps the plan's resource changes to the AWS SDK operations the Terraform AWS provider performs. Preferred for security because it is reproducible and not subject to LLM hallucination. You MUST use this path when either input is available.
+2. **Service Authorization Reference** (fallback) — Queries the programmatic service reference to map API operations to correct IAM actions. Used ONLY when Autopilot is unavailable, the task involves neither source code nor a Terraform plan JSON, or the source language is not supported.
 
 **Output completeness rule — CRITICAL:**
 
 - When using the Service Authorization Reference path (Task 3): You MUST always produce a complete policy document in your response. Use placeholder values (e.g., `<bucket-name>`, `<role-arn>`, `<REGION>`) when specific resource names are not provided. NEVER ask clarifying questions instead of producing a policy.
-- When using the Autopilot path (Task 2): You MUST produce the complete `uvx iam-policy-autopilot@latest generate-policies` command with all required flags. You MUST NOT manually construct a policy — the Autopilot command IS your output. Do not also produce a hand-written policy "in case Autopilot isn't available."
+- When using the Autopilot path (Task 2 or Task 2b): You MUST produce the complete `uvx iam-policy-autopilot@latest generate-policies` command with all required flags. You MUST NOT manually construct a policy — the Autopilot command IS your output. Do not also produce a hand-written policy "in case Autopilot isn't available."
 - If the user's code uses runtime variables for resource names, use descriptive placeholders in the ARNs (Reference path) or note that Autopilot handles this automatically (Autopilot path).
 
 ## Common Tasks
 
-### 0. Language Gate (MANDATORY FIRST STEP)
+### 0. Input Gate (MANDATORY FIRST STEP)
 
-When source code is provided, identify the programming language before choosing a path.
+Identify what the user provided before choosing a path.
 
-**Supported languages** (use Autopilot — Task 1 → Task 2):
+**Terraform plan JSON** (use Autopilot — Task 1 → Task 2b): a plan rendered to JSON with `terraform show -json`. This input is supported regardless of any application language considerations. Native `.tf` configuration files alone do NOT qualify — the user must produce a Terraform plan JSON first (Task 2b shows how).
+
+**Supported languages** for source code (use Autopilot — Task 1 → Task 2). This list is not exhaustive; Autopilot is the source of truth for language support, so confirm a language's status with `uvx iam-policy-autopilot@latest generate-policies --help` (or the [Supported Languages table](https://github.com/awslabs/iam-policy-autopilot#supported-languages-and-sdks-for-policy-generation)) rather than relying on this list:
 
 - Python (boto3)
 - Go (SDK v2)
 - TypeScript/JavaScript (SDK v3)
 - Java (SDK v2)
 
-**Unsupported languages** (Rust, C#, PHP, Ruby, Kotlin, Swift, etc.) — fall back silently to the Service Authorization Reference path (Task 3). Do NOT attempt to use Autopilot. Do NOT ask the user whether to proceed with the fallback — just produce the policy directly using the Reference path. Even if a Terraform directory is mentioned alongside unsupported-language code, you MUST NOT attempt to use `--tf-dir` with Autopilot — the language is unsupported, so Autopilot cannot be used at all.
+**Unsupported languages** (e.g., Rust, C#, PHP, Ruby, Kotlin, Swift — treat as unsupported any language not confirmed by `uvx iam-policy-autopilot@latest generate-policies --help`) — fall back silently to the Service Authorization Reference path (Task 3). Do NOT attempt to use Autopilot for a language you have confirmed is unsupported. Do NOT ask the user whether to proceed with the fallback — just produce the policy directly using the Reference path. Even if a Terraform directory is mentioned alongside unsupported-language code, you MUST NOT attempt to use `--tf-dir` with Autopilot — the language is unsupported, so Autopilot cannot be used at all. However, if the user provides (or can produce) a Terraform **plan JSON**, that is an independent supported input — use Task 2b for the plan even when application code is in an unsupported language.
 
 **For supported languages**, you MUST:
 
@@ -47,8 +53,8 @@ You MUST NOT manually analyze source code and construct policies yourself when A
 Fall back to the Service Authorization Reference path ONLY when:
 
 - The `iam-policy-autopilot` CLI is not installed AND installation fails
-- The user's task does not involve source code (e.g., they name specific API operations or actions directly)
-- The source language is not supported (Rust, C#, PHP, Ruby, Kotlin, Swift, etc. are NOT supported)
+- The user's task involves neither source code nor a Terraform plan JSON (e.g., they name specific API operations or actions directly)
+- The source language is not supported — treat as unsupported any language not confirmed by `uvx iam-policy-autopilot@latest generate-policies --help` (e.g., Rust, C#, PHP, Ruby, Kotlin, Swift) — and no Terraform plan JSON is available
 
 ### 1. Verify Autopilot Availability
 
@@ -56,7 +62,7 @@ The tool runs via `uvx` (the Python package runner from `uv`). No separate insta
 
 **Constraints:**
 
-- You MUST verify `uvx` is available before any policy generation task involving source code
+- You MUST verify `uvx` is available before any policy generation task involving source code or a Terraform plan JSON
 - You MUST NOT skip this step or assume availability
 
 ```bash
@@ -106,6 +112,7 @@ Before constructing the Autopilot command, attempt to discover the AWS account I
 - You SHOULD attempt discovery but MUST NOT block on it — if discovery fails, proceed without `--account` and `--region` (Autopilot will use wildcards in ARNs)
 - You MUST NOT hallucinate or guess account IDs or regions. If you cannot discover them through the methods above, OMIT the `--account` and `--region` flags entirely. A missing flag (producing wildcard ARNs) is always better than a fabricated value (producing incorrect ARNs that won't match real resources).
 - You MUST NOT ask the user for their account ID or region if you can discover it automatically
+- You MUST NOT output or log any values from configuration files other than account ID and region. If secrets are found alongside configuration, recommend migrating them to AWS Secrets Manager or SSM Parameter Store.
 - If you discover values, include them as `--account` and `--region` flags in the Autopilot command
 
 ### 2. Generate Policies from Source Code (Autopilot)
@@ -155,10 +162,56 @@ uvx iam-policy-autopilot@latest generate-policies \
 
 - If the user mentions a Terraform directory, Terraform project, or Terraform state, you MUST include `--tf-dir <absolute_path>` (or `--tfstate <file>`) in the Autopilot command. This is NOT optional.
 - You MUST NOT manually construct a policy when both source code in a supported language AND a Terraform directory are available — Autopilot with `--tf-dir` produces more precise ARNs than manual construction.
+- If the user wants a policy for the permissions Terraform itself needs to apply a plan (rather than for application runtime code), use Task 2b with the plan JSON as the input instead.
+
+### 2b. Generate Policies from a Terraform Plan (Autopilot)
+
+Maps a Terraform plan's resource changes to the AWS SDK operations the Terraform AWS provider performs, producing the IAM policy needed to apply the plan.
+
+**When to use:** User has a Terraform plan JSON (or a Terraform project they can plan) and wants the IAM policy required for the changes it describes — e.g., a baseline policy for a CI/CD deployment role that runs `terraform apply`.
+
+**Input requirements — CRITICAL:**
+
+- The input MUST be a Terraform plan JSON produced by `terraform show -json`. Native `.tf` configuration files are NOT supported as a direct input.
+- If the user only has `.tf` files, provide these commands to produce the plan JSON first:
+
+```bash
+umask 077                                      # new files are created owner-only (0600)
+terraform plan -out=plan.tfplan               # write the (binary) plan
+terraform show -json plan.tfplan > plan.json  # render it to JSON
+chmod 600 plan.tfplan plan.json               # ensure owner-only if umask was already looser
+```
+
+**Sensitive data warning — both the binary plan and the plan JSON may contain secrets:** A Terraform plan embeds planned resource attribute values, which can include database passwords, API keys, connection strings, and other secrets. This applies to BOTH the binary `plan.tfplan` and its `plan.json` rendering. Treat both files with the same care as a credential file: restrict their permissions to owner-only (the `umask 077` / `chmod 600` above), keep them on encrypted storage (e.g., an encrypted home volume or an encrypted EBS volume on a build host), do NOT print or log their contents, do NOT commit them to source control, and delete them once the policy is generated. You MUST NOT echo the plan contents into your response. Autopilot reads only the resource change actions, not secret values, so nothing sensitive needs to be surfaced to the user.
+
+Then pass the plan JSON in place of source files:
+
+```bash
+uvx iam-policy-autopilot@latest generate-policies \
+  /home/user/project/plan.json \
+  --region us-east-1 \
+  --account 123456789012 \
+  --pretty
+
+rm -f plan.tfplan plan.json                    # delete the sensitive plan files once done
+```
+
+**Constraints:**
+
+- You MUST use an absolute path to the plan JSON file
+- The input kind (source code vs Terraform plan) is detected automatically — you MUST NOT mix source files and a plan JSON in a single invocation. If the user needs both an application runtime policy and a Terraform deployment policy, run two separate invocations.
+- You MUST include `--region` and `--account` if values were discovered in Task 1b or provided by the user
+- You MUST NOT manually map Terraform resources to IAM actions yourself — delegate to Autopilot
+- You MUST NOT upload or apply policies without explicit user confirmation
+- The `--tf-dir` and `--tfstate` flags do not apply to this path — they refine ARNs during source-code analysis. When the plan JSON is the input, precision comes from the plan itself.
+- When the generated policy is for a CI/CD role that runs `terraform apply`, recommend the pipeline assume the role via short-lived federated credentials (e.g., GitHub Actions or GitLab CI OIDC, or an instance profile / IAM Roles Anywhere) rather than long-lived IAM user access keys. Ephemeral credentials that rotate automatically are strongly preferred for deployment roles.
+  - Scope the role's trust policy so only the intended pipeline can assume it. For GitHub Actions OIDC, restrict `token.actions.githubusercontent.com:sub` to specific `repo:<org>/<repo>:ref:<branch>` (or environment) values and pin `:aud` to `sts.amazonaws.com`; for GitLab CI OIDC, restrict the equivalent `:sub`/`:aud` claims. Without a `sub` condition, any workflow (or any repo in the org) that reaches the OIDC provider could assume the role.
+  - A role that can run `terraform apply` can create, modify, and delete infrastructure, so recommend enabling CloudTrail logging of its activity and CloudWatch alarms for unexpected or privilege-escalating actions (e.g., `iam:*`, `CreatePolicyVersion`, `AttachRolePolicy`). Encrypt the CloudTrail S3 bucket with SSE-KMS (and enable log file validation), encrypt any CloudWatch Logs log groups that receive these events with a KMS key, and encrypt the SNS topic used for alarm notifications (and confirm its subscribers are authorized personnel), since deployment activity can reference sensitive resource names.
+  - Any secrets the pipeline needs (Terraform variables holding passwords, API keys, or connection strings referenced by the plan) should be sourced from AWS Secrets Manager or SSM Parameter Store at apply time rather than hardcoded in `.tf` files, `.tfvars`, or CI environment variables committed to source control.
 
 ### 3. Generate Policies from API Operations (Service Authorization Reference)
 
-**When to use:** Autopilot is unavailable, the task does not involve source code, or the user names specific API operations/IAM actions directly.
+**When to use:** Autopilot is unavailable, the task involves neither source code nor a Terraform plan JSON, or the user names specific API operations/IAM actions directly.
 
 #### 3a. Verify Dependencies
 
@@ -215,7 +268,7 @@ curl -s "https://servicereference.us-east-1.amazonaws.com/v1/lambda/lambda.json"
 - You MUST include ALL actions listed in `AuthorizedActions` for each operation, including cross-service actions (e.g., `iam:PassRole` for `lambda:CreateFunction`) and prerequisite actions (e.g., `lambda:GetLayerVersion` for `lambda:CreateFunction` — required to attach layers during creation). Do NOT omit actions from the AuthorizedActions list based on your own judgment about whether they seem "optional" — if the service reference lists them, include them.
 - You MUST NOT include actions for optional service variants (e.g., `s3-object-lambda:*`, `s3:GetObjectVersion`, `s3:GetObjectTagging`) unless the user explicitly mentions Object Lambda, versioning, tagging, access points, or similar features
 - You MUST NOT use the API operation name as the IAM action unless the reference confirms they match
-- You MUST NOT add actions for operations the user did not request — least privilege means exactly what was asked
+- You MUST NOT add actions for operations the user did not request — the policy must cover exactly what was asked
 - If the user names a specific IAM action directly (e.g., "allow s3:PutObject"), you MUST use that exact action without expanding it to all authorized actions for the underlying API operation
 - If the user names a specific condition key (e.g., "use aws:TagKeys"), you MUST use that exact key — do not substitute a service-specific alternative
 - You SHOULD explain to the user what you are querying and why
@@ -231,9 +284,9 @@ Build the IAM policy document from the queried actions.
 - You MUST scope resources using specific ARNs when possible — avoid `*`
 - You MUST separate cross-service actions (e.g., `iam:PassRole`) into their own statement with appropriate conditions
 - You MUST present the complete policy to the user and explain each statement before considering the task complete
-- You MUST NOT include "optional", "additional", or "you may also need" permissions sections in your response. If the user asked for permission to create an API, provide ONLY the creation permission. Do not suggest read, update, or delete permissions "in case they need them later." This violates least privilege even when labeled as optional.
+- You MUST NOT include "optional", "additional", or "you may also need" permissions sections in your response. If the user asked for permission to create an API, provide ONLY the creation permission. Do not suggest read, update, or delete permissions "in case they need them later." This over-grants permissions even when labeled as optional.
 - Your response MUST contain exactly ONE policy document. Do not present a "minimal" policy followed by a "comprehensive" or "expanded" policy — only the minimal one. If the user needs more permissions, they will ask.
-- You MUST NOT add actions for operations the user did not request — least privilege means exactly what was asked, nothing more
+- You MUST NOT add actions for operations the user did not request — the policy must cover exactly what was asked, nothing more
 
 **Resource-based policy requirements:**
 
@@ -296,16 +349,18 @@ See [common pitfalls](common-pitfalls.md) for additional examples.
 
 ## Decision Guide
 
-| Situation                                           | Path      | Command/Approach                       |
-| --------------------------------------------------- | --------- | -------------------------------------- |
-| Source code using AWS SDKs                          | Autopilot | `generate-policies` with source files  |
-| Policy seems too broad from Autopilot               | Autopilot | Re-run with `--service-hints`          |
-| Need to understand a specific action                | Autopilot | Use `--explain` with an action pattern |
-| Using Terraform and want precise ARNs               | Autopilot | Add `--tf-dir` or `--tfstate` flags    |
-| Autopilot unavailable or install failed             | Reference | Query service authorization reference  |
-| User names specific API operations (no source code) | Reference | Query service authorization reference  |
-| Unsupported language                                | Reference | Query service authorization reference  |
-| Need resource-based policies                        | Reference | Autopilot only supports identity-based |
+| Situation                                            | Path      | Command/Approach                                   |
+| ---------------------------------------------------- | --------- | -------------------------------------------------- |
+| Source code using AWS SDKs                           | Autopilot | `generate-policies` with source files              |
+| Terraform plan JSON (`terraform show -json` output)  | Autopilot | `generate-policies` with the plan JSON file        |
+| Only native `.tf` files, want a deployment policy    | Autopilot | `terraform plan` + `terraform show -json`, then 2b |
+| Policy seems too broad from Autopilot                | Autopilot | Re-run with `--service-hints`                      |
+| Need to understand a specific action                 | Autopilot | Use `--explain` with an action pattern             |
+| Source code + Terraform project, want precise ARNs   | Autopilot | Add `--tf-dir` or `--tfstate` flags                |
+| Autopilot unavailable or install failed              | Reference | Query service authorization reference              |
+| User names specific API operations (no code or plan) | Reference | Query service authorization reference              |
+| Unsupported language (and no Terraform plan JSON)    | Reference | Query service authorization reference              |
+| Need resource-based policies                         | Reference | Autopilot only supports identity-based             |
 
 ## Security Considerations
 
@@ -372,7 +427,7 @@ When in doubt, ALWAYS query the service authorization reference. Never guess act
 
 ### API Gateway resource ARN patterns
 
-API Gateway uses HTTP-verb-based actions (POST, GET, PUT, PATCH, DELETE). Always scope to the specific resource path — do NOT use `"Resource": "*"`:
+API Gateway uses HTTP-verb-based actions (POST, GET, PUT, PATCH, DELETE). Always scope to the specific resource path — do NOT use `"Resource": "*"`. This table is an illustrative cache for commonly hallucinated patterns — verify against the service authorization reference for current mappings:
 
 | Operation            | Action(s)                           | Resource ARN                                    |
 | -------------------- | ----------------------------------- | ----------------------------------------------- |
@@ -400,7 +455,7 @@ API Gateway uses HTTP-verb-based actions (POST, GET, PUT, PATCH, DELETE). Always
 
 Some operations require actions in other services (e.g., `lambda:CreateFunction` requires `iam:PassRole`). Always check the full `AuthorizedActions` list including entries where `Service` differs from the queried service.
 
-**Lambda CreateFunction — complete action list (commonly incomplete):**
+**Lambda CreateFunction — commonly incomplete action list (verify against service reference):**
 The `CreateFunction` operation requires ALL of the following:
 
 - `lambda:CreateFunction` (core action)
@@ -418,7 +473,7 @@ These operators have critical edge cases with missing context keys. See [common 
 
 Verify the resource ARN format matches what the service expects. Use query pattern 3 from the [service authorization reference](service-authorization.md) to look up the correct ARN format.
 
-## Supported Languages (Autopilot)
+## Supported Inputs (Autopilot)
 
 | Language   | SDK                       |
 | ---------- | ------------------------- |
@@ -428,11 +483,18 @@ Verify the resource ARN format matches what the service expects. Use query patte
 | JavaScript | AWS SDK for JavaScript v3 |
 | Java       | AWS SDK for Java v2       |
 
+This table is not exhaustive; Autopilot is the source of truth for language and SDK support. Confirm a language's status with `uvx iam-policy-autopilot@latest generate-policies --help` or the [Supported Languages table](https://github.com/awslabs/iam-policy-autopilot#supported-languages-and-sdks-for-policy-generation) rather than relying on this table.
+
+In addition to source code, Autopilot accepts a **Terraform plan JSON** (`terraform show -json` output) as a direct input — see Task 2b. Native `.tf` configuration files are not supported as a direct input.
+
 ## Scope and Limitations
 
 - Autopilot produces IAM **identity-based policies** only
 - Autopilot does NOT support resource-based policies, RCPs, SCPs, or permission boundaries — use the Reference path for these
 - Runtime-determined resource names cannot be predicted by Autopilot — use `--tfstate` for deployed resource ARNs
+- Terraform plans MUST be rendered to JSON (`terraform show -json`) before use — native `.tf` configuration files are not supported as a direct input
+- Source code and a Terraform plan JSON cannot be mixed in a single invocation — run separately for each
+- A Terraform plan JSON may contain sensitive planned attribute values (passwords, API keys, connection strings). Handle it like a credential file: restrict access, never log or echo its contents, keep it out of source control, and delete it after policy generation
 - The Reference path can construct both identity and resource-based policies
 
 ## Additional Resources

--- a/skills/core-skills/aws-iam/SKILL.md
+++ b/skills/core-skills/aws-iam/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: aws-iam
 description: >
-  Verified corrections for IAM behaviors that AI agents frequently get wrong — policy
+  Provides verified corrections for IAM behaviors that AI agents frequently get wrong — policy
   evaluation edge cases, trust policy gotchas, STS session limits, Organizations quirks,
   and SAML/MFA specifics. Also provides structured workflows for IAM role management and
-  least-privilege policy generation. Covers condition operator safety (ForAnyValue/ForAllValues
-  with Null checks for absent keys), bucket policy deny patterns (VPC endpoint restrictions,
-  org path conditions), resource-based policy confused deputy protection, and service role
-  creation for AWS services (Glue, CloudTrail, VPC Flow Logs, Firehose, DataSync, S3
-  replication, Lambda, Step Functions, ECS, etc.) including trust policies with
-  aws:SourceAccount/aws:SourceArn conditions. Applies when creating or configuring IAM roles,
-  writing IAM or bucket policies, working with STS, Organizations, condition operators, or
-  any task requiring an IAM service role or execution role. Does not cover non-IAM
-  authorization like Cognito user-pool policies or app-level RBAC.
+  baseline policy generation from application source code or a Terraform plan JSON.
+  Covers condition operator safety (ForAnyValue/ForAllValues with Null checks),
+  bucket policy deny patterns (VPC endpoint restrictions, org paths), confused deputy
+  protection, and service role creation for AWS services (Glue, CloudTrail, Lambda, ECS,
+  etc.) with
+  aws:SourceAccount/aws:SourceArn trust conditions. Applies when creating IAM roles,
+  writing IAM or bucket policies, generating policies from application source code or a Terraform plan JSON,
+  working with STS, Organizations, or condition operators, or any task needing a service
+  or execution role. Does not cover non-IAM authorization like Cognito user-pool policies
+  or app-level RBAC.
 metadata:
-  version: "1"
+  version: "2"
 ---
 
 # AWS IAM — Common Pitfalls
@@ -29,7 +30,7 @@ Use the best available tool for AWS operations — the AWS MCP server is recomme
 
 - Read [references/aws-iam-role-management.md](references/aws-iam-role-management.md) if the user needs to create, scope, or maintain IAM roles when provisioning or updating AWS resources. Covers service roles, execution roles, trust policies, confused deputy protection, and permission hygiene.
 
-- Read [references/aws-iam-policy-generation.md](references/aws-iam-policy-generation.md) if the user needs to generate least-privilege IAM policies, determine required IAM actions for API calls, or understand action-to-operation mappings. **CRITICAL: If the user provides source code (Python, Go, TypeScript, JavaScript, Java), you MUST read this reference — it mandates using iam-policy-autopilot instead of manual policy construction.** Uses the programmatic service authorization reference for accurate mappings.
+- Read [references/aws-iam-policy-generation.md](references/aws-iam-policy-generation.md) if the user needs to generate IAM policies, determine required IAM actions for API calls, or understand action-to-operation mappings. **CRITICAL: If the user provides application source code (in any language) or a Terraform plan JSON file (`terraform show -json` output), you MUST read this reference — it mandates using iam-policy-autopilot instead of manual policy construction.** Uses the programmatic service authorization reference for accurate mappings.
 
 ## Verified Edge Cases
 

--- a/skills/core-skills/aws-iam/references/aws-iam-policy-generation.md
+++ b/skills/core-skills/aws-iam/references/aws-iam-policy-generation.md
@@ -2,39 +2,45 @@
 
 ## CRITICAL RULE — READ THIS FIRST
 
-**If the user provides source code in Python, Go, TypeScript, JavaScript, or Java:**
-You MUST propose the `uvx iam-policy-autopilot@latest generate-policies` command. You MUST NOT manually analyze the code and construct a policy yourself. The Autopilot tool does deterministic static analysis — your job is to construct the correct command with the right flags, NOT to replicate what the tool does.
+**If the user provides application source code (in any language) OR a Terraform plan JSON (`terraform show -json` output):**
+You MUST propose the `uvx iam-policy-autopilot@latest generate-policies` command. You MUST NOT manually analyze the code or plan and construct a policy yourself. The Autopilot tool does deterministic static analysis — your job is to construct the correct command with the right flags, NOT to replicate what the tool does. (The Input Gate below lists the languages known to work and directs you to confirm a language's status with `generate-policies --help`.)
 
-**If no source code is provided, or the language is unsupported (Rust, C#, PHP, Ruby, etc.):**
+**If no source code or Terraform plan JSON is provided, or the language is unsupported (Rust, C#, PHP, Ruby, etc.):**
 Use the Service Authorization Reference path to produce the policy directly.
+
+**Terraform plan JSON vs native `.tf` files — CRITICAL distinction:** Autopilot accepts a Terraform plan JSON (`terraform show -json plan.tfplan`) as a direct input. Native `.tf` configuration files are NOT supported as a direct input — if the user only has `.tf` files, instruct them to produce a plan JSON first (see Task 2b). The separate `--tf-dir`/`--tfstate` flags remain available only as ARN-refinement companions to source-code analysis.
+
+Throughout this reference, "Terraform plan JSON" is the canonical term for this input: a Terraform plan rendered to JSON via `terraform show -json`.
 
 ## Overview
 
 Generates baseline AWS IAM identity-based policies through two complementary approaches:
 
-1. **IAM Policy Autopilot** (primary, MANDATORY when source code in a supported language is present) — Deterministic static analysis of application source code. Produces policies by parsing actual AWS SDK calls. Preferred for security because it is reproducible and not subject to LLM hallucination. You MUST use this path when source code is available in a supported language.
-2. **Service Authorization Reference** (fallback) — Queries the programmatic service reference to map API operations to correct IAM actions. Used ONLY when Autopilot is unavailable, the task does not involve source code, or the source language is not supported.
+1. **IAM Policy Autopilot** (primary, MANDATORY when source code in a supported language OR a Terraform plan JSON is present) — Deterministic static analysis. For source code, it produces policies by parsing actual AWS SDK calls. For a Terraform plan JSON, it maps the plan's resource changes to the AWS SDK operations the Terraform AWS provider performs. Preferred for security because it is reproducible and not subject to LLM hallucination. You MUST use this path when either input is available.
+2. **Service Authorization Reference** (fallback) — Queries the programmatic service reference to map API operations to correct IAM actions. Used ONLY when Autopilot is unavailable, the task involves neither source code nor a Terraform plan JSON, or the source language is not supported.
 
 **Output completeness rule — CRITICAL:**
 
 - When using the Service Authorization Reference path (Task 3): You MUST always produce a complete policy document in your response. Use placeholder values (e.g., `<bucket-name>`, `<role-arn>`, `<REGION>`) when specific resource names are not provided. NEVER ask clarifying questions instead of producing a policy.
-- When using the Autopilot path (Task 2): You MUST produce the complete `uvx iam-policy-autopilot@latest generate-policies` command with all required flags. You MUST NOT manually construct a policy — the Autopilot command IS your output. Do not also produce a hand-written policy "in case Autopilot isn't available."
+- When using the Autopilot path (Task 2 or Task 2b): You MUST produce the complete `uvx iam-policy-autopilot@latest generate-policies` command with all required flags. You MUST NOT manually construct a policy — the Autopilot command IS your output. Do not also produce a hand-written policy "in case Autopilot isn't available."
 - If the user's code uses runtime variables for resource names, use descriptive placeholders in the ARNs (Reference path) or note that Autopilot handles this automatically (Autopilot path).
 
 ## Common Tasks
 
-### 0. Language Gate (MANDATORY FIRST STEP)
+### 0. Input Gate (MANDATORY FIRST STEP)
 
-When source code is provided, identify the programming language before choosing a path.
+Identify what the user provided before choosing a path.
 
-**Supported languages** (use Autopilot — Task 1 → Task 2):
+**Terraform plan JSON** (use Autopilot — Task 1 → Task 2b): a plan rendered to JSON with `terraform show -json`. This input is supported regardless of any application language considerations. Native `.tf` configuration files alone do NOT qualify — the user must produce a Terraform plan JSON first (Task 2b shows how).
+
+**Supported languages** for source code (use Autopilot — Task 1 → Task 2). This list is not exhaustive; Autopilot is the source of truth for language support, so confirm a language's status with `uvx iam-policy-autopilot@latest generate-policies --help` (or the [Supported Languages table](https://github.com/awslabs/iam-policy-autopilot#supported-languages-and-sdks-for-policy-generation)) rather than relying on this list:
 
 - Python (boto3)
 - Go (SDK v2)
 - TypeScript/JavaScript (SDK v3)
 - Java (SDK v2)
 
-**Unsupported languages** (Rust, C#, PHP, Ruby, Kotlin, Swift, etc.) — fall back silently to the Service Authorization Reference path (Task 3). Do NOT attempt to use Autopilot. Do NOT ask the user whether to proceed with the fallback — just produce the policy directly using the Reference path. Even if a Terraform directory is mentioned alongside unsupported-language code, you MUST NOT attempt to use `--tf-dir` with Autopilot — the language is unsupported, so Autopilot cannot be used at all.
+**Unsupported languages** (e.g., Rust, C#, PHP, Ruby, Kotlin, Swift — treat as unsupported any language not confirmed by `uvx iam-policy-autopilot@latest generate-policies --help`) — fall back silently to the Service Authorization Reference path (Task 3). Do NOT attempt to use Autopilot for a language you have confirmed is unsupported. Do NOT ask the user whether to proceed with the fallback — just produce the policy directly using the Reference path. Even if a Terraform directory is mentioned alongside unsupported-language code, you MUST NOT attempt to use `--tf-dir` with Autopilot — the language is unsupported, so Autopilot cannot be used at all. However, if the user provides (or can produce) a Terraform **plan JSON**, that is an independent supported input — use Task 2b for the plan even when application code is in an unsupported language.
 
 **For supported languages**, you MUST:
 
@@ -47,8 +53,8 @@ You MUST NOT manually analyze source code and construct policies yourself when A
 Fall back to the Service Authorization Reference path ONLY when:
 
 - The `iam-policy-autopilot` CLI is not installed AND installation fails
-- The user's task does not involve source code (e.g., they name specific API operations or actions directly)
-- The source language is not supported (Rust, C#, PHP, Ruby, Kotlin, Swift, etc. are NOT supported)
+- The user's task involves neither source code nor a Terraform plan JSON (e.g., they name specific API operations or actions directly)
+- The source language is not supported — treat as unsupported any language not confirmed by `uvx iam-policy-autopilot@latest generate-policies --help` (e.g., Rust, C#, PHP, Ruby, Kotlin, Swift) — and no Terraform plan JSON is available
 
 ### 1. Verify Autopilot Availability
 
@@ -56,7 +62,7 @@ The tool runs via `uvx` (the Python package runner from `uv`). No separate insta
 
 **Constraints:**
 
-- You MUST verify `uvx` is available before any policy generation task involving source code
+- You MUST verify `uvx` is available before any policy generation task involving source code or a Terraform plan JSON
 - You MUST NOT skip this step or assume availability
 
 ```bash
@@ -106,6 +112,7 @@ Before constructing the Autopilot command, attempt to discover the AWS account I
 - You SHOULD attempt discovery but MUST NOT block on it — if discovery fails, proceed without `--account` and `--region` (Autopilot will use wildcards in ARNs)
 - You MUST NOT hallucinate or guess account IDs or regions. If you cannot discover them through the methods above, OMIT the `--account` and `--region` flags entirely. A missing flag (producing wildcard ARNs) is always better than a fabricated value (producing incorrect ARNs that won't match real resources).
 - You MUST NOT ask the user for their account ID or region if you can discover it automatically
+- You MUST NOT output or log any values from configuration files other than account ID and region. If secrets are found alongside configuration, recommend migrating them to AWS Secrets Manager or SSM Parameter Store.
 - If you discover values, include them as `--account` and `--region` flags in the Autopilot command
 
 ### 2. Generate Policies from Source Code (Autopilot)
@@ -155,10 +162,56 @@ uvx iam-policy-autopilot@latest generate-policies \
 
 - If the user mentions a Terraform directory, Terraform project, or Terraform state, you MUST include `--tf-dir <absolute_path>` (or `--tfstate <file>`) in the Autopilot command. This is NOT optional.
 - You MUST NOT manually construct a policy when both source code in a supported language AND a Terraform directory are available — Autopilot with `--tf-dir` produces more precise ARNs than manual construction.
+- If the user wants a policy for the permissions Terraform itself needs to apply a plan (rather than for application runtime code), use Task 2b with the plan JSON as the input instead.
+
+### 2b. Generate Policies from a Terraform Plan (Autopilot)
+
+Maps a Terraform plan's resource changes to the AWS SDK operations the Terraform AWS provider performs, producing the IAM policy needed to apply the plan.
+
+**When to use:** User has a Terraform plan JSON (or a Terraform project they can plan) and wants the IAM policy required for the changes it describes — e.g., a baseline policy for a CI/CD deployment role that runs `terraform apply`.
+
+**Input requirements — CRITICAL:**
+
+- The input MUST be a Terraform plan JSON produced by `terraform show -json`. Native `.tf` configuration files are NOT supported as a direct input.
+- If the user only has `.tf` files, provide these commands to produce the plan JSON first:
+
+```bash
+umask 077                                      # new files are created owner-only (0600)
+terraform plan -out=plan.tfplan               # write the (binary) plan
+terraform show -json plan.tfplan > plan.json  # render it to JSON
+chmod 600 plan.tfplan plan.json               # ensure owner-only if umask was already looser
+```
+
+**Sensitive data warning — both the binary plan and the plan JSON may contain secrets:** A Terraform plan embeds planned resource attribute values, which can include database passwords, API keys, connection strings, and other secrets. This applies to BOTH the binary `plan.tfplan` and its `plan.json` rendering. Treat both files with the same care as a credential file: restrict their permissions to owner-only (the `umask 077` / `chmod 600` above), keep them on encrypted storage (e.g., an encrypted home volume or an encrypted EBS volume on a build host), do NOT print or log their contents, do NOT commit them to source control, and delete them once the policy is generated. You MUST NOT echo the plan contents into your response. Autopilot reads only the resource change actions, not secret values, so nothing sensitive needs to be surfaced to the user.
+
+Then pass the plan JSON in place of source files:
+
+```bash
+uvx iam-policy-autopilot@latest generate-policies \
+  /home/user/project/plan.json \
+  --region us-east-1 \
+  --account 123456789012 \
+  --pretty
+
+rm -f plan.tfplan plan.json                    # delete the sensitive plan files once done
+```
+
+**Constraints:**
+
+- You MUST use an absolute path to the plan JSON file
+- The input kind (source code vs Terraform plan) is detected automatically — you MUST NOT mix source files and a plan JSON in a single invocation. If the user needs both an application runtime policy and a Terraform deployment policy, run two separate invocations.
+- You MUST include `--region` and `--account` if values were discovered in Task 1b or provided by the user
+- You MUST NOT manually map Terraform resources to IAM actions yourself — delegate to Autopilot
+- You MUST NOT upload or apply policies without explicit user confirmation
+- The `--tf-dir` and `--tfstate` flags do not apply to this path — they refine ARNs during source-code analysis. When the plan JSON is the input, precision comes from the plan itself.
+- When the generated policy is for a CI/CD role that runs `terraform apply`, recommend the pipeline assume the role via short-lived federated credentials (e.g., GitHub Actions or GitLab CI OIDC, or an instance profile / IAM Roles Anywhere) rather than long-lived IAM user access keys. Ephemeral credentials that rotate automatically are strongly preferred for deployment roles.
+  - Scope the role's trust policy so only the intended pipeline can assume it. For GitHub Actions OIDC, restrict `token.actions.githubusercontent.com:sub` to specific `repo:<org>/<repo>:ref:<branch>` (or environment) values and pin `:aud` to `sts.amazonaws.com`; for GitLab CI OIDC, restrict the equivalent `:sub`/`:aud` claims. Without a `sub` condition, any workflow (or any repo in the org) that reaches the OIDC provider could assume the role.
+  - A role that can run `terraform apply` can create, modify, and delete infrastructure, so recommend enabling CloudTrail logging of its activity and CloudWatch alarms for unexpected or privilege-escalating actions (e.g., `iam:*`, `CreatePolicyVersion`, `AttachRolePolicy`). Encrypt the CloudTrail S3 bucket with SSE-KMS (and enable log file validation), encrypt any CloudWatch Logs log groups that receive these events with a KMS key, and encrypt the SNS topic used for alarm notifications (and confirm its subscribers are authorized personnel), since deployment activity can reference sensitive resource names.
+  - Any secrets the pipeline needs (Terraform variables holding passwords, API keys, or connection strings referenced by the plan) should be sourced from AWS Secrets Manager or SSM Parameter Store at apply time rather than hardcoded in `.tf` files, `.tfvars`, or CI environment variables committed to source control.
 
 ### 3. Generate Policies from API Operations (Service Authorization Reference)
 
-**When to use:** Autopilot is unavailable, the task does not involve source code, or the user names specific API operations/IAM actions directly.
+**When to use:** Autopilot is unavailable, the task involves neither source code nor a Terraform plan JSON, or the user names specific API operations/IAM actions directly.
 
 #### 3a. Verify Dependencies
 
@@ -215,7 +268,7 @@ curl -s "https://servicereference.us-east-1.amazonaws.com/v1/lambda/lambda.json"
 - You MUST include ALL actions listed in `AuthorizedActions` for each operation, including cross-service actions (e.g., `iam:PassRole` for `lambda:CreateFunction`) and prerequisite actions (e.g., `lambda:GetLayerVersion` for `lambda:CreateFunction` — required to attach layers during creation). Do NOT omit actions from the AuthorizedActions list based on your own judgment about whether they seem "optional" — if the service reference lists them, include them.
 - You MUST NOT include actions for optional service variants (e.g., `s3-object-lambda:*`, `s3:GetObjectVersion`, `s3:GetObjectTagging`) unless the user explicitly mentions Object Lambda, versioning, tagging, access points, or similar features
 - You MUST NOT use the API operation name as the IAM action unless the reference confirms they match
-- You MUST NOT add actions for operations the user did not request — least privilege means exactly what was asked
+- You MUST NOT add actions for operations the user did not request — the policy must cover exactly what was asked
 - If the user names a specific IAM action directly (e.g., "allow s3:PutObject"), you MUST use that exact action without expanding it to all authorized actions for the underlying API operation
 - If the user names a specific condition key (e.g., "use aws:TagKeys"), you MUST use that exact key — do not substitute a service-specific alternative
 - You SHOULD explain to the user what you are querying and why
@@ -231,9 +284,9 @@ Build the IAM policy document from the queried actions.
 - You MUST scope resources using specific ARNs when possible — avoid `*`
 - You MUST separate cross-service actions (e.g., `iam:PassRole`) into their own statement with appropriate conditions
 - You MUST present the complete policy to the user and explain each statement before considering the task complete
-- You MUST NOT include "optional", "additional", or "you may also need" permissions sections in your response. If the user asked for permission to create an API, provide ONLY the creation permission. Do not suggest read, update, or delete permissions "in case they need them later." This violates least privilege even when labeled as optional.
+- You MUST NOT include "optional", "additional", or "you may also need" permissions sections in your response. If the user asked for permission to create an API, provide ONLY the creation permission. Do not suggest read, update, or delete permissions "in case they need them later." This over-grants permissions even when labeled as optional.
 - Your response MUST contain exactly ONE policy document. Do not present a "minimal" policy followed by a "comprehensive" or "expanded" policy — only the minimal one. If the user needs more permissions, they will ask.
-- You MUST NOT add actions for operations the user did not request — least privilege means exactly what was asked, nothing more
+- You MUST NOT add actions for operations the user did not request — the policy must cover exactly what was asked, nothing more
 
 **Resource-based policy requirements:**
 
@@ -296,16 +349,18 @@ See [common pitfalls](common-pitfalls.md) for additional examples.
 
 ## Decision Guide
 
-| Situation                                           | Path      | Command/Approach                       |
-| --------------------------------------------------- | --------- | -------------------------------------- |
-| Source code using AWS SDKs                          | Autopilot | `generate-policies` with source files  |
-| Policy seems too broad from Autopilot               | Autopilot | Re-run with `--service-hints`          |
-| Need to understand a specific action                | Autopilot | Use `--explain` with an action pattern |
-| Using Terraform and want precise ARNs               | Autopilot | Add `--tf-dir` or `--tfstate` flags    |
-| Autopilot unavailable or install failed             | Reference | Query service authorization reference  |
-| User names specific API operations (no source code) | Reference | Query service authorization reference  |
-| Unsupported language                                | Reference | Query service authorization reference  |
-| Need resource-based policies                        | Reference | Autopilot only supports identity-based |
+| Situation                                            | Path      | Command/Approach                                   |
+| ---------------------------------------------------- | --------- | -------------------------------------------------- |
+| Source code using AWS SDKs                           | Autopilot | `generate-policies` with source files              |
+| Terraform plan JSON (`terraform show -json` output)  | Autopilot | `generate-policies` with the plan JSON file        |
+| Only native `.tf` files, want a deployment policy    | Autopilot | `terraform plan` + `terraform show -json`, then 2b |
+| Policy seems too broad from Autopilot                | Autopilot | Re-run with `--service-hints`                      |
+| Need to understand a specific action                 | Autopilot | Use `--explain` with an action pattern             |
+| Source code + Terraform project, want precise ARNs   | Autopilot | Add `--tf-dir` or `--tfstate` flags                |
+| Autopilot unavailable or install failed              | Reference | Query service authorization reference              |
+| User names specific API operations (no code or plan) | Reference | Query service authorization reference              |
+| Unsupported language (and no Terraform plan JSON)    | Reference | Query service authorization reference              |
+| Need resource-based policies                         | Reference | Autopilot only supports identity-based             |
 
 ## Security Considerations
 
@@ -372,7 +427,7 @@ When in doubt, ALWAYS query the service authorization reference. Never guess act
 
 ### API Gateway resource ARN patterns
 
-API Gateway uses HTTP-verb-based actions (POST, GET, PUT, PATCH, DELETE). Always scope to the specific resource path — do NOT use `"Resource": "*"`:
+API Gateway uses HTTP-verb-based actions (POST, GET, PUT, PATCH, DELETE). Always scope to the specific resource path — do NOT use `"Resource": "*"`. This table is an illustrative cache for commonly hallucinated patterns — verify against the service authorization reference for current mappings:
 
 | Operation            | Action(s)                           | Resource ARN                                    |
 | -------------------- | ----------------------------------- | ----------------------------------------------- |
@@ -400,7 +455,7 @@ API Gateway uses HTTP-verb-based actions (POST, GET, PUT, PATCH, DELETE). Always
 
 Some operations require actions in other services (e.g., `lambda:CreateFunction` requires `iam:PassRole`). Always check the full `AuthorizedActions` list including entries where `Service` differs from the queried service.
 
-**Lambda CreateFunction — complete action list (commonly incomplete):**
+**Lambda CreateFunction — commonly incomplete action list (verify against service reference):**
 The `CreateFunction` operation requires ALL of the following:
 
 - `lambda:CreateFunction` (core action)
@@ -418,7 +473,7 @@ These operators have critical edge cases with missing context keys. See [common 
 
 Verify the resource ARN format matches what the service expects. Use query pattern 3 from the [service authorization reference](service-authorization.md) to look up the correct ARN format.
 
-## Supported Languages (Autopilot)
+## Supported Inputs (Autopilot)
 
 | Language   | SDK                       |
 | ---------- | ------------------------- |
@@ -428,11 +483,18 @@ Verify the resource ARN format matches what the service expects. Use query patte
 | JavaScript | AWS SDK for JavaScript v3 |
 | Java       | AWS SDK for Java v2       |
 
+This table is not exhaustive; Autopilot is the source of truth for language and SDK support. Confirm a language's status with `uvx iam-policy-autopilot@latest generate-policies --help` or the [Supported Languages table](https://github.com/awslabs/iam-policy-autopilot#supported-languages-and-sdks-for-policy-generation) rather than relying on this table.
+
+In addition to source code, Autopilot accepts a **Terraform plan JSON** (`terraform show -json` output) as a direct input — see Task 2b. Native `.tf` configuration files are not supported as a direct input.
+
 ## Scope and Limitations
 
 - Autopilot produces IAM **identity-based policies** only
 - Autopilot does NOT support resource-based policies, RCPs, SCPs, or permission boundaries — use the Reference path for these
 - Runtime-determined resource names cannot be predicted by Autopilot — use `--tfstate` for deployed resource ARNs
+- Terraform plans MUST be rendered to JSON (`terraform show -json`) before use — native `.tf` configuration files are not supported as a direct input
+- Source code and a Terraform plan JSON cannot be mixed in a single invocation — run separately for each
+- A Terraform plan JSON may contain sensitive planned attribute values (passwords, API keys, connection strings). Handle it like a credential file: restrict access, never log or echo its contents, keep it out of source control, and delete it after policy generation
 - The Reference path can construct both identity and resource-based policies
 
 ## Additional Resources


### PR DESCRIPTION
## Summary

Updates the `aws-iam` skill (version 2). iam-policy-autopilot 0.3.0 accepts a Terraform plan rendered to JSON (`terraform show -json` output) as a direct input to `generate-policies`, mapping the plan's resource changes to the AWS SDK operations the Terraform AWS provider performs — producing the IAM policy a deployment role needs to run `terraform apply`. The skill's policy-generation workflow now covers this input path (new Task 2b), including guidance that native `.tf` files must be rendered to a plan JSON first, that source code and a plan JSON cannot be mixed in one invocation, and security handling for sensitive plan files.

## Details

- Text-only
- Security-reviewed: Guardian PASS
- Tested with: Kiro (evaluated end-to-end across 3 models x 3 runs; >=80% task completion on every model with a large lift over baseline)

## Checklist

- [x] Internal-only frontmatter fields removed (`owner_team`, `owner_cti`, `stages`, `metadata`)
- [x] No internal links or references in skill content
- [x] No internal details in commit messages
- [x] CI checks pass