### PR TITLE
feat: update amazon-opensearch-service skill

### DIFF
--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/log-analytics-guide.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/log-analytics-guide.md
@@ -1,5 +1,7 @@
 # Log-analytics capability — entry point and guide
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard `awscurl` / AWS CLI syntax.
+
 This file is the **entry point** for the `log-analytics` capability. It covers log search at scale, observability, PPL queries, anomaly detection, OpenSearch Dashboards, alerting, and SIEM patterns — including replatforming from Splunk, Datadog, or self-managed ELK.
 
 ## When to use this capability
@@ -30,6 +32,24 @@ Cross-cutting refs you may also load: [`observability.md`](observability.md) (IS
 
 This guide instructs you on how to perform log analytics against an existing OpenSearch domain or collection. The approach is discovery-first: understand what indices exist, learn the schema, sample the data, then build queries. Do not assume any particular index pattern or field names — discover them.
 
+For the full PPL command and function catalog, see [`observability-ppl-reference.md`](observability-ppl-reference.md).
+
+## Query discipline (MUST follow)
+
+- **Unknown command → upstream grammar.** If a PPL command or function is not in
+  [`observability-ppl-reference.md`](observability-ppl-reference.md), or an emitted query fails with a
+  syntax error, you MUST fetch the raw upstream doc from `opensearch-project/sql` under `docs/user/ppl/`
+  before answering. You MUST NOT invent PPL syntax, because OpenSearch PPL has version-specific commands
+  that do not exist in other query languages.
+- **Verify or disclose.** When the domain/collection endpoint is reachable, you MUST validate every
+  emitted query against `_plugins/_ppl`; on 0 rows, fall back to `_plugins/_ppl/_explain` to confirm the
+  plan and surface the empty result; on error, fix and re-validate. When no endpoint is reachable, you
+  MUST state that the query is unverified, because an untested query can silently reference a
+  non-existent field.
+- **Backtick-quote dotted fields.** Field names containing a dot MUST be backtick-quoted (`` `log.level` ``,
+  `` `host.name` ``), because an unquoted dot is parsed as a path separator and silently resolves to a
+  non-existent field.
+
 ## Data Plane Access with awscurl
 
 Use `awscurl` for SigV4-authenticated HTTP requests to AOS/AOSS endpoints.
@@ -39,6 +59,8 @@ Use `awscurl` for SigV4-authenticated HTTP requests to AOS/AOSS endpoints.
 ```bash
 pip install awscurl
 ```
+
+> **Credentials:** source SigV4 signing credentials from an IAM role (instance profile, ECS task role, or an SSO session) rather than static access keys, and keep endpoints and other config in AWS Secrets Manager or SSM Parameter Store rather than hardcoding them.
 
 ### Environment Variables
 

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/log-analytics-osi-pipelines.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/log-analytics-osi-pipelines.md
@@ -4,6 +4,8 @@
 
 OpenSearch Ingestion (OSI) is a fully managed, serverless pipeline service that delivers logs from sources like CloudWatch Logs, Fluent Bit, and HTTP into AOS/AOSS without managing infrastructure.
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 ## Creating a Pipeline for CloudWatch Logs
 
 ### Step 1: Create Pipeline Role
@@ -24,7 +26,7 @@ aws iam create-role --role-name OSIPipelineRole \
   }'
 ```
 
-Both `aws:SourceAccount` and `aws:SourceArn` conditions are required to prevent the **confused-deputy** pattern: without `aws:SourceArn`, any OSIS pipeline in the same account could assume this role; the `ArnLike` condition narrows the trust to your OSIS pipelines only. For a single-pipeline trust, replace `pipeline/*` with the specific pipeline name.
+Both `aws:SourceAccount` and `aws:SourceArn` conditions are required to prevent the **confused-deputy** pattern: without `aws:SourceArn`, any OSI pipeline in the same account could assume this role; the `ArnLike` condition narrows the trust to your OSI pipelines only. For a single-pipeline trust, replace `pipeline/*` with the specific pipeline name.
 
 Attach policies for CloudWatch Logs source and OpenSearch sink:
 
@@ -132,13 +134,52 @@ aws logs put-subscription-filter \
 
 ## AOSS Considerations
 
-- Data access policy must grant the pipeline role `aoss:BatchGetCollection` and `aoss:APIAccessAll`
+- The pipeline role's **IAM policy** must grant `aoss:BatchGetCollection` and `aoss:APIAccessAll` (these are IAM data-plane permissions, not data access policy permissions)
+- The **data access policy** must grant the pipeline role the index/collection actions it needs (e.g. `aoss:CreateIndex`, `aoss:WriteDocument`) — see the merge step below
 - Network policy must allow OSI pipeline VPC access
 - Use `serverless: true` in the sink configuration
+
+### Adding the pipeline role to an AOSS data access policy
+
+You MUST merge the pipeline role into the existing policy rather than replacing it, because overwriting the policy would drop other principals and rules already granted on the collection.
+
+1. Get the current policy and note its `policyVersion`. Use the data access policy name created during provisioning — `<collection-name>-data` in [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md) (Step 3); substitute your actual policy name if it differs:
+
+   ```bash
+   aws opensearchserverless get-access-policy --type data \
+     --name <collection-name>-data --region <region>
+   ```
+
+2. Append the pipeline role ARN to the existing `Principal` array (preserve all existing rules/principals). Grant it only the minimum actions the pipeline needs — scope index-level writes to the target index pattern rather than `aoss:*` on all resource types, because a broad grant lets the pipeline role read or delete unrelated data:
+   - `collection` rule: `aoss:DescribeCollectionItems` on `collection/<collection-name>`
+   - `index` rule: `aoss:CreateIndex`, `aoss:DescribeIndex`, `aoss:WriteDocument` on `index/<collection-name>/<target-index>*`
+   - The role also needs the IAM permissions `aoss:BatchGetCollection` and `aoss:APIAccessAll` (data-plane access), granted in its IAM policy — not the data access policy.
+3. Update with the captured version:
+
+   ```bash
+   aws opensearchserverless update-access-policy --type data \
+     --name <collection-name>-data \
+     --policy-version "<current-version>" \
+     --policy '<merged-policy-json>' --region <region>
+   ```
+
+4. Wait ~30 seconds for propagation, then stop/start the pipeline (see the gotcha below).
+
+## After Changing IAM or Data Access Policies
+
+> **After changing the pipeline role's IAM permissions or an AOSS data access policy, you MUST stop and restart the pipeline**, because OSI caches the assumed-role credentials and will keep failing on the stale permissions until it re-assumes the role:
+>
+> ```bash
+> aws osis stop-pipeline  --pipeline-name <pipeline-name> --region <region>   # wait for STOPPED
+> aws osis start-pipeline --pipeline-name <pipeline-name> --region <region>
+> ```
+>
+> After restart, confirm delivery has recovered rather than assuming success: verify CloudTrail recorded the `StopPipeline`/`StartPipeline` calls, and check that the pipeline's health metrics return to normal (e.g. `opensearch.documentsSuccess` climbing and `opensearch.documentErrors`/`dlqS3RecordsFailed` flat) via a CloudWatch alarm on the failure metrics, because a silent post-restart failure means data loss until the next manual check.
 
 ## Security Considerations
 
 - Apply least-privilege IAM policies: grant only the specific actions needed (e.g., `es:ESHttpPost`, `es:ESHttpPut`) scoped to the target domain/collection resource ARN.
 - All data in transit between OSI pipelines and OpenSearch is encrypted via TLS. Ensure domain or collection enforces HTTPS-only access.
 - Use dedicated IAM roles for pipeline execution rather than sharing roles across services.
-- Enable CloudTrail at the account level to audit all OSIS API calls (pipeline creation, modification, deletion) for compliance monitoring.
+- Enable CloudTrail at the account level to audit all OSI API calls (pipeline creation, modification, deletion) for compliance monitoring.
+- Encrypt the pipeline's CloudWatch log group with a customer-managed KMS key, because pipeline error logs and DLQ records may contain document field values from your data. Create the log group with encryption *before* pipeline creation so it applies from first write — `aws logs create-log-group --log-group-name /aws/vendedlogs/osi-pipeline --kms-key-id <key-arn>` — or attach a key to an existing group with `aws logs associate-kms-key`.

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/observability-ppl-reference.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/observability-ppl-reference.md
@@ -1,0 +1,222 @@
+# PPL language reference (observability)
+
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard `awscurl` / AWS CLI syntax.
+
+Shared PPL reference for the `log-analytics` and `trace-analytics` capabilities.
+Queries follow pipe-delimited syntax: `source=<index> | command1 | command2 ...`.
+Grammar is sourced from [opensearch-project/sql](https://github.com/opensearch-project/sql) under `docs/user/ppl/`.
+
+Loaded from: [`log-analytics-guide.md`](log-analytics-guide.md), [`trace-analytics-trace-queries.md`](trace-analytics-trace-queries.md).
+
+## Query discipline (MUST follow)
+
+1. **Unknown command or function — you MUST consult the upstream grammar before answering.** If a
+   command, function, or parameter is not in this reference, you MUST fetch the raw markdown from
+   `opensearch-project/sql` (URLs below). You MUST NOT invent PPL syntax and you MUST NOT claim a
+   command does not exist without checking first, because OpenSearch PPL includes many commands
+   (for example `graphLookup`, `explain`, `append`, `join`) that do not exist in other query systems.
+2. **You MUST verify emitted queries when a cluster endpoint is reachable.** When the AOS domain or
+   AOSS collection endpoint is available, every emitted PPL query MUST be validated with a best-effort
+   cascade before you return it:
+   1. Execute it against `_plugins/_ppl` and capture the row count and any error.
+   2. If it succeeds but returns 0 rows, run `_plugins/_ppl/_explain` to confirm the plan parses and
+      resolves field references, then surface the empty-result observation.
+   3. If `_plugins/_ppl` errors, fix the query (consult the upstream grammar as needed) and re-validate.
+   When no endpoint is reachable, you MUST state explicitly that the query is unverified, because an
+   untested PPL query can silently reference a non-existent field or use version-specific syntax.
+
+## Field name escaping
+
+Dotted field names MUST be backtick-quoted, because an unquoted dot is parsed as a path separator and
+fails: `` `attributes.gen_ai.operation.name` ``, `` `status.code` ``,
+`` `resource.attributes.service.name` ``.
+
+Field names beginning with a special character (e.g. the `@`-prefixed `` `@timestamp` ``) must also be
+backtick-quoted, because the leading character is not a valid bare identifier.
+
+## API endpoints
+
+Query (AOS uses `--service es`; AOSS uses `--service aoss`):
+
+The endpoint URL MUST use HTTPS (not HTTP). `awscurl` will not upgrade an HTTP URL to HTTPS, so verify
+`$OPENSEARCH_ENDPOINT` starts with `https://` before executing any command below, because an
+unencrypted data-plane request exposes the query and results in transit.
+
+Source the SigV4 signing credentials from an IAM role (instance profile, ECS task role, or SSO session)
+rather than static access keys, because static access keys are a standing exfiltration risk.
+
+    awscurl --service es --region $AWS_REGION \
+      -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+      -H 'Content-Type: application/json' \
+      -d '{"query": "source=otel-v1-apm-span-* | stats count() by serviceName"}'
+
+Explain (query-plan debugging):
+
+    awscurl --service es --region $AWS_REGION \
+      -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl/_explain" \
+      -H 'Content-Type: application/json' \
+      -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | stats count() by serviceName"}'
+
+`_explain` accepts an optional `mode` (`standard` / `simple` / `cost` / `extended`). `simple`, `cost`,
+and `extended` require the v3 engine (`plugins.calcite.enabled=true`); `standard` works on v2 and v3.
+Engine requirements are version-specific — verify whether the v3 engine is available and enabled on the
+target domain/collection by checking `GET _cluster/settings` for `plugins.calcite.enabled`, or consult the
+upstream `opensearch-project/sql` docs rather than assuming these constraints are fixed.
+
+## Core commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `source` | `source=<index>` | Start query from index pattern |
+| `search` | `search source=<index> [<expr>]` | Alternative first command; search-expression syntax (`field=value`, `AND/OR/NOT`, time modifiers) |
+| `where` | `where <condition>` | Filter rows |
+| `regex` | `regex <field> = '<pattern>'` (or `!=`) | Filter rows by Java regex on a field |
+| `fields` | `fields [+\|-] <list>` | Select / exclude fields |
+| `table` | `table [+\|-] <list>` | Alias for `fields` |
+| `stats` | `stats <agg>... [by <field>]` | Aggregate data |
+| `sort` | `sort [+\|-] <field>` | Order results (+ asc, - desc) |
+| `reverse` | `reverse` | Reverse result order (no-op without a preceding `sort`/`@timestamp`; collation-destroying ops such as `stats`/`join` make it a no-op) |
+| `head` | `head [N]` | Limit results (default 10) |
+| `tail` | `tail [N]` | Return the last N results (default 10) |
+| `eval` | `eval <new> = <expr>` | Compute new fields |
+| `fieldformat` | `fieldformat <field>=[(prefix).]<expr>[.(suffix)]` | `eval` alias with prefix/suffix string concat for display |
+| `dedup` | `dedup [N] <field>` | Remove duplicates |
+| `rename` | `rename <old> AS <new>` | Rename fields |
+| `replace` | `replace '<pat>' WITH '<repl>' IN <field>` | Literal/wildcard string replace (supports `*`) |
+| `convert` | `convert <fn>(<field>) [AS <field>]` | Type-coerce (`auto()`, `num()`, `mktime()`, `ctime()`, `dur2sec()`, `mstime()`, `memk()`, `rmcomma()`, `rmunit()`, `none()`) |
+| `top` | `top [N] <field>` | Most frequent values |
+| `rare` | `rare <field>` | Least frequent values |
+
+## Time-series commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `bin` | `bin <field> [span=<int>] [bins=<n>] [minspan=<int>] [aligntime=...] [start=<v>] [end=<v>]` | Bucket numeric/time values (`bins=` on timestamps requires `plugins.calcite.pushdown.enabled=true` and the binned field inside a `stats` aggregation; otherwise use `span=`; verify v3 engine availability on the target domain/collection before relying on this flag) |
+| `timechart` | `timechart span=<interval> <agg> [by <field>]` | Time-bucketed aggregation |
+| `chart` | `chart <agg> [by <row> <col>] \| [over <row> [by <col>]] [limit=topN] [useother=<bool>] [usenull=<bool>]` | Aggregate + pivot for 2D charts |
+| `span()` | `span(<field>, <interval>)` | Bucket numeric/date values |
+| `trendline` | `trendline sort <field> sma(<N>, <field>)` | Moving average |
+| `streamstats` | `streamstats <agg> [by <field>]` | Running statistics (memory-intensive) |
+| `eventstats` | `eventstats <agg> [by <field>]` | Add agg as field without collapsing rows (memory-intensive) |
+
+Span time units: `ms`, `s`, `m`, `h`, `d`, `w`, `M`, `q`, `y` (`bin` also accepts `us`, `cs`, `ds` and
+longhand forms). Timechart rate functions: `per_second()`, `per_minute()`, `per_hour()`, `per_day()`.
+
+## Parse / extract commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `parse` | `parse <field> '<regex>'` | Regex extraction (may drop fields on some versions) |
+| `grok` | `grok <field> '<pattern>'` | Grok pattern extraction (memory-intensive) |
+| `rex` | `rex field=<field> '<regex>'` | Named capture groups |
+| `patterns` | `patterns <field>` | Auto-discover log patterns |
+| `spath` | `spath input=<field> [output=<field>] [path=<path>]` | Extract from structured JSON (runs on the coordinator node; prefer indexing fields directly on large datasets) |
+
+## Join / lookup / set commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `join` | `join left=a right=b ON a.f = b.f <index>` | Cross-index join |
+| `lookup` | `lookup <index> <field> [OUTPUT <fields>]` | Enrich from another index |
+| `subquery` | `where <f> IN [source=<idx> \| ... \| fields <f>]` | Nested query filter |
+| `union` | `union [maxout=<n>] <ds1> <ds2> [...]` | UNION ALL across datasets; auto type-coerces conflicting schemas |
+| `multisearch` | `multisearch [<sub1>] [<sub2>] [...]` | Run + merge subsearches; supports timestamp interleaving |
+| `append` | `append [source=<idx> \| ...]` | Append results from another query |
+| `appendcol` | `appendcol [override=<bool>] [<subsearch>]` | Append subsearch result as additional columns |
+| `appendpipe` | `appendpipe [<subpipeline>]` | Append subpipeline results (runs lazily) |
+| `graphLookup` | `graphLookup <idx> start=<expr> edge=<from><op><to> [maxDepth=<n>] ... as <out>` | (Experimental) recursive BFS graph traversal |
+
+Cross-index `join` reliability varies by engine version, so you MUST test the join on the target
+domain/collection (per the query-discipline cascade above) rather than assuming it works. If it returns 0 rows
+unexpectedly, fall back to separate queries correlated by `traceId`.
+
+## Transform commands
+
+| Command | Description |
+|---|---|
+| `fillnull` | Replace nulls (backtick fields not supported in field list) |
+| `flatten` | Flatten nested fields to top level |
+| `expand` | Expand arrays into separate rows |
+| `mvexpand` | `mvexpand <field> [limit=<n>]` — expand each multivalue element into its own row |
+| `mvcombine` | Combine a target field into a multivalue array across otherwise-identical rows |
+| `nomv` | Convert a multivalue field to a single string (joined by `\n`) |
+| `transpose` | Pivot rows into columns |
+| `addtotals` | `addtotals [field-list] [row=<bool>] [col=<bool>] [label=<s>] [labelfield=<f>] [fieldname=<f>]` — row/column totals (numeric only) |
+| `addcoltotals` | Column-only totals; equivalent to `addtotals row=false col=true` |
+
+## Function families
+
+- **Aggregation:** `count()`, `sum(f)`, `avg(f)`, `max(f)`/`min(f)`, `distinct_count(f)`, `percentile(f, pct)`, `var_samp(f)`/`stddev_samp(f)`, `earliest(f)`/`latest(f)`, `values(f)`.
+- **Statistical (eval-context, scalar):** `MAX(x, y, ...)`, `MIN(x, y, ...)` — these return a single value across their arguments and do NOT aggregate across rows, because they are scalar; use aggregate `max(field)`/`min(field)` inside `stats` instead.
+- **Condition:** `isnull(f)`/`isnotnull(f)`, `if(cond, t, f)`, `case(c1, v1, ..., else)`, `coalesce(v1, v2, ...)`, `like`/`in`/`between`.
+- **Conversion:** `cast(f AS type)`, `tostring()`, `toint()`, `tolong()`, `tofloat()`, `todouble()` (types: STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, DATE, TIMESTAMP).
+- **Datetime:** `now()`, `date_format(date, fmt)`, `date_add(date, INTERVAL n unit)`, `date_sub(date, INTERVAL n unit)`, `datediff(d1, d2)`, `day()`/`month()`/`year()`/`hour()`/`minute()`/`second()`.
+- **String:** `concat()`, `length()`/`lower()`/`upper()`/`trim()`, `substring(s, start, len)`, `replace(s, from, to)`, `regexp_extract(s, pat, grp)`, `regexp_replace(s, pat, repl)`.
+- **Relevance:** `match(field, query)`, `match_phrase(field, phrase)`, `multi_match([f1, f2], query)`, `query_string([f1, f2], query)`, `wildcard_query(field, pattern)`.
+- **Math:** `abs()`, `ceil()`, `floor()`, `round(val, decimals)`, `sqrt()`, `pow()`, `mod()`, `log()`, `log10()`, `exp()`.
+- **Collection (multivalue):** `array(...)`, `array_length(arr)`, `mvjoin(arr, sep)`, `mvfilter(expr)`, `mvindex(arr, start [, end])`, `mvappend(...)`.
+- **JSON** (path notation `<key>{<idx>}...`; `{}` = all elements): `json(value)`, `json_extract(json, path)`, `json_array(...)`, `json_object(...)`, `json_keys(json)`.
+- **IP:** `cidrmatch(ip, cidr)`, `geoip(ip)`.
+- **Cryptographic:** `md5(str)`, `sha1(str)`, `sha2(str, bits)` (hex-encoded STRING digests).
+- **System:** `typeof(expr)`.
+
+## Operators
+
+Arithmetic: `+`, `-`, `*`, `/`, `%`; use parentheses for precedence. Division behavior depends on the
+cluster setting `plugins.ppl.syntax.legacy.preferred`: when `true` integer/integer is truncated; when
+`false` operands are promoted to floating point. Do not assume a default — read the effective value on
+the target domain/collection with `GET _cluster/settings?include_defaults=true` (inspect
+`defaults.plugins.ppl.syntax.legacy.preferred` unless overridden under `persistent`/`transient`) before
+relying on the division semantics. Division by zero returns `NULL`, not an error. Modulo (`%`) is
+integer-only and raises a type error on floats, because the operator has no float overload.
+
+## ML commands
+
+| Command | Description |
+|---|---|
+| `ad` | Anomaly detection (auto-detects input fields from the pipeline) |
+| `kmeans` | K-means clustering (operates on all numeric fields) |
+
+`ml action=rcf` support varies by cluster version — prefer the `ad` command directly, and if you need
+`ml action=rcf`, verify it against the target domain/collection (test the command) or the upstream
+`opensearch-project/sql` docs for that version rather than assuming a fixed constraint.
+
+## System / inspection commands
+
+| Command | Description |
+|---|---|
+| `describe <index>` | Inspect index mapping and field types (use a concrete index name, not a wildcard) |
+| `show datasources` | List configured data sources |
+| `explain [<mode>] <query>` | Display the execution plan (MUST be the first command); `mode` ∈ `standard` (default) / `simple` / `cost` / `extended`; non-`standard` modes require the v3 engine |
+
+## Looking up PPL documentation
+
+When a command/function is missing here, a query fails with a syntax error, or the user's cluster
+version may differ, you MUST fetch the canonical grammar from `opensearch-project/sql`:
+
+- Commands: `https://raw.githubusercontent.com/opensearch-project/sql/main/docs/user/ppl/cmd/<command>.md`
+- Functions: `https://raw.githubusercontent.com/opensearch-project/sql/main/docs/user/ppl/functions/<category>.md`
+  (categories: `aggregations`, `collection`, `condition`, `conversion`, `cryptographic`, `datetime`,
+  `expressions`, `ip`, `json`, `math`, `relevance`, `statistical`, `string`, `system`)
+
+Prefer the `opensearch-project/sql` source over `opensearch.org` documentation pages, because the docs
+site MAY trail the SQL repository by one or more releases.
+
+## Security Considerations
+
+- **Authenticate every query with SigV4 (IAM auth), never open access.** PPL queries hit the data plane
+  (`_plugins/_ppl`), so requests MUST be SigV4-signed — AOS uses `--service es`, AOSS uses `--service aoss`.
+  Do NOT rely on public/unauthenticated endpoints, because an open data plane exposes all indexed data.
+- **PPL results can expose sensitive data.** A query returns whatever fields the caller's index-level
+  permissions allow. Callers MUST have appropriately scoped access via FGAC (AOS domains) or the collection's
+  data access policy (AOSS), because a broad grant lets a query surface PII or other restricted fields.
+- **Enable audit logging.** Turn on CloudTrail for the management-plane API calls and OpenSearch audit logs
+  for data-plane access so you can attribute who ran which queries, because an unaudited data plane makes
+  misuse undetectable.
+- **Do not log full query results to CloudWatch if they may contain PII** unless the log group is encrypted
+  with a customer-managed KMS key, because query output can carry sensitive document fields into logs.
+- **Rate-limit, time-bound, and monitor the PPL endpoint.** Enforce rate limits on `_plugins/_ppl` traffic
+  (via a fronting API gateway/proxy or AWS WAF rate-based rules) and set query timeouts so a runaway
+  aggregation or `join` cannot exhaust cluster resources; alarm on CloudWatch `_plugins/_ppl` call volume and
+  error rates to catch abuse. This matters most for agentic search, where each query invokes a Bedrock model —
+  an unthrottled path there drives both resource exhaustion and unbounded per-call cost.

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/observability.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/observability.md
@@ -154,14 +154,14 @@ source=logs-app-2026-06-01 | where status >= 500 | stats count() by service | so
 ```
 
 ```ppl
-source=logs-app-* | where @timestamp >= now() - 1h | parse uri "(?<endpoint>/api/[^?]+)" | stats avg(latency_ms), p99(latency_ms) by endpoint
+source=logs-app-* | where @timestamp >= now() - 1h | parse uri "(?<endpoint>/api/[^?]+)" | stats avg(latency_ms), percentile(latency_ms, 99) by endpoint
 ```
 
 ```ppl
 source=logs-app-* | eval is_error = if(status >= 500, 1, 0) | stats sum(is_error) as errors, count() as total by service | eval error_rate = errors / total | where error_rate > 0.01
 ```
 
-PPL operators: `where`, `stats`, `fields`, `eval`, `dedup`, `sort`, `head`, `tail`, `parse`, `rename`, `top`.
+Common PPL operators: `where`, `stats`, `fields`, `eval`, `dedup`, `sort`, `head`, `tail`, `parse`, `rename`, `top`. For the full command and function catalog (time-series, join/transform, all function families, `_explain`), see [`observability-ppl-reference.md`](observability-ppl-reference.md).
 
 ## Replacing Splunk
 

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-agentic-setup.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-agentic-setup.md
@@ -1,6 +1,10 @@
 # Amazon OpenSearch Service Domain — Agentic Search Setup
 
-Configure conversational agents with QueryPlanningTool for natural language search. Requires OpenSearch 3.3+ on a managed AOS domain. Uses Bedrock Claude as reasoning model.
+Configure conversational agents with QueryPlanningTool for natural language search on a managed AOS domain. QueryPlanningTool requires OpenSearch 3.3+; verify the minimum version against the AWS docs or `aws opensearch list-versions`. Uses Bedrock Claude as the reasoning model.
+
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+>
+> **Scope: managed AOS domains (conversational, stateful agents).** Amazon OpenSearch Serverless also supports agentic search — via a **flow agent** (`type: flow`, stateless), configured separately. For a Serverless VECTORSEARCH collection, follow [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md); that path covers the flow-agent shape and the `agent` data access policy ResourceType required to avoid a `403 Forbidden` on pipeline queries.
 
 ## Step 1: Create IAM Role for Bedrock Access
 

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-reference.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-reference.md
@@ -19,7 +19,9 @@ After loading this entry, you can discover every provisioning-capability file fr
 | Deploy search config to a domain | [`provisioning-domain-deploy-search.md`](provisioning-domain-deploy-search.md) |
 | Create AOSS collection | [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md) |
 | Deploy search config to a collection | [`provisioning-serverless-deploy-search.md`](provisioning-serverless-deploy-search.md) |
-| Configure agentic search on a domain | [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md) |
+| Tear down (deprovision) an AOSS collection | [`provisioning-serverless-deprovision.md`](provisioning-serverless-deprovision.md) |
+| Configure agentic search on a domain (conversational, stateful) | [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md) |
+| Configure agentic search on a serverless collection (flow agent, stateless) | [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md) |
 | Upgrade domain version | [`provisioning-upgrades.md`](provisioning-upgrades.md) |
 | Storage tier management (UltraWarm, cold) | [`provisioning-storage-tiers.md`](provisioning-storage-tiers.md) |
 | CloudWatch alarms / monitoring | [`provisioning-monitoring.md`](provisioning-monitoring.md) |
@@ -29,7 +31,7 @@ Cross-cutting refs you may also load: [`sizing.md`](sizing.md) (instance/storage
 
 ## Sizing-related universal rules (apply when this capability sizes a domain)
 
-- **Current-generation instances.** Default to Graviton (`r7g`/`r8g` for memory-optimized; `m7g`/`m8g` for cluster managers). `r6g`/`r6gd` only with explicit justification (existing RIs, specific compatibility need). Full instance family list: see [supported-instance-types.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html); rule and rationale: [sizing.md §Instance family selection](sizing.md).
+- **Current-generation instances.** Prefer Graviton and the latest generation available. Always fetch the authoritative list for the target region and engine version with `aws opensearch list-instance-type-details --engine-version <version>` (or [supported-instance-types.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html)) — new generations supersede older ones and the supported set varies by region. As a fallback if the API is unavailable, prefer the latest Graviton memory-optimized family for data nodes and the latest Graviton general-purpose family for cluster managers; use earlier Graviton generations only with explicit justification (existing RIs, specific compatibility need). Rule and rationale: [sizing.md §Instance family selection](sizing.md).
 - **Input honesty.** When sizing on UNKNOWN inputs, lead with `[BLOCKER — need input]` OR present 2–3 tiered bands (small/medium/large workload assumption). Never present a single point estimate built on invented numbers.
 
 ## Cross-capability handoff

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-serverless-agentic-setup.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-serverless-agentic-setup.md
@@ -1,0 +1,200 @@
+# Amazon OpenSearch Serverless — Agentic Search Setup (Flow Agent)
+
+Configure agentic search on an Amazon OpenSearch Serverless collection using a **flow agent** with `QueryPlanningTool`. Uses Bedrock Claude as the reasoning model.
+
+Serverless collections MUST use a flow agent (`type: flow`); conversational agents are not supported on AOSS, because Amazon OpenSearch Serverless does not provide the stateful conversation-memory backing that conversational agents require. Verify agent-type support against the AWS docs (or `aws opensearchserverless` API capabilities) before assuming this limitation still holds. Flow agents are stateless — each query is planned and executed independently. For stateful multi-turn agentic search (memory + RAG), use an Amazon OpenSearch Service **domain** instead; see [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md).
+
+## Prerequisites
+
+- A **NextGen** collection, ACTIVE — see [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md).
+- Index created with data — see [`provisioning-serverless-deploy-search.md`](provisioning-serverless-deploy-search.md).
+- The collection's data access policy MUST include the `agent` ResourceType (Step 4), because pipeline-invoked agentic queries fail with `403 Forbidden` without it.
+- The AWS MCP server is recommended for executing these commands but is not required — steps use standard AWS CLI and `awscurl` syntax. IAM/policy steps use `aws` CLI; the data-plane `_plugins/_ml` and `_search/pipeline` calls (Steps 2, 3, 5, 6) are OpenSearch REST requests — send them with `awscurl` (AOSS uses `--service aoss --region <region>`), e.g. `awscurl --service aoss --region <region> -X POST "<collection-endpoint>/_plugins/_ml/models/_register?deploy=true" -H 'Content-Type: application/json' -d '<body>'`.
+
+## Step 1: Create IAM Role for Bedrock Access
+
+```bash
+aws iam create-role --role-name opensearch-bedrock-agent-role \
+  --assume-role-policy-document '{
+    "Version":"2012-10-17",
+    "Statement":[{
+      "Effect":"Allow",
+      "Principal":{"Service":"ml.opensearchservice.amazonaws.com"},
+      "Action":"sts:AssumeRole",
+      "Condition":{
+        "StringEquals":{"aws:SourceAccount":"<account>"},
+        "ArnLike":     {"aws:SourceArn":    "arn:aws:aoss:<region>:<account>:collection/<collection-id>"}
+      }
+    }]
+  }'
+
+aws iam put-role-policy --role-name opensearch-bedrock-agent-role \
+  --policy-name BedrockClaudeInvokePolicy \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"bedrock:InvokeModel","Resource":["arn:aws:bedrock:<region>::foundation-model/<model-id>","arn:aws:bedrock:<region>:<account>:inference-profile/<inference-profile-id>"]}]}'
+```
+
+Scope `Resource` to the exact model and inference-profile you call — the same `<model-id>` referenced in the connector `parameters.model` (Step 2). Do NOT use a `foundation-model/*` wildcard, because it grants invoke on every Bedrock model in the region and this example is frequently copy-pasted as-is into production.
+
+## Step 2: Register Model with Inline Connector
+
+Register the model and its connector in one call. The connector `request_body` MUST use the agent-framework template variables (`user_prompt`, `_chat_history`, `_interactions`, `tool_configs`), because the flow agent injects planning context through these variables at query time.
+
+Set `parameters.model` to a model ID you have verified exists, because Bedrock model IDs change as new versions ship and the one shown below may have been superseded. Look up available IDs first with `aws bedrock list-foundation-models` or `aws bedrock list-inference-profiles`, and use the same ID in the IAM policy ARN (Step 1) and the `QueryPlanningTool` model_id (Step 3).
+
+```bash
+awscurl --service aoss --region <region> \
+  -X POST "<collection-endpoint>/_plugins/_ml/models/_register?deploy=true" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "agentic search base model",
+  "function_name": "remote",
+  "connector": {
+    "name": "Bedrock Claude Connector",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "parameters": {
+      "region": "<aws_region>",
+      "service_name": "bedrock",
+      "model": "<model-id>",
+      "system_prompt": "You are a search query planning assistant."
+    },
+    "credential": { "roleArn": "<iam_role_arn>" },
+    "actions": [{
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+      "headers": { "content-type": "application/json" },
+      "request_body": "{ \"system\": [{\"text\": \"${parameters.system_prompt}\"}], \"messages\": [${parameters._chat_history:-}{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}${parameters._interactions:-}]${parameters.tool_configs:-} }"
+    }]
+  }
+}'
+```
+
+Wait until model state is `DEPLOYED` before continuing, because the agent registration in Step 3 references a deployed model.
+
+## Step 3: Create Flow Agent
+
+```bash
+awscurl --service aoss --region <region> \
+  -X POST "<collection-endpoint>/_plugins/_ml/agents/_register" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "Agentic Search Agent",
+  "type": "flow",
+  "description": "Flow agent for natural language search with query planning",
+  "tools": [{
+    "type": "QueryPlanningTool",
+    "description": "A general tool to answer any question",
+    "parameters": {
+      "model_id": "<model_id>",
+      "response_filter": "$.output.message.content[0].text"
+    }
+  }]
+}'
+```
+
+- `type` MUST be `flow` (see rationale above).
+- Use only `QueryPlanningTool`, because it introspects the index mapping internally and generates the DSL; additional tools are not needed for stateless query translation.
+- The model is referenced inside the tool's `parameters` — do NOT add a top-level `llm` block, because flow agents resolve the model through the tool, not an agent-level LLM binding.
+- `response_filter` extracts the LLM text from the Bedrock Converse response shape.
+
+## Step 4: Data Access Policy for Pipeline Search (CRITICAL)
+
+The IAM role in the connector's `credential.roleArn` MUST be a principal in the collection's data access policy with all four ResourceTypes — `collection`, `index`, `model`, and `agent`. Pipeline-invoked `agentic` queries fail with `403 Forbidden` without this, because the pipeline uses the connector's IAM role (not the caller's identity) to read mappings, execute the generated DSL, invoke the model, and execute the agent. Direct `_execute` calls can still succeed because they run under the caller's identity, which masks the misconfiguration.
+
+You MUST merge the new `model` and `agent` rules into the **existing** policy rather than replacing it, because `update-access-policy` overwrites the entire policy body and silently drops any rules already present (e.g., the `WriteDocument`/`CreateIndex` grants from provisioning Step 3).
+
+```bash
+# 1. Retrieve the current policy and note its policyVersion
+aws opensearchserverless get-access-policy --type data \
+  --name <collection-name>-data --region <region>
+# 2. Copy the existing Rules array from the output, then append the model and
+#    agent rules below to it. Use the returned policyVersion in step 3.
+```
+
+> **⚠️ Least-privilege NOTE — `aoss:*` on `model`/`agent` is a platform constraint, not a
+> discretionary grant.** AOSS does not expose granular data-access actions for the `model` and `agent`
+> ResourceTypes, so `aoss:*` is the narrowest functional grant for these two rules — no tighter action
+> list exists to substitute. It is broader than least-privilege ideally allows, so treat
+> it as a standing gap to tighten, not a permanent target: track it against an open ticket
+> (`<tracking-ticket-url>`) and re-check on every AOSS agentic-search version bump and on a recurring
+> (quarterly) audit. If AWS exposes granular actions for these ResourceTypes, replace `aoss:*` with
+> the specific actions AND narrow the `model/*/*` and `agent/*/*` resources to the specific model and
+> agent IDs this collection uses (see the note after the command block). The `collection` and `index`
+> rules below are already scoped to minimum actions and should stay that way.
+
+```bash
+# 3. Update with the MERGED policy (existing rules + new model/agent rules):
+aws opensearchserverless update-access-policy --type data \
+  --name <collection-name>-data \
+  --policy-version <current-version> \
+  --policy '[{
+    "Rules":[
+      {"Resource":["collection/<collection-name>"],"Permission":["aoss:DescribeCollectionItems"],"ResourceType":"collection"},
+      {"Resource":["index/<collection-name>/*"],"Permission":["aoss:DescribeIndex","aoss:ReadDocument"],"ResourceType":"index"},
+      {"Resource":["model/*/*"],"Permission":["aoss:*"],"ResourceType":"model"},
+      {"Resource":["agent/*/*"],"Permission":["aoss:*"],"ResourceType":"agent"}
+    ],
+    "Principal":["<caller-principal-arn>","<iam_role_arn>"]
+  }]'
+```
+
+Notes on this policy:
+
+- **`model` and `agent` MUST use the `*/*` pattern**, not `model/<collection-name>/*` — this matches the guidance in [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md), because ML connectors and agents are registered at the account level rather than scoped under the collection name; using the collection-scoped pattern causes the very `403` this step prevents. As noted in the WARNING above, AOSS exposes no granular data-access actions for the `model`/`agent` resource types, so `aoss:*` is the narrowest functional grant for those two rules — tighten it (both permission and resource) if AWS exposes granular actions; re-check [serverless-data-access.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-data-access.html) on the audit cadence above.
+- **Scope `collection` and `index` to the minimum documented actions** (shown above) rather than `aoss:*`, because least-privilege limits blast radius if the connector role is compromised. A read-only agentic index needs only describe/read; add `aoss:WriteDocument` only if the same role also ingests.
+- List **both** the caller principal (for manual API calls) and the connector IAM role (for pipeline-invoked calls).
+- The connector role must also hold the IAM permissions `aoss:APIAccessAll` (and `aoss:DashboardsAccessAll` for Dashboards) on the collection, because data access policy grants alone are insufficient to reach the data plane.
+
+## Step 5: Create Agentic Search Pipeline
+
+```bash
+awscurl --service aoss --region <region> \
+  -X PUT "<collection-endpoint>/_search/pipeline/agentic-search-pipeline" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "request_processors": [{ "agentic_query_translator": { "agent_id": "<agent_id>" } }]
+}'
+```
+
+The pipeline above is the **secure default**: it plans and executes the query but does NOT surface the generated `dsl_query` or `agent_steps_summary` to callers.
+
+> **Sensitive-data warning:** the `agentic_context` response processor attaches `dsl_query` and `agent_steps_summary` to the response `ext` block, exposing internal index field names, the generated query logic, and potentially sensitive filter values to every caller of the pipeline. Leave it OFF in production. Enable it **only** for an authorized debugging session by adding a `response_processors` block to the pipeline, and remove it afterward:
+>
+> ```json
+> "response_processors": [{ "agentic_context": { "agent_steps_summary": true, "dsl_query": true } }]
+> ```
+>
+> If enabled for debugging, ensure any CloudWatch Logs receiving these responses are encrypted with a customer-managed KMS key and access is restricted to authorized personnel only, because the exposed query logic and field names must not be logged to unencrypted logs.
+
+## Step 6: Test Agentic Search
+
+```bash
+awscurl --service aoss --region <region> \
+  -X GET "<collection-endpoint>/<index-name>/_search?search_pipeline=agentic-search-pipeline" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "query": { "agentic": { "query_text": "Find documents about machine learning" } }
+}'
+```
+
+The response includes search hits. The agent analyzes the question, introspects the index mapping via `QueryPlanningTool`, generates DSL, and executes it. The generated DSL is returned in `ext.dsl_query` only when the `agentic_context` response processor is enabled for debugging (Step 5); with the secure default it is not surfaced to callers.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `403 Forbidden` on pipeline query, but `_execute` works | Connector IAM role missing from data access policy | Add the role as a principal with all four ResourceTypes (Step 4) |
+| Model stuck below `DEPLOYED` | Bedrock region/model unavailable or IAM invoke denied | Verify the model is enabled in the region and the role policy allows `bedrock:InvokeModel` on that model ARN |
+| Empty / malformed DSL | `response_filter` does not match the Converse output shape | Confirm `response_filter` is `$.output.message.content[0].text` |
+
+## Security Considerations
+
+- **Audit logging:** Enable AWS CloudTrail so that `_plugins/_ml` model/agent registration and agentic search API calls are recorded — this attributes who created connectors/agents and who ran queries.
+- **Anomaly monitoring:** Set CloudWatch alarms on the collection's `4xx`/`5xx` error rates and on unusual agentic query volume, because a spike can indicate a misconfigured or abused pipeline.
+- **Encryption at rest:** AOSS encrypts all data at rest by default (AWS-owned key). For compliance workloads, use a customer-managed KMS key on the encryption policy — see [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md).
+- **Bedrock role hygiene:** Review the `opensearch-bedrock-agent-role` trust policy and attached permissions on a regular cadence, and keep the `bedrock:InvokeModel` resource scoped to the specific model ARN (Step 1), because a broad role is a standing invoke path into every model in the region.
+- **Sensitive-field exposure:** The LLM generates DSL from natural language and can surface any field in the index. If the index contains PII or other sensitive fields, apply field-level access control or a response filter, because an unconstrained query planner may return fields the caller should not see.
+- **Encryption in transit:** AOSS enforces HTTPS-only access to the data plane. Verify the collection endpoint starts with `https://` before issuing any query or index call, because an unencrypted request would expose the query and results in transit.
+- **Input validation & rate limiting:** `query_text` is arbitrary natural language passed to an LLM that generates executable DSL. Apply input validation (length limits, disallowed patterns) to mitigate prompt injection, and throttle/rate-limit the pipeline endpoint, because crafted prompts can manipulate DSL generation and high volume drives runaway Bedrock invocation cost.
+- **AWS WAF (defense in depth):** if the endpoint is reachable from outside a trusted VPC, front it with AWS WAF using request-size limits and rate-based rules, because WAF blocks oversized/known-malicious requests at the edge before they reach the LLM query planner.

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-serverless-deploy-search.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-serverless-deploy-search.md
@@ -1,5 +1,7 @@
 # Amazon OpenSearch Serverless — Deploy Search Configuration
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 Deploy indices, ML models, and pipelines to a provisioned serverless collection.
 
 ## Route by Strategy
@@ -131,15 +133,23 @@ PUT <collection-endpoint>/_ingest/pipeline/bedrock-embedding-pipeline
 ```
 PUT <collection-endpoint>/<index-name>
 {
-  "settings": { "index": { "knn": true, "default_pipeline": "bedrock-embedding-pipeline" } },
+  "settings": {
+    "index.knn": true,
+    "index.default_pipeline": "bedrock-embedding-pipeline"
+  },
   "mappings": {
     "properties": {
       "<text-field>": { "type": "text" },
-      "<vector-field>": { "type": "knn_vector", "dimension": 1024, "method": { "name": "hnsw", "engine": "faiss" } }
+      "<vector-field>": {
+        "type": "knn_vector",
+        "dimension": 1024
+      }
     }
   }
 }
 ```
+
+> **Note:** Omit `engine`/`mode` unless you have confirmed support for your collection generation — NextGen rejects them (`Field parameter 'engine' is not supported`) and auto-selects the engine. NextGen support can change over time, so rather than treating this as a fixed prohibition, prefer omitting these fields and, if you need to set them, attempt creation and handle any validation error (same pattern used for OCU values in [provisioning-serverless-provision.md](provisioning-serverless-provision.md)). `space_type` is optional (defaults to L2); to use another metric, add it at the field level, e.g. `"space_type": "cosinesimil"`.
 
 ### 6. Search Pipeline (hybrid only)
 
@@ -177,3 +187,13 @@ After index creation (all paths):
    - Neural Sparse: standard `match` queries (auto-rewritten)
    - Dense Vector: `neural` query with `model_id`
    - BM25: standard `match` queries
+
+## Next Step (optional)
+
+- **Agentic search** (natural-language query → DSL, flow agent): see [provisioning-serverless-agentic-setup.md](provisioning-serverless-agentic-setup.md).
+
+## Security Considerations
+
+- **Encryption in transit:** all data-plane calls (index creation, indexing, search) MUST use HTTPS. Verify the collection endpoint starts with `https://`, because an unencrypted request exposes documents and queries in transit.
+- **Encryption at rest:** indexed embeddings and document content are sensitive; AOSS encrypts at rest by default, and compliance workloads should use a customer-managed KMS key on the encryption policy (see [provisioning-serverless-provision.md](provisioning-serverless-provision.md)).
+- **Least-privilege connector role:** scope the ML model connector role to the minimum data-access actions and the specific model ARN it invokes, because a broad connector role is a standing path into the data plane.

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-serverless-deprovision.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-serverless-deprovision.md
@@ -1,0 +1,54 @@
+# Amazon OpenSearch Serverless — Deprovision (Teardown)
+
+Delete serverless resources in strict dependency order. Reversing the order fails, because a collection group cannot be deleted while it still has collections, and a security policy cannot be deleted while a collection it covers still exists.
+
+The AWS MCP server is recommended for executing these teardown commands but is not required — all steps use standard AWS CLI syntax.
+
+## Order (MUST follow)
+
+1. Delete collection(s)
+2. Wait until each collection is fully gone
+3. Delete the collection group (NextGen only)
+4. Delete the security/data access policies
+
+> **Destructive-action rule:** before deleting anything below, list every resource that will be removed and get explicit user confirmation, because collection deletion (Step 1) is irreversible and destroys all indexed data.
+
+## Step 1: Delete collection(s)
+
+```bash
+aws opensearchserverless delete-collection --id <collection-id>
+```
+
+A collection MUST be ACTIVE (or FAILED) before it can be deleted. If delete returns `ConflictException` about status, the collection is still being created — wait and retry, because AOSS rejects deletes on collections mid-creation.
+
+## Step 2: Confirm deletion completed
+
+```bash
+aws opensearchserverless batch-get-collection --ids <id1> <id2>
+```
+
+Deletion is complete when EITHER the id appears in `collectionErrorDetails` with `"errorCode":"NOT_FOUND"` OR `collectionDetails` is empty. Do NOT poll for a `DELETED` status, because AOSS removes the collection entirely and returns NOT_FOUND rather than a terminal status.
+
+## Step 3: Delete the collection group (NextGen)
+
+```bash
+aws opensearchserverless delete-collection-group --id <group-id>
+```
+
+If this returns `ValidationException` ("has collections associated"), a collection in the group is still active or still deleting — delete/await remaining collections first, because a non-empty group cannot be removed.
+
+## Step 4: Delete policies
+
+```bash
+aws opensearchserverless delete-security-policy --type network    --name <name>-network
+aws opensearchserverless delete-security-policy --type encryption --name <name>-encryption
+aws opensearchserverless delete-access-policy   --type data       --name <name>-data
+```
+
+## Security Considerations
+
+- **Verify a backup exists first, and that it is encrypted at rest.** Collection deletion is irrecoverable — confirm a snapshot or exported copy exists before proceeding if the data may still be needed, because there is no undo. Ensure the backup itself is encrypted at rest (e.g., S3 server-side encryption with a customer-managed KMS key for a manual snapshot or export), because an unencrypted copy of sensitive data is a standing exposure risk even after the collection is deleted.
+- **Audit who initiated the teardown.** Confirm AWS CloudTrail is enabled so the `DeleteCollection`/`DeleteCollectionGroup`/`Delete*Policy` calls are recorded with the caller identity and timestamp.
+- **Alert in real time on teardown calls.** Beyond passive CloudTrail logging, configure an EventBridge rule (or a CloudTrail → CloudWatch metric filter) on `DeleteCollection`/`DeleteCollectionGroup` from unexpected principals that notifies via SNS, because an irreversible delete warrants immediate detection rather than after-the-fact log review. Encrypt the SNS topic with a customer-managed KMS key and restrict `sns:Subscribe` to authorized principals via a topic policy, because teardown alerts carry resource identifiers that should not reach unintended recipients.
+- **Use least-privilege, collection-scoped permissions.** The caller SHOULD hold only the delete actions needed on the specific collection/group ARNs rather than `aoss:*` on all resources, because a broad teardown identity can remove unrelated production collections.
+- **Guard against accidental production teardown.** Assume any collection is production unless its name/tags clearly indicate otherwise, and require explicit confirmation before deleting, because an accidental delete causes an outage and permanent data loss.

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-serverless-provision.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-serverless-provision.md
@@ -1,5 +1,7 @@
 # Amazon OpenSearch Serverless — Provision Collection
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 ## Prerequisites
 
 1. Confirm AWS credentials: `aws sts get-caller-identity`
@@ -43,17 +45,72 @@ aws opensearchserverless create-security-policy \
 
 ## Step 3: Create Data Access Policy
 
+**Base policy (BM25 — least-privilege default).** Grants no `model` access. Use this as-is for plain keyword/BM25 collections:
+
 ```bash
 aws opensearchserverless create-access-policy \
   --name <collection-name>-data --type data \
-  --policy '[{"Rules":[{"ResourceType":"index","Resource":["index/<collection-name>/*"],"Permission":["aoss:CreateIndex","aoss:DescribeIndex","aoss:UpdateIndex","aoss:DeleteIndex","aoss:ReadDocument","aoss:WriteDocument"]},{"ResourceType":"collection","Resource":["collection/<collection-name>"],"Permission":["aoss:CreateCollectionItems","aoss:DescribeCollectionItems"]},{"ResourceType":"model","Resource":["model/<collection-name>/*"],"Permission":["aoss:CreateMLResource"]}],"Principal":["<principal_arn>"]}]'
+  --policy '[{"Rules":[{"ResourceType":"index","Resource":["index/<collection-name>/*"],"Permission":["aoss:CreateIndex","aoss:DescribeIndex","aoss:UpdateIndex","aoss:DeleteIndex","aoss:ReadDocument","aoss:WriteDocument"]},{"ResourceType":"collection","Resource":["collection/<collection-name>"],"Permission":["aoss:CreateCollectionItems","aoss:DescribeCollectionItems"]}],"Principal":["<principal_arn>"]}]'
+```
+
+**ML addendum (neural-sparse / agentic only).** Only when the collection uses ML, append this rule to the `Rules` array above — do NOT include it in BM25-only collections, because it grants every AOSS action on every model in the account:
+
+```json
+{"ResourceType":"model","Resource":["model/*/*"],"Permission":["aoss:*"]}
 ```
 
 > **Note:** AOSS data access policies do not support IAM condition keys. Use network policies (VPC endpoints) and principal scoping for access control.
 >
 > **Tip:** Remove permissions not needed for your use case. For read-only collections, remove aoss:WriteDocument, aoss:UpdateIndex, aoss:DeleteIndex.
+>
+> For neural-sparse (semantic enrichment) or agentic strategies, the data access policy MUST also grant the `model` and `agent` ResourceTypes, and the `model` resource MUST be `model/*/*` (not `model/<collection-name>/*`), because semantic enrichment registers ML connectors at the account level rather than under the collection name. Omit these rules for plain BM25 collections, because BM25 uses no ML resources. For the full agentic data access policy, see [provisioning-serverless-agentic-setup.md](provisioning-serverless-agentic-setup.md).
+>
+> **Least-privilege warning:** `aoss:*` on `model/*/*` grants every AOSS action on every model in the account — broader than least-privilege ideally allows. AOSS does not expose scoped per-model ML actions for data access policies, so `aoss:*` is the narrowest functional grant here. Track it and tighten the `Permission` list if AOSS exposes granular model actions. See the fuller discussion in [provisioning-serverless-agentic-setup.md](provisioning-serverless-agentic-setup.md).
 
-## Step 4: Create Collection
+## Step 4a: Create Collection Group (NextGen — default)
+
+NextGen is the default serverless target for all strategies except conversational agentic search. A NextGen collection MUST belong to a collection group, so create the group before the collection. Because generation defaults and per-strategy support change over time, verify the current default generation and supported strategies against the AWS docs or `aws opensearchserverless` API capabilities before relying on this.
+
+```bash
+aws opensearchserverless create-collection-group \
+  --name <collection-name>-group \
+  --standby-replicas ENABLED \
+  --generation NEXTGEN
+```
+
+- `--generation NEXTGEN` is REQUIRED, because omitting it creates a Classic group and NextGen-only features are unavailable and the generation cannot be changed after creation. Verify the current NextGen feature set against the AWS docs ([serverless-overview.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html)) rather than relying on a hardcoded list.
+- `--standby-replicas ENABLED` is required for NextGen — NextGen groups reject `DISABLED`, which is a Classic-only dev/test option. This constraint is generation-specific and may be relaxed — verify whether `DISABLED` is supported for the chosen generation via the AWS docs, or attempt creation and handle any validation error (same pattern used for OCU values below).
+- Capacity limits are optional. When set, each OCU value must be one of a service-defined set of allowed steps, and AOSS rejects any other value with an `Invalid value for maxIndexingCapacityInOCU` error. The allowed steps are service-specific limits that change over time — fetch the allowed values from the AWS docs ([serverless-scaling.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-scaling.html)), or attempt creation and parse the validation error message, rather than hardcoding a specific value:
+
+  ```bash
+  aws opensearchserverless create-collection-group \
+    --name <collection-name>-group --standby-replicas ENABLED --generation NEXTGEN \
+    --capacity-limits '{"minIndexingCapacityInOCU":4,"maxIndexingCapacityInOCU":16,"minSearchCapacityInOCU":4,"maxSearchCapacityInOCU":16}'
+  ```
+
+Then create the collection **into the group** instead of standalone:
+
+```bash
+aws opensearchserverless create-collection \
+  --name <collection-name> --type <SEARCH|VECTORSEARCH> \
+  --collection-group-name <collection-name>-group
+```
+
+> SEARCH and VECTORSEARCH are supported on NextGen while TIMESERIES is Classic-only (see assessment-gotchas.md §9). Supported collection types are generation-specific — verify the valid types against the AWS docs ([serverless-overview.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html)) at creation time, or attempt creation and handle the validation error, rather than relying on this list.
+
+### Add a collection to an existing group
+
+```bash
+aws opensearchserverless list-collection-groups          # find the group name + capacityLimits
+aws opensearchserverless create-collection --name <new-name> --type <TYPE> \
+  --collection-group-name <existing-group-name>
+```
+
+Before creating, verify an encryption policy and network policy already cover `<new-name>` (or a `collection/*` wildcard), because a collection cannot be created if no encryption policy matches its name.
+
+## Step 4b: Create Collection (Classic — standalone fallback)
+
+Use the Classic standalone flow **only when Classic is explicitly required** (e.g. a TIMESERIES collection, or a feature not yet on NextGen), because NextGen is the default target everywhere else in this runbook.
 
 Choose type based on strategy:
 

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-troubleshooting.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/provisioning-troubleshooting.md
@@ -1,5 +1,7 @@
 # Troubleshooting AOS Domains and Collections
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 ## Common Issues
 
 | Error | Cause | Fix |
@@ -10,6 +12,19 @@
 | Upgrade fails at pre-checks | Incompatible settings or plugins | Run `get-compatible-versions`; address breaking changes listed in upgrade guide |
 | `DisabledOperationException` | Operation not available for config | Some operations (cold storage, UltraWarm) require specific instance families |
 | Snapshot failure | S3 bucket permissions or IAM role | Verify snapshot role has `s3:PutObject` on the bucket; check trust policy |
+
+## Serverless (AOSS) provisioning & teardown errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `ConflictException` / "already exists" on create | Resource name taken in this account+region | Choose a new name, because collection/policy names must be unique per account per region |
+| `Invalid value for maxIndexingCapacityInOCU` | OCU value outside the allowed set | Set a valid OCU value per [serverless-scaling.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-scaling.html), because AOSS rejects capacity numbers outside the allowed set |
+| "Providing VectorOptions ... not supported for account" | Account lacks vector acceleration | Retry without `vectorOptions`, because acceleration needs account-level enablement |
+| `ConflictException` on `delete-collection` (status not ACTIVE/FAILED) | Collection still creating | Poll `batch-get-collection` until `status` is `ACTIVE`/`FAILED`, then retry, because a mid-creation collection cannot be deleted |
+| `ValidationException` "has collections associated" on `delete-collection-group` | Group still holds collections | Delete/await member collections first, because a non-empty group cannot be removed |
+| Partial-failure mid-provision (group created, collection failed) | One step failed after earlier steps succeeded | Report what exists, then use the deprovision flow to clean up, because orphaned policies/groups still bill and block name reuse |
+
+For the full teardown ordering, see [provisioning-serverless-deprovision.md](provisioning-serverless-deprovision.md).
 
 ## Debugging Domain Creation Failures
 

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/search-document-processing-guide.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/search-document-processing-guide.md
@@ -2,6 +2,8 @@
 
 This guide covers how to process PDF, DOCX, PPTX, XLSX, HTML, and other document formats for ingestion into OpenSearch using [Docling](https://docling.site/).
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 ## Overview
 
 Docling is an open-source Python library (MIT license) by IBM Research that converts unstructured documents into structured data. It detects page layout, reading order, table structure, code blocks, formulas, and images using AI models, and runs locally on commodity hardware.
@@ -9,6 +11,22 @@ Docling is an open-source Python library (MIT license) by IBM Research that conv
 ## Supported Input Formats
 
 PDF, DOCX, PPTX, XLSX, HTML, Markdown, AsciiDoc, CSV, images (PNG, JPEG, TIFF, BMP, WEBP), audio (MP3, WAV).
+
+## Choosing a processing approach
+
+Match the Docling pipeline to the document's dominant content, because a single
+default pipeline degrades on tables, scans, and figures.
+
+| Document character | Approach | What to enable | Why |
+|---|---|---|---|
+| Digital-text, prose-heavy (papers, reports, contracts) | Semantic | Hierarchy-aware `HybridChunker` respecting headings | Preserves section boundaries so chunks stay self-contained |
+| Table-heavy (financial reports, spec sheets) | Tables | TableFormer table extraction; serialize tables to markdown | You MUST enable table extraction explicitly, because auto-detection does NOT reliably recognize table-heavy documents and untreated tables collapse into unusable text |
+| Scanned / image-only pages | Scanned | OCR (`do_ocr=True`; RapidOCR / PP-OCRv4) before chunking | Digital-text pipelines produce empty chunks on scans because there is no extractable text layer |
+| Figure / diagram-rich | Multimodal | VLM picture descriptions (e.g. SmolVLM-256M) | Figures carry meaning that is lost unless described, because embeddings index text only |
+
+You SHOULD default to the semantic approach for digital-text documents and disable OCR
+(`do_ocr=False`, since Docling enables it by default), because OCR adds significant
+latency and is unnecessary when a text layer exists.
 
 ## Chunking for Search Ingestion
 
@@ -22,7 +40,7 @@ Splits at every section/heading boundary. Produces many small chunks that respec
 
 Combines structure-aware splitting with token limits. Preserves document hierarchy while ensuring chunks fit within embedding model constraints.
 
-Parameters: `max_tokens=512, overlap_tokens=50`
+Parameters: `max_tokens=512` (HybridChunker takes no overlap parameter — it merges adjacent peer chunks rather than applying a fixed overlap).
 
 ## Processing Pipeline for Document Search
 
@@ -34,15 +52,92 @@ The recommended end-to-end flow:
 4. **Index** — Load into OpenSearch using the ingest pipeline.
 5. **Search** — Query using your configured search pipeline.
 
+## JSONL chunk format
+
+Each line of the exported `.jsonl` MUST be a standalone JSON object with at
+minimum a `text` field, because the downstream bulk-index and OSIS ingestion
+paths reject lines that lack indexable content.
+
+```json
+{"text": "...", "headings": ["Section Title"], "source_file": "doc.pdf", "chunk_id": 0, "page_number": 1}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Chunk content (required) |
+| `headings` | array | Section headings this chunk belongs to |
+| `source_file` | string | Original source filename |
+| `chunk_id` | int | Sequential chunk index within the file |
+| `page_number` | int | Source page number |
+
+You SHOULD validate that every line parses as JSON and carries a non-empty
+`text` field before uploading to S3, because a single malformed line can fail an
+entire bulk request.
+
 ## Choosing Chunk Size
 
 - For BM25 (keyword search): larger chunks (1000+ tokens) work well since BM25 benefits from more context.
 - For dense vector / semantic search: 256–512 tokens is typical, matching embedding model input limits.
-- For hybrid search: 512 tokens with 50-token overlap is a good default.
+- For hybrid search: 512 tokens is a good default. The `HybridChunker` above has no overlap parameter (it merges adjacent peer chunks); a fixed ~50-token overlap applies only if you use a custom, non-Docling chunker.
+
+## Adjusting chunking when retrieval quality is poor
+
+Re-processing is expensive, so you SHOULD change chunking only when a quality
+check provides evidence, because blind re-ingestion wastes compute without a
+targeted fix.
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Results lack surrounding context | Chunks too small | Increase `max_tokens` |
+| Results contain irrelevant noise | Chunks too large | Decrease `max_tokens` |
+| Tables absent from results | Table extraction not run | Re-process with TableFormer enabled |
+| Scanned pages return empty or garbled text | OCR not run | Re-process with OCR enabled |
+| Figures / diagrams missing from results | Visual content not described | Re-process with VLM picture descriptions |
+
+You MUST NOT automatically re-ingest on a poor result, because re-ingestion is
+costly and may not address the true cause; confirm the symptom and the intended
+fix first.
+
+## Evaluating chunk quality
+
+Before indexing at scale, you SHOULD sample chunks and judge them against the
+dimensions that matter for the document type, because indexing low-fidelity
+chunks propagates the defect into every downstream search result.
+
+| Document type | Dimensions to judge |
+|---|---|
+| Prose / semantic | text fidelity, reading order, chunk boundaries, heading structure |
+| Tables | table structure, table-content fidelity, text fidelity, completeness |
+| Scanned | OCR text fidelity, reading order, completeness |
+| Multimodal | image descriptions, text fidelity, reading order, completeness |
+
+Rate each dimension `good | fair | poor`. When any dimension is `poor`, explain
+the cause and recommend a specific re-process; you MUST NOT re-ingest without
+user confirmation, because re-processing is expensive.
 
 ## Performance Tips
 
 - Skip page images if not needed to save memory.
 - Use `max_num_pages` or `page_range` to limit processing for large documents.
 - Enable parallel processing for multi-core systems.
-- For scanned PDFs, OCR is enabled by default. Disable if not needed.
+- Docling enables OCR by default (`do_ocr=True`); disable it (`do_ocr=False`) for digital-text documents in the semantic profile, and keep it on only for scanned / image-only pages, since OCR adds significant latency.
+
+## Security Considerations
+
+Exported chunks (JSONL) and the S3 objects that stage them carry the full text of
+the source documents, so treat them with the same sensitivity as the originals.
+
+- **Encryption at rest.** Enable server-side encryption on the target S3 bucket —
+  SSE-S3 at minimum, and SSE-KMS with a customer-managed KMS key for compliance
+  workloads (PCI-DSS, HIPAA) so you retain key control and an audit trail. Apply
+  the same encryption posture (AWS-owned key by default, customer-managed KMS key for compliance) to
+  the destination OpenSearch collection or domain that ingests the chunks.
+- **Access control.** Restrict the S3 bucket with a bucket policy (and, where
+  applicable, `aws:SourceVpce` / IAM principal conditions) so only the ingestion
+  role and authorized operators can read the staged JSONL. Block public access at
+  the account and bucket level.
+- **Sensitive / PII content.** Source documents may contain PII or other regulated
+  data, which propagates verbatim into chunks, the index, and any search result or
+  agent response. Classify sources before ingesting, redact or exclude fields you
+  do not intend to make searchable, and delete the intermediate JSONL from S3 once
+  indexing is confirmed rather than leaving it as a long-lived copy of the corpus.

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/search-semantic-search-guide.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/search-semantic-search-guide.md
@@ -416,3 +416,37 @@ OpenSearch provides several normalization techniques (Min-Max, L2, Harmonic Mean
 - Development/prototype phase (start simple)
 
 ---
+
+## 5. Agentic Search (Natural-Language Query Translation)
+
+### 5.1 Overview
+
+Agentic search uses an LLM to translate a natural-language question into OpenSearch DSL, then executes it — the caller asks a question in plain language instead of authoring a query. It is a standalone retrieval method that returns synthesized answers, implemented as a natural-language query-authoring layer over BM25/dense/hybrid retrieval.
+
+### 5.2 When to Use Agentic Search
+
+**Recommended:**
+
+- Callers who cannot author DSL/PPL (business users, natural-language front-ends).
+- Ad-hoc exploratory questions over a well-mapped index.
+
+**Not Recommended:**
+
+- Latency-sensitive paths, because each query adds an LLM round-trip (typically 200–2000 ms) plus per-query model cost on top of retrieval.
+- High-QPS production traffic with fixed query shapes — author the DSL once instead, because a static query avoids the per-call LLM cost.
+
+### 5.3 Conversational vs Flow
+
+- **Conversational (AOS domain, stateful):** multi-turn with conversation memory + RAG. Setup: [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md).
+- **Flow (AOSS Serverless, stateless):** each query planned independently, lower latency/cost, no memory. Setup: [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md).
+
+### 5.4 Security Considerations
+
+- **Field exposure:** the LLM can generate DSL that surfaces any field in the index, including PII. Apply field-level access control (document/field security) so an agentic query cannot return fields the caller is not authorized to see.
+- **Cost abuse:** each agentic query incurs a Bedrock model invocation. Throttle/rate-limit the agentic path to prevent runaway per-call model cost.
+- **Logging & monitoring:** enable CloudTrail for `_plugins/_ml` model/agent calls and set CloudWatch alarms on agentic query error rates and unusual invocation volume. See the detailed monitoring guidance in [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md) and [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md).
+- **Log confidentiality:** when `agentic_context` is enabled for debugging, the generated DSL surfaces in the response metadata (and thus in any logs that capture full responses). Encrypt any CloudWatch log group that receives agentic responses with a customer-managed KMS key and restrict its access policy, because those logs can contain the same sensitive field values the query returned.
+- **AWS WAF (defense in depth):** if the endpoint is internet-facing, front it with AWS WAF using request-size limits and rate-based rules, because WAF filters oversized and abusive free-form input at the edge before it reaches the LLM query planner.
+- For setup-time security guidance (IAM scoping, model/agent access policies), see the security sections in [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md) (conversational) and [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md) (flow).
+
+---

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/sizing.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/sizing.md
@@ -170,6 +170,8 @@ OS 3.0 introduces GPU-accelerated index build, derived-source vectors (reduced s
 | Redundancy ON (production default) | 1 OCU (0.5 × 2) | 1 OCU (0.5 × 2) | 4 × 0.5 OCU |
 | Redundancy OFF (dev/test) | 0.5 OCU × 2 | 0.5 OCU × 2 | 2 × 0.5 OCU per workload type |
 
+> **Scale-to-zero:** Serverless NextGen collections scale to zero OCUs when idle (an idle NextGen collection bills nothing for compute), whereas Classic collections hold the minimum OCU floor above at all times because Classic keeps warm capacity provisioned. Minimum-billing behavior can change per generation, so verify it against [serverless-scaling.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-scaling.html) (as the Caps section also references) before relying on it for cost projections. Where it holds, factor it into cost projections for intermittently-used collections: NextGen is materially cheaper when traffic is bursty or dev/test.
+
 ### Caps
 
 For current OCU defaults and account-level caps, see [serverless-scaling.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-scaling.html).

--- a/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/trace-analytics-trace-queries.md
+++ b/plugins/aws-data-analytics/skills/amazon-opensearch-service/references/trace-analytics-trace-queries.md
@@ -1,5 +1,7 @@
 # Trace-analytics capability — entry point and query templates
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard `awscurl` / AWS CLI syntax.
+
 This file is the **entry point** for the `trace-analytics` capability. It covers distributed traces with OpenTelemetry — span queries, service maps, latency analysis (p50/p95/p99), error rate by service, and root-cause via parent/child spans.
 
 ## When to use this capability
@@ -25,9 +27,26 @@ Cross-cutting refs you may also load: [`security.md`](security.md), [`personas.m
 - For **provisioning the trace-collector infra** (Data Prepper / OSI / IAM): see [`provisioning-reference.md`](provisioning-reference.md).
 - For **OSI pipeline configuration shared with logs**: see [`log-analytics-osi-pipelines.md`](log-analytics-osi-pipelines.md).
 
+## Query discipline (MUST follow)
+
+For the full PPL command and function catalog, see [`observability-ppl-reference.md`](observability-ppl-reference.md).
+
+- **Unknown command → upstream grammar.** If a PPL command or function is not in
+  [`observability-ppl-reference.md`](observability-ppl-reference.md), or an emitted query fails with a
+  syntax error, you MUST fetch the raw upstream doc from `opensearch-project/sql` under `docs/user/ppl/`
+  before answering. You MUST NOT invent PPL syntax, because OpenSearch PPL has version-specific commands
+  that do not exist in other query languages.
+- **Verify or disclose.** When the domain/collection endpoint is reachable, you MUST validate every
+  emitted query against `_plugins/_ppl`; on 0 rows, fall back to `_plugins/_ppl/_explain` to confirm the
+  plan and surface the empty result; on error, fix and re-validate. When no endpoint is reachable, you
+  MUST state that the query is unverified, because an untested query can silently reference a
+  non-existent field.
+
 ## Data Plane Access with awscurl
 
 All queries below use the PPL API at `/_plugins/_ppl`. Use `awscurl` for SigV4-authenticated requests:
+
+> **Credentials & monitoring:** source the SigV4 signing credentials from an IAM role (instance profile, ECS task role, or SSO session), not static access keys. Enable CloudTrail for management-plane audit and OpenSearch audit logs for data-plane access (to attribute PPL queries to callers), and alarm on `_plugins/_ppl` error rates.
 
 ### Base Command (AOS)
 

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/log-analytics-guide.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/log-analytics-guide.md
@@ -1,5 +1,7 @@
 # Log-analytics capability — entry point and guide
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard `awscurl` / AWS CLI syntax.
+
 This file is the **entry point** for the `log-analytics` capability. It covers log search at scale, observability, PPL queries, anomaly detection, OpenSearch Dashboards, alerting, and SIEM patterns — including replatforming from Splunk, Datadog, or self-managed ELK.
 
 ## When to use this capability
@@ -30,6 +32,24 @@ Cross-cutting refs you may also load: [`observability.md`](observability.md) (IS
 
 This guide instructs you on how to perform log analytics against an existing OpenSearch domain or collection. The approach is discovery-first: understand what indices exist, learn the schema, sample the data, then build queries. Do not assume any particular index pattern or field names — discover them.
 
+For the full PPL command and function catalog, see [`observability-ppl-reference.md`](observability-ppl-reference.md).
+
+## Query discipline (MUST follow)
+
+- **Unknown command → upstream grammar.** If a PPL command or function is not in
+  [`observability-ppl-reference.md`](observability-ppl-reference.md), or an emitted query fails with a
+  syntax error, you MUST fetch the raw upstream doc from `opensearch-project/sql` under `docs/user/ppl/`
+  before answering. You MUST NOT invent PPL syntax, because OpenSearch PPL has version-specific commands
+  that do not exist in other query languages.
+- **Verify or disclose.** When the domain/collection endpoint is reachable, you MUST validate every
+  emitted query against `_plugins/_ppl`; on 0 rows, fall back to `_plugins/_ppl/_explain` to confirm the
+  plan and surface the empty result; on error, fix and re-validate. When no endpoint is reachable, you
+  MUST state that the query is unverified, because an untested query can silently reference a
+  non-existent field.
+- **Backtick-quote dotted fields.** Field names containing a dot MUST be backtick-quoted (`` `log.level` ``,
+  `` `host.name` ``), because an unquoted dot is parsed as a path separator and silently resolves to a
+  non-existent field.
+
 ## Data Plane Access with awscurl
 
 Use `awscurl` for SigV4-authenticated HTTP requests to AOS/AOSS endpoints.
@@ -39,6 +59,8 @@ Use `awscurl` for SigV4-authenticated HTTP requests to AOS/AOSS endpoints.
 ```bash
 pip install awscurl
 ```
+
+> **Credentials:** source SigV4 signing credentials from an IAM role (instance profile, ECS task role, or an SSO session) rather than static access keys, and keep endpoints and other config in AWS Secrets Manager or SSM Parameter Store rather than hardcoding them.
 
 ### Environment Variables
 

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/log-analytics-osi-pipelines.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/log-analytics-osi-pipelines.md
@@ -4,6 +4,8 @@
 
 OpenSearch Ingestion (OSI) is a fully managed, serverless pipeline service that delivers logs from sources like CloudWatch Logs, Fluent Bit, and HTTP into AOS/AOSS without managing infrastructure.
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 ## Creating a Pipeline for CloudWatch Logs
 
 ### Step 1: Create Pipeline Role
@@ -24,7 +26,7 @@ aws iam create-role --role-name OSIPipelineRole \
   }'
 ```
 
-Both `aws:SourceAccount` and `aws:SourceArn` conditions are required to prevent the **confused-deputy** pattern: without `aws:SourceArn`, any OSIS pipeline in the same account could assume this role; the `ArnLike` condition narrows the trust to your OSIS pipelines only. For a single-pipeline trust, replace `pipeline/*` with the specific pipeline name.
+Both `aws:SourceAccount` and `aws:SourceArn` conditions are required to prevent the **confused-deputy** pattern: without `aws:SourceArn`, any OSI pipeline in the same account could assume this role; the `ArnLike` condition narrows the trust to your OSI pipelines only. For a single-pipeline trust, replace `pipeline/*` with the specific pipeline name.
 
 Attach policies for CloudWatch Logs source and OpenSearch sink:
 
@@ -132,13 +134,52 @@ aws logs put-subscription-filter \
 
 ## AOSS Considerations
 
-- Data access policy must grant the pipeline role `aoss:BatchGetCollection` and `aoss:APIAccessAll`
+- The pipeline role's **IAM policy** must grant `aoss:BatchGetCollection` and `aoss:APIAccessAll` (these are IAM data-plane permissions, not data access policy permissions)
+- The **data access policy** must grant the pipeline role the index/collection actions it needs (e.g. `aoss:CreateIndex`, `aoss:WriteDocument`) — see the merge step below
 - Network policy must allow OSI pipeline VPC access
 - Use `serverless: true` in the sink configuration
+
+### Adding the pipeline role to an AOSS data access policy
+
+You MUST merge the pipeline role into the existing policy rather than replacing it, because overwriting the policy would drop other principals and rules already granted on the collection.
+
+1. Get the current policy and note its `policyVersion`. Use the data access policy name created during provisioning — `<collection-name>-data` in [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md) (Step 3); substitute your actual policy name if it differs:
+
+   ```bash
+   aws opensearchserverless get-access-policy --type data \
+     --name <collection-name>-data --region <region>
+   ```
+
+2. Append the pipeline role ARN to the existing `Principal` array (preserve all existing rules/principals). Grant it only the minimum actions the pipeline needs — scope index-level writes to the target index pattern rather than `aoss:*` on all resource types, because a broad grant lets the pipeline role read or delete unrelated data:
+   - `collection` rule: `aoss:DescribeCollectionItems` on `collection/<collection-name>`
+   - `index` rule: `aoss:CreateIndex`, `aoss:DescribeIndex`, `aoss:WriteDocument` on `index/<collection-name>/<target-index>*`
+   - The role also needs the IAM permissions `aoss:BatchGetCollection` and `aoss:APIAccessAll` (data-plane access), granted in its IAM policy — not the data access policy.
+3. Update with the captured version:
+
+   ```bash
+   aws opensearchserverless update-access-policy --type data \
+     --name <collection-name>-data \
+     --policy-version "<current-version>" \
+     --policy '<merged-policy-json>' --region <region>
+   ```
+
+4. Wait ~30 seconds for propagation, then stop/start the pipeline (see the gotcha below).
+
+## After Changing IAM or Data Access Policies
+
+> **After changing the pipeline role's IAM permissions or an AOSS data access policy, you MUST stop and restart the pipeline**, because OSI caches the assumed-role credentials and will keep failing on the stale permissions until it re-assumes the role:
+>
+> ```bash
+> aws osis stop-pipeline  --pipeline-name <pipeline-name> --region <region>   # wait for STOPPED
+> aws osis start-pipeline --pipeline-name <pipeline-name> --region <region>
+> ```
+>
+> After restart, confirm delivery has recovered rather than assuming success: verify CloudTrail recorded the `StopPipeline`/`StartPipeline` calls, and check that the pipeline's health metrics return to normal (e.g. `opensearch.documentsSuccess` climbing and `opensearch.documentErrors`/`dlqS3RecordsFailed` flat) via a CloudWatch alarm on the failure metrics, because a silent post-restart failure means data loss until the next manual check.
 
 ## Security Considerations
 
 - Apply least-privilege IAM policies: grant only the specific actions needed (e.g., `es:ESHttpPost`, `es:ESHttpPut`) scoped to the target domain/collection resource ARN.
 - All data in transit between OSI pipelines and OpenSearch is encrypted via TLS. Ensure domain or collection enforces HTTPS-only access.
 - Use dedicated IAM roles for pipeline execution rather than sharing roles across services.
-- Enable CloudTrail at the account level to audit all OSIS API calls (pipeline creation, modification, deletion) for compliance monitoring.
+- Enable CloudTrail at the account level to audit all OSI API calls (pipeline creation, modification, deletion) for compliance monitoring.
+- Encrypt the pipeline's CloudWatch log group with a customer-managed KMS key, because pipeline error logs and DLQ records may contain document field values from your data. Create the log group with encryption *before* pipeline creation so it applies from first write — `aws logs create-log-group --log-group-name /aws/vendedlogs/osi-pipeline --kms-key-id <key-arn>` — or attach a key to an existing group with `aws logs associate-kms-key`.

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/observability-ppl-reference.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/observability-ppl-reference.md
@@ -1,0 +1,222 @@
+# PPL language reference (observability)
+
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard `awscurl` / AWS CLI syntax.
+
+Shared PPL reference for the `log-analytics` and `trace-analytics` capabilities.
+Queries follow pipe-delimited syntax: `source=<index> | command1 | command2 ...`.
+Grammar is sourced from [opensearch-project/sql](https://github.com/opensearch-project/sql) under `docs/user/ppl/`.
+
+Loaded from: [`log-analytics-guide.md`](log-analytics-guide.md), [`trace-analytics-trace-queries.md`](trace-analytics-trace-queries.md).
+
+## Query discipline (MUST follow)
+
+1. **Unknown command or function — you MUST consult the upstream grammar before answering.** If a
+   command, function, or parameter is not in this reference, you MUST fetch the raw markdown from
+   `opensearch-project/sql` (URLs below). You MUST NOT invent PPL syntax and you MUST NOT claim a
+   command does not exist without checking first, because OpenSearch PPL includes many commands
+   (for example `graphLookup`, `explain`, `append`, `join`) that do not exist in other query systems.
+2. **You MUST verify emitted queries when a cluster endpoint is reachable.** When the AOS domain or
+   AOSS collection endpoint is available, every emitted PPL query MUST be validated with a best-effort
+   cascade before you return it:
+   1. Execute it against `_plugins/_ppl` and capture the row count and any error.
+   2. If it succeeds but returns 0 rows, run `_plugins/_ppl/_explain` to confirm the plan parses and
+      resolves field references, then surface the empty-result observation.
+   3. If `_plugins/_ppl` errors, fix the query (consult the upstream grammar as needed) and re-validate.
+   When no endpoint is reachable, you MUST state explicitly that the query is unverified, because an
+   untested PPL query can silently reference a non-existent field or use version-specific syntax.
+
+## Field name escaping
+
+Dotted field names MUST be backtick-quoted, because an unquoted dot is parsed as a path separator and
+fails: `` `attributes.gen_ai.operation.name` ``, `` `status.code` ``,
+`` `resource.attributes.service.name` ``.
+
+Field names beginning with a special character (e.g. the `@`-prefixed `` `@timestamp` ``) must also be
+backtick-quoted, because the leading character is not a valid bare identifier.
+
+## API endpoints
+
+Query (AOS uses `--service es`; AOSS uses `--service aoss`):
+
+The endpoint URL MUST use HTTPS (not HTTP). `awscurl` will not upgrade an HTTP URL to HTTPS, so verify
+`$OPENSEARCH_ENDPOINT` starts with `https://` before executing any command below, because an
+unencrypted data-plane request exposes the query and results in transit.
+
+Source the SigV4 signing credentials from an IAM role (instance profile, ECS task role, or SSO session)
+rather than static access keys, because static access keys are a standing exfiltration risk.
+
+    awscurl --service es --region $AWS_REGION \
+      -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+      -H 'Content-Type: application/json' \
+      -d '{"query": "source=otel-v1-apm-span-* | stats count() by serviceName"}'
+
+Explain (query-plan debugging):
+
+    awscurl --service es --region $AWS_REGION \
+      -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl/_explain" \
+      -H 'Content-Type: application/json' \
+      -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | stats count() by serviceName"}'
+
+`_explain` accepts an optional `mode` (`standard` / `simple` / `cost` / `extended`). `simple`, `cost`,
+and `extended` require the v3 engine (`plugins.calcite.enabled=true`); `standard` works on v2 and v3.
+Engine requirements are version-specific — verify whether the v3 engine is available and enabled on the
+target domain/collection by checking `GET _cluster/settings` for `plugins.calcite.enabled`, or consult the
+upstream `opensearch-project/sql` docs rather than assuming these constraints are fixed.
+
+## Core commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `source` | `source=<index>` | Start query from index pattern |
+| `search` | `search source=<index> [<expr>]` | Alternative first command; search-expression syntax (`field=value`, `AND/OR/NOT`, time modifiers) |
+| `where` | `where <condition>` | Filter rows |
+| `regex` | `regex <field> = '<pattern>'` (or `!=`) | Filter rows by Java regex on a field |
+| `fields` | `fields [+\|-] <list>` | Select / exclude fields |
+| `table` | `table [+\|-] <list>` | Alias for `fields` |
+| `stats` | `stats <agg>... [by <field>]` | Aggregate data |
+| `sort` | `sort [+\|-] <field>` | Order results (+ asc, - desc) |
+| `reverse` | `reverse` | Reverse result order (no-op without a preceding `sort`/`@timestamp`; collation-destroying ops such as `stats`/`join` make it a no-op) |
+| `head` | `head [N]` | Limit results (default 10) |
+| `tail` | `tail [N]` | Return the last N results (default 10) |
+| `eval` | `eval <new> = <expr>` | Compute new fields |
+| `fieldformat` | `fieldformat <field>=[(prefix).]<expr>[.(suffix)]` | `eval` alias with prefix/suffix string concat for display |
+| `dedup` | `dedup [N] <field>` | Remove duplicates |
+| `rename` | `rename <old> AS <new>` | Rename fields |
+| `replace` | `replace '<pat>' WITH '<repl>' IN <field>` | Literal/wildcard string replace (supports `*`) |
+| `convert` | `convert <fn>(<field>) [AS <field>]` | Type-coerce (`auto()`, `num()`, `mktime()`, `ctime()`, `dur2sec()`, `mstime()`, `memk()`, `rmcomma()`, `rmunit()`, `none()`) |
+| `top` | `top [N] <field>` | Most frequent values |
+| `rare` | `rare <field>` | Least frequent values |
+
+## Time-series commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `bin` | `bin <field> [span=<int>] [bins=<n>] [minspan=<int>] [aligntime=...] [start=<v>] [end=<v>]` | Bucket numeric/time values (`bins=` on timestamps requires `plugins.calcite.pushdown.enabled=true` and the binned field inside a `stats` aggregation; otherwise use `span=`; verify v3 engine availability on the target domain/collection before relying on this flag) |
+| `timechart` | `timechart span=<interval> <agg> [by <field>]` | Time-bucketed aggregation |
+| `chart` | `chart <agg> [by <row> <col>] \| [over <row> [by <col>]] [limit=topN] [useother=<bool>] [usenull=<bool>]` | Aggregate + pivot for 2D charts |
+| `span()` | `span(<field>, <interval>)` | Bucket numeric/date values |
+| `trendline` | `trendline sort <field> sma(<N>, <field>)` | Moving average |
+| `streamstats` | `streamstats <agg> [by <field>]` | Running statistics (memory-intensive) |
+| `eventstats` | `eventstats <agg> [by <field>]` | Add agg as field without collapsing rows (memory-intensive) |
+
+Span time units: `ms`, `s`, `m`, `h`, `d`, `w`, `M`, `q`, `y` (`bin` also accepts `us`, `cs`, `ds` and
+longhand forms). Timechart rate functions: `per_second()`, `per_minute()`, `per_hour()`, `per_day()`.
+
+## Parse / extract commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `parse` | `parse <field> '<regex>'` | Regex extraction (may drop fields on some versions) |
+| `grok` | `grok <field> '<pattern>'` | Grok pattern extraction (memory-intensive) |
+| `rex` | `rex field=<field> '<regex>'` | Named capture groups |
+| `patterns` | `patterns <field>` | Auto-discover log patterns |
+| `spath` | `spath input=<field> [output=<field>] [path=<path>]` | Extract from structured JSON (runs on the coordinator node; prefer indexing fields directly on large datasets) |
+
+## Join / lookup / set commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `join` | `join left=a right=b ON a.f = b.f <index>` | Cross-index join |
+| `lookup` | `lookup <index> <field> [OUTPUT <fields>]` | Enrich from another index |
+| `subquery` | `where <f> IN [source=<idx> \| ... \| fields <f>]` | Nested query filter |
+| `union` | `union [maxout=<n>] <ds1> <ds2> [...]` | UNION ALL across datasets; auto type-coerces conflicting schemas |
+| `multisearch` | `multisearch [<sub1>] [<sub2>] [...]` | Run + merge subsearches; supports timestamp interleaving |
+| `append` | `append [source=<idx> \| ...]` | Append results from another query |
+| `appendcol` | `appendcol [override=<bool>] [<subsearch>]` | Append subsearch result as additional columns |
+| `appendpipe` | `appendpipe [<subpipeline>]` | Append subpipeline results (runs lazily) |
+| `graphLookup` | `graphLookup <idx> start=<expr> edge=<from><op><to> [maxDepth=<n>] ... as <out>` | (Experimental) recursive BFS graph traversal |
+
+Cross-index `join` reliability varies by engine version, so you MUST test the join on the target
+domain/collection (per the query-discipline cascade above) rather than assuming it works. If it returns 0 rows
+unexpectedly, fall back to separate queries correlated by `traceId`.
+
+## Transform commands
+
+| Command | Description |
+|---|---|
+| `fillnull` | Replace nulls (backtick fields not supported in field list) |
+| `flatten` | Flatten nested fields to top level |
+| `expand` | Expand arrays into separate rows |
+| `mvexpand` | `mvexpand <field> [limit=<n>]` — expand each multivalue element into its own row |
+| `mvcombine` | Combine a target field into a multivalue array across otherwise-identical rows |
+| `nomv` | Convert a multivalue field to a single string (joined by `\n`) |
+| `transpose` | Pivot rows into columns |
+| `addtotals` | `addtotals [field-list] [row=<bool>] [col=<bool>] [label=<s>] [labelfield=<f>] [fieldname=<f>]` — row/column totals (numeric only) |
+| `addcoltotals` | Column-only totals; equivalent to `addtotals row=false col=true` |
+
+## Function families
+
+- **Aggregation:** `count()`, `sum(f)`, `avg(f)`, `max(f)`/`min(f)`, `distinct_count(f)`, `percentile(f, pct)`, `var_samp(f)`/`stddev_samp(f)`, `earliest(f)`/`latest(f)`, `values(f)`.
+- **Statistical (eval-context, scalar):** `MAX(x, y, ...)`, `MIN(x, y, ...)` — these return a single value across their arguments and do NOT aggregate across rows, because they are scalar; use aggregate `max(field)`/`min(field)` inside `stats` instead.
+- **Condition:** `isnull(f)`/`isnotnull(f)`, `if(cond, t, f)`, `case(c1, v1, ..., else)`, `coalesce(v1, v2, ...)`, `like`/`in`/`between`.
+- **Conversion:** `cast(f AS type)`, `tostring()`, `toint()`, `tolong()`, `tofloat()`, `todouble()` (types: STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, DATE, TIMESTAMP).
+- **Datetime:** `now()`, `date_format(date, fmt)`, `date_add(date, INTERVAL n unit)`, `date_sub(date, INTERVAL n unit)`, `datediff(d1, d2)`, `day()`/`month()`/`year()`/`hour()`/`minute()`/`second()`.
+- **String:** `concat()`, `length()`/`lower()`/`upper()`/`trim()`, `substring(s, start, len)`, `replace(s, from, to)`, `regexp_extract(s, pat, grp)`, `regexp_replace(s, pat, repl)`.
+- **Relevance:** `match(field, query)`, `match_phrase(field, phrase)`, `multi_match([f1, f2], query)`, `query_string([f1, f2], query)`, `wildcard_query(field, pattern)`.
+- **Math:** `abs()`, `ceil()`, `floor()`, `round(val, decimals)`, `sqrt()`, `pow()`, `mod()`, `log()`, `log10()`, `exp()`.
+- **Collection (multivalue):** `array(...)`, `array_length(arr)`, `mvjoin(arr, sep)`, `mvfilter(expr)`, `mvindex(arr, start [, end])`, `mvappend(...)`.
+- **JSON** (path notation `<key>{<idx>}...`; `{}` = all elements): `json(value)`, `json_extract(json, path)`, `json_array(...)`, `json_object(...)`, `json_keys(json)`.
+- **IP:** `cidrmatch(ip, cidr)`, `geoip(ip)`.
+- **Cryptographic:** `md5(str)`, `sha1(str)`, `sha2(str, bits)` (hex-encoded STRING digests).
+- **System:** `typeof(expr)`.
+
+## Operators
+
+Arithmetic: `+`, `-`, `*`, `/`, `%`; use parentheses for precedence. Division behavior depends on the
+cluster setting `plugins.ppl.syntax.legacy.preferred`: when `true` integer/integer is truncated; when
+`false` operands are promoted to floating point. Do not assume a default — read the effective value on
+the target domain/collection with `GET _cluster/settings?include_defaults=true` (inspect
+`defaults.plugins.ppl.syntax.legacy.preferred` unless overridden under `persistent`/`transient`) before
+relying on the division semantics. Division by zero returns `NULL`, not an error. Modulo (`%`) is
+integer-only and raises a type error on floats, because the operator has no float overload.
+
+## ML commands
+
+| Command | Description |
+|---|---|
+| `ad` | Anomaly detection (auto-detects input fields from the pipeline) |
+| `kmeans` | K-means clustering (operates on all numeric fields) |
+
+`ml action=rcf` support varies by cluster version — prefer the `ad` command directly, and if you need
+`ml action=rcf`, verify it against the target domain/collection (test the command) or the upstream
+`opensearch-project/sql` docs for that version rather than assuming a fixed constraint.
+
+## System / inspection commands
+
+| Command | Description |
+|---|---|
+| `describe <index>` | Inspect index mapping and field types (use a concrete index name, not a wildcard) |
+| `show datasources` | List configured data sources |
+| `explain [<mode>] <query>` | Display the execution plan (MUST be the first command); `mode` ∈ `standard` (default) / `simple` / `cost` / `extended`; non-`standard` modes require the v3 engine |
+
+## Looking up PPL documentation
+
+When a command/function is missing here, a query fails with a syntax error, or the user's cluster
+version may differ, you MUST fetch the canonical grammar from `opensearch-project/sql`:
+
+- Commands: `https://raw.githubusercontent.com/opensearch-project/sql/main/docs/user/ppl/cmd/<command>.md`
+- Functions: `https://raw.githubusercontent.com/opensearch-project/sql/main/docs/user/ppl/functions/<category>.md`
+  (categories: `aggregations`, `collection`, `condition`, `conversion`, `cryptographic`, `datetime`,
+  `expressions`, `ip`, `json`, `math`, `relevance`, `statistical`, `string`, `system`)
+
+Prefer the `opensearch-project/sql` source over `opensearch.org` documentation pages, because the docs
+site MAY trail the SQL repository by one or more releases.
+
+## Security Considerations
+
+- **Authenticate every query with SigV4 (IAM auth), never open access.** PPL queries hit the data plane
+  (`_plugins/_ppl`), so requests MUST be SigV4-signed — AOS uses `--service es`, AOSS uses `--service aoss`.
+  Do NOT rely on public/unauthenticated endpoints, because an open data plane exposes all indexed data.
+- **PPL results can expose sensitive data.** A query returns whatever fields the caller's index-level
+  permissions allow. Callers MUST have appropriately scoped access via FGAC (AOS domains) or the collection's
+  data access policy (AOSS), because a broad grant lets a query surface PII or other restricted fields.
+- **Enable audit logging.** Turn on CloudTrail for the management-plane API calls and OpenSearch audit logs
+  for data-plane access so you can attribute who ran which queries, because an unaudited data plane makes
+  misuse undetectable.
+- **Do not log full query results to CloudWatch if they may contain PII** unless the log group is encrypted
+  with a customer-managed KMS key, because query output can carry sensitive document fields into logs.
+- **Rate-limit, time-bound, and monitor the PPL endpoint.** Enforce rate limits on `_plugins/_ppl` traffic
+  (via a fronting API gateway/proxy or AWS WAF rate-based rules) and set query timeouts so a runaway
+  aggregation or `join` cannot exhaust cluster resources; alarm on CloudWatch `_plugins/_ppl` call volume and
+  error rates to catch abuse. This matters most for agentic search, where each query invokes a Bedrock model —
+  an unthrottled path there drives both resource exhaustion and unbounded per-call cost.

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/observability.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/observability.md
@@ -154,14 +154,14 @@ source=logs-app-2026-06-01 | where status >= 500 | stats count() by service | so
 ```
 
 ```ppl
-source=logs-app-* | where @timestamp >= now() - 1h | parse uri "(?<endpoint>/api/[^?]+)" | stats avg(latency_ms), p99(latency_ms) by endpoint
+source=logs-app-* | where @timestamp >= now() - 1h | parse uri "(?<endpoint>/api/[^?]+)" | stats avg(latency_ms), percentile(latency_ms, 99) by endpoint
 ```
 
 ```ppl
 source=logs-app-* | eval is_error = if(status >= 500, 1, 0) | stats sum(is_error) as errors, count() as total by service | eval error_rate = errors / total | where error_rate > 0.01
 ```
 
-PPL operators: `where`, `stats`, `fields`, `eval`, `dedup`, `sort`, `head`, `tail`, `parse`, `rename`, `top`.
+Common PPL operators: `where`, `stats`, `fields`, `eval`, `dedup`, `sort`, `head`, `tail`, `parse`, `rename`, `top`. For the full command and function catalog (time-series, join/transform, all function families, `_explain`), see [`observability-ppl-reference.md`](observability-ppl-reference.md).
 
 ## Replacing Splunk
 

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-agentic-setup.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-agentic-setup.md
@@ -1,6 +1,10 @@
 # Amazon OpenSearch Service Domain — Agentic Search Setup
 
-Configure conversational agents with QueryPlanningTool for natural language search. Requires OpenSearch 3.3+ on a managed AOS domain. Uses Bedrock Claude as reasoning model.
+Configure conversational agents with QueryPlanningTool for natural language search on a managed AOS domain. QueryPlanningTool requires OpenSearch 3.3+; verify the minimum version against the AWS docs or `aws opensearch list-versions`. Uses Bedrock Claude as the reasoning model.
+
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+>
+> **Scope: managed AOS domains (conversational, stateful agents).** Amazon OpenSearch Serverless also supports agentic search — via a **flow agent** (`type: flow`, stateless), configured separately. For a Serverless VECTORSEARCH collection, follow [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md); that path covers the flow-agent shape and the `agent` data access policy ResourceType required to avoid a `403 Forbidden` on pipeline queries.
 
 ## Step 1: Create IAM Role for Bedrock Access
 

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-reference.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-reference.md
@@ -19,7 +19,9 @@ After loading this entry, you can discover every provisioning-capability file fr
 | Deploy search config to a domain | [`provisioning-domain-deploy-search.md`](provisioning-domain-deploy-search.md) |
 | Create AOSS collection | [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md) |
 | Deploy search config to a collection | [`provisioning-serverless-deploy-search.md`](provisioning-serverless-deploy-search.md) |
-| Configure agentic search on a domain | [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md) |
+| Tear down (deprovision) an AOSS collection | [`provisioning-serverless-deprovision.md`](provisioning-serverless-deprovision.md) |
+| Configure agentic search on a domain (conversational, stateful) | [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md) |
+| Configure agentic search on a serverless collection (flow agent, stateless) | [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md) |
 | Upgrade domain version | [`provisioning-upgrades.md`](provisioning-upgrades.md) |
 | Storage tier management (UltraWarm, cold) | [`provisioning-storage-tiers.md`](provisioning-storage-tiers.md) |
 | CloudWatch alarms / monitoring | [`provisioning-monitoring.md`](provisioning-monitoring.md) |
@@ -29,7 +31,7 @@ Cross-cutting refs you may also load: [`sizing.md`](sizing.md) (instance/storage
 
 ## Sizing-related universal rules (apply when this capability sizes a domain)
 
-- **Current-generation instances.** Default to Graviton (`r7g`/`r8g` for memory-optimized; `m7g`/`m8g` for cluster managers). `r6g`/`r6gd` only with explicit justification (existing RIs, specific compatibility need). Full instance family list: see [supported-instance-types.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html); rule and rationale: [sizing.md §Instance family selection](sizing.md).
+- **Current-generation instances.** Prefer Graviton and the latest generation available. Always fetch the authoritative list for the target region and engine version with `aws opensearch list-instance-type-details --engine-version <version>` (or [supported-instance-types.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-instance-types.html)) — new generations supersede older ones and the supported set varies by region. As a fallback if the API is unavailable, prefer the latest Graviton memory-optimized family for data nodes and the latest Graviton general-purpose family for cluster managers; use earlier Graviton generations only with explicit justification (existing RIs, specific compatibility need). Rule and rationale: [sizing.md §Instance family selection](sizing.md).
 - **Input honesty.** When sizing on UNKNOWN inputs, lead with `[BLOCKER — need input]` OR present 2–3 tiered bands (small/medium/large workload assumption). Never present a single point estimate built on invented numbers.
 
 ## Cross-capability handoff

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-serverless-agentic-setup.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-serverless-agentic-setup.md
@@ -1,0 +1,200 @@
+# Amazon OpenSearch Serverless — Agentic Search Setup (Flow Agent)
+
+Configure agentic search on an Amazon OpenSearch Serverless collection using a **flow agent** with `QueryPlanningTool`. Uses Bedrock Claude as the reasoning model.
+
+Serverless collections MUST use a flow agent (`type: flow`); conversational agents are not supported on AOSS, because Amazon OpenSearch Serverless does not provide the stateful conversation-memory backing that conversational agents require. Verify agent-type support against the AWS docs (or `aws opensearchserverless` API capabilities) before assuming this limitation still holds. Flow agents are stateless — each query is planned and executed independently. For stateful multi-turn agentic search (memory + RAG), use an Amazon OpenSearch Service **domain** instead; see [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md).
+
+## Prerequisites
+
+- A **NextGen** collection, ACTIVE — see [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md).
+- Index created with data — see [`provisioning-serverless-deploy-search.md`](provisioning-serverless-deploy-search.md).
+- The collection's data access policy MUST include the `agent` ResourceType (Step 4), because pipeline-invoked agentic queries fail with `403 Forbidden` without it.
+- The AWS MCP server is recommended for executing these commands but is not required — steps use standard AWS CLI and `awscurl` syntax. IAM/policy steps use `aws` CLI; the data-plane `_plugins/_ml` and `_search/pipeline` calls (Steps 2, 3, 5, 6) are OpenSearch REST requests — send them with `awscurl` (AOSS uses `--service aoss --region <region>`), e.g. `awscurl --service aoss --region <region> -X POST "<collection-endpoint>/_plugins/_ml/models/_register?deploy=true" -H 'Content-Type: application/json' -d '<body>'`.
+
+## Step 1: Create IAM Role for Bedrock Access
+
+```bash
+aws iam create-role --role-name opensearch-bedrock-agent-role \
+  --assume-role-policy-document '{
+    "Version":"2012-10-17",
+    "Statement":[{
+      "Effect":"Allow",
+      "Principal":{"Service":"ml.opensearchservice.amazonaws.com"},
+      "Action":"sts:AssumeRole",
+      "Condition":{
+        "StringEquals":{"aws:SourceAccount":"<account>"},
+        "ArnLike":     {"aws:SourceArn":    "arn:aws:aoss:<region>:<account>:collection/<collection-id>"}
+      }
+    }]
+  }'
+
+aws iam put-role-policy --role-name opensearch-bedrock-agent-role \
+  --policy-name BedrockClaudeInvokePolicy \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"bedrock:InvokeModel","Resource":["arn:aws:bedrock:<region>::foundation-model/<model-id>","arn:aws:bedrock:<region>:<account>:inference-profile/<inference-profile-id>"]}]}'
+```
+
+Scope `Resource` to the exact model and inference-profile you call — the same `<model-id>` referenced in the connector `parameters.model` (Step 2). Do NOT use a `foundation-model/*` wildcard, because it grants invoke on every Bedrock model in the region and this example is frequently copy-pasted as-is into production.
+
+## Step 2: Register Model with Inline Connector
+
+Register the model and its connector in one call. The connector `request_body` MUST use the agent-framework template variables (`user_prompt`, `_chat_history`, `_interactions`, `tool_configs`), because the flow agent injects planning context through these variables at query time.
+
+Set `parameters.model` to a model ID you have verified exists, because Bedrock model IDs change as new versions ship and the one shown below may have been superseded. Look up available IDs first with `aws bedrock list-foundation-models` or `aws bedrock list-inference-profiles`, and use the same ID in the IAM policy ARN (Step 1) and the `QueryPlanningTool` model_id (Step 3).
+
+```bash
+awscurl --service aoss --region <region> \
+  -X POST "<collection-endpoint>/_plugins/_ml/models/_register?deploy=true" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "agentic search base model",
+  "function_name": "remote",
+  "connector": {
+    "name": "Bedrock Claude Connector",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "parameters": {
+      "region": "<aws_region>",
+      "service_name": "bedrock",
+      "model": "<model-id>",
+      "system_prompt": "You are a search query planning assistant."
+    },
+    "credential": { "roleArn": "<iam_role_arn>" },
+    "actions": [{
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+      "headers": { "content-type": "application/json" },
+      "request_body": "{ \"system\": [{\"text\": \"${parameters.system_prompt}\"}], \"messages\": [${parameters._chat_history:-}{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}${parameters._interactions:-}]${parameters.tool_configs:-} }"
+    }]
+  }
+}'
+```
+
+Wait until model state is `DEPLOYED` before continuing, because the agent registration in Step 3 references a deployed model.
+
+## Step 3: Create Flow Agent
+
+```bash
+awscurl --service aoss --region <region> \
+  -X POST "<collection-endpoint>/_plugins/_ml/agents/_register" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "name": "Agentic Search Agent",
+  "type": "flow",
+  "description": "Flow agent for natural language search with query planning",
+  "tools": [{
+    "type": "QueryPlanningTool",
+    "description": "A general tool to answer any question",
+    "parameters": {
+      "model_id": "<model_id>",
+      "response_filter": "$.output.message.content[0].text"
+    }
+  }]
+}'
+```
+
+- `type` MUST be `flow` (see rationale above).
+- Use only `QueryPlanningTool`, because it introspects the index mapping internally and generates the DSL; additional tools are not needed for stateless query translation.
+- The model is referenced inside the tool's `parameters` — do NOT add a top-level `llm` block, because flow agents resolve the model through the tool, not an agent-level LLM binding.
+- `response_filter` extracts the LLM text from the Bedrock Converse response shape.
+
+## Step 4: Data Access Policy for Pipeline Search (CRITICAL)
+
+The IAM role in the connector's `credential.roleArn` MUST be a principal in the collection's data access policy with all four ResourceTypes — `collection`, `index`, `model`, and `agent`. Pipeline-invoked `agentic` queries fail with `403 Forbidden` without this, because the pipeline uses the connector's IAM role (not the caller's identity) to read mappings, execute the generated DSL, invoke the model, and execute the agent. Direct `_execute` calls can still succeed because they run under the caller's identity, which masks the misconfiguration.
+
+You MUST merge the new `model` and `agent` rules into the **existing** policy rather than replacing it, because `update-access-policy` overwrites the entire policy body and silently drops any rules already present (e.g., the `WriteDocument`/`CreateIndex` grants from provisioning Step 3).
+
+```bash
+# 1. Retrieve the current policy and note its policyVersion
+aws opensearchserverless get-access-policy --type data \
+  --name <collection-name>-data --region <region>
+# 2. Copy the existing Rules array from the output, then append the model and
+#    agent rules below to it. Use the returned policyVersion in step 3.
+```
+
+> **⚠️ Least-privilege NOTE — `aoss:*` on `model`/`agent` is a platform constraint, not a
+> discretionary grant.** AOSS does not expose granular data-access actions for the `model` and `agent`
+> ResourceTypes, so `aoss:*` is the narrowest functional grant for these two rules — no tighter action
+> list exists to substitute. It is broader than least-privilege ideally allows, so treat
+> it as a standing gap to tighten, not a permanent target: track it against an open ticket
+> (`<tracking-ticket-url>`) and re-check on every AOSS agentic-search version bump and on a recurring
+> (quarterly) audit. If AWS exposes granular actions for these ResourceTypes, replace `aoss:*` with
+> the specific actions AND narrow the `model/*/*` and `agent/*/*` resources to the specific model and
+> agent IDs this collection uses (see the note after the command block). The `collection` and `index`
+> rules below are already scoped to minimum actions and should stay that way.
+
+```bash
+# 3. Update with the MERGED policy (existing rules + new model/agent rules):
+aws opensearchserverless update-access-policy --type data \
+  --name <collection-name>-data \
+  --policy-version <current-version> \
+  --policy '[{
+    "Rules":[
+      {"Resource":["collection/<collection-name>"],"Permission":["aoss:DescribeCollectionItems"],"ResourceType":"collection"},
+      {"Resource":["index/<collection-name>/*"],"Permission":["aoss:DescribeIndex","aoss:ReadDocument"],"ResourceType":"index"},
+      {"Resource":["model/*/*"],"Permission":["aoss:*"],"ResourceType":"model"},
+      {"Resource":["agent/*/*"],"Permission":["aoss:*"],"ResourceType":"agent"}
+    ],
+    "Principal":["<caller-principal-arn>","<iam_role_arn>"]
+  }]'
+```
+
+Notes on this policy:
+
+- **`model` and `agent` MUST use the `*/*` pattern**, not `model/<collection-name>/*` — this matches the guidance in [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md), because ML connectors and agents are registered at the account level rather than scoped under the collection name; using the collection-scoped pattern causes the very `403` this step prevents. As noted in the WARNING above, AOSS exposes no granular data-access actions for the `model`/`agent` resource types, so `aoss:*` is the narrowest functional grant for those two rules — tighten it (both permission and resource) if AWS exposes granular actions; re-check [serverless-data-access.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-data-access.html) on the audit cadence above.
+- **Scope `collection` and `index` to the minimum documented actions** (shown above) rather than `aoss:*`, because least-privilege limits blast radius if the connector role is compromised. A read-only agentic index needs only describe/read; add `aoss:WriteDocument` only if the same role also ingests.
+- List **both** the caller principal (for manual API calls) and the connector IAM role (for pipeline-invoked calls).
+- The connector role must also hold the IAM permissions `aoss:APIAccessAll` (and `aoss:DashboardsAccessAll` for Dashboards) on the collection, because data access policy grants alone are insufficient to reach the data plane.
+
+## Step 5: Create Agentic Search Pipeline
+
+```bash
+awscurl --service aoss --region <region> \
+  -X PUT "<collection-endpoint>/_search/pipeline/agentic-search-pipeline" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "request_processors": [{ "agentic_query_translator": { "agent_id": "<agent_id>" } }]
+}'
+```
+
+The pipeline above is the **secure default**: it plans and executes the query but does NOT surface the generated `dsl_query` or `agent_steps_summary` to callers.
+
+> **Sensitive-data warning:** the `agentic_context` response processor attaches `dsl_query` and `agent_steps_summary` to the response `ext` block, exposing internal index field names, the generated query logic, and potentially sensitive filter values to every caller of the pipeline. Leave it OFF in production. Enable it **only** for an authorized debugging session by adding a `response_processors` block to the pipeline, and remove it afterward:
+>
+> ```json
+> "response_processors": [{ "agentic_context": { "agent_steps_summary": true, "dsl_query": true } }]
+> ```
+>
+> If enabled for debugging, ensure any CloudWatch Logs receiving these responses are encrypted with a customer-managed KMS key and access is restricted to authorized personnel only, because the exposed query logic and field names must not be logged to unencrypted logs.
+
+## Step 6: Test Agentic Search
+
+```bash
+awscurl --service aoss --region <region> \
+  -X GET "<collection-endpoint>/<index-name>/_search?search_pipeline=agentic-search-pipeline" \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "query": { "agentic": { "query_text": "Find documents about machine learning" } }
+}'
+```
+
+The response includes search hits. The agent analyzes the question, introspects the index mapping via `QueryPlanningTool`, generates DSL, and executes it. The generated DSL is returned in `ext.dsl_query` only when the `agentic_context` response processor is enabled for debugging (Step 5); with the secure default it is not surfaced to callers.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `403 Forbidden` on pipeline query, but `_execute` works | Connector IAM role missing from data access policy | Add the role as a principal with all four ResourceTypes (Step 4) |
+| Model stuck below `DEPLOYED` | Bedrock region/model unavailable or IAM invoke denied | Verify the model is enabled in the region and the role policy allows `bedrock:InvokeModel` on that model ARN |
+| Empty / malformed DSL | `response_filter` does not match the Converse output shape | Confirm `response_filter` is `$.output.message.content[0].text` |
+
+## Security Considerations
+
+- **Audit logging:** Enable AWS CloudTrail so that `_plugins/_ml` model/agent registration and agentic search API calls are recorded — this attributes who created connectors/agents and who ran queries.
+- **Anomaly monitoring:** Set CloudWatch alarms on the collection's `4xx`/`5xx` error rates and on unusual agentic query volume, because a spike can indicate a misconfigured or abused pipeline.
+- **Encryption at rest:** AOSS encrypts all data at rest by default (AWS-owned key). For compliance workloads, use a customer-managed KMS key on the encryption policy — see [`provisioning-serverless-provision.md`](provisioning-serverless-provision.md).
+- **Bedrock role hygiene:** Review the `opensearch-bedrock-agent-role` trust policy and attached permissions on a regular cadence, and keep the `bedrock:InvokeModel` resource scoped to the specific model ARN (Step 1), because a broad role is a standing invoke path into every model in the region.
+- **Sensitive-field exposure:** The LLM generates DSL from natural language and can surface any field in the index. If the index contains PII or other sensitive fields, apply field-level access control or a response filter, because an unconstrained query planner may return fields the caller should not see.
+- **Encryption in transit:** AOSS enforces HTTPS-only access to the data plane. Verify the collection endpoint starts with `https://` before issuing any query or index call, because an unencrypted request would expose the query and results in transit.
+- **Input validation & rate limiting:** `query_text` is arbitrary natural language passed to an LLM that generates executable DSL. Apply input validation (length limits, disallowed patterns) to mitigate prompt injection, and throttle/rate-limit the pipeline endpoint, because crafted prompts can manipulate DSL generation and high volume drives runaway Bedrock invocation cost.
+- **AWS WAF (defense in depth):** if the endpoint is reachable from outside a trusted VPC, front it with AWS WAF using request-size limits and rate-based rules, because WAF blocks oversized/known-malicious requests at the edge before they reach the LLM query planner.

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-serverless-deploy-search.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-serverless-deploy-search.md
@@ -1,5 +1,7 @@
 # Amazon OpenSearch Serverless — Deploy Search Configuration
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 Deploy indices, ML models, and pipelines to a provisioned serverless collection.
 
 ## Route by Strategy
@@ -131,15 +133,23 @@ PUT <collection-endpoint>/_ingest/pipeline/bedrock-embedding-pipeline
 ```
 PUT <collection-endpoint>/<index-name>
 {
-  "settings": { "index": { "knn": true, "default_pipeline": "bedrock-embedding-pipeline" } },
+  "settings": {
+    "index.knn": true,
+    "index.default_pipeline": "bedrock-embedding-pipeline"
+  },
   "mappings": {
     "properties": {
       "<text-field>": { "type": "text" },
-      "<vector-field>": { "type": "knn_vector", "dimension": 1024, "method": { "name": "hnsw", "engine": "faiss" } }
+      "<vector-field>": {
+        "type": "knn_vector",
+        "dimension": 1024
+      }
     }
   }
 }
 ```
+
+> **Note:** Omit `engine`/`mode` unless you have confirmed support for your collection generation — NextGen rejects them (`Field parameter 'engine' is not supported`) and auto-selects the engine. NextGen support can change over time, so rather than treating this as a fixed prohibition, prefer omitting these fields and, if you need to set them, attempt creation and handle any validation error (same pattern used for OCU values in [provisioning-serverless-provision.md](provisioning-serverless-provision.md)). `space_type` is optional (defaults to L2); to use another metric, add it at the field level, e.g. `"space_type": "cosinesimil"`.
 
 ### 6. Search Pipeline (hybrid only)
 
@@ -177,3 +187,13 @@ After index creation (all paths):
    - Neural Sparse: standard `match` queries (auto-rewritten)
    - Dense Vector: `neural` query with `model_id`
    - BM25: standard `match` queries
+
+## Next Step (optional)
+
+- **Agentic search** (natural-language query → DSL, flow agent): see [provisioning-serverless-agentic-setup.md](provisioning-serverless-agentic-setup.md).
+
+## Security Considerations
+
+- **Encryption in transit:** all data-plane calls (index creation, indexing, search) MUST use HTTPS. Verify the collection endpoint starts with `https://`, because an unencrypted request exposes documents and queries in transit.
+- **Encryption at rest:** indexed embeddings and document content are sensitive; AOSS encrypts at rest by default, and compliance workloads should use a customer-managed KMS key on the encryption policy (see [provisioning-serverless-provision.md](provisioning-serverless-provision.md)).
+- **Least-privilege connector role:** scope the ML model connector role to the minimum data-access actions and the specific model ARN it invokes, because a broad connector role is a standing path into the data plane.

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-serverless-deprovision.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-serverless-deprovision.md
@@ -1,0 +1,54 @@
+# Amazon OpenSearch Serverless — Deprovision (Teardown)
+
+Delete serverless resources in strict dependency order. Reversing the order fails, because a collection group cannot be deleted while it still has collections, and a security policy cannot be deleted while a collection it covers still exists.
+
+The AWS MCP server is recommended for executing these teardown commands but is not required — all steps use standard AWS CLI syntax.
+
+## Order (MUST follow)
+
+1. Delete collection(s)
+2. Wait until each collection is fully gone
+3. Delete the collection group (NextGen only)
+4. Delete the security/data access policies
+
+> **Destructive-action rule:** before deleting anything below, list every resource that will be removed and get explicit user confirmation, because collection deletion (Step 1) is irreversible and destroys all indexed data.
+
+## Step 1: Delete collection(s)
+
+```bash
+aws opensearchserverless delete-collection --id <collection-id>
+```
+
+A collection MUST be ACTIVE (or FAILED) before it can be deleted. If delete returns `ConflictException` about status, the collection is still being created — wait and retry, because AOSS rejects deletes on collections mid-creation.
+
+## Step 2: Confirm deletion completed
+
+```bash
+aws opensearchserverless batch-get-collection --ids <id1> <id2>
+```
+
+Deletion is complete when EITHER the id appears in `collectionErrorDetails` with `"errorCode":"NOT_FOUND"` OR `collectionDetails` is empty. Do NOT poll for a `DELETED` status, because AOSS removes the collection entirely and returns NOT_FOUND rather than a terminal status.
+
+## Step 3: Delete the collection group (NextGen)
+
+```bash
+aws opensearchserverless delete-collection-group --id <group-id>
+```
+
+If this returns `ValidationException` ("has collections associated"), a collection in the group is still active or still deleting — delete/await remaining collections first, because a non-empty group cannot be removed.
+
+## Step 4: Delete policies
+
+```bash
+aws opensearchserverless delete-security-policy --type network    --name <name>-network
+aws opensearchserverless delete-security-policy --type encryption --name <name>-encryption
+aws opensearchserverless delete-access-policy   --type data       --name <name>-data
+```
+
+## Security Considerations
+
+- **Verify a backup exists first, and that it is encrypted at rest.** Collection deletion is irrecoverable — confirm a snapshot or exported copy exists before proceeding if the data may still be needed, because there is no undo. Ensure the backup itself is encrypted at rest (e.g., S3 server-side encryption with a customer-managed KMS key for a manual snapshot or export), because an unencrypted copy of sensitive data is a standing exposure risk even after the collection is deleted.
+- **Audit who initiated the teardown.** Confirm AWS CloudTrail is enabled so the `DeleteCollection`/`DeleteCollectionGroup`/`Delete*Policy` calls are recorded with the caller identity and timestamp.
+- **Alert in real time on teardown calls.** Beyond passive CloudTrail logging, configure an EventBridge rule (or a CloudTrail → CloudWatch metric filter) on `DeleteCollection`/`DeleteCollectionGroup` from unexpected principals that notifies via SNS, because an irreversible delete warrants immediate detection rather than after-the-fact log review. Encrypt the SNS topic with a customer-managed KMS key and restrict `sns:Subscribe` to authorized principals via a topic policy, because teardown alerts carry resource identifiers that should not reach unintended recipients.
+- **Use least-privilege, collection-scoped permissions.** The caller SHOULD hold only the delete actions needed on the specific collection/group ARNs rather than `aoss:*` on all resources, because a broad teardown identity can remove unrelated production collections.
+- **Guard against accidental production teardown.** Assume any collection is production unless its name/tags clearly indicate otherwise, and require explicit confirmation before deleting, because an accidental delete causes an outage and permanent data loss.

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-serverless-provision.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-serverless-provision.md
@@ -1,5 +1,7 @@
 # Amazon OpenSearch Serverless — Provision Collection
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 ## Prerequisites
 
 1. Confirm AWS credentials: `aws sts get-caller-identity`
@@ -43,17 +45,72 @@ aws opensearchserverless create-security-policy \
 
 ## Step 3: Create Data Access Policy
 
+**Base policy (BM25 — least-privilege default).** Grants no `model` access. Use this as-is for plain keyword/BM25 collections:
+
 ```bash
 aws opensearchserverless create-access-policy \
   --name <collection-name>-data --type data \
-  --policy '[{"Rules":[{"ResourceType":"index","Resource":["index/<collection-name>/*"],"Permission":["aoss:CreateIndex","aoss:DescribeIndex","aoss:UpdateIndex","aoss:DeleteIndex","aoss:ReadDocument","aoss:WriteDocument"]},{"ResourceType":"collection","Resource":["collection/<collection-name>"],"Permission":["aoss:CreateCollectionItems","aoss:DescribeCollectionItems"]},{"ResourceType":"model","Resource":["model/<collection-name>/*"],"Permission":["aoss:CreateMLResource"]}],"Principal":["<principal_arn>"]}]'
+  --policy '[{"Rules":[{"ResourceType":"index","Resource":["index/<collection-name>/*"],"Permission":["aoss:CreateIndex","aoss:DescribeIndex","aoss:UpdateIndex","aoss:DeleteIndex","aoss:ReadDocument","aoss:WriteDocument"]},{"ResourceType":"collection","Resource":["collection/<collection-name>"],"Permission":["aoss:CreateCollectionItems","aoss:DescribeCollectionItems"]}],"Principal":["<principal_arn>"]}]'
+```
+
+**ML addendum (neural-sparse / agentic only).** Only when the collection uses ML, append this rule to the `Rules` array above — do NOT include it in BM25-only collections, because it grants every AOSS action on every model in the account:
+
+```json
+{"ResourceType":"model","Resource":["model/*/*"],"Permission":["aoss:*"]}
 ```
 
 > **Note:** AOSS data access policies do not support IAM condition keys. Use network policies (VPC endpoints) and principal scoping for access control.
 >
 > **Tip:** Remove permissions not needed for your use case. For read-only collections, remove aoss:WriteDocument, aoss:UpdateIndex, aoss:DeleteIndex.
+>
+> For neural-sparse (semantic enrichment) or agentic strategies, the data access policy MUST also grant the `model` and `agent` ResourceTypes, and the `model` resource MUST be `model/*/*` (not `model/<collection-name>/*`), because semantic enrichment registers ML connectors at the account level rather than under the collection name. Omit these rules for plain BM25 collections, because BM25 uses no ML resources. For the full agentic data access policy, see [provisioning-serverless-agentic-setup.md](provisioning-serverless-agentic-setup.md).
+>
+> **Least-privilege warning:** `aoss:*` on `model/*/*` grants every AOSS action on every model in the account — broader than least-privilege ideally allows. AOSS does not expose scoped per-model ML actions for data access policies, so `aoss:*` is the narrowest functional grant here. Track it and tighten the `Permission` list if AOSS exposes granular model actions. See the fuller discussion in [provisioning-serverless-agentic-setup.md](provisioning-serverless-agentic-setup.md).
 
-## Step 4: Create Collection
+## Step 4a: Create Collection Group (NextGen — default)
+
+NextGen is the default serverless target for all strategies except conversational agentic search. A NextGen collection MUST belong to a collection group, so create the group before the collection. Because generation defaults and per-strategy support change over time, verify the current default generation and supported strategies against the AWS docs or `aws opensearchserverless` API capabilities before relying on this.
+
+```bash
+aws opensearchserverless create-collection-group \
+  --name <collection-name>-group \
+  --standby-replicas ENABLED \
+  --generation NEXTGEN
+```
+
+- `--generation NEXTGEN` is REQUIRED, because omitting it creates a Classic group and NextGen-only features are unavailable and the generation cannot be changed after creation. Verify the current NextGen feature set against the AWS docs ([serverless-overview.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html)) rather than relying on a hardcoded list.
+- `--standby-replicas ENABLED` is required for NextGen — NextGen groups reject `DISABLED`, which is a Classic-only dev/test option. This constraint is generation-specific and may be relaxed — verify whether `DISABLED` is supported for the chosen generation via the AWS docs, or attempt creation and handle any validation error (same pattern used for OCU values below).
+- Capacity limits are optional. When set, each OCU value must be one of a service-defined set of allowed steps, and AOSS rejects any other value with an `Invalid value for maxIndexingCapacityInOCU` error. The allowed steps are service-specific limits that change over time — fetch the allowed values from the AWS docs ([serverless-scaling.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-scaling.html)), or attempt creation and parse the validation error message, rather than hardcoding a specific value:
+
+  ```bash
+  aws opensearchserverless create-collection-group \
+    --name <collection-name>-group --standby-replicas ENABLED --generation NEXTGEN \
+    --capacity-limits '{"minIndexingCapacityInOCU":4,"maxIndexingCapacityInOCU":16,"minSearchCapacityInOCU":4,"maxSearchCapacityInOCU":16}'
+  ```
+
+Then create the collection **into the group** instead of standalone:
+
+```bash
+aws opensearchserverless create-collection \
+  --name <collection-name> --type <SEARCH|VECTORSEARCH> \
+  --collection-group-name <collection-name>-group
+```
+
+> SEARCH and VECTORSEARCH are supported on NextGen while TIMESERIES is Classic-only (see assessment-gotchas.md §9). Supported collection types are generation-specific — verify the valid types against the AWS docs ([serverless-overview.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-overview.html)) at creation time, or attempt creation and handle the validation error, rather than relying on this list.
+
+### Add a collection to an existing group
+
+```bash
+aws opensearchserverless list-collection-groups          # find the group name + capacityLimits
+aws opensearchserverless create-collection --name <new-name> --type <TYPE> \
+  --collection-group-name <existing-group-name>
+```
+
+Before creating, verify an encryption policy and network policy already cover `<new-name>` (or a `collection/*` wildcard), because a collection cannot be created if no encryption policy matches its name.
+
+## Step 4b: Create Collection (Classic — standalone fallback)
+
+Use the Classic standalone flow **only when Classic is explicitly required** (e.g. a TIMESERIES collection, or a feature not yet on NextGen), because NextGen is the default target everywhere else in this runbook.
 
 Choose type based on strategy:
 

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-troubleshooting.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/provisioning-troubleshooting.md
@@ -1,5 +1,7 @@
 # Troubleshooting AOS Domains and Collections
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 ## Common Issues
 
 | Error | Cause | Fix |
@@ -10,6 +12,19 @@
 | Upgrade fails at pre-checks | Incompatible settings or plugins | Run `get-compatible-versions`; address breaking changes listed in upgrade guide |
 | `DisabledOperationException` | Operation not available for config | Some operations (cold storage, UltraWarm) require specific instance families |
 | Snapshot failure | S3 bucket permissions or IAM role | Verify snapshot role has `s3:PutObject` on the bucket; check trust policy |
+
+## Serverless (AOSS) provisioning & teardown errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `ConflictException` / "already exists" on create | Resource name taken in this account+region | Choose a new name, because collection/policy names must be unique per account per region |
+| `Invalid value for maxIndexingCapacityInOCU` | OCU value outside the allowed set | Set a valid OCU value per [serverless-scaling.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-scaling.html), because AOSS rejects capacity numbers outside the allowed set |
+| "Providing VectorOptions ... not supported for account" | Account lacks vector acceleration | Retry without `vectorOptions`, because acceleration needs account-level enablement |
+| `ConflictException` on `delete-collection` (status not ACTIVE/FAILED) | Collection still creating | Poll `batch-get-collection` until `status` is `ACTIVE`/`FAILED`, then retry, because a mid-creation collection cannot be deleted |
+| `ValidationException` "has collections associated" on `delete-collection-group` | Group still holds collections | Delete/await member collections first, because a non-empty group cannot be removed |
+| Partial-failure mid-provision (group created, collection failed) | One step failed after earlier steps succeeded | Report what exists, then use the deprovision flow to clean up, because orphaned policies/groups still bill and block name reuse |
+
+For the full teardown ordering, see [provisioning-serverless-deprovision.md](provisioning-serverless-deprovision.md).
 
 ## Debugging Domain Creation Failures
 

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/search-document-processing-guide.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/search-document-processing-guide.md
@@ -2,6 +2,8 @@
 
 This guide covers how to process PDF, DOCX, PPTX, XLSX, HTML, and other document formats for ingestion into OpenSearch using [Docling](https://docling.site/).
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard AWS CLI syntax.
+
 ## Overview
 
 Docling is an open-source Python library (MIT license) by IBM Research that converts unstructured documents into structured data. It detects page layout, reading order, table structure, code blocks, formulas, and images using AI models, and runs locally on commodity hardware.
@@ -9,6 +11,22 @@ Docling is an open-source Python library (MIT license) by IBM Research that conv
 ## Supported Input Formats
 
 PDF, DOCX, PPTX, XLSX, HTML, Markdown, AsciiDoc, CSV, images (PNG, JPEG, TIFF, BMP, WEBP), audio (MP3, WAV).
+
+## Choosing a processing approach
+
+Match the Docling pipeline to the document's dominant content, because a single
+default pipeline degrades on tables, scans, and figures.
+
+| Document character | Approach | What to enable | Why |
+|---|---|---|---|
+| Digital-text, prose-heavy (papers, reports, contracts) | Semantic | Hierarchy-aware `HybridChunker` respecting headings | Preserves section boundaries so chunks stay self-contained |
+| Table-heavy (financial reports, spec sheets) | Tables | TableFormer table extraction; serialize tables to markdown | You MUST enable table extraction explicitly, because auto-detection does NOT reliably recognize table-heavy documents and untreated tables collapse into unusable text |
+| Scanned / image-only pages | Scanned | OCR (`do_ocr=True`; RapidOCR / PP-OCRv4) before chunking | Digital-text pipelines produce empty chunks on scans because there is no extractable text layer |
+| Figure / diagram-rich | Multimodal | VLM picture descriptions (e.g. SmolVLM-256M) | Figures carry meaning that is lost unless described, because embeddings index text only |
+
+You SHOULD default to the semantic approach for digital-text documents and disable OCR
+(`do_ocr=False`, since Docling enables it by default), because OCR adds significant
+latency and is unnecessary when a text layer exists.
 
 ## Chunking for Search Ingestion
 
@@ -22,7 +40,7 @@ Splits at every section/heading boundary. Produces many small chunks that respec
 
 Combines structure-aware splitting with token limits. Preserves document hierarchy while ensuring chunks fit within embedding model constraints.
 
-Parameters: `max_tokens=512, overlap_tokens=50`
+Parameters: `max_tokens=512` (HybridChunker takes no overlap parameter — it merges adjacent peer chunks rather than applying a fixed overlap).
 
 ## Processing Pipeline for Document Search
 
@@ -34,15 +52,92 @@ The recommended end-to-end flow:
 4. **Index** — Load into OpenSearch using the ingest pipeline.
 5. **Search** — Query using your configured search pipeline.
 
+## JSONL chunk format
+
+Each line of the exported `.jsonl` MUST be a standalone JSON object with at
+minimum a `text` field, because the downstream bulk-index and OSIS ingestion
+paths reject lines that lack indexable content.
+
+```json
+{"text": "...", "headings": ["Section Title"], "source_file": "doc.pdf", "chunk_id": 0, "page_number": 1}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `text` | string | Chunk content (required) |
+| `headings` | array | Section headings this chunk belongs to |
+| `source_file` | string | Original source filename |
+| `chunk_id` | int | Sequential chunk index within the file |
+| `page_number` | int | Source page number |
+
+You SHOULD validate that every line parses as JSON and carries a non-empty
+`text` field before uploading to S3, because a single malformed line can fail an
+entire bulk request.
+
 ## Choosing Chunk Size
 
 - For BM25 (keyword search): larger chunks (1000+ tokens) work well since BM25 benefits from more context.
 - For dense vector / semantic search: 256–512 tokens is typical, matching embedding model input limits.
-- For hybrid search: 512 tokens with 50-token overlap is a good default.
+- For hybrid search: 512 tokens is a good default. The `HybridChunker` above has no overlap parameter (it merges adjacent peer chunks); a fixed ~50-token overlap applies only if you use a custom, non-Docling chunker.
+
+## Adjusting chunking when retrieval quality is poor
+
+Re-processing is expensive, so you SHOULD change chunking only when a quality
+check provides evidence, because blind re-ingestion wastes compute without a
+targeted fix.
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Results lack surrounding context | Chunks too small | Increase `max_tokens` |
+| Results contain irrelevant noise | Chunks too large | Decrease `max_tokens` |
+| Tables absent from results | Table extraction not run | Re-process with TableFormer enabled |
+| Scanned pages return empty or garbled text | OCR not run | Re-process with OCR enabled |
+| Figures / diagrams missing from results | Visual content not described | Re-process with VLM picture descriptions |
+
+You MUST NOT automatically re-ingest on a poor result, because re-ingestion is
+costly and may not address the true cause; confirm the symptom and the intended
+fix first.
+
+## Evaluating chunk quality
+
+Before indexing at scale, you SHOULD sample chunks and judge them against the
+dimensions that matter for the document type, because indexing low-fidelity
+chunks propagates the defect into every downstream search result.
+
+| Document type | Dimensions to judge |
+|---|---|
+| Prose / semantic | text fidelity, reading order, chunk boundaries, heading structure |
+| Tables | table structure, table-content fidelity, text fidelity, completeness |
+| Scanned | OCR text fidelity, reading order, completeness |
+| Multimodal | image descriptions, text fidelity, reading order, completeness |
+
+Rate each dimension `good | fair | poor`. When any dimension is `poor`, explain
+the cause and recommend a specific re-process; you MUST NOT re-ingest without
+user confirmation, because re-processing is expensive.
 
 ## Performance Tips
 
 - Skip page images if not needed to save memory.
 - Use `max_num_pages` or `page_range` to limit processing for large documents.
 - Enable parallel processing for multi-core systems.
-- For scanned PDFs, OCR is enabled by default. Disable if not needed.
+- Docling enables OCR by default (`do_ocr=True`); disable it (`do_ocr=False`) for digital-text documents in the semantic profile, and keep it on only for scanned / image-only pages, since OCR adds significant latency.
+
+## Security Considerations
+
+Exported chunks (JSONL) and the S3 objects that stage them carry the full text of
+the source documents, so treat them with the same sensitivity as the originals.
+
+- **Encryption at rest.** Enable server-side encryption on the target S3 bucket —
+  SSE-S3 at minimum, and SSE-KMS with a customer-managed KMS key for compliance
+  workloads (PCI-DSS, HIPAA) so you retain key control and an audit trail. Apply
+  the same encryption posture (AWS-owned key by default, customer-managed KMS key for compliance) to
+  the destination OpenSearch collection or domain that ingests the chunks.
+- **Access control.** Restrict the S3 bucket with a bucket policy (and, where
+  applicable, `aws:SourceVpce` / IAM principal conditions) so only the ingestion
+  role and authorized operators can read the staged JSONL. Block public access at
+  the account and bucket level.
+- **Sensitive / PII content.** Source documents may contain PII or other regulated
+  data, which propagates verbatim into chunks, the index, and any search result or
+  agent response. Classify sources before ingesting, redact or exclude fields you
+  do not intend to make searchable, and delete the intermediate JSONL from S3 once
+  indexing is confirmed rather than leaving it as a long-lived copy of the corpus.

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/search-semantic-search-guide.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/search-semantic-search-guide.md
@@ -416,3 +416,37 @@ OpenSearch provides several normalization techniques (Min-Max, L2, Harmonic Mean
 - Development/prototype phase (start simple)
 
 ---
+
+## 5. Agentic Search (Natural-Language Query Translation)
+
+### 5.1 Overview
+
+Agentic search uses an LLM to translate a natural-language question into OpenSearch DSL, then executes it — the caller asks a question in plain language instead of authoring a query. It is a standalone retrieval method that returns synthesized answers, implemented as a natural-language query-authoring layer over BM25/dense/hybrid retrieval.
+
+### 5.2 When to Use Agentic Search
+
+**Recommended:**
+
+- Callers who cannot author DSL/PPL (business users, natural-language front-ends).
+- Ad-hoc exploratory questions over a well-mapped index.
+
+**Not Recommended:**
+
+- Latency-sensitive paths, because each query adds an LLM round-trip (typically 200–2000 ms) plus per-query model cost on top of retrieval.
+- High-QPS production traffic with fixed query shapes — author the DSL once instead, because a static query avoids the per-call LLM cost.
+
+### 5.3 Conversational vs Flow
+
+- **Conversational (AOS domain, stateful):** multi-turn with conversation memory + RAG. Setup: [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md).
+- **Flow (AOSS Serverless, stateless):** each query planned independently, lower latency/cost, no memory. Setup: [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md).
+
+### 5.4 Security Considerations
+
+- **Field exposure:** the LLM can generate DSL that surfaces any field in the index, including PII. Apply field-level access control (document/field security) so an agentic query cannot return fields the caller is not authorized to see.
+- **Cost abuse:** each agentic query incurs a Bedrock model invocation. Throttle/rate-limit the agentic path to prevent runaway per-call model cost.
+- **Logging & monitoring:** enable CloudTrail for `_plugins/_ml` model/agent calls and set CloudWatch alarms on agentic query error rates and unusual invocation volume. See the detailed monitoring guidance in [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md) and [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md).
+- **Log confidentiality:** when `agentic_context` is enabled for debugging, the generated DSL surfaces in the response metadata (and thus in any logs that capture full responses). Encrypt any CloudWatch log group that receives agentic responses with a customer-managed KMS key and restrict its access policy, because those logs can contain the same sensitive field values the query returned.
+- **AWS WAF (defense in depth):** if the endpoint is internet-facing, front it with AWS WAF using request-size limits and rate-based rules, because WAF filters oversized and abusive free-form input at the edge before it reaches the LLM query planner.
+- For setup-time security guidance (IAM scoping, model/agent access policies), see the security sections in [`provisioning-agentic-setup.md`](provisioning-agentic-setup.md) (conversational) and [`provisioning-serverless-agentic-setup.md`](provisioning-serverless-agentic-setup.md) (flow).
+
+---

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/sizing.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/sizing.md
@@ -170,6 +170,8 @@ OS 3.0 introduces GPU-accelerated index build, derived-source vectors (reduced s
 | Redundancy ON (production default) | 1 OCU (0.5 × 2) | 1 OCU (0.5 × 2) | 4 × 0.5 OCU |
 | Redundancy OFF (dev/test) | 0.5 OCU × 2 | 0.5 OCU × 2 | 2 × 0.5 OCU per workload type |
 
+> **Scale-to-zero:** Serverless NextGen collections scale to zero OCUs when idle (an idle NextGen collection bills nothing for compute), whereas Classic collections hold the minimum OCU floor above at all times because Classic keeps warm capacity provisioned. Minimum-billing behavior can change per generation, so verify it against [serverless-scaling.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-scaling.html) (as the Caps section also references) before relying on it for cost projections. Where it holds, factor it into cost projections for intermittently-used collections: NextGen is materially cheaper when traffic is bursty or dev/test.
+
 ### Caps
 
 For current OCU defaults and account-level caps, see [serverless-scaling.html](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-scaling.html).

--- a/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/trace-analytics-trace-queries.md
+++ b/skills/specialized-skills/analytics-skills/amazon-opensearch-service/references/trace-analytics-trace-queries.md
@@ -1,5 +1,7 @@
 # Trace-analytics capability — entry point and query templates
 
+> The AWS MCP server is recommended for executing these commands but is not required — all steps use standard `awscurl` / AWS CLI syntax.
+
 This file is the **entry point** for the `trace-analytics` capability. It covers distributed traces with OpenTelemetry — span queries, service maps, latency analysis (p50/p95/p99), error rate by service, and root-cause via parent/child spans.
 
 ## When to use this capability
@@ -25,9 +27,26 @@ Cross-cutting refs you may also load: [`security.md`](security.md), [`personas.m
 - For **provisioning the trace-collector infra** (Data Prepper / OSI / IAM): see [`provisioning-reference.md`](provisioning-reference.md).
 - For **OSI pipeline configuration shared with logs**: see [`log-analytics-osi-pipelines.md`](log-analytics-osi-pipelines.md).
 
+## Query discipline (MUST follow)
+
+For the full PPL command and function catalog, see [`observability-ppl-reference.md`](observability-ppl-reference.md).
+
+- **Unknown command → upstream grammar.** If a PPL command or function is not in
+  [`observability-ppl-reference.md`](observability-ppl-reference.md), or an emitted query fails with a
+  syntax error, you MUST fetch the raw upstream doc from `opensearch-project/sql` under `docs/user/ppl/`
+  before answering. You MUST NOT invent PPL syntax, because OpenSearch PPL has version-specific commands
+  that do not exist in other query languages.
+- **Verify or disclose.** When the domain/collection endpoint is reachable, you MUST validate every
+  emitted query against `_plugins/_ppl`; on 0 rows, fall back to `_plugins/_ppl/_explain` to confirm the
+  plan and surface the empty result; on error, fix and re-validate. When no endpoint is reachable, you
+  MUST state that the query is unverified, because an untested query can silently reference a
+  non-existent field.
+
 ## Data Plane Access with awscurl
 
 All queries below use the PPL API at `/_plugins/_ppl`. Use `awscurl` for SigV4-authenticated requests:
+
+> **Credentials & monitoring:** source the SigV4 signing credentials from an IAM role (instance profile, ECS task role, or SSO session), not static access keys. Enable CloudTrail for management-plane audit and OpenSearch audit logs for data-plane access (to attribute PPL queries to callers), and alarm on `_plugins/_ppl` error rates.
 
 ### Base Command (AOS)
 


### PR DESCRIPTION
## Description

## Summary

Updates the `amazon-opensearch-service` skill with expanded serverless,
observability, and search guidance.

## New reference files

- `observability-ppl-reference.md` — full PPL command/function catalog
  (time-series, join/transform, function families, `_explain`).
- `provisioning-serverless-agentic-setup.md` — flow-agent (stateless) setup
  for Serverless VECTORSEARCH collections, including the `agent` data access
  policy ResourceType required to avoid a 403 on pipeline queries.
- `provisioning-serverless-deprovision.md` — teardown flow for AOSS collections.

## Notable changes

- **Serverless NextGen** — collection-group creation is now the default path
  (`--generation NEXTGEN`, `--standby-replicas`, capacity limits); Classic is
  documented as a standalone fallback.
- **Data access policy** — least-privilege BM25 base policy split from an
  optional ML addendum; removed a non-existent AOSS permission and corrected
  the ML resource scope to `model/*/*`.
- **Sizing** — added serverless scale-to-zero cost note for NextGen vs Classic.
- **Observability / trace / log analytics** — clarified PPL operators, added
  OSI pipeline access-policy merge steps, and cross-links.
- **Provisioning** — agentic setup scoped to managed domains, instance-family
  guidance now points at `list-instance-type-details` for authoritative data.
## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [x] Other: update existing skill

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
