### PR TITLE
feat(workspaces-applications): add amazon-workspaces-agent-access skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -63,6 +63,7 @@ Specialized skills are organized by AWS service category:
 - **[Analytics](specialized-skills/analytics-skills/)**
 - **[Database](specialized-skills/database-skills/)**
 - **[EC2](specialized-skills/ec2-skills/)**
+- **[End User Computing](specialized-skills/end-user-computing-skills/)**
 - **[Messaging & Streaming](specialized-skills/messaging-and-streaming-skills/)**
 - **[Migration & Modernization](specialized-skills/migration-and-modernization-skills/)**
 - **[Networking & Content Delivery](specialized-skills/networking-and-content-delivery-skills/)**

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/SKILL.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: amazon-workspaces-agent-access
+description: Connects AI agents to remote Windows desktop applications on Amazon WorkSpaces Applications (AppStream 2.0) through the managed Agent Access MCP server, and guides reliable desktop automation. Covers connecting an agent to the MCP endpoint (SigV4, streaming URL, and Active Directory SAML/Domain Join), BLOCKING vs POLLING connect modes, the computer-use tools (screenshot, click, type, key, scroll), screenshot-budget and action-batching discipline, MCP tool forwarding (forwarded___ tools), session lifecycle and expire-on-delete, and troubleshooting connection errors. Use when building or debugging an agent that drives a remote Windows desktop or GUI application via WorkSpaces Applications / AppStream — including "dcv session not ready", "client_disconnected", 400 signing-region, POLLING/connection_status, SAML assertion, or forwarded tool questions. Not for Amazon WorkSpaces Personal/Core virtual desktops or general AppStream fleet administration unrelated to agent access.
+version: 1
+---
+
+# Amazon WorkSpaces Applications — Agent Access
+
+Domain expertise for connecting AI agents to remote Windows desktops on Amazon WorkSpaces Applications (AppStream 2.0) via the managed **Agent Access MCP server**, and for driving those desktops reliably.
+
+**How it works:** Agent Access is **MCP-only** — there is no AWS CLI/SDK command that calls the desktop tools. Agents connect to `https://agentaccess-mcp.{region}.api.aws/mcp` over Streamable HTTP, SigV4-signed with service name `agentaccess-mcp`, and call MCP tools (`screenshot`, `left_click`, `type_text`, ...) to drive the desktop. The AWS CLI/SDK is used only for *setup* — `appstream create-streaming-url`, fleet/stack configuration. `mcp-proxy-for-aws` handles the SigV4 signing.
+
+**Recommended setup:** use `mcp-proxy-for-aws` (Python) as the transport; it signs each request and manages the DELETE lifecycle. Any MCP client that supports Streamable HTTP + SigV4 works. When running the AWS CLI/SDK *setup* steps (create-streaming-url, stack/fleet configuration), the AWS MCP server is recommended for sandboxed execution and audit logging.
+
+## Guardrail — where this skill's own files live (MCP vs local install)
+
+This skill can be loaded two ways, and they resolve the skill's own bundled files from different places. Determine how the skill was loaded before reading a reference:
+
+- **Loaded through the AWS MCP `retrieve_skill` tool:** The skill is not installed on the local filesystem. You MUST fetch each reference via `retrieve_skill` with the `file` parameter (e.g. `file="references/connection-setup.md"`), and use the returned content. Do NOT `file_read` these paths locally — they do not exist on disk.
+- **Installed locally** (e.g. `.kiro/skills/amazon-workspaces-agent-access/` or `~/.claude/skills/amazon-workspaces-agent-access/`): Read files from the local skill directory using relative paths.
+
+This distinction applies only to the skill's own packaged files. User data and session artifacts are always read from and written to the user's working directory. Never fetch or write customer data through `retrieve_skill`.
+
+## Key facts agents get wrong (load the reference before answering in detail)
+
+These are HTTP headers / metadata on the MCP connection — **not** tool parameters, and there is no `connect_to_desktop` tool. Do not invent tools or parameters; the desktop tools are exactly those in tools-reference.md.
+
+- **Connect mode.** Selected by the **`X-Amzn-AgentAccess-Connect-Mode` HTTP header** (value `BLOCKING`, the default, or `POLLING`) — sent on the MCP request alongside the streaming-URL/SAML auth. It is **NOT** a JSON tool argument.
+  - ❌ WRONG (common hallucination): calling a `connect_to_desktop` tool with a `connection_mode: "POLLING"` parameter, or a `session_id`/`application_id`/`user_id` argument. None of those exist.
+  - ✅ RIGHT: set the `X-Amzn-AgentAccess-Connect-Mode: POLLING` header. Then `tools/list` initially returns **only** the `connection_status` tool; the agent calls `connection_status` repeatedly until its returned state is `CONNECTED`, and **only then** does `tools/list` return the full desktop tool set (`screenshot`, `left_click`, ...). (details: connection-modes.md)
+
+    ```python
+    # Correct POLLING usage — the mode is an HTTP header on the MCP connection:
+    async with aws_iam_streamablehttp_client(
+        endpoint="https://agentaccess-mcp.us-east-1.api.aws/mcp",  # use YOUR fleet's region
+        aws_service="agentaccess-mcp", aws_region="us-east-1",  # region must match the fleet (else 400)
+        headers={
+            "X-Amzn-AgentAccess-Streaming-Session-Url": streaming_url,
+            "X-Amzn-AgentAccess-Connect-Mode": "POLLING",   # header, not a tool arg
+        },
+    ) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            # tools/list now returns ONLY connection_status until the desktop is up:
+            while json.loads((await session.call_tool("connection_status", {})).content[0].text)["state"] != "CONNECTED":
+                await asyncio.sleep(2)
+            tools = await session.list_tools()   # now the full desktop tool set
+    ```
+- **Streaming session** (non-domain-joined) is the `X-Amzn-AgentAccess-Streaming-Session-Url` header. **Domain-joined** fleets instead pass the SAML assertion + stack ARN via MCP `_meta` keys `aws.agentaccess/workspacesApplicationsSamlAssertion` and `aws.agentaccess/workspacesApplicationsStackArn`. (details: connection-setup.md)
+- **Expire-on-delete** is the `X-Amzn-AgentAccess-Expire-Streaming-Session-On-Delete` header (`true`/`false`; **default `false`**). Expiry happens on the client's explicit HTTP `DELETE` — `mcp-proxy-for-aws` sends it automatically on clean close. (details: session-lifecycle.md)
+- **Forwarded tools are namespaced by server:** `forwarded___<server-name>___<tool-name>` (e.g. `forwarded___filesystem___read_file`) — **not** `forwarded___<tool-name>`. (details: tool-forwarding.md)
+- **`COMPUTER_INPUT` requires `COMPUTER_VISION`** to also be ENABLED in the stack's `AgentAccessConfig`. (details: enabling-agent-access.md)
+
+## Routing
+
+| User need | Read |
+|-----------|------|
+| **Enable agent access on a stack** (`AgentAccessConfig`: COMPUTER_INPUT/COMPUTER_VISION/FORWARD_MCP_TOOLS, screen resolution/format, prerequisites) — the admin setup step before any agent can connect | [enabling-agent-access.md](references/enabling-agent-access.md) |
+| Connect an agent to the MCP server — endpoint, SigV4, streaming URL (non-domain-joined), or Active Directory SAML/Domain Join | [connection-setup.md](references/connection-setup.md) |
+| Choose BLOCKING vs POLLING; poll `connection_status` until the desktop is ready | [connection-modes.md](references/connection-modes.md) |
+| The computer-use tool set (mouse, keyboard, screenshot) and their parameters | [tools-reference.md](references/tools-reference.md) |
+| Automate reliably — screenshot budget, action batching, trusting UI actions, coordinate planning, dialog recovery | [automation-best-practices.md](references/automation-best-practices.md) |
+| Expose your own MCP servers on the fleet as `forwarded___<server>___<tool>` tools; prefer forwarded tools for file/web tasks | [tool-forwarding.md](references/tool-forwarding.md) |
+| Session lifecycle — cleanup, expire-on-delete, idle timeout, one-agent-per-session | [session-lifecycle.md](references/session-lifecycle.md) |
+| Debug an error (exact string → cause → fix): `dcv session not ready`, `client_disconnected`, 400/401/403, `Unknown tool` | [troubleshooting.md](references/troubleshooting.md) |
+
+## Security Considerations
+
+- **The agent acts under the caller's AWS identity.** Every MCP request is SigV4-signed with service `agentaccess-mcp`; the desktop session runs with those credentials. Grant only the specific `agentaccess-mcp` actions the agent calls (e.g. `InvokeMcp`, `GetScreenshot`, `LeftClick`, `TypeText`) and scope them with the `agentaccess-mcp:StackArn` condition key — avoid a blanket `agentaccess-mcp:*` or `Resource: *`. Prefer IAM roles over long-lived users. (Full action list + example: connection-setup.md → IAM permissions.)
+- **Screenshots can capture sensitive data.** `COMPUTER_VISION` captures whatever is on the desktop — treat screenshots as potentially containing PII or secrets. If screenshot storage is enabled, the S3 bucket must enforce encryption **at rest and in transit** and least-privilege access: grant the AppStream service principal only what it needs and the connecting agent only `s3:PutObject` (see enabling-agent-access.md).
+- **Enable only the capabilities you need.** `COMPUTER_INPUT`, `COMPUTER_VISION`, and `FORWARD_MCP_TOOLS` are independent — do not enable input/forwarding on stacks that only need vision.
+- **Tool forwarding executes code on the fleet.** Forwarded MCP servers run on the instance under the session context. Install only trusted servers system-wide, gate with `FORWARD_MCP_TOOLS`, and scope the `CallForwardedTool` IAM action by `agentaccess-mcp:StackArn` (see tool-forwarding.md).
+- **Keep a human in the loop where warranted.** `UserControlMode: VIEW_STOP` lets an observer watch the live session and stop the agent. Treat agent-driven desktop actions as capable of arbitrary UI operations.
+- **Audit with CloudTrail.** Agent session events are logged; tool calls are CloudTrail **data events** and require a trail configured to log them. Create a trail with `agentaccess-mcp` data events enabled, encrypt it with SSE-KMS, and add CloudWatch alarms for anomalous patterns (e.g. high screenshot volume, unexpected `TypeText`, repeated auth failures). If screenshot storage is enabled, turn on S3 server access logging for the bucket.
+- **Protect federation material.** For domain-joined (SAML) fleets, safeguard the IdP signing certificate and the IAM SAML provider/role trust policy, and do not log the SAML assertion. Traffic is HTTPS + SigV4 — never disable TLS verification.
+- **Treat typed input as potentially sensitive.** `type_text` can enter secrets (passwords, tokens); these may then appear in screenshots, screenshot-storage S3, and CloudTrail data events. Avoid typing long-lived secrets into the desktop where possible, and restrict who can read those sinks.
+- Refer to the current [Agent Access documentation](https://docs.aws.amazon.com/appstream2/latest/developerguide/agent-access-mcp-server.html) and [AWS security best practices](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html) for the latest guidance.
+
+**Note:** Regional endpoints, feature availability, and quotas change. When precision matters, confirm against the current [Agent Access MCP server documentation](https://docs.aws.amazon.com/appstream2/latest/developerguide/agent-access-mcp-server.html). The references focus on the values and gotchas that are easy to get wrong.

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/SKILL.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/SKILL.md
@@ -46,6 +46,7 @@ These are HTTP headers / metadata on the MCP connection — **not** tool paramet
                 await asyncio.sleep(2)
             tools = await session.list_tools()   # now the full desktop tool set
     ```
+
 - **Streaming session** (non-domain-joined) is the `X-Amzn-AgentAccess-Streaming-Session-Url` header. **Domain-joined** fleets instead pass the SAML assertion + stack ARN via MCP `_meta` keys `aws.agentaccess/workspacesApplicationsSamlAssertion` and `aws.agentaccess/workspacesApplicationsStackArn`. (details: connection-setup.md)
 - **Expire-on-delete** is the `X-Amzn-AgentAccess-Expire-Streaming-Session-On-Delete` header (`true`/`false`; **default `false`**). Expiry happens on the client's explicit HTTP `DELETE` — `mcp-proxy-for-aws` sends it automatically on clean close. (details: session-lifecycle.md)
 - **Forwarded tools are namespaced by server:** `forwarded___<server-name>___<tool-name>` (e.g. `forwarded___filesystem___read_file`) — **not** `forwarded___<tool-name>`. (details: tool-forwarding.md)

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/automation-best-practices.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/automation-best-practices.md
@@ -16,6 +16,7 @@ Screenshots are large image payloads. A naive agent screenshots after every clic
 ## Batch actions
 
 Group related actions into one sequence with no intermediate screenshots:
+
 - **Setup then act:** select tool → set options → act — no screenshot between setup steps.
 - **Repeat similar actions together:** e.g. fill five form fields or draw four shapes in sequence, then one screenshot at the end — not one per element.
 
@@ -38,6 +39,7 @@ If the fleet has MCP tool forwarding enabled, use forwarded filesystem/fetch too
 ## Handle unexpected dialogs
 
 Apps show update prompts, recovery dialogs, setup wizards. When one appears:
+
 - `key("Escape")` to dismiss, or `key("alt+F4")` to close a window.
 - For save prompts choose "Don't Save"/"Discard" unless the task requires saving.
 - `key("alt+Tab")` to bring the target window back to focus.

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/automation-best-practices.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/automation-best-practices.md
@@ -1,0 +1,51 @@
+# Desktop Automation Best Practices
+
+These practices come from how computer-use models actually behave: they analyze screenshots pixel-by-pixel, and the screenshot round-trip is the dominant cost in tokens and latency. Following them produces dramatically more reliable, cheaper runs.
+
+> Tool names used below (`key`, `type_text`, `screenshot`, ...) are the desktop tools defined in [tools-reference.md](tools-reference.md). Anything described as a client-side pause or loop runs in your agent's own code, not on the desktop.
+
+## Minimize screenshots (the #1 rule)
+
+Screenshots are large image payloads. A naive agent screenshots after every click and burns tokens for no benefit.
+
+- Take **one** screenshot to establish state, perform **3–5 actions**, then screenshot only to verify a meaningful unit of work.
+- **Trust predictable UI actions.** Tool/menu selections, color/dropdown settings, typing, and keyboard shortcuts reliably succeed — do **not** screenshot to confirm them. Proceed directly to the next action.
+- Only screenshot after completing a batch, or when something unexpected happens and you need to diagnose.
+- Treat a screenshot budget as a hard target: if you are screenshotting after single actions, you are doing it wrong.
+
+## Batch actions
+
+Group related actions into one sequence with no intermediate screenshots:
+- **Setup then act:** select tool → set options → act — no screenshot between setup steps.
+- **Repeat similar actions together:** e.g. fill five form fields or draw four shapes in sequence, then one screenshot at the end — not one per element.
+
+## Plan coordinates up front
+
+- From the establishing screenshot, note reference points (window corners, toolbar edges, canvas origin) and derive all target coordinates before acting.
+- For drags, compute both start and end coordinates before beginning.
+- Don't discover coordinates by trial and error — it wastes screenshots.
+
+## Launch applications reliably
+
+- Prefer the **Run dialog**: `key("super+r")` → `type_text("notepad")` → `key("Return")`. It is more reliable than Start-menu search.
+- If the fleet exposes Application Catalog tools (`launch_application`), use those instead of navigating the shell.
+- After launching, pause 3–5 seconds client-side before interacting so the app is ready (e.g. `time.sleep(3)` / `await asyncio.sleep(3)` in your agent loop — the desktop toolset has no `wait` tool, unlike some computer-use APIs).
+
+## Prefer forwarded tools for file/web work
+
+If the fleet has MCP tool forwarding enabled, use forwarded filesystem/fetch tools instead of driving an app by pixels — reading a file with a forwarded tool is far more reliable than opening it and reading the screen. See tool-forwarding.md.
+
+## Handle unexpected dialogs
+
+Apps show update prompts, recovery dialogs, setup wizards. When one appears:
+- `key("Escape")` to dismiss, or `key("alt+F4")` to close a window.
+- For save prompts choose "Don't Save"/"Discard" unless the task requires saving.
+- `key("alt+Tab")` to bring the target window back to focus.
+
+## Don't repeat failures
+
+If an action fails twice, change approach — take a screenshot to re-orient, try a different launch path or coordinates, or use a forwarded tool. Repeating the same failing action wastes budget.
+
+## Verify by outcome, not mechanics
+
+To confirm a task succeeded, check the produced artifact (a saved file via a forwarded filesystem tool, an uploaded screenshot in S3, a changed window title) rather than screenshotting every intermediate step.

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/connection-modes.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/connection-modes.md
@@ -33,6 +33,7 @@ tools = await session.list_tools()          # -> screenshot, left_click, type_te
 ```
 
 Key points:
+
 - In POLLING mode, calling a desktop tool before `connection_status` reports `CONNECTED` will not work — only `connection_status` is exposed until the desktop connects.
 - Re-list tools after `CONNECTED` to pick up the full set.
 - The desktop typically connects in 5–30s (longer on cold starts).

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/connection-modes.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/connection-modes.md
@@ -1,0 +1,38 @@
+# Connection Modes: BLOCKING vs POLLING
+
+> **Connect mode is an HTTP header, not a tool parameter.** There is no `connect_to_desktop` tool and no `connection_mode` argument. You select the mode with the `X-Amzn-AgentAccess-Connect-Mode` request header (`BLOCKING` or `POLLING`), sent alongside your streaming-URL/SAML auth.
+
+Control how the agent waits for the desktop session with the `X-Amzn-AgentAccess-Connect-Mode` header. Applies to both non-domain-joined and domain-joined fleets — set it alongside whichever auth mechanism the fleet uses.
+
+| Mode | Behavior | When to use |
+|---|---|---|
+| `BLOCKING` (default) | Server waits until the desktop connection is fully established before responding. When `tools/list` returns, all desktop tools are immediately available. | Simple agents that can afford to wait on connect. |
+| `POLLING` | Server responds immediately. `tools/list` initially returns only the `connection_status` tool. The agent polls it until the desktop is ready, then the full tool set appears. | The agent wants to do other work while the desktop starts, or you want explicit control over connection-timeout behavior. |
+
+## POLLING flow
+
+```python
+headers = {
+    "X-Amzn-AgentAccess-Streaming-Session-Url": streaming_url,  # non-domain-joined
+    "X-Amzn-AgentAccess-Connect-Mode": "POLLING",
+}
+
+# After initialize, tools/list returns immediately with only connection_status:
+tools = await session.list_tools()          # -> [connection_status]
+
+# Poll until CONNECTED:
+while True:
+    result = await session.call_tool("connection_status", {})
+    status = json.loads(result.content[0].text)
+    if status["state"] == "CONNECTED":
+        break
+    await asyncio.sleep(2)
+
+# Now the full desktop tool set is available:
+tools = await session.list_tools()          # -> screenshot, left_click, type_text, ...
+```
+
+Key points:
+- In POLLING mode, calling a desktop tool before `connection_status` reports `CONNECTED` will not work — only `connection_status` is exposed until the desktop connects.
+- Re-list tools after `CONNECTED` to pick up the full set.
+- The desktop typically connects in 5–30s (longer on cold starts).

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/connection-setup.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/connection-setup.md
@@ -1,0 +1,113 @@
+# Connecting to the Agent Access MCP Server
+
+## Endpoint and auth
+
+- **Endpoint:** `https://agentaccess-mcp.{region}.api.aws/mcp` (Streamable HTTP transport).
+- **Signing:** every request is SigV4-signed with service name `agentaccess-mcp`.
+- **IAM:** grant the caller the specific `agentaccess-mcp` actions the agent uses, scoped by the `agentaccess-mcp:StackArn` condition key (see [IAM permissions](#iam-permissions-least-privilege)).
+- **Signing region MUST match the fleet region.** Signing for a different region than the fleet lives in is rejected with `400 Bad Request` (cross-region mismatch). Set `AWS_REGION` / the MCP signing region to the fleet's region and use the matching regional endpoint.
+- There is **no AWS CLI/SDK command** that invokes the desktop tools — interaction is MCP-only. The CLI/SDK is used only for setup (streaming URL, fleet/stack config).
+- **Connect mode:** you can also control how the connection waits for the desktop via the `X-Amzn-AgentAccess-Connect-Mode` header (`BLOCKING` default, or `POLLING`), sent alongside the auth headers below — see connection-modes.md.
+
+## IAM permissions (least privilege)
+
+The service has **no resource ARN hierarchy** — the only resource scoping is the `agentaccess-mcp:StackArn` condition key (the AppStream stack ARN, derived from the streaming URL or supplied via the SAML path). So least privilege = **enumerate only the actions your agent calls** and **scope them by stack**.
+
+Available actions: `InvokeMcp` (initialize / `tools/list` / ping — required to connect), `GetScreenshot`, `LeftClick`, `DoubleClick`, `TripleClick`, `RightClick`, `MiddleClick`, `TypeText`, `KeyPress`, `HoldKey`, `Scroll`, `MovePointer`, `LeftClickDrag`, `LeftMouseDown`, `LeftMouseUp`, `CheckConnectionStatus`, `CallForwardedTool`. This list is illustrative — consult the current [Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/) for the authoritative, complete set of `agentaccess-mcp` actions.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "agentaccess-mcp:InvokeMcp",
+      "agentaccess-mcp:GetScreenshot",
+      "agentaccess-mcp:LeftClick",
+      "agentaccess-mcp:TypeText",
+      "agentaccess-mcp:KeyPress",
+      "agentaccess-mcp:Scroll"
+    ],
+    "Resource": "*",
+    "Condition": {
+      "ArnLike": { "agentaccess-mcp:StackArn": "arn:aws:appstream:<region>:<account>:stack/<stack>" }
+    }
+  }]
+}
+```
+
+Add the specific actions your agent uses (e.g. other click/drag tools, `HoldKey`, `MovePointer`, `CheckConnectionStatus` for POLLING, `CallForwardedTool` for forwarding). For *setup* the caller also needs `appstream:CreateStreamingURL` (and `appstream:DescribeFleets`), on the setup principal.
+
+> `agentaccess-mcp:*` with `Resource: *` (as some AWS docs show) also works but is broader than necessary — prefer the enumerated, stack-scoped policy above.
+
+Prefer an **IAM role** (EC2 instance profile, ECS task role, or Lambda execution role) over an IAM user with long-lived access keys for the principal that signs MCP requests and calls `CreateStreamingURL`.
+
+## Choose your path by fleet type
+
+| Fleet type | Session auth | How it's passed |
+|---|---|---|
+| Non-domain-joined | Streaming URL from `CreateStreamingURL` | `X-Amzn-AgentAccess-Streaming-Session-Url` **header** |
+| Domain-joined (Active Directory) | Signed base64 SAML assertion + stack ARN | MCP **`_meta`/metadata** field (not a header) |
+
+## Non-domain-joined fleets (streaming URL)
+
+1. Generate a streaming URL:
+   ```
+   aws appstream create-streaming-url \
+     --stack-name <stack> --fleet-name <fleet> \
+     --user-id <user> --validity 3600 \
+     --query StreamingURL --output text
+   ```
+   Sets how long the URL stays valid for *initiating* a connection: `Validity` accepts 1–604800 seconds (7 days); the API default is 60 seconds. The streaming URL is a **bearer credential** that grants desktop access — use the shortest validity that covers your connection window (e.g. 300 s if the agent connects immediately) to limit the exposure window. Once connected, how long the session runs is governed by the fleet's `MaxUserDurationInSeconds` and disconnect/idle timeouts, not by this value (see session-lifecycle.md).
+2. Pass it on every request as the `X-Amzn-AgentAccess-Streaming-Session-Url` header.
+
+> **Treat the streaming URL as a secret.** It is a bearer token — retrieve it ephemerally at connect time; do not log it, persist it to disk, or pass it through insecure channels. If your orchestrator logs MCP headers, redact `X-Amzn-AgentAccess-Streaming-Session-Url`.
+
+Python (`mcp-proxy-for-aws` signs each request; requires Python 3.10+ — running it via `uvx mcp-proxy-for-aws ...` avoids system-Python version issues):
+```python
+from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
+
+async with aws_iam_streamablehttp_client(
+    endpoint="https://agentaccess-mcp.us-east-1.api.aws/mcp",  # use YOUR fleet's region
+    aws_service="agentaccess-mcp",
+    aws_region="us-east-1",  # must match the fleet's region — mismatch is rejected with 400
+    headers={"X-Amzn-AgentAccess-Streaming-Session-Url": streaming_url},
+) as (read, write, _):
+    ...
+```
+
+## Domain-joined fleets (SAML / Domain Join)
+
+Domain-joined streaming instances must be accessed through SAML federation; a streaming URL is not used. **Certificate-Based Authentication (CBA)** is required for agent sessions.
+
+The encoded SAML assertion exceeds HTTP header size limits, so it is injected via the MCP `_meta` field. `mcp-proxy-for-aws` 1.6.1+ exposes this as the `metadata` parameter:
+
+```python
+async with aws_iam_streamablehttp_client(
+    endpoint="https://agentaccess-mcp.us-east-1.api.aws/mcp",  # use YOUR fleet's region
+    aws_service="agentaccess-mcp",
+    aws_region="us-east-1",  # must match the fleet's region — mismatch is rejected with 400
+    metadata={
+        # Verified _meta keys read by the server's input_resolver:
+        "aws.agentaccess/workspacesApplicationsSamlAssertion": saml_response,  # signed, base64-encoded assertion
+        "aws.agentaccess/workspacesApplicationsStackArn": stack_arn,           # AppStream stack ARN for the AD user
+    },
+) as (read, write, _):
+    ...
+```
+
+The MCP server provisions a desktop session bound to the AD user identity in the assertion. Prerequisites: an IAM SAML provider registered with your IdP certificate, an IAM role trusting that provider, and a base64 assertion from your IdP (Okta, Entra ID, Ping, etc.).
+
+> **Keep federation material ephemeral and secret.** The SAML assertion is sensitive — do not log or persist it. Issue short-lived assertions (e.g. 5–15 min) and scope the assumed IAM role's `MaxSessionDuration` to the minimum the agent's task needs. Store IdP signing credentials in AWS Secrets Manager.
+
+## Connection methods (transport-level)
+
+| Method | Auth handling | Use case |
+|---|---|---|
+| Direct via `mcp-proxy-for-aws` | Signs each request locally | SDK integrations, custom agents |
+| AgentCore Gateway | Gateway signs on your behalf; can auto-provision sessions | Managed deployments, no streaming-URL management |
+| AgentCore Harness | Fully managed orchestration | Zero-code agents |
+
+## Concurrency
+
+Only one agent can connect to a given session at a time, and a named user (`UserId`) can have only one active session per fleet at a time. To run agents in parallel, give each its own session/user.

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/connection-setup.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/connection-setup.md
@@ -52,18 +52,21 @@ Prefer an **IAM role** (EC2 instance profile, ECS task role, or Lambda execution
 ## Non-domain-joined fleets (streaming URL)
 
 1. Generate a streaming URL:
+
    ```
    aws appstream create-streaming-url \
      --stack-name <stack> --fleet-name <fleet> \
      --user-id <user> --validity 3600 \
      --query StreamingURL --output text
    ```
+
    Sets how long the URL stays valid for *initiating* a connection: `Validity` accepts 1–604800 seconds (7 days); the API default is 60 seconds. The streaming URL is a **bearer credential** that grants desktop access — use the shortest validity that covers your connection window (e.g. 300 s if the agent connects immediately) to limit the exposure window. Once connected, how long the session runs is governed by the fleet's `MaxUserDurationInSeconds` and disconnect/idle timeouts, not by this value (see session-lifecycle.md).
 2. Pass it on every request as the `X-Amzn-AgentAccess-Streaming-Session-Url` header.
 
 > **Treat the streaming URL as a secret.** It is a bearer token — retrieve it ephemerally at connect time; do not log it, persist it to disk, or pass it through insecure channels. If your orchestrator logs MCP headers, redact `X-Amzn-AgentAccess-Streaming-Session-Url`.
 
 Python (`mcp-proxy-for-aws` signs each request; requires Python 3.10+ — running it via `uvx mcp-proxy-for-aws ...` avoids system-Python version issues):
+
 ```python
 from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
 

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/enabling-agent-access.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/enabling-agent-access.md
@@ -26,6 +26,7 @@ Agent access is enabled by supplying an **`AgentAccessConfig`** when you **`Crea
 | `FORWARD_MCP_TOOLS` | Forwards MCP tools on the session to the agent (see tool-forwarding.md) |
 
 Other fields:
+
 - `ScreenResolution` — `W_1280xH_720` is the **only** value the API accepts (single-value enum).
 - `ScreenImageFormat` — `PNG` or `JPEG`.
 - `S3BucketArn` + `ScreenshotsUploadEnabled: true` — optional screenshot storage.

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/enabling-agent-access.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/enabling-agent-access.md
@@ -1,0 +1,61 @@
+# Enabling Agent Access (prerequisites & stack setup)
+
+Before an agent can connect, **agent access must be enabled on the stack**. This is an admin/setup step, distinct from the agent-side connection in connection-setup.md.
+
+## Prerequisites
+
+- An active WorkSpaces Applications **fleet** (Always-On or On-Demand) — **Elastic and multi-session fleets are not supported**, and only **Windows Server** images are supported.
+- A **stack associated with that fleet** (agents cannot connect to a stack without an associated fleet).
+- The fleet running a recent WorkSpaces Applications Agent.
+- AWS permissions to create/manage stacks; the connecting agent needs the specific `agentaccess-mcp` actions it calls, scoped by the `agentaccess-mcp:StackArn` condition key — avoid a blanket `agentaccess-mcp:*` (see connection-setup.md → IAM permissions).
+- (Optional) For screenshot storage: an S3 bucket whose policy grants the AppStream service principal access, and the connecting agent needs `s3:PutObject` on it. Scope the service-principal grant with `aws:SourceAccount` / `aws:SourceArn` (confused-deputy protection), enable encryption **at rest** (SSE-S3 or SSE-KMS), and enforce encryption **in transit** (bucket policy denying requests where `aws:SecureTransport` is `false`).
+- **VPC endpoints are not supported** for agent access.
+
+## How you enable it
+
+Agent access is enabled by supplying an **`AgentAccessConfig`** when you **`CreateStack`** (or add it later with **`UpdateStack`**). If `AgentAccessConfig` is present, agent access is on and the stack is configured with agent-specific settings instead of the human-user settings.
+
+`AgentAccessConfig` required fields: `Settings` (≥1), `ScreenResolution`, `ScreenImageFormat`.
+
+**Agent actions** (`Settings[].AgentAction`, each with `Permission: ENABLED|DISABLED`) — you must enable **at least one** capability:
+
+| AgentAction | Enables |
+|---|---|
+| `COMPUTER_VISION` | Agent can take screenshots of the desktop |
+| `COMPUTER_INPUT` | Agent can click, type, scroll — **requires `COMPUTER_VISION` also ENABLED** |
+| `FORWARD_MCP_TOOLS` | Forwards MCP tools on the session to the agent (see tool-forwarding.md) |
+
+Other fields:
+- `ScreenResolution` — `W_1280xH_720` is the **only** value the API accepts (single-value enum).
+- `ScreenImageFormat` — `PNG` or `JPEG`.
+- `S3BucketArn` + `ScreenshotsUploadEnabled: true` — optional screenshot storage.
+- `UserControlMode` — `VIEW_ONLY`, `VIEW_STOP` (observer can stop the agent), or `DISABLED`.
+
+## CLI example
+
+```bash
+aws appstream create-stack \
+    --name your-stack-name \
+    --agent-access-config '{
+        "Settings": [
+            {"AgentAction": "COMPUTER_VISION", "Permission": "ENABLED"},
+            {"AgentAction": "COMPUTER_INPUT", "Permission": "ENABLED"}
+        ],
+        "ScreenResolution": "W_1280xH_720",
+        "ScreenImageFormat": "PNG"
+    }'
+```
+
+Enable only the capabilities the workflow needs — this baseline (vision + input) covers standard desktop automation. `FORWARD_MCP_TOOLS` is optional and only needed for the tool-forwarding workflow; add `{"AgentAction": "FORWARD_MCP_TOOLS", "Permission": "ENABLED"}` when setting that up (see tool-forwarding.md).
+
+To add screenshot storage, include `"S3BucketArn": "arn:aws:s3:::your-bucket", "ScreenshotsUploadEnabled": true`.
+
+## Updating / removing
+
+- **Update:** `aws appstream update-stack --name <stack-name> --agent-access-config '{...}'` supports partial updates — send only the fields you want to change.
+- **Remove agent access:** `aws appstream update-stack --name <stack-name> --attributes-to-delete AGENT_ACCESS_CONFIG`.
+- Config changes take effect on **new** sessions; already-running sessions keep the settings they launched with.
+
+## After enabling
+
+The agent connects to `https://agentaccess-mcp.{region}.api.aws/mcp` and authenticates the session (streaming URL, or SAML for domain-joined) — see connection-setup.md. Agent behavior is governed by the stack's `AgentAccessConfig`, not by parameters on the connection.

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/session-lifecycle.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/session-lifecycle.md
@@ -7,6 +7,7 @@
 3. **Ends** when the connection closes, the session hits the fleet's timeouts, or the streaming URL's validity window lapses before it is used to connect.
 
 Two separate limits are often confused:
