### PR TITLE
fix(asm-exec): resolve secrets via run_script (fixes #293)

### DIFF
--- a/plugins/aws-core/skills/aws-secrets-manager/SKILL.md
+++ b/plugins/aws-core/skills/aws-secrets-manager/SKILL.md
@@ -83,7 +83,8 @@ asm-exec -- mysql \
 2. Resolves each reference through the first available backend, in order:
    1. **AWS Secrets Manager Agent (SMA)** on localhost:2773 (zero-latency, cached)
    2. **AWS MCP endpoint** (`https://aws-mcp.us-east-1.api.aws/mcp`), calling the
-      `aws___call_aws` tool over a SigV4-signed request
+      `aws___run_script` tool over a SigV4-signed request (the tool runs a short
+      server-side Python script that fetches the secret via `call_boto3`)
    3. Determines the secret's region from an ARN's region segment, or from
       `AWS_REGION` / `AWS_DEFAULT_REGION`, and passes it to the resolver
 3. Substitutes resolved values using `re.sub` with a callable (single-pass --
@@ -104,7 +105,8 @@ does **not** depend on botocore or spin up the `mcp-proxy-for-aws-cli` proxy, ke
 the wrapper a lightweight ephemeral process. The signing service and region are
 inferred from the endpoint hostname (e.g. `aws-mcp.us-east-1.api.aws` ->
 service `aws-mcp`, region `us-east-1`); this signing region is independent of the
-secret's own region, which is passed as `--region` to the server-side CLI command.
+secret's own region, which is passed as the `region_name` argument to the
+server-side `call_boto3` call.
 
 Credentials for signing are resolved in order: environment variables
 (`AWS_ACCESS_KEY_ID` etc.), `aws configure export-credentials` (AWS CLI v2), then
@@ -167,11 +169,16 @@ resolvable (see SigV4 signing above) so that backend can authenticate.
 
 ### "Failed to resolve" errors
 
-Both backends were unreachable or returned no value. Check that either SMA is
+Both backends were unreachable or returned no value. When MCP resolution fails,
+`asm-exec` prints the specific cause to stderr (`asm-exec: MCP resolution failed:
+...`) -- a timeout, an unreachable endpoint, an HTTP status, a denied permission,
+or a missing value -- so read that line first. Check that either SMA is
 running or AWS credentials are valid (`aws sts get-caller-identity`), that the
 secret's region is correct (set `AWS_REGION` or use a full ARN), and that your
 identity has `secretsmanager:GetSecretValue` on the secret. A `401` from the MCP
-endpoint indicates a SigV4 signing or credential problem, not a missing secret.
+endpoint indicates a SigV4 signing or credential problem, not a missing secret. If
+the failure is a timeout, the server-side call may need longer than the default
+30s -- raise it with `ASM_EXEC_MCP_TIMEOUT` (seconds).
 
 ### Resolution produces empty string
 

--- a/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
+++ b/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
@@ -20,7 +20,6 @@ import hmac
 import json
 import os
 import re
-import shlex
 import subprocess
 import sys
 import urllib.error
@@ -28,14 +27,14 @@ import urllib.parse
 import urllib.request
 
 
-def _shell_quote(value):
-    """Quote a value for safe inclusion in the cli_command string."""
-    return shlex.quote(value)
-
 PATTERN = re.compile(r'\{\{resolve:secretsmanager:([^}]+)\}\}')
 SMA_ENDPOINT = os.environ.get('AWS_SECRETS_MANAGER_AGENT_ENDPOINT', 'http://localhost:2773')
 SSRF_TOKEN = os.environ.get('AWS_SESSION_TOKEN', os.environ.get('AWS_TOKEN', ''))
 MCP_ENDPOINT = os.environ.get('ASM_EXEC_MCP_ENDPOINT', 'https://aws-mcp.us-east-1.api.aws/mcp')
+# run_script performs a server-side boto3 round trip (measured ~13s), well beyond
+# the old hard-coded 10s ceiling. Keep the transport timeout generous and let
+# operators raise it further via ASM_EXEC_MCP_TIMEOUT (seconds).
+MCP_TIMEOUT = float(os.environ.get('ASM_EXEC_MCP_TIMEOUT', '30'))
 
 _sma_available = None
 
@@ -168,7 +167,7 @@ def _sign_v4(method, path, body, creds, service, region, now):
     return headers
 
 
-def _mcp_post(payload, session_id=None):
+def _mcp_post(payload, session_id=None, timeout=None):
     """POST a SigV4-signed JSON-RPC request to the AWS MCP endpoint.
 
     Returns (parsed_response, session_id_from_response). The caller passes the
@@ -193,7 +192,7 @@ def _mcp_post(payload, session_id=None):
     for k, v in sig_headers.items():
         req.add_header(k, v)
 
-    resp = urllib.request.urlopen(req, timeout=10)
+    resp = urllib.request.urlopen(req, timeout=timeout or MCP_TIMEOUT)
     session_out = resp.headers.get('Mcp-Session-Id')
     raw = resp.read()
     parsed = json.loads(raw) if raw else {}
@@ -205,8 +204,9 @@ def _extract_secret_string(payload):
     if isinstance(payload, dict):
         if "SecretString" in payload:
             return payload["SecretString"]
-        # call_aws may nest the CLI output under a results/output key
-        for key in ("result", "results", "output", "stdout"):
+        # run_script returns the API response under `return_value`; the legacy
+        # call_aws path nested CLI output under result/output/stdout. Traverse all.
+        for key in ("return_value", "result", "results", "output", "stdout"):
             if key in payload:
                 nested = payload[key]
                 if isinstance(nested, str):
@@ -220,57 +220,99 @@ def _extract_secret_string(payload):
     return None
 
 
+def _mcp_error(resp):
+    """Return the JSON-RPC error message from an MCP response, or None."""
+    if isinstance(resp, dict) and isinstance(resp.get("error"), dict):
+        return resp["error"].get("message") or str(resp["error"])
+    return None
+
+
 def _resolve_via_mcp(secret_name, label, region):
     """Resolve a secret via the SigV4-authenticated AWS MCP endpoint.
 
-    The server exposes 'aws___call_aws', which runs a full AWS CLI command
-    (passed as the 'cli_command' string) server-side and returns its output.
-    The SecretString returns into this process and never reaches the agent.
-    Returns the value or None.
+    Uses the server's 'aws___run_script' tool (the successor to the removed
+    'aws___call_aws'): it runs a short Python script server-side that calls
+    call_boto3('secretsmanager', 'GetSecretValue', ...) and returns the API
+    response as the script's return_value. The SecretString returns into this
+    process and never reaches the agent.
+
+    Returns the resolved value, or None. On failure the specific cause is
+    printed to stderr -- a removed/renamed tool, a timeout, a signing or
+    permission error, and a missing secret each report distinctly instead of
+    collapsing into one message. Secret values are never included in diagnostics.
     """
     try:
         # Initialize and capture the session id for subsequent calls.
-        _, session_id = _mcp_post(
+        init_resp, session_id = _mcp_post(
             {"jsonrpc": "2.0", "id": 1, "method": "initialize",
              "params": {"protocolVersion": "2024-11-05",
                         "clientInfo": {"name": "asm-exec", "version": "1.0.0"},
                         "capabilities": {}}})
+        err = _mcp_error(init_resp)
+        if err:
+            raise RuntimeError("MCP initialize rejected: %s" % err)
         # Notify initialized
         _mcp_post({"jsonrpc": "2.0", "method": "notifications/initialized"},
                   session_id)
-        # Build the CLI command string the MCP server will execute. Include
-        # --region so cross-region secrets resolve regardless of the endpoint's
-        # home region. The secret id is quoted to tolerate ARNs and shell metachars.
-        cmd_parts = ["aws", "secretsmanager", "get-secret-value",
-                     "--secret-id", _shell_quote(secret_name),
-                     "--version-stage", _shell_quote(label),
-                     "--output", "json"]
+        # Build the Python script the sandbox will run. call_boto3 takes the
+        # secret id and version stage as params; region_name covers cross-region
+        # secrets regardless of the endpoint's home region. Values are embedded
+        # with %r (repr) so quotes and metacharacters are escaped into valid
+        # Python literals -- no shell quoting is involved on this path. The
+        # trailing bare `result` expression makes the API response the script's
+        # return_value.
+        params = {"SecretId": secret_name, "VersionStage": label}
+        call_args = ("service_name='secretsmanager', "
+                     "operation_name='GetSecretValue', params=%r" % (params,))
         if region:
-            cmd_parts += ["--region", region]
-        cli_command = " ".join(cmd_parts)
+            call_args += ", region_name=%r" % (region,)
+        code = "result = await call_boto3(%s)\nresult" % (call_args,)
         # Call tool
         resp, _ = _mcp_post(
             {"jsonrpc": "2.0", "id": 2, "method": "tools/call",
-             "params": {"name": "aws___call_aws",
-                        "arguments": {"cli_command": cli_command}}},
+             "params": {"name": "aws___run_script",
+                        "arguments": {"code": code}}},
             session_id)
+        err = _mcp_error(resp)
+        if err:
+            raise RuntimeError("aws___run_script call rejected: %s" % err)
         result = resp.get("result", {})
-        # tools/call returns a content array of text items
+        # tools/call returns a content array of text items; each item's text is
+        # the run_script envelope {status, stdout, stderr, return_value, ...}.
+        envelopes = []
         if isinstance(result, dict) and "content" in result:
             for item in result["content"]:
                 if item.get("type") == "text":
                     try:
-                        data = json.loads(item["text"])
+                        envelopes.append(json.loads(item["text"]))
                     except (json.JSONDecodeError, TypeError):
                         continue
-                    found = _extract_secret_string(data)
-                    if found:
-                        return found
-        if isinstance(result, dict):
-            return _extract_secret_string(result)
-    except (urllib.error.URLError, OSError, json.JSONDecodeError,
-            KeyError, TypeError, RuntimeError):
-        pass
+        elif isinstance(result, dict):
+            envelopes.append(result)
+        for envelope in envelopes:
+            if isinstance(envelope, dict) and envelope.get("status") == "error":
+                raise RuntimeError(
+                    "run_script reported an error: %s"
+                    % (envelope.get("error") or envelope.get("stderr")
+                       or "unknown error"))
+            found = _extract_secret_string(envelope)
+            if found:
+                return found
+        # The call succeeded but carried no SecretString -- typically a denied
+        # permission or a wrong secret id/stage rather than a transport fault.
+        raise RuntimeError(
+            "no SecretString in run_script response (check "
+            "secretsmanager:GetSecretValue permission and the secret id/stage)")
+    except TimeoutError as exc:
+        reason = ("timed out after %ss -- raise ASM_EXEC_MCP_TIMEOUT if the "
+                  "server-side call needs longer (%s)" % (MCP_TIMEOUT, exc))
+    except urllib.error.HTTPError as exc:
+        reason = "HTTP %s from MCP endpoint (%s)" % (exc.code, exc.reason)
+    except urllib.error.URLError as exc:
+        reason = "cannot reach MCP endpoint: %s" % (exc.reason,)
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, RuntimeError) as exc:
+        reason = "%s: %s" % (type(exc).__name__, exc)
+    print("asm-exec: MCP resolution failed: %s" % reason, file=sys.stderr)
     return None
 
 

--- a/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
+++ b/plugins/aws-core/skills/aws-secrets-manager/references/asm-exec
@@ -167,7 +167,7 @@ def _sign_v4(method, path, body, creds, service, region, now):
     return headers
 
 
-def _mcp_post(payload, session_id=None, timeout=None):
+def _mcp_post(payload, session_id=None):
     """POST a SigV4-signed JSON-RPC request to the AWS MCP endpoint.
 
     Returns (parsed_response, session_id_from_response). The caller passes the
@@ -192,7 +192,7 @@ def _mcp_post(payload, session_id=None, timeout=None):
     for k, v in sig_headers.items():
         req.add_header(k, v)
 
-    resp = urllib.request.urlopen(req, timeout=timeout or MCP_TIMEOUT)
+    resp = urllib.request.urlopen(req, timeout=MCP_TIMEOUT)
     session_out = resp.headers.get('Mcp-Session-Id')
     raw = resp.read()
     parsed = json.loads(raw) if raw else {}


### PR DESCRIPTION
## Summary

Fixes #293. With no Secrets Manager Agent on `localhost:2773`, `asm-exec` resolved no secrets because its MCP fallback called `aws___call_aws`, which was removed on 2026-08-31. Two further defects made the failure impossible to diagnose.

## Changes

- **Port `_resolve_via_mcp` to `aws___run_script`.** Instead of building an AWS CLI string for the removed `call_aws` tool, it sends a short server-side script that calls `call_boto3('secretsmanager', 'GetSecretValue', ...)` and returns the response as the script's `return_value`. `call_boto3` arguments are embedded with `repr`, so secret ids / version stages can't break out of the generated script (this replaces the old shell-quoting; `shlex` dropped).
- **Configurable, generous timeout.** The transport timeout was hardcoded to 10s, but the `run_script` boto3 round trip measures ~13s, so every attempt timed out. Default is now 30s, overridable via `ASM_EXEC_MCP_TIMEOUT`.
- **Failures name their cause.** `_resolve_via_mcp` no longer collapses every exception into one `Failed to resolve` string. A removed/renamed tool, a timeout, an unreachable endpoint / HTTP status, a denied permission, and a genuinely-missing secret each print a distinct `asm-exec: MCP resolution failed: ...` line to stderr. Secret values are never included in diagnostics.
- **`return_value` traversal.** `_extract_secret_string` now checks the `run_script` envelope's `return_value` (legacy `result`/`output`/`stdout` keys kept for back-compat).
- Updated `SKILL.md` to match (tool name, `region_name` argument, timeout + cause-naming troubleshooting).

## Testing

- Confirmed the `run_script` response contract (`{status, stdout, stderr, return_value, ...}`) and the sandbox `call_boto3(service_name, operation_name, params, region_name)` signature.
- Ran a local regression suite that fails on the pre-fix script (2/6) and passes on the fix (6/6): resolves a secret from a `return_value` envelope, calls `aws___run_script`, exposes the configurable timeout, and names the failure cause on stderr. Also verified a malicious secret id still yields syntactically valid generated code (injection-safety).
- Ran e2e test that created a secret and fetched it with the impacted script. Validated the test failed pre-fix and passed post-fix.
- AST parse / `py_compile` clean.

