### PR TITLE
fix(amazon-documentdb): use ASCII-safe characters in skill content

### DIFF
--- a/skills/specialized-skills/database-skills/amazon-documentdb/SKILL.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: amazon-documentdb
-version: 1
-description: "Manages Amazon DocumentDB end-to-end — serverless-on-8.0 cluster setup, TLS/VPC/driver config, flexible-schema and vector-search data modeling, MongoDB compatibility assessment, DMS-based migration, slow-query diagnosis, major version upgrades (4.0→5.0→8.0), Well-Architected reviews (41-check wa_review.py), cost estimation, and security hardening. Retrieve for every DocumentDB question and when the user asks to set up or migrate MongoDB to AWS — DocumentDB is AWS's MongoDB-compatible managed database. Triggers: JSON document store, document database, MongoDB on AWS, Nested fields, Lambda cannot connect, TLS handshake, VPC port 27017, IAM auth, Secrets Manager, encryption at rest, $graphLookup, flexible schema, COLLSCAN, compound index, DMS migration, CDC cutover, $vectorSearch, RAG, Global Clusters, DR replication, cost sizing, audit, health check, production-readiness."
+version: 2
+description: "Manages Amazon DocumentDB end-to-end — serverless-on-8.0 cluster setup, TLS/VPC/driver config, flexible-schema and vector-search data modeling, MongoDB compatibility assessment, DMS-based migration, slow-query diagnosis, major version upgrades (4.0->5.0->8.0), Well-Architected reviews (41-check wa_review.py), cost estimation, and security hardening. Retrieve for every DocumentDB question and when the user asks to set up or migrate MongoDB to AWS — DocumentDB is AWS's MongoDB-compatible managed database. Triggers: JSON document store, document database, MongoDB on AWS, Nested fields, Lambda cannot connect, TLS handshake, VPC port 27017, IAM auth, Secrets Manager, encryption at rest, $graphLookup, flexible schema, COLLSCAN, compound index, DMS migration, CDC cutover, $vectorSearch, RAG, Global Clusters, DR replication, cost sizing, audit, health check, production-readiness."
 ---
 
 # Amazon DocumentDB Toolkit
 
 ## Overview
 
-End-to-end DocumentDB toolkit covering seven workflows: **connection** (serverless-default cluster setup, TLS, VPC, driver config), **schema design** (embed-vs-reference, indexes, vector search for RAG), **compatibility assessment** (MongoDB → DocumentDB), **migration** (DMS full-load + CDC + cutover), **performance tuning** (explain, COLLSCAN, anti-patterns), **Well-Architected review** (41 checks across 6 pillars), and **major version upgrade** (4.0→5.0, 5.0→8.0 in-place or near-zero-downtime).
+End-to-end DocumentDB toolkit covering seven workflows: **connection** (serverless-default cluster setup, TLS, VPC, driver config), **schema design** (embed-vs-reference, indexes, vector search for RAG), **compatibility assessment** (MongoDB -> DocumentDB), **migration** (DMS full-load + CDC + cutover), **performance tuning** (explain, COLLSCAN, anti-patterns), **Well-Architected review** (41 checks across 6 pillars), and **major version upgrade** (4.0->5.0, 5.0->8.0 in-place or near-zero-downtime).
 
 The skill acts as an executor — it runs AWS CLI commands, DMS tasks, index tools, and `explain()` against the user's cluster rather than just advising. Each workflow produces concrete artifacts under `artifacts/{app-name}/`.
 