+
 - **Streaming URL validity** — how long the URL can be used to *initiate* a connection. Set by the `Validity` parameter of `CreateStreamingURL`: 1–604800 seconds (7 days); API default 60 seconds. (AWS sample tooling commonly passes 3600 / 1 hour.) Once connected, the URL's validity no longer matters. It is a **bearer credential** — do not log it or pass it via environment variables that may be captured in process listings or crash dumps; redact `X-Amzn-AgentAccess-Streaming-Session-Url` if MCP headers are logged.
 - **Maximum session duration** — how long a connected session may run. Governed by the fleet's `MaxUserDurationInSeconds`, plus `DisconnectTimeoutInSeconds` and `IdleDisconnectTimeoutInSeconds` for teardown after disconnect/idle. These are per-fleet configuration, not a fixed Agent Access cap — confirm the values on your fleet (see [CreateFleet](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateFleet.html) for allowed ranges).
 

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/session-lifecycle.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/session-lifecycle.md
@@ -1,0 +1,30 @@
+# Session Lifecycle
+
+## Lifecycle
+
+1. **Starts** on the first MCP `initialize` with a streaming URL (or auto-provisioned via an AgentCore Gateway). The request is authorized by the `agentaccess-mcp:InvokeMcp` IAM action (see connection-setup.md → IAM permissions).
+2. **Active** while the MCP connection is open — tools can be called repeatedly and desktop state persists (apps stay open, files remain on disk).
+3. **Ends** when the connection closes, the session hits the fleet's timeouts, or the streaming URL's validity window lapses before it is used to connect.
+
+Two separate limits are often confused:
+- **Streaming URL validity** — how long the URL can be used to *initiate* a connection. Set by the `Validity` parameter of `CreateStreamingURL`: 1–604800 seconds (7 days); API default 60 seconds. (AWS sample tooling commonly passes 3600 / 1 hour.) Once connected, the URL's validity no longer matters. It is a **bearer credential** — do not log it or pass it via environment variables that may be captured in process listings or crash dumps; redact `X-Amzn-AgentAccess-Streaming-Session-Url` if MCP headers are logged.
+- **Maximum session duration** — how long a connected session may run. Governed by the fleet's `MaxUserDurationInSeconds`, plus `DisconnectTimeoutInSeconds` and `IdleDisconnectTimeoutInSeconds` for teardown after disconnect/idle. These are per-fleet configuration, not a fixed Agent Access cap — confirm the values on your fleet (see [CreateFleet](https://docs.aws.amazon.com/appstream2/latest/APIReference/API_CreateFleet.html) for allowed ranges).
+
+## Cleanup and expire-on-delete
+
+Control whether the underlying streaming session is expired when the agent disconnects with the `X-Amzn-AgentAccess-Expire-Streaming-Session-On-Delete` header:
+
+| Value | Behavior |
+|---|---|
+| `true` | On an explicit HTTP `DELETE`, the server expires the streaming session as part of cleanup. This terminates the streaming instance and triggers the fleet's autoscaling policy. |
+| `false` (default) | The session keeps running until the fleet's disconnect timeout is reached. |
+
+`mcp-proxy-for-aws` issues the `DELETE` automatically when you end the client lifecycle cleanly (e.g. exit the `async with` block). So to reclaim capacity promptly after a run, set the header to `true` and let the client close normally.
+
+## One agent per session
+
+Only one agent can be connected to a given session at a time. A named user (`UserId`) can have only one active session per fleet at a time. To run multiple agents concurrently, give each its own session (and distinct `UserId`).
+
+## Idle behavior
+
+Sessions have an idle/disconnect timeout at the fleet level. For long-lived automations, keep the MCP connection active or plan for reconnection (a fresh streaming URL) if the session times out. If a later tool call returns `client_disconnected`, the session was stopped or the auth expired — reconnect with fresh auth (a new streaming URL for non-domain-joined, or a new SAML assertion for domain-joined) rather than retrying the same connection (see troubleshooting.md).

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/tool-forwarding.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/tool-forwarding.md
@@ -12,6 +12,7 @@ Tool forwarding needs **both** an IAM grant and a service setting — IAM access
 
 1. **Enable the service action:** turn on `FORWARD_MCP_TOOLS` in the stack's agent action configuration (API or console).
 2. **IAM:** grant `agentaccess-mcp:CallForwardedTool` (plus `agentaccess-mcp:InvokeMcp` to establish the session, and any computer-use actions the agent also uses), scoped to the stack with the `agentaccess-mcp:StackArn` condition key. Prefer enumerated actions over `agentaccess-mcp:*`:
+
    ```json
    {
      "Effect": "Allow",
@@ -25,7 +26,9 @@ Tool forwarding needs **both** an IAM grant and a service setting — IAM access
      }
    }
    ```
+
 3. **Manifest on the fleet image** at `C:/ProgramData/NICE/dcv/mcp_server_redirection_config.json`:
+
    ```json
    {
      "mcpServers": {
@@ -39,6 +42,7 @@ Tool forwarding needs **both** an IAM grant and a service setting — IAM access
      }
    }
    ```
+
    Only `command` (required, absolute path) and `args` (optional) are supported — no env vars or working directory. Servers inherit the session environment and run as the session user. The manifest must be saved as UTF-8 **without a BOM** — the service rejects a manifest that has one (Windows PowerShell 5.1's `Out-File -Encoding utf8` writes a BOM; ensure your editor/tool saves plain UTF-8).
 
 ## Constraints
@@ -50,9 +54,11 @@ Tool forwarding needs **both** an IAM grant and a service setting — IAM access
 ## How forwarded tools appear
 
 Forwarded tools are renamed to avoid collisions:
+
 ```
 forwarded___<server-name>___<original-tool-name>
 ```
+
 e.g. a `get_forecast` tool on the `weather` server appears as `forwarded___weather___get_forecast`. Agent code matching on tool names must expect this prefix. (Note: Bedrock Converse requires tool names match `[a-zA-Z0-9_-]+`, so some clients normalize dots to dashes — match forwarded tools by description, not exact spelling.)
 
 ## Requirements

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/tool-forwarding.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/tool-forwarding.md
@@ -1,0 +1,60 @@
+# MCP Tool Forwarding
+
+Tool forwarding lets agents call MCP servers running **on the Windows fleet host** — filesystem, fetch, or your own tools — alongside the desktop computer-use tools, through the same endpoint. Prefer forwarded tools over desktop automation for file and web tasks: reading a file with a forwarded tool is far more reliable than opening it in an app and reading pixels.
+
+```
+Agent → Agent Access MCP Server → DCV Server → your MCP server (stdio on the host)
+```
+
+## Setup (both are required)
+
+Tool forwarding needs **both** an IAM grant and a service setting — IAM access does not override the service setting.
+
+1. **Enable the service action:** turn on `FORWARD_MCP_TOOLS` in the stack's agent action configuration (API or console).
+2. **IAM:** grant `agentaccess-mcp:CallForwardedTool` (plus `agentaccess-mcp:InvokeMcp` to establish the session, and any computer-use actions the agent also uses), scoped to the stack with the `agentaccess-mcp:StackArn` condition key. Prefer enumerated actions over `agentaccess-mcp:*`:
+   ```json
+   {
+     "Effect": "Allow",
+     "Action": [
+       "agentaccess-mcp:InvokeMcp",
+       "agentaccess-mcp:CallForwardedTool"
+     ],
+     "Resource": "*",
+     "Condition": {
+       "ArnLike": { "agentaccess-mcp:StackArn": "arn:aws:appstream:<region>:<account>:stack/<stack>" }
+     }
+   }
+   ```
+3. **Manifest on the fleet image** at `C:/ProgramData/NICE/dcv/mcp_server_redirection_config.json`:
+   ```json
+   {
+     "mcpServers": {
+       "filesystem": {
+         "command": "C:/path/to/python.exe",
+         "args": ["C:/mcpServerPath/filesystem.py", "C:/Users/Public/Documents"]
+       },
+       "weather": {
+         "command": "C:/Program Files/my-mcp/weather.exe"
+       }
+     }
+   }
+   ```
+   Only `command` (required, absolute path) and `args` (optional) are supported — no env vars or working directory. Servers inherit the session environment and run as the session user. The manifest must be saved as UTF-8 **without a BOM** — the service rejects a manifest that has one (Windows PowerShell 5.1's `Out-File -Encoding utf8` writes a BOM; ensure your editor/tool saves plain UTF-8).
+
+## Constraints
+
+- **stdio transport only.** Each entry launches a process that speaks MCP over stdin/stdout. Remote HTTP/SSE endpoints are not supported — wrap a remote endpoint in a local stdio server if needed.
+- **Use forward slashes** in paths (JSON treats `\` as an escape). Windows accepts `/` in absolute paths.
+- **5-second tool-call timeout.** Each forwarded tool call must complete within 5s or the server cancels it and returns an error. Design forwarded tools to return quickly.
+
+## How forwarded tools appear
+
+Forwarded tools are renamed to avoid collisions:
+```
+forwarded___<server-name>___<original-tool-name>
+```
+e.g. a `get_forecast` tool on the `weather` server appears as `forwarded___weather___get_forecast`. Agent code matching on tool names must expect this prefix. (Note: Bedrock Converse requires tool names match `[a-zA-Z0-9_-]+`, so some clients normalize dots to dashes — match forwarded tools by description, not exact spelling.)
+
+## Requirements
+
+Fleet image with a DCV Server build that supports MCP forwarding (check the current [Agent Access documentation](https://docs.aws.amazon.com/appstream2/latest/developerguide/agent-access-mcp-server.html) for the minimum version), Desktop stream view, `FORWARD_MCP_TOOLS` enabled on the stack, and MCP server binaries installed system-wide on the image.

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/tools-reference.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/tools-reference.md
@@ -1,0 +1,39 @@
+# Computer-Use Tools Reference
+
+All tool names are prefixed with `agentaccess___` by the server. `mcp-proxy-for-aws` handles the prefix transparently — use the base names below when reasoning about tools. (Forwarded tools use a different `forwarded___` prefix — see tool-forwarding.md.)
+
+The `screenshot` image dimensions define the coordinate space for all mouse tools. Coordinates are pixels from the top-left.
+
+## Mouse
+
+| Tool | Parameters | Notes |
+|---|---|---|
+| `left_click` | `x`, `y`, `modifiers?` | `modifiers` e.g. `"ctrl"`, `"ctrl+shift"` for modified clicks |
+| `double_click` | `x`, `y`, `modifiers?` | |
+| `triple_click` | `x`, `y`, `modifiers?` | Selects a line/paragraph |
+| `right_click` | `x`, `y`, `modifiers?` | Context menu |
+| `middle_click` | `x`, `y`, `modifiers?` | |
+| `left_click_drag` | `start_x`, `start_y`, `end_x`, `end_y` | Drag/select/draw |
+| `left_mouse_down` / `left_mouse_up` | `x`, `y`, `modifiers?` | Fine-grained drag control |
+| `move_pointer` | `x`, `y` | Move without clicking (hover) |
+| `scroll` | `x`, `y`, `scroll_direction` (`Up`/`Down`/`Left`/`Right`), `scroll_amount`, `modifiers?` | `scroll_amount` is in ticks; 120 ticks = one wheel notch |
+
+## Keyboard
+
+| Tool | Parameters | Notes |
+|---|---|---|
+| `type_text` | `text` (up to 10,000 chars) | Types character by character |
+| `key` | `keys` | Single key or combo joined by `+`, e.g. `a`, `ctrl+c`, `ctrl+shift+s`, `Return`, `Escape`, `Tab`, `alt+F4`, `super`, `super+r`, `alt+Tab` |
+| `hold_key` | `keys`, `duration` (1–30s) | Hold a key/combo for a duration |
+
+Common combos: `ctrl+c`/`ctrl+v` (copy/paste), `ctrl+a` (select all), `ctrl+z` (undo), `alt+F4` (close window), `super` (Start menu), `super+r` (Run dialog), `alt+Tab` (switch windows), `Return` (Enter), `Escape` (dismiss dialog).
+
+## Screen
+
+| Tool | Parameters | Notes |
+|---|---|---|
+| `screenshot` | `include_cursor?` (default false) | Returns a PNG. Defines the coordinate space for mouse tools. Expensive — see automation-best-practices.md. |
+
+## Application Catalog (when enabled on the fleet)
+
+Some fleets expose app-mode tools: `list_applications`, `launch_application`, `toggle_app_switcher`. Use these to enumerate and launch published applications instead of navigating the desktop shell. Check `tools/list` to see whether they are present.

--- a/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/troubleshooting.md
+++ b/skills/specialized-skills/end-user-computing-skills/amazon-workspaces-agent-access/references/troubleshooting.md
@@ -1,0 +1,27 @@
+# Troubleshooting
+
+Match on the exact error string, then apply the fix. The key distinction: **warmup/transient errors should be retried; `client_disconnected` should not** — it means the session is gone.
+
+## Error string → cause → fix
+
+| Error | Cause | Fix |
+|---|---|---|
+| `dcv session not ready` | Desktop still connecting after the streaming URL was created (5–30s, sometimes longer). | Retry with backoff. The service retries connection readiness for up to ~10 minutes; wait and retry rather than failing. |
+| `Unknown tool` (right after connect) | DCV desktop session not fully connected yet, so tools aren't registered. | Same as above — poll/retry until tools appear (or use POLLING mode + `connection_status`). |
+| `backend unavailable` | Transient service issue. | Retry briefly (a handful of attempts). |
+| `client_disconnected` | The session was **stopped, or the auth (streaming URL / SAML assertion) expired or was revoked** — the user or orchestrator ended it, or it timed out. | Do **not** just retry the same connection. Reconnect with **fresh auth** — a new streaming URL (non-domain-joined) or a new SAML assertion (domain-joined). |
+| `400 Bad Request` | SigV4 **signing region does not match the fleet region** (cross-region). | Sign for the fleet's region — set `AWS_REGION`/the MCP signing region to the fleet region and use the matching regional endpoint. |
+| `401 Unauthorized` | SigV4 signing failed / credentials can't sign. | Check AWS credentials (`aws sts get-caller-identity`); verify the correct profile is used for MCP signing. |
+| `403 Forbidden` | Missing IAM permissions for Agent Access. | Grant the specific `agentaccess-mcp` actions the agent calls (e.g. `InvokeMcp`, `GetScreenshot`, `LeftClick`, `TypeText`; add `CallForwardedTool` for forwarding), scoped by the `agentaccess-mcp:StackArn` condition key — avoid a blanket `agentaccess-mcp:*` (see connection-setup.md). |
+| `DCV proxy not initialized` | No streaming URL (or SAML assertion) was provided. | Pass the streaming URL header (non-domain-joined) or the SAML `_meta` (domain-joined), or connect via a Gateway that auto-provisions. |
+| Forwarded tool returns an error string | Often a path outside the sandbox, or the 5s tool-call timeout. | Read the error; fix the argument (keep paths in the server's sandbox) and retry once. Ensure the tool returns within 5s. |
+
+## Retryable vs fatal (client behavior)
+
+- **Retryable** (wait + reconnect): `dcv session not ready`, `Unknown tool` at startup, `channel not connected`, `connection to the mcp server was closed`, `timed out`, `backend unavailable`. Back off (e.g. increasing delay) across a few attempts.
+- **Fatal without fresh auth:** `client_disconnected` — reconnect with a new streaming URL (non-domain-joined) or a new SAML assertion (domain-joined).
+- **Fix-then-retry (config, not transient):** `400` (signing region), `401` (credentials), `403` (IAM) — correct the cause; retrying unchanged won't help.
+
+## Cold start note
+
+The first tool call after a cold start can take 10–30s while the desktop connects. This is expected — build in a wait/retry rather than treating the first slow call as a failure.


### PR DESCRIPTION
## Description

Adds the `amazon-workspaces-agent-access` skill for Amazon WorkSpaces Applications (AppStream 2.0). It covers connecting an AI agent to a remote Windows desktop through the managed Agent Access MCP server and driving it reliably: SigV4 / streaming-URL / SAML connection, BLOCKING vs POLLING connect modes, the computer-use tools, screenshot-budget and action-batching discipline, MCP tool forwarding, session lifecycle, and troubleshooting.

Placed under `specialized-skills/end-user-computing-skills/`. End User Computing is the AWS product category for WorkSpaces and AppStream, and no such category existed yet.

Text-only skill (no executable code). Security-reviewed (Guardian PASS). Tested with Kiro; evaluated across Claude Sonnet, Claude Opus, and GPT models.

## Type of Change

- [x] New skill

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My changes pass `python3 tools/validate.py`
- [x] No documentation changes required (new skill only)
