### PR TITLE
fix(aws-core): block get-secret-value via MCP proxy cli_command

### DIFF
--- a/plugins/aws-core/com.anthropic.claude-code/hooks/secret-safety.py
+++ b/plugins/aws-core/com.anthropic.claude-code/hooks/secret-safety.py
@@ -21,9 +21,20 @@ SMA_PATTERN = re.compile(
     r'(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|::1):2773/secretsmanager/get'
 )
 
-# Match the operation regardless of casing/separators:
-# GetSecretValue, get_secret_value, get-secret-value, BatchGetSecretValue, ...
-GSV_PATTERN = re.compile(r'(batch[-_]?)?get[-_]?secret[-_]?value', re.I)
+# AWS CLI invocation shape. Shared by the Bash and MCP branches so the two paths
+# cannot drift. Tolerates global flags interleaved before the service name or the
+# operation (e.g. `aws --region us-east-1 secretsmanager get-secret-value`).
+#
+# A flag token is `-` plus greedy non-whitespace, so it has exactly one possible
+# parse; an optional value token must not itself start with `-`. Both properties,
+# plus the bounded repetition, keep this linear — an ambiguous flag pattern here
+# backtracks catastrophically on long flag runs, and because the hook has a 5s
+# timeout in hooks.json, a hang would let the tool call through (fail-open).
+_CLI_FLAGS = r'(?:-\S+(?:\s+[^-\s]\S*)?\s+){0,12}'
+CLI_GSV_PATTERN = re.compile(
+    rf'aws\s+{_CLI_FLAGS}secretsmanager\s+{_CLI_FLAGS}(?:batch-)?get-secret-value\b',
+    re.I
+)
 
 # Structured operation names normalized to lowercase, no separators.
 GSV_OPERATIONS = ("getsecretvalue", "batchgetsecretvalue")
@@ -120,6 +131,10 @@ def main():
         if SDK_CALL_PATTERN.search(input_str):
             if "secretsmanager" in input_str.lower():
                 deny()
+        # AWS CLI command strings routed through an MCP proxy (e.g. call_aws's
+        # cli_command), which carry neither structured fields nor SDK call syntax.
+        if CLI_GSV_PATTERN.search(input_str):
+            deny()
         allow()
 
     # Check run_script tools for secret fetching in code
@@ -133,7 +148,7 @@ def main():
     if tool_name == "Bash":
         command = tool_input.get("command", "")
         # AWS CLI secret fetching (shape-aware: actual `aws secretsmanager get-secret-value`)
-        if re.search(r'aws\s+secretsmanager\s+(get-secret-value|batch-get-secret-value)', command, re.I):
+        if CLI_GSV_PATTERN.search(command):
             deny()
         # Direct SMA access (shape-aware: actual URL to the agent)
         if SMA_PATTERN.search(command):


### PR DESCRIPTION
## Description

Closes #249.

The `secret-safety` PreToolUse hook blocked `get-secret-value` on the `Bash` path and for structured MCP tool calls, but not when the same command arrived as a CLI string through the AWS MCP proxy's `call_aws` tool — the AWS access path that `aws configure agent-toolkit` installs by default, which made the unprotected route the most travelled one.

**Root cause.** The MCP branch applied only two checks before falling through to an unconditional `allow()`: the structured `service_name`/`operation_name` fields, which `call_aws` does not send, and `SDK_CALL_PATTERN`, which is deliberately call-shaped (it requires a leading `.` or a trailing `(`) and so cannot match a bare CLI string. The regex that would have caught it existed only in the `Bash` branch, unreachable from the MCP path because each branch terminates in its own `allow()`/`deny()`.

**Fix.** Add a CLI-shape check to the MCP branch before `allow()`, extracted into a single `CLI_GSV_PATTERN` shared with the `Bash` branch so the two paths cannot drift apart again. The shared pattern also tolerates global flags interleaved before the service name or the operation (`aws --region us-east-1 secretsmanager get-secret-value`), which bypassed the previous `Bash`-only regex as well — so the `Bash` path gets slightly stricter too.

Drops the unused `GSV_PATTERN`, which was defined for this case but never referenced anywhere in the repo. Wiring it in as-is would have denied bare mentions such as `grep -rn get-secret-value .`, so the CLI-shape pattern replaces it rather than reusing it.

The pattern is written to parse unambiguously and with bounded repetition: a flag token is `-` plus greedy non-whitespace, and an optional value token may not itself start with `-`, so a non-dash token can never begin a repetition and the flag/value ambiguity collapses instead of branching. This matters because `hooks.json` gives the hook a 5s timeout, so a regex hang would fail open and let the tool call through.

## Verification

The issue's four-case table, fed to the hook via `python3 secret-safety.py < payload`:

| # | `tool_name` | `tool_input` | Before | After |
|---|---|---|---|---|
| 1 | `Bash` | `{"command": "aws secretsmanager get-secret-value --secret-id prod/db"}` | deny | deny |
| 2 | `mcp__aws-mcp__aws___call_aws` | `{"cli_command": "aws secretsmanager get-secret-value --secret-id prod/db"}` | **allow** | **deny** |
| 3 | `mcp__aws-mcp__x` | `{"service_name": "secretsmanager", "operation_name": "GetSecretValue"}` | deny | deny |
| 4 | `Bash` | `{"command": "grep -rn get-secret-value ."}` | allow | allow |

Also checked, diffed against the pre-change hook:

- No previously-denied case became allowed.
- Legitimate Secrets Manager operations still pass: `list-secrets`, `describe-secret`, `put-secret-value`, and `ssm get-parameter --with-decryption`.
- Read-only mentions still pass on the `Bash` path: `grep`, `rg`, `git log --grep`, `echo`.
- Existing detections still fire: the SMA daemon URL, and `get_secret_value` in inline interpreter code.
- Newly caught on both paths: interleaved global flags, `batch-get-secret-value`, casing and whitespace variations.
- Adversarial inputs stay linear — 400 flag/value pairs and 10KB `\S+` runs resolve in under 1ms, well inside the 5s timeout.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [x] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [ ] I have updated relevant documentation — not applicable, see note below

## Notes

No documentation change is needed: the [Secrets Manager guidance for AI agents](https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets-ai-agents.html) already describes the hook as blocking `GetSecretValue` via "AWS CLI, SDK, MCP tools, or direct access to the AWS Workload Credentials Provider daemon". This change makes the behaviour match that existing description rather than altering it.

Two limitations are left as follow-ups, neither reachable through normal agent behaviour:

- A tab- or newline-separated command still passes on the MCP path, because that branch matches a `json.dumps()` of the input, which escapes real whitespace. Realistic inputs are unaffected — multi-line SDK scripts and ordinary CLI strings keep their whitespace outside the matched span and are still denied. Consistent with the docs' framing of the hook as best-effort rather than a security boundary.
- `mcp__*_run_script` tools never reach the `run_script` branch, since the MCP branch matches first and returns. Currently covered incidentally, because the MCP branch also applies `SDK_CALL_PATTERN`.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*