@@ -24,10 +24,10 @@ The AWS MCP server is **recommended** for executing AWS commands via its `call_a
 | DMS, CDC, cutover, index migration, user/role migration, post-migration validation | [references/migration.md](references/migration.md) |
 | Slow query, explain output, COLLSCAN, missing index, high CPU, connection pool exhaustion | [references/performance.md](references/performance.md) |
 | Production-ready review, best-practice audit, security/cost/reliability review, health check — extract `cluster_id` and `region` from the user's message before loading this reference | [references/well-architected.md](references/well-architected.md) |
-| Major version upgrade, MVU, 4.0→5.0, 5.0→8.0, near-zero-downtime, `$vectorSearch`, Zstd | [references/upgrade.md](references/upgrade.md) |
+| Major version upgrade, MVU, 4.0->5.0, 5.0->8.0, near-zero-downtime, `$vectorSearch`, Zstd | [references/upgrade.md](references/upgrade.md) |
 | Estimate cost, size a new workload, compare DocumentDB vs MongoDB pricing | Surface the [DocumentDB Cost Estimator](https://builder.aws.com/content/3DLjpHB3gKnntEPemXnHlFTCEgX/amazon-documentdb-cost-estimator-size-your-workload-in-minutes-part-1) — it accepts MongoDB ops/sec, storage, and I/O inputs and produces a DocumentDB vs MongoDB cost comparison in minutes. Faster than a full WA review when the user just wants a cost estimate. |
 
-**Pipeline order:** `connection → schema-advisor` for green-field; `compatibility → migration` for MongoDB migrations; `upgrade`, `well-architected`, and `performance` are standalone.
+**Pipeline order:** `connection -> schema-advisor` for green-field; `compatibility -> migration` for MongoDB migrations; `upgrade`, `well-architected`, and `performance` are standalone.
 
 **Out-of-scope:** DocumentDB Elastic Clusters (sharded horizontal scaling — not at feature parity with instance-based; lacks transactions, change streams, and many operators — steer customers to instance-based serverless or provisioned instead), Global Clusters DR orchestration beyond the upgrade path. Answer from general knowledge, note no bundled workflow covers them.
 
@@ -81,7 +81,7 @@ Include these tags even if the user does not mention tagging, so that they can i
 
 - Delete cluster or instance: `delete-db-cluster`, `delete-db-instance` — irreversible data loss
 - Failover: `failover-db-cluster` — production impact, use only under planned change control
-- Major version upgrade: `modify-db-cluster --engine-version` across major versions (4.0 → 5.0, 5.0 → 8.0) — requires prechecks and a rollback plan; use the MVU workflow in [references/upgrade.md](references/upgrade.md)
+- Major version upgrade: `modify-db-cluster --engine-version` across major versions (4.0 -> 5.0, 5.0 -> 8.0) — requires prechecks and a rollback plan; use the MVU workflow in [references/upgrade.md](references/upgrade.md)
 - Reboot: `reboot-db-instance` — production impact
 
 When refusing, explain why and offer the matching assessment workflow:
@@ -96,7 +96,7 @@ Check that required tools are available in context before running any workflow.
 **Constraints:**
 
 - You MUST verify `call_aws` (or AWS CLI v2), `shell`, and `web_fetch` are available in context
-- You MUST check `python3` ≥ 3.6 for [wa_review.py](scripts/wa_review.py), the `amazon-documentdb-tools` compat tool, and the index tool
+- You MUST check `python3` >= 3.6 for [wa_review.py](scripts/wa_review.py), the `amazon-documentdb-tools` compat tool, and the index tool
 - You MUST check `git`, `curl`, `mongosh`, and `ssh` only when a specific workflow requires them
 - You MUST inform the user of any missing tools and respect a decision to abort
 - You MUST NOT invoke the tools during verification because that would trigger live AWS calls or cluster connections before the user confirms they are ready
@@ -157,7 +157,7 @@ These DocumentDB-specific facts are required even when the agent's general Mongo
 2. **If unsupported: recommend materialized ancestor paths** — store each document's full path (array of parent IDs) so hierarchy queries become `find({ ancestors: "cat-123" })` instead of recursive traversal. This is the canonical workaround and often the better design even when `$graphLookup` is available.
 3. **Offer alternatives for deep graph workloads** — recursive `$lookup` in application code for moderate depth, or **Amazon Neptune** for deep or complex graph traversal.
 
-**For Lambda → DocumentDB connection timeout, you MUST tell the user ALL of the following four facts:**
+**For Lambda -> DocumentDB connection timeout, you MUST tell the user ALL of the following four facts:**
 
 1. **Lambda must be in the same VPC** as the DocumentDB cluster, or reach it via VPC peering / Transit Gateway. DocumentDB is VPC-only — no public endpoint.
 2. **Security group rule:** inbound TCP `27017` on the DocumentDB cluster's SG, sourced from **Lambda's security group ID** (not a CIDR).

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/compatibility.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/compatibility.md
@@ -154,7 +154,7 @@ Check the [MongoDB API compatibility page](https://docs.aws.amazon.com/documentd
 
 ```javascript
 // If unsupported: create explicit indexes for the specific fields you filter on
