### PR TITLE
fix(aws-core): retry transient asm-exec MCP timeouts (#229)

### DIFF
--- a/plugins/aws-core/skills/aws-secrets-manager/SKILL.md
+++ b/plugins/aws-core/skills/aws-secrets-manager/SKILL.md
@@ -165,6 +165,13 @@ The Secrets Manager Agent may not be running. This is non-fatal: `asm-exec`
 falls through to the SigV4-signed MCP endpoint. Ensure AWS credentials are
 resolvable (see SigV4 signing above) so that backend can authenticate.
 
+### "Timed out resolving" errors
+
+Transient, not a config problem -- the server-side lookup was slow. `asm-exec`
+retries automatically (`ASM_EXEC_MAX_ATTEMPTS`, default 3). If timeouts persist,
+the user can raise the per-attempt timeout: `export ASM_EXEC_TIMEOUT=45`
+(seconds, default 20).
+
 ### "Failed to resolve" errors
 
 Both backends were unreachable or returned no value. Check that either SMA is

--- a/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
+++ b/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
@@ -347,7 +347,7 @@ def resolve_one(ref):
                 if attempt < MCP_MAX_ATTEMPTS - 1:
                     time.sleep(0.5 * (2 ** attempt))  # 0.5s, 1s, 2s, ...
                     continue
-                print(f'asm-exec: ERROR: Timed out resolving {ref} after '
+                print('asm-exec: ERROR: Timed out resolving secret reference after '
                       f'{MCP_MAX_ATTEMPTS} attempts ({MCP_TIMEOUT:.0f}s each) '
                       f'contacting the MCP endpoint. This is usually transient; '
                       f'retry, or raise ASM_EXEC_TIMEOUT.', file=sys.stderr)

--- a/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
+++ b/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
@@ -21,8 +21,10 @@ import json
 import os
 import re
 import shlex
+import socket
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -36,6 +38,8 @@ PATTERN = re.compile(r'\{\{resolve:secretsmanager:([^}]+)\}\}')
 SMA_ENDPOINT = os.environ.get('AWS_SECRETS_MANAGER_AGENT_ENDPOINT', 'http://localhost:2773')
 SSRF_TOKEN = os.environ.get('AWS_SESSION_TOKEN', os.environ.get('AWS_TOKEN', ''))
 MCP_ENDPOINT = os.environ.get('ASM_EXEC_MCP_ENDPOINT', 'https://aws-mcp.us-east-1.api.aws/mcp')
+MCP_TIMEOUT = float(os.environ.get('ASM_EXEC_TIMEOUT', '20')) # user changes via export ASM_EXEC_TIMEOUT=x
+MCP_MAX_ATTEMPTS = max(1, int(os.environ.get('ASM_EXEC_MAX_ATTEMPTS', '3'))) # user changes via export ASM_EXEC_MAX_ATTEMPTS=x
 
 _sma_available = None
 
@@ -193,7 +197,7 @@ def _mcp_post(payload, session_id=None):
     for k, v in sig_headers.items():
         req.add_header(k, v)
 
-    resp = urllib.request.urlopen(req, timeout=10)
+    resp = urllib.request.urlopen(req, timeout=MCP_TIMEOUT)
     session_out = resp.headers.get('Mcp-Session-Id')
     raw = resp.read()
     parsed = json.loads(raw) if raw else {}
@@ -268,8 +272,9 @@ def _resolve_via_mcp(secret_name, label, region):
                         return found
         if isinstance(result, dict):
             return _extract_secret_string(result)
-    except (urllib.error.URLError, OSError, json.JSONDecodeError,
-            KeyError, TypeError, RuntimeError):
+    except (socket.timeout, TimeoutError):
+        raise
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, RuntimeError):
         pass
     return None
 
@@ -330,9 +335,23 @@ def resolve_one(ref):
         except (urllib.error.URLError, OSError, json.JSONDecodeError):
             pass
 
-    # 2. Resolve via Streamable HTTP MCP
+    # 2. Resolve via Streamable HTTP MCP. get-secret-value is an idempotent
+    #    read, so retry transient timeouts with bounded exponential backoff
+    #    before surfacing a timeout-specific error. (issue #229)
     if not value:
-        value = _resolve_via_mcp(secret_name, label, region)
+        for attempt in range(MCP_MAX_ATTEMPTS):
+            try:
+                value = _resolve_via_mcp(secret_name, label, region)
+                break
+            except (socket.timeout, TimeoutError):
+                if attempt < MCP_MAX_ATTEMPTS - 1:
+                    time.sleep(0.5 * (2 ** attempt))  # 0.5s, 1s, 2s, ...
+                    continue
+                print(f'asm-exec: ERROR: Timed out resolving {ref} after '
+                      f'{MCP_MAX_ATTEMPTS} attempts ({MCP_TIMEOUT:.0f}s each) '
+                      f'contacting the MCP endpoint. This is usually transient; '
+                      f'retry, or raise ASM_EXEC_TIMEOUT.', file=sys.stderr)
+                sys.exit(1)
 
     if not value:
         print(f'asm-exec: ERROR: Failed to resolve: {ref}', file=sys.stderr)


### PR DESCRIPTION
## Description

`asm-exec` reported transient MCP `tools/call` read timeouts as an unrecoverable
`Failed to resolve` — indistinguishable from "secret not found" or "access denied" —
with no retry. Fixes #229.

Because the `secret-safety.py` PreToolUse hook blocks `get-secret-value` outright,
`asm-exec` is the only sanctioned path to secret material, so a transient failure
here has no fallback and reads as a hard configuration error.

**Changes**

- Retry the idempotent MCP read with bounded exponential backoff
  (`ASM_EXEC_MAX_ATTEMPTS`, default 3; 0.5s/1s waits, no sleep after the final attempt)
- Raise and expose the read timeout: `ASM_EXEC_TIMEOUT`, default 20s (was hardcoded 10s)
- Separate `socket.timeout`/`TimeoutError` from the broad handler so a timeout surfaces
  a distinct, actionable message instead of the generic one
- Narrow the broad `except`: drop `KeyError`/`TypeError` so genuine code bugs propagate
  rather than being swallowed into `None`
- Document both env vars in `SKILL.md` troubleshooting

**Measured impact** (live AWS MCP endpoint, us-west-2 secret, n=30)

| Config | Resolved |
|---|---|
| 10s, 1 attempt (old) | **0/30** |
| 20s, 3 attempts (new) | **30/30** |

Latency of successful calls: p50 **12.42s**, p95 13.30s, p99 **13.58s**, max 13.58s.
All 30 successful resolutions exceeded the old 10s timeout. This is more severe than
the ~15–30% reported in the issue because that measurement used a secret in the
endpoint's own region; cross-region resolution (us-east-1 endpoint → us-west-2 secret)
pushed every call past 10s. `asm-exec` explicitly supports cross-region via `--region`,
so this is not an exotic configuration.

On this evidence the raised timeout does the corrective work; the retry is insurance
for environments whose tail exceeds 20s, and `ASM_EXEC_TIMEOUT` allows tuning without
a code change.

**Testing**

- 35 local checks: all four fixes, retry edge cases (non-timeouts not retried,
  `json_key` still applied after a retry, `MAX_ATTEMPTS` floor guard), and regressions
  (ARN parsing, `SecretBinary` rejection, SMA preference, single-pass injection defense,
  `shell_quote`, end-to-end `main()` with argv + exported-env resolution)
- Local fake MCP server over real sockets: 20% → 0% failure. The retry path was verified
  there rather than live, since at 20s nothing times out against the real endpoint
- Live endpoint: 30/30 in both raw-latency and shipped-defaults modes
- `mise run validate`, markdownlint, and gitleaks all pass

**Note for maintainers** (separate from this fix): published `aws-core` 1.1.0 still ships
the pre-#147 `asm-exec` — exported env-var references are handed to the child unresolved
with exit status 0 (silent fail-open). `main` has the fix; a release is needed to get it
to users. Raised in #229's closing note.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [x] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*