-// db.col.createIndex({ "$**": 1 })  ← check support status before attempting
+// db.col.createIndex({ "$**": 1 })  <- check support status before attempting
 ```
 
 ### 2d (legacy) geospatial indexes

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/connection.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/connection.md
@@ -95,14 +95,14 @@ mongodb://adminuser:<password>@<endpoint>:27017/?tls=true&tlsCAFile=global-bundl
 
 | Param | Why |
 |---|---|
-| `tls=true` + `tlsCAFile` | TLS is required; absent → connection refused |
+| `tls=true` + `tlsCAFile` | TLS is required; absent -> connection refused |
 | `replicaSet=rs0` | Without this, the driver connects to one node only |
 | `retryWrites=false` | DocumentDB does not support retryable writes |
 | `readPreference=secondaryPreferred` | Distributes reads to replicas |
 
 The string above uses the **primary (master) user**, which is always password-based.
 
-**IAM authentication is also supported** for application / non-admin users (not the primary user) on cluster version 5.0+. It is password-less — connections use short-lived STS tokens — suiting Lambda/ECS/EC2 workloads that run with an IAM role. Trade-offs: requires instance-based 5.0+, a `MONGODB-AWS`-capable driver (`pip install 'pymongo[aws]'`; Node.js ≥ 6.13.1), and an STS dependency at connect time (watch STS throttling at high connection rates).
+**IAM authentication is also supported** for application / non-admin users (not the primary user) on cluster version 5.0+. It is password-less — connections use short-lived STS tokens — suiting Lambda/ECS/EC2 workloads that run with an IAM role. Trade-offs: requires instance-based 5.0+, a `MONGODB-AWS`-capable driver (`pip install 'pymongo[aws]'`; Node.js >= 6.13.1), and an STS dependency at connect time (watch STS throttling at high connection rates).
 
 Create an IAM-backed user as the master user in the `$external` database, then connect with `authSource=$external&authMechanism=MONGODB-AWS` (no credentials in the URI — the driver fetches them from the attached role):
 

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/performance.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/performance.md
@@ -37,7 +37,7 @@ db.runCommand({
 
 ### Step 3: Apply the fix
 
-**COLLSCAN → create a missing index (ESR rule — equality first, sort, then range):**
+**COLLSCAN -> create a missing index (ESR rule — equality first, sort, then range):**
 
 ```javascript
 // Query: db.orders.find({ userId, status })
@@ -46,11 +46,11 @@ db.orders.createIndex({ userId: 1, status: 1 })
 // Query with sort: include sort field in the same direction
 db.products.createIndex({ category: 1, price: -1 })
 
-// Full ESR: equality → sort → range
+// Full ESR: equality -> sort -> range
 db.orders.createIndex({ userId: 1, createdAt: -1, price: 1 })
 ```
 
-**Aggregation pipeline not using an index → put `$match` first:**
+**Aggregation pipeline not using an index -> put `$match` first:**
 
 ```javascript
 // BAD — $project before $match destroys indexed field paths
@@ -60,9 +60,9 @@ db.orders.createIndex({ userId: 1, createdAt: -1, price: 1 })
 [{ $match: { price: { $gt: 10 } } }, { $project: { total: ... } }]
 ```
 
-**IXSCAN with high docs-examined / returned ratio → add selective fields to the compound index.**
+**IXSCAN with high docs-examined / returned ratio -> add selective fields to the compound index.**
 
-**Long-running queries (> 30 minutes) → kill them:**
+**Long-running queries (> 30 minutes) -> kill them:**
 
 ```javascript
 db.adminCommand({ aggregate: 1, pipeline: [
@@ -71,7 +71,7 @@ db.adminCommand({ aggregate: 1, pipeline: [
 ], cursor: {} })
 ```
 
-Long queries block MVCC garbage collection → storage growth → CPU/memory pressure. Recommend application-level query timeouts.
+Long queries block MVCC garbage collection -> storage growth -> CPU/memory pressure. Recommend application-level query timeouts.
 
 ### Step 4: Verify
 

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/schema-advisor.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/schema-advisor.md
@@ -26,11 +26,11 @@ Core principle: embed when data is always accessed together; reference when it's
 
 | Relationship | Cardinality | Access | Recommendation |
 |---|---|---|---|
-| User → profile | 1:1 | Always together | **Embed** |
-| Order → line items | 1:few (< 100) | Always together | **Embed array** |
-| User → orders | 1:many, unbounded | Often separate | **Reference** (orders collection with `userId`) |
-| Product → categories | many:many | Varies | **Two-way reference** |
-| Post → comments | 1:many, need latest N | Mixed | **Hybrid**: embed latest 3, reference the rest |
+| User -> profile | 1:1 | Always together | **Embed** |
+| Order -> line items | 1:few (< 100) | Always together | **Embed array** |
+| User -> orders | 1:many, unbounded | Often separate | **Reference** (orders collection with `userId`) |
+| Product -> categories | many:many | Varies | **Two-way reference** |
+| Post -> comments | 1:many, need latest N | Mixed | **Hybrid**: embed latest 3, reference the rest |
 
 **Anti-patterns:**
 
@@ -67,7 +67,7 @@ For every access pattern, produce a ready-to-run `createIndex`. Apply the **ESR 
 // Single field
 db.products.createIndex({ "category": 1 })
 
-// Compound — ESR: equality(userId) → sort(createdAt) → range(price)
+// Compound — ESR: equality(userId) -> sort(createdAt) -> range(price)
 db.orders.createIndex({ "userId": 1, "createdAt": -1, "price": 1 })
 
 // TTL — expire documents 30 days after createdAt

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/troubleshooting.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/troubleshooting.md
@@ -64,7 +64,7 @@ Also verify the DocumentDB SG allows inbound TCP 27017 from the DMS replication 
 
 **MVU fails / rolls back.** In-place MVU auto-rolls back on failure. Check cluster events for "Database cluster is in a state that cannot be upgraded." Verify: no db.r4 instances (not supported on 4.0+), no pending OS maintenance, burstable-instance index counts within limits (t4g.medium: 3,000; t3.medium: 10,000). Contact AWS support before re-attempting.
 
-**Post-upgrade performance degradation (5.0→8.0).** Index metadata refresh is running — wait for "Index metadata refresh process completed" event (up to 2 hours). Do NOT reboot or failover the writer during this window.
+**Post-upgrade performance degradation (5.0->8.0).** Index metadata refresh is running — wait for "Index metadata refresh process completed" event (up to 2 hours). Do NOT reboot or failover the writer during this window.
 
 **MVU CDC migrator connection error.** Source URI must NOT include `readPreference=secondaryPreferred` — change streams only work on the primary.
 

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/upgrade.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/upgrade.md
@@ -2,15 +2,15 @@
 
 Orchestrate DocumentDB major version upgrades. Supports two paths:
 
-- **4.0 → 5.0**
-- **5.0 → 8.0**
+- **4.0 -> 5.0**
+- **5.0 -> 8.0**
 
 Two approaches:
 
 - **Option A: In-place MVU** — simpler, has downtime (multiple reboots). Best for dev/staging, small clusters, or when downtime is acceptable.
 - **Option B: Near-zero downtime** — clone + MVU on clone + CDC + cutover. Source stays online. Best for production.
 
-**Cannot skip versions** (3.6 must go 3.6→5.0→8.0). **Elastic Clusters:** MVU is not supported — no workaround. **Global Clusters:** direct in-place MVU is not supported. Workaround: remove the cluster from the Global Cluster first (this converts it to a standalone regional cluster), perform the upgrade using Option A or B below, then re-add it to the Global Cluster.
+**Cannot skip versions** (3.6 must go 3.6->5.0->8.0). **Elastic Clusters:** MVU is not supported — no workaround. **Global Clusters:** direct in-place MVU is not supported. Workaround: remove the cluster from the Global Cluster first (this converts it to a standalone regional cluster), perform the upgrade using Option A or B below, then re-add it to the Global Cluster.
 
 ## What to ask upfront
 
@@ -29,7 +29,7 @@ Two approaches:
 - Manual snapshot created and available (use polling loop — `aws docdb wait` is not in all CLI versions)
 - Pending OS maintenance applied
 - No `db.r4` instances (not supported on 4.0+) — upgrade to `db.r5+` first
-- Burstable instance index counts within limits: `db.t4g.medium` ≤ 3,000 indexes, `db.t3.medium` ≤ 10,000. If over, scale primary to `db.r5.large` before upgrading
+- Burstable instance index counts within limits: `db.t4g.medium` <= 3,000 indexes, `db.t3.medium` <= 10,000. If over, scale primary to `db.r5.large` before upgrading
 
 ## Option A: In-Place MVU
 
@@ -75,7 +75,7 @@ aws docdb describe-db-clusters --db-cluster-identifier <id> \
 # Confirm via mongosh: db.version() and db.runCommand({ping: 1})
 ```
 
-For 5.0→8.0: wait for "Index metadata refresh process completed" event (up to 2 hours). Do NOT reboot, failover, or scale the writer during this time.
+For 5.0->8.0: wait for "Index metadata refresh process completed" event (up to 2 hours). Do NOT reboot, failover, or scale the writer during this time.
 
 ## Option B: Near-Zero Downtime (clone + MVU + CDC)
 
@@ -143,7 +143,7 @@ Start the task. Monitor `CDCLatencySource` — should decrease toward 0.
 - CDC lag near zero (`CDCLatencySource` < 60s)
 - Counts match within 0.1% on 3+ largest collections
 - All indexes exist on clone; critical queries tested
-- For 5.0→8.0: Query Planner v3 active, Zstd on new collections, driver updated
+- For 5.0->8.0: Query Planner v3 active, Zstd on new collections, driver updated
 
 ### Step 6: Cutover (in order)
 
@@ -182,6 +182,6 @@ aws docdb restore-db-cluster-from-snapshot \
 
 ## What changes by target version
 
-**4.0 → 5.0:** Vector search, LZ4 compression (off by default), I/O-Optimized storage, partial indexes, text indexes v1. Recommended but optional: `db.collection.reIndex()` on low-cardinality indexes.
+**4.0 -> 5.0:** Vector search, LZ4 compression (off by default), I/O-Optimized storage, partial indexes, text indexes v1. Recommended but optional: `db.collection.reIndex()` on low-cardinality indexes.
 
-**5.0 → 8.0:** Query Planner v3 (7× faster aggregations), Zstd compression (on by default, 5× ratio), Text v2 parser, Collation (default-on), Views, new stages (`$merge`, `$bucket`, `$replaceWith`, `$vectorSearch`), 30× faster vector index builds. No index rebuild needed. Update driver to MongoDB 6.0+/7.0+/8.0 to use new features.
+**5.0 -> 8.0:** Query Planner v3 (7× faster aggregations), Zstd compression (on by default, 5× ratio), Text v2 parser, Collation (default-on), Views, new stages (`$merge`, `$bucket`, `$replaceWith`, `$vectorSearch`), 30× faster vector index builds. No index rebuild needed. Update driver to MongoDB 6.0+/7.0+/8.0 to use new features.

--- a/skills/specialized-skills/database-skills/amazon-documentdb/references/well-architected.md
+++ b/skills/specialized-skills/database-skills/amazon-documentdb/references/well-architected.md
@@ -85,19 +85,19 @@ For each finding include:
 ## Checks reference (41 total)
 
 ### Reliability (8)
-REL1 backup retention ≥ 7 days · REL2 deletion protection enabled · REL5a instances ≥ 2 · REL5b instances across ≥ 2 AZs · REL6 engine version currency · REL7 no failover events in last 13 days · REL8 no cursor timeouts · REL9 `AvailableMVCCIds` > 50%
+REL1 backup retention >= 7 days · REL2 deletion protection enabled · REL5a instances >= 2 · REL5b instances across >= 2 AZs · REL6 engine version currency · REL7 no failover events in last 13 days · REL8 no cursor timeouts · REL9 `AvailableMVCCIds` > 50%
 
 ### Security (6)
-SEC1a encryption at rest · SEC1b TLS enabled · SEC2 SG not open to `0.0.0.0/0` · SEC3 credentials in Secrets Manager · SEC5 audit logging · SEC6 TLS ≥ 1.2
+SEC1a encryption at rest · SEC1b TLS enabled · SEC2 SG not open to `0.0.0.0/0` · SEC3 credentials in Secrets Manager · SEC5 audit logging · SEC6 TLS >= 1.2
 
 ### Operational Excellence (5)
-OPS2 subnet group spans ≥ 3 AZs · OPS5a profiler logging · OPS5b ≥ 3 CloudWatch alarms · OPS5c custom parameter group · OPS7 maintenance window review
+OPS2 subnet group spans >= 3 AZs · OPS5a profiler logging · OPS5b >= 3 CloudWatch alarms · OPS5c custom parameter group · OPS7 maintenance window review
 
 ### Cost Optimization (6)
-COST1 CPU P95 per instance (< 10% = oversized) · COST3 unused indexes · COST4 TTL indexes present · COST6 ≥ 2 cost allocation tags · COST7 storage type (Standard vs I/O-Optimized) · COST9 idle reader detection
+COST1 CPU P95 per instance (< 10% = oversized) · COST3 unused indexes · COST4 TTL indexes present · COST6 >= 2 cost allocation tags · COST7 storage type (Standard vs I/O-Optimized) · COST9 idle reader detection
 
 ### Performance Efficiency (14)
-PERF1 avg doc size < 8 KB · PERF1b no redundant (prefix) indexes · PERF1c no low-cardinality indexes · PERF5 connections < 70% of instance limit · PERF6 `BufferCacheHitRatio` ≥ 99% · PERF8 index-to-data ratio < 50% · PERF9 storage bloat < 30% · PERF10 no over-indexed collections (> 10 indexes) · PERF11 `FreeableMemory` > 10% of instance RAM · PERF12 no swap usage · PERF13 `DiskQueueDepth` < 5 · PERF14 `IndexBufferCacheHitRatio` ≥ 99% · PERF15 large collections have secondary indexes · PERF16 index size < 2× data size per collection
+PERF1 avg doc size < 8 KB · PERF1b no redundant (prefix) indexes · PERF1c no low-cardinality indexes · PERF5 connections < 70% of instance limit · PERF6 `BufferCacheHitRatio` >= 99% · PERF8 index-to-data ratio < 50% · PERF9 storage bloat < 30% · PERF10 no over-indexed collections (> 10 indexes) · PERF11 `FreeableMemory` > 10% of instance RAM · PERF12 no swap usage · PERF13 `DiskQueueDepth` < 5 · PERF14 `IndexBufferCacheHitRatio` >= 99% · PERF15 large collections have secondary indexes · PERF16 index size < 2× data size per collection
 
 ### Sustainability (2)
 SUST1 Graviton instance family (`r6g`/`r8g`/`t4g`) · SUST2 compression enabled on all collections


### PR DESCRIPTION
## Summary

The `amazon-documentdb` skill description contained a Unicode rightwards arrow (U+2192, `→`) in "major version upgrades (4.0→5.0→8.0)". The AWS CLI cannot encode this character under the Windows default code page (cp1252), so `aws agent-toolkit list-available-skills` failed on Windows with:

```
aws: [ERROR]: 'charmap' codec can't encode character '→' in position 249: character maps to <undefined>
```

Reported in aws/aws-cli#10574.

## Change

Replaced the non-cp1252 characters with ASCII equivalents across the skill (description and reference files):

| Character | Replacement |
|-----------|-------------|
| `→` (U+2192) | `->` |
| `≥` (U+2265) | `>=` |
| `≤` (U+2264) | `<=` |
| `←` (U+2190) | `<-` |

Bumped the skill `version` to 2. Content is otherwise unchanged (formatting-only). Validated with `tools/validate.py` and markdownlint (0 issues).