### PR TITLE
feat(amazon-ses): add zero-to-first-send onboarding

### DIFF
--- a/skills/specialized-skills/messaging-and-streaming-skills/amazon-ses/SKILL.md
+++ b/skills/specialized-skills/messaging-and-streaming-skills/amazon-ses/SKILL.md
@@ -1,45 +1,207 @@
 ---
 name: amazon-ses
-description: "Configures Amazon SES V2 for production email sending — including domain identity creation, DKIM/SPF/DMARC authentication, one-shot DNS record presentation, and Route 53 automation — for developers setting up or troubleshooting SES domain verification and deliverability. Applicable when developers need to send emails from their domain via SES, verify a domain identity, configure email authentication, troubleshoot DKIM verification issues, or ensure their sending setup follows best practices. Not for email-address-only verification, Mail Manager inbound routing, SNS, Pinpoint, or WorkMail."
-version: 1
+description: "Guides Amazon SES onboarding for domain-based email sending. Covers identity configuration, production access, an optional first test send, and troubleshooting setup, authentication, or sending failures. Use when setting up SES, resuming incomplete onboarding, or leaving the sandbox. Does not cover inbound email or Mail Manager, SMS/voice, WhatsApp, SNS, Pinpoint, or WorkMail."
+version: 2
 ---
 
 # Amazon SES
 
+## Overview
+
 > **Recommended**: Use the [AWS MCP Server](https://docs.aws.amazon.com/aws-mcp/latest/userguide/what-is-mcp-server.html) with SES permissions for sandboxed execution and CloudTrail audit logging.
 > **Without MCP**: All operations use standard AWS CLI syntax (`aws sesv2 ...`).
 
-## Overview
+Takes a developer who is not an email authentication expert from an empty AWS account to a
+real, authenticated email in their inbox, and on to production sending if AWS approves the
+request.
 
-This skill helps developers and DevOps engineers configure Amazon SES for production email sending. It targets users who are not email authentication experts — guiding them through complete domain setup following AWS best practices without requiring deep knowledge of DKIM, SPF, or DMARC.
+Read the account and identity state before touching anything, and complete only the parts of
+domain setup that are actually missing. Request production access only after domain setup is
+complete and the user has given explicit consent. A test send is optional: run it when the user
+asks for one, to a recipient the account's current state permits.
 
 ## Routing
 
 | If the user wants to... | Read |
 |-------------------------|------|
+| Get started with SES, set up email sending, send a first or test email, move out of the sandbox, or diagnose `MessageRejected: Email address is not verified` | [SES onboarding: zero to first delivered email](references/onboarding.md) |
 | Set up a domain for sending, configure email authentication, or troubleshoot DKIM | [Setting up SES domain identity](references/setting-up-ses-domain-identity.md) |
 
-## Security
+## Guardrail — where this skill's own files live (MCP vs local install)
 
-- Use IAM roles with ephemeral credentials (STS) — never long-lived access keys
-- Scope IAM permissions to specific SES actions per workflow (see reference files for required permissions)
-- Enable CloudTrail for SES API call auditing
-- DMARC `p=none` is monitoring only — plan progression to `p=quarantine` after confirming alignment
-- Never hardcode credentials, endpoints, or secrets in examples
+This skill can be loaded two ways, and they resolve its own bundled files from different places. Determine how the skill was loaded before reading a reference:
+
+- **Loaded through the AWS MCP `retrieve_skill` tool:** the skill is not on the local filesystem. **You MUST fetch each reference** via `retrieve_skill` with the `file` parameter (e.g. `file="references/onboarding.md"`). Do NOT `file_read` these paths locally — they do not exist on disk.
+- **Installed locally** (e.g. `~/.kiro/skills/amazon-ses/`, `.kiro/skills/amazon-ses/`, or `~/.claude/skills/amazon-ses/`): read files from the local skill directory using the relative paths above.
+
+This distinction applies only to the skill's own packaged files. User data and session artifacts are always read from and written to the user's working directory — never fetch or write customer data through `retrieve_skill`.
 
 ## Critical Rules
 
-- **MUST** create a domain identity (not email identity) for production sending
-- **MUST** configure custom MAIL FROM subdomain for SPF alignment
-- **MUST** configure DMARC TXT record (`p=none` minimum) for domain alignment
-- **MUST** present all DNS records together in one batch
-- **MUST** ask user for preferred MAIL FROM subdomain (do not assume a default)
-- **SHOULD** check if Route 53 hosts the domain and offer automatic DNS creation
-- **SHOULD NOT** claim 72-hour wait — verification typically completes in minutes once DNS propagates
+- **MUST** use the SES v2 API: `aws sesv2 ...`, never the v1 `aws ses ...` commands. A v1
+  command reports no error signalling the wrong API was chosen, so the mistake is silent, and
+  the operations this journey needs — production-access requests, and DKIM plus MAIL FROM
+  attributes in a single identity read — exist only in v2. Models trained on published CLI
+  examples tend to default to the v1 syntax.
+- **MUST NOT** volunteer API version mechanics, internal limit figures, or other plumbing.
+  Explain only what the user has to decide, consent to, pay for, or act on. Surface the rest
+  only when they ask, when their problem turns on it, or when a reference file names the
+  disclosure as required.
+- **MUST** ask for missing inputs in ONE question set rather than one at a time — and **MUST NOT**
+  ask for inputs the request does not need. Scope the questions to what the user asked for: a
+  request that already names the domain and MAIL FROM subdomain is a complete domain-setup
+  request, so read state and execute rather than stalling for send-time or production-access
+  inputs. If nothing is missing for the chosen scope, ask nothing.
+- **MUST NOT** ask which AWS CLI profile or Region to use while either can still be resolved.
+  Honour `--profile` only if the user names one. **Resolve the Region in this order, taking the
+  first that yields a value:** a Region the user named; `AWS_REGION`; `AWS_DEFAULT_REGION`;
+  `aws configure get region`, adding `--profile '{PROFILE}'` when the user named a profile, since
+  a profile can carry its own Region. That last command reads the CLI configuration files only and
+  does **not** see the environment, which is why the two environment variables are checked
+  separately and ahead of it. **State the resolved Region before any mutation**, because SES state
+  is per-Region, and report the account and principal from `aws sts get-caller-identity`. Two
+  cases, and only these two, are where you do ask: nothing in that chain yields a Region, because
+  every `aws sesv2` call fails without one; and `aws sts get-caller-identity` fails on expired or
+  invalid credentials, in which case ask which account (profile) and Region to use once they are
+  refreshed, because the configured defaults are no longer trustworthy. Fold either into the one
+  question set rather than spending an extra turn on it.
+- **MUST** pass request payloads (change batches and message content) to the CLI as inline JSON
+  strings, never as `file://` paths — `file://` is AWS-CLI-specific and does not resolve when
+  the CLI is executed through the AWS MCP server.
+- **MUST** read current state before each step and skip steps already satisfied. In particular:
+  never call `create-email-identity` for an identity that already exists (it returns
+  `AlreadyExistsException`), and never re-run `put-email-identity-dkim-signing-attributes` on an
+  identity whose `DkimAttributes.Status` is `SUCCESS`, because re-initialising can change its
+  tokens. **Gate that call on status, not on whether the published CNAMEs resolve** — on a
+  `FAILED` identity the records often do resolve and are simply not being honoured, which is
+  what `FAILED` means, so resolving records are not a reason to withhold the recovery. The
+  status-gated recovery paths, and the BYODKIM check that precedes them, are owned by
+  `setting-up-ses-domain-identity.md`.
+- **For domain setup, create a domain identity.** Create an email-address identity only when the
+  user explicitly chooses verification of that individual address.
+
+## Invariants
+
+These hold everywhere in this skill. The reference files apply them, and may add
+workflow-specific detail on top of them — a reference may state how an invariant is checked at a
+particular step, or narrow it for that step's state. None of them may contradict or relax what is
+written here.
+
+- **Domain setup complete** means all three of these are true in one
+  `aws sesv2 get-email-identity` response: `VerifiedForSendingStatus` is `true`, **and**
+  `DkimAttributes.Status` is `SUCCESS`, **and** `MailFromAttributes.MailFromDomainStatus` is
+  `SUCCESS`. Two of the three is not complete. While `MailFromDomainStatus` is `PENDING`,
+  `FAILED` or `TEMPORARY_FAILURE`, AWS documents that SES uses the custom MAIL FROM fallback
+  setting: with `USE_DEFAULT_VALUE` it sends using a subdomain of `amazonses.com`, so SPF
+  validates but the envelope sender does not align with the `From` domain and DMARC cannot
+  pass on its SPF leg; with `REJECT_MESSAGE` SES returns `MailFromDomainNotVerified` and does
+  not attempt delivery. This is the gate the rest of the skill calls "domain setup complete".
+- **Sandbox recipient rule.** While `ProductionAccessEnabled` is `false`, AWS documents that
+  you can only send **to** verified email addresses and domains, or to the Amazon SES mailbox
+  simulator. That means, in the order this skill always presents them: (1) an address verified
+  as its own email identity, (2) the Amazon SES mailbox simulator, or (3) any address at **any**
+  verified domain in the account — not only the domain just set up. The restriction is on the
+  **recipient**, not the sender: a fully verified sending domain does not lift it, and you must
+  never attempt to work around it. **Production access is governed by `ProductionAccessEnabled`
+  alone** — while it is `false`, these three options apply whatever `Details.ReviewDetails.Status`
+  says. When you explain the restriction to a user, you MUST name all three recipient options that
+  work right now, in that same numbering, before proposing production access as the remedy, and you MUST NOT
+  describe the restriction as "each recipient must be individually verified": a verified **domain**
+  covers every address at that domain.
+- **The sender must be verified too, in every account state.** AWS documents that after an
+  account moves into production "you still have to verify all identities that you use as
+  'From', 'Source', 'Sender', or 'Return-Path' addresses." So `MessageRejected: Email address
+  is not verified` has two causes: an unpermitted recipient in the sandbox, and an unverified
+  sending identity in any state. Read the address named in the error before choosing a fix,
+  and check that the From address is at a domain or address verified in this Region.
+- **A verified sender is the SES service minimum; this skill's journey asks for more.** SES
+  itself will accept a send from an identity that is verified for sending even when DKIM has not
+  reached `SUCCESS`. This skill deliberately does not stop there: its goal is a **delivered,
+  authenticated** first email, so it requires `DkimAttributes.Status: SUCCESS` before it claims
+  domain setup or authentication is complete, and before it sends. That stricter bar is stated
+  once, as the send prerequisite in `onboarding.md`'s domain-verification step, and every send
+  path applies it. The two are not in conflict — one is what the service enforces, the other is
+  what this journey promises the user.
+- **Validate every substituted value, then quote it for its context.** A value interpolated
+  directly into a shell command is single-quoted; a value placed inside inline JSON is
+  JSON-encoded (double quotes, per JSON rules), and only the whole JSON blob is single-quoted
+  for the shell — never shell-quote an individual value inside JSON. This applies to **every** user-supplied value this skill substitutes —
+  `DOMAIN`, the MAIL FROM subdomain, `FROM_ADDRESS`, `TEST_RECIPIENT`, `CHOSEN_RECIPIENT`,
+  `MAIL_TYPE`, `WEBSITE_URL`, `REGION`, `PROFILE` — not only the DNS names. Reject any value
+  containing a
+  single or double quote, a backtick, `$`, `;`, a backslash, or whitespace, and ask the user to
+  re-provide it; never escape a rejected value into shape. Per-value shapes: `DOMAIN` and the
+  MAIL FROM subdomain — DNS labels only, letters, digits, hyphens and dots; From address and
+  **every recipient value, `TEST_RECIPIENT` and `CHOSEN_RECIPIENT` alike** — a single address
+  with one `@`, and reject a comma-separated list (put multiple
+  recipients in the `ToAddresses` array instead); `MAIL_TYPE` — exactly `TRANSACTIONAL` or
+  `MARKETING`; `WEBSITE_URL` — an `http`/`https` URL of 1–1000 characters, which need **not** be
+  at the verified domain, since any business site the mail relates to is acceptable to AWS, so
+  the question set may offer `https://{DOMAIN}` as a suggested default only; `REGION` — an AWS
+  Region code; `PROFILE` — a CLI profile name. A `CHOSEN_RECIPIENT` bound from an option the
+  skill supplies rather than the user — the mailbox simulator address — is validated the same
+  way. JSON-encode any user-supplied subject or body
+  text with a serialiser rather than pasting it between quotes.
+
+## IAM Permissions
+
+Grant only the actions the workflow being run actually calls, and nothing more — never `ses:*`
+or `*FullAccess`. Each reference file has a `Required IAM actions` section listing exactly what
+it calls; use that list, not a wildcard.
+
+Scope per-identity actions to the identity each call actually acts on:
+
+- `arn:aws:ses:{region}:{account-id}:identity/{domain}` for domain operations.
+- `arn:aws:ses:{region}:{account-id}:identity/{address}` for an email-address identity — the
+  identity used for sandbox recipient verification, and equally the From identity when the
+  sender is a separately verified email address rather than an address at the domain. A policy
+  scoped only to the domain denies those calls. **Reads are scoped the same way:** the
+  `ses:GetEmailIdentity` statement must carry the ARN of every identity actually read, which
+  includes a recipient address identity and — for sandbox recipient option 3 — the exact identity
+  ARN of the other verified domain the user names. A policy scoped only to the sending domain
+  denies that read, which reads as a broken permission rather than as a missing recipient.
+  **A send is authorized by the identity that
+  covers its From address**, so scope `ses:SendEmail` to whichever identity that is; the three cases are
+  listed in `onboarding.md`'s `Required IAM actions`.
+- Route 53 zone actions (`route53:GetHostedZone`, `route53:ListResourceRecordSets`,
+  `route53:ChangeResourceRecordSets`) to `arn:aws:route53:::hostedzone/{hosted_zone_id}`, using the
+  **bare** zone ID — `list-hosted-zones-by-name` returns `/hostedzone/Z123ABC`, so strip that prefix
+  before building the ARN or the result is double-prefixed and matches nothing. The zone **reads** are
+  needed whenever the agent checks whether Route 53 hosts the domain; only
+  `route53:ChangeResourceRecordSets` is conditional on the user approving a write.
+
+Only genuinely account-level and list actions (`sts:GetCallerIdentity`, `ses:GetAccount`,
+`ses:ListEmailIdentities`, `route53:ListHostedZonesByName`, `route53:TestDNSAnswer`) have no
+resource-level scoping and must be granted on `*`. Grant `ses:PutAccountDetails` deliberately,
+because it changes account-wide sending posture.
+
+## Security Considerations
+
+- **Ephemeral credentials.** Use IAM roles with STS — never long-lived access keys.
+- **Consent gates.** Opening a production-access review and sending a real message both commit
+  the user in ways no API can undo, and a Route 53 change can affect live traffic. Each gate —
+  the production-access consent gate, the send confirmation, and the DNS-write permission — is owned by the
+  reference file that performs the action; never proceed past one because this file summarises it.
+- **Delivery TLS is opportunistic by default.** AWS documents that SES always attempts a secure
+  connection to the receiving mail server and sends the message unencrypted if it cannot establish
+  one, and that requiring TLS means setting a configuration set's `TlsPolicy` to `REQUIRE` — a
+  configuration-set workflow outside this skill's scope.
+- **Validate and quote every user-supplied value** before it enters a shell command or inline
+  JSON. The rules and character sets are under Invariants above.
+- **Never place message bodies or recipient lists in logs.**
+- **Never hardcode credentials, endpoints, or secrets in examples.** Store any application
+  credentials in AWS Secrets Manager or Parameter Store.
+- **Enable CloudTrail** for SES API call auditing, and alarm on repeated
+  `AccessDeniedException` and unusual send volume. Encrypt the trail's log files with an AWS KMS
+  key (SSE-KMS) and restrict access to the trail's S3 bucket and CloudWatch Logs group, and
+  encrypt that log group with a KMS key (`--kms-key-id` on `create-log-group`) — SES CloudTrail
+  entries carry email addresses, domain names, and account details.
 
 ## Additional Resources
 
+- [Request production access](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html)
 - [SES Domain Verification](https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html)
 - [DKIM in SES](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dkim.html)
 - [Custom MAIL FROM](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html)
 - [DMARC Authentication](https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dmarc.html)
+- [SESv2 API Reference](https://docs.aws.amazon.com/ses/latest/APIReference-V2/Welcome.html)

--- a/skills/specialized-skills/messaging-and-streaming-skills/amazon-ses/references/onboarding.md
+++ b/skills/specialized-skills/messaging-and-streaming-skills/amazon-ses/references/onboarding.md
@@ -1,0 +1,463 @@
+# SES Onboarding: Zero to First Delivered Email
+
+> Operations below use AWS CLI syntax. For sandboxed execution, use the [AWS MCP Server](https://docs.aws.amazon.com/aws-mcp/latest/userguide/what-is-mcp-server.html).
+> The two risks here — sending on someone's behalf, and the commitments in a production-access request — are
+> gated at the steps that perform them. SKILL.md's "Invariants" own the domain-setup-complete gate, the
+> sandbox recipient rule, and the value-validation rules.
+
+## Session state
+
+Carry these forward between steps; re-read rather than assume.
+
+| Value | Format | Source |
+|---|---|---|
+| `REGION` | `us-east-1` | user if named, else `AWS_REGION`, `AWS_DEFAULT_REGION`, then `aws configure get region`; asked for only if none of those resolves |
+| `PROFILE` | CLI profile name, may be empty | user only if they name one |
+| `DOMAIN` | `example.com` | user |
+| `MAIL_FROM` | `mail.example.com` | user, Step 1 |
+| `FROM_ADDRESS` | `onboarding@{DOMAIN}` default (stated, overridable), at `{DOMAIN}` or another verified identity | defaulted at Step 1 or Step 5; overridable |
+| `TEST_RECIPIENT` | `you@example.com` | user, collected at Step 1, Step 4 or Step 5 |
+| `MAIL_TYPE` | `TRANSACTIONAL` or `MARKETING` | user, Step 3 |
+| `WEBSITE_URL` | `https://example.com` | user, Step 3 |
+| `CASE_ID` | Support case ID, may be absent | `get-account` → `Details.ReviewDetails.CaseId` |
+| `MAX_24_HOUR_SEND` | number; `-1` means unlimited | `get-account` → `SendQuota.Max24HourSend` |
+| `CHOSEN_RECIPIENT_OPTION` | `1` (verify the mailbox as its own identity), `2` (mailbox simulator) or `3` (existing mailbox at a verified domain) | selected in Step 4's "Sandbox recipient options"; **consumed in Step 5**, which picks its delivery check from it |
+| `CHOSEN_RECIPIENT` | the address the send goes to; a single address, validated like every other substituted value | in the sandbox, bound in Step 4 from the option chosen — option 1: `TEST_RECIPIENT`; option 2: `success@simulator.amazonses.com`; option 3: the mailbox the user names at an already-verified domain. With `ProductionAccessEnabled: true`, from `TEST_RECIPIENT` if it was collected, never from a null, else asked for in Step 5 |
+| `PA_DECLINED` | `true`, else unset | set `true` when the user declines production access at Step 3; routing must not re-propose it |
+| `MESSAGE_ID` | returned by the send | `send-email` |
+| `ACCOUNT_ID` | 12 digits | `sts get-caller-identity` |
+
+If `PROFILE` is set, append `--profile '{PROFILE}'` to every command; all `sesv2` commands also take
+`--region '{REGION}'`. Every substituted value is validated and single-quoted first.
+
+## Required IAM actions
+
+**This list covers only the actions this file calls.** The domain-setup leg is owned by
+`setting-up-ses-domain-identity.md`, which has its own list; the **full journey** needs the union, because
+Step 2 hands the DNS and identity-creation work to that file. Scope as SKILL.md describes; never a wildcard.
+
+- **Read, always needed:** `sts:GetCallerIdentity`, `ses:GetAccount`, `ses:ListEmailIdentities`,
+  `ses:GetEmailIdentity`. **Scope the `ses:GetEmailIdentity` statement to every identity this file reads**,
+  not only `identity/{DOMAIN}`: Step 4 reads `identity/{CHOSEN_RECIPIENT}` for option 1, and for **option 3**
+  the **exact identity ARN of the other verified domain the user names**. A policy scoped only to the sending
+  domain denies those reads, and the failure looks like a missing recipient rather than a missing permission.
+- **Write, only for the scope actually being run.** A read-only or domain-setup-only request needs
+  **none of the three writes below**, though domain setup still needs the other file's writes:
+  - `ses:PutAccountDetails` — only when requesting production access (Step 3).
+  - `ses:SendEmail` — only when a first or test send is in scope (Step 5).
+  - `ses:CreateEmailIdentity` — **two distinct scopes, and only one belongs here.** Creating the **domain**
+    identity is owned by `setting-up-ses-domain-identity.md`, scoped to `identity/{DOMAIN}`. What this file
+    calls it for is narrower: verifying an individual **address** as a sandbox recipient (Step 4, option 1),
+    scoped to `identity/{CHOSEN_RECIPIENT}`. A policy scoped only to the domain denies that call.
+- Narrow `ses:SendEmail` so a confused or compromised caller cannot send as anyone from this domain.
+  **Scope the statement to the identity that authorizes `{FROM_ADDRESS}`** — three cases: an address at
+  `{DOMAIN}` (the default and common case) → `identity/{DOMAIN}`; an address verified as its **own email
+  identity** → `identity/{FROM_ADDRESS}`; an address at a **different** verified domain → that domain's
+  identity ARN. Then pin the sender with the `ses:FromAddress` condition key:
+
+  ```json
+  {
+    "Effect": "Allow",
+    "Action": "ses:SendEmail",
+    "Resource": "arn:aws:ses:{REGION}:{ACCOUNT_ID}:identity/{DOMAIN}",
+    "Condition": {"StringEquals": {"ses:FromAddress": "{FROM_ADDRESS}"}}
+  }
+  ```
+
+  `ses:FromAddress` is an exact string match, so pin it to the `{FROM_ADDRESS}` collected for this workflow —
+  pinned elsewhere it denies every send and reads like a broken permission.
+
+## How to run this: check, then do
+
+Every step is **check, then do**: read current state first, and if a step is already satisfied say so in one
+line (`✓ Domain already verified`) and move on.
+
+**Precedence: identity state is evaluated before review state**, and a `Details.ReviewDetails` row never
+overrides identity state. **The table is ordered to match**: account-state rows, then identity rows, then
+review rows. Two thresholds matter and differ: the **full** domain-setup-complete gate, which Step 3
+requires, and the narrower **send prerequisite** stated in Step 2. Route to Step 2 before a send only when
+that prerequisite fails — read it in Step 2, not from a row.
+
+| State you read | Do this |
+|---|---|
+| `ProductionAccessEnabled: true` **and** `SendQuota.SentLast24Hours > 0` | Already sending **in this Region** — `SentLast24Hours` is account-wide within the Region, so it says nothing about this identity. **The user's stated intent decides what happens next.** A **new domain or Region** → Step 2, then Step 5; Steps 3 and 4 are already satisfied. A question about an existing send → do NOT run the journey; route it to [Failure modes](#failure-modes), or to `setting-up-ses-domain-identity.md`'s "Troubleshooting: DKIM Stuck in PENDING" and "Step 7" sections for stuck DKIM or MAIL FROM. If intent is ambiguous, ask: setting something new up, or debugging an existing send? |
+| `ProductionAccessEnabled: true`, no sending yet | Skip Steps 3 and 4 — **the identity rows below still apply**, so this row does not skip Step 2. Bind `CHOSEN_RECIPIENT` from `TEST_RECIPIENT` if it was collected, never from a null; if not, Step 5 asks. Then Step 5. |
+| No domain identity | Start at Step 2. |
+| Domain identity exists and the domain-setup-complete gate passes | Skip Step 2. |
+| Domain identity exists, `DkimAttributes.Status` is not `SUCCESS` | Do NOT create it again — that returns `AlreadyExistsException`. Go to Step 2, which routes to `setting-up-ses-domain-identity.md`'s Step 2 existing-identity branch and adds only what is missing. |
+| Domain identity exists, `MailFromDomainStatus` is `PENDING`, `FAILED` or `TEMPORARY_FAILURE` | The full gate has not passed, so Step 3 is unavailable. Whether a **send** may proceed turns on `BehaviorOnMxFailure` — apply Step 2's send prerequisite: `USE_DEFAULT_VALUE` permits it, `REJECT_MESSAGE` does not. Either way, do not re-create the identity or re-run DKIM signing setup. |
+| Domain identity exists, `MailFromAttributes` **absent** | No custom MAIL FROM was ever configured — the field is optional, so this differs from `PENDING`. The full gate has not passed, so Step 3 is unavailable. Go to Step 2 for the MAIL FROM step only; do not re-create the identity or re-run DKIM signing setup. |
+| Domain identity exists and **any** other reason leaves the gate unmet — including `VerifiedForSendingStatus: false` while DKIM and MAIL FROM both read `SUCCESS` | Treat it like the rows above: the gate has not passed, so Step 3 is unavailable. Go to Step 2, and **name the field that failed** rather than reporting the two that passed. Do not re-create the identity. |
+| `Details.ReviewDetails.Status: PENDING` | A request is in flight. Do NOT submit another. If Step 2's send prerequisite is not met, go to Step 2 first — a pending review does not give you a verified sender. Once met, Step 4 owns this branch and routes to "Sandbox recipient options". |
+| `Details.ReviewDetails.Status: GRANTED` | Skip Step 3 — the request has already been decided, so never resubmit. `ProductionAccessEnabled` alone governs the sandbox: `true` → confirm with Step 4, then Step 5. Still `false` → the sandbox applies, so bind a permitted recipient through Step 4's "Sandbox recipient options" before Step 5. |
+| `Details.ReviewDetails.Status: DENIED` | Do NOT resubmit. Step 4 owns this branch — the Support case at `CASE_ID`, an absent or closed `CaseId`, and the route into "Sandbox recipient options" that keeps Step 5 available while the case is pursued. |
+| `Details.ReviewDetails.Status: FAILED` | AWS did not receive the request. Submitting again at Step 3 is safe, then through Step 4 (the new review is `PENDING` — bind the recipient there) to Step 5. |
+| `Details.ReviewDetails` absent | No request has ever been submitted in this Region. Step 3 is safe once the domain gate passes — but only run it if the user wants production access and `PA_DECLINED` is not set. Otherwise the account is still in the sandbox: go to Step 4's "Sandbox recipient options" to bind a permitted recipient, then Step 5. |
+
+## Step 1: Preflight — one question set, then read state
+
+**Ask in ONE message, and ask only for what the request needs.** Do not drip-feed questions; equally, do not
+block domain setup on inputs belonging to a later step. **Never ask for anything already supplied, and never
+ask for the AWS CLI profile or Region** — SKILL.md's Critical Rules own both, including the two
+credential/Region cases where you do ask. Two ordering requirements here.
+
+First, **run `aws sts get-caller-identity` before composing the question set** — credentials found dead
+afterwards throw the answers away and may have pointed at the wrong account. If it fails, say how to refresh
+them and ask, in the same message, which account (profile) and Region to use once back.
+
+Second, **resolve the Region by SKILL.md's precedence chain before any `aws sesv2` call** — user-named,
+`AWS_REGION`, `AWS_DEFAULT_REGION`, then `aws configure get region` (profile-aware). If none yields a value,
+ask for one in the same question set. Bind it as `REGION` and **state it before any mutation**.
+
+**Scope the question set to the request:**
+
+| The user asked for… | Ask only for | Defer |
+|---|---|---|
+| Domain setup / verification only | sending domain; MAIL FROM subdomain | everything else, until they ask to send |
+| The full journey to a delivered email | sending domain; MAIL FROM subdomain; test recipient (From address is defaulted, not asked) | mail type and website URL — collected **at Step 3**, never at preflight |
+| Production access | sending domain; MAIL FROM subdomain | mail type and website URL — collected **at Step 3**; From address defaulted, test recipient deferred to Step 5. Production access requires the domain gate first, so this routes through Step 2 then Step 3; it is not a shortcut past domain setup. |
+
+**The From address is never one of the questions.** Default it to `onboarding@{DOMAIN}` — the bare address,
+with no display name — **state** it in the same message as the question set, and invite an override in the
+same breath. Bounce notices arrive there by default, so a real mailbox is worth having. Because it is stated
+rather than asked, the question set **for the full journey** carries three items.
+
+> Example, for the full journey:
+>
+> To get you from nothing to a delivered email I need three things:
+>
+> 1. **Sending domain** — the domain you want mail to come from, e.g. `example.com`. You need to be
+>    able to add DNS records for it.
+> 2. **MAIL FROM subdomain** — a subdomain used as the envelope sender, which is what makes SPF
+>    align. Common choices are `mail.example.com` or `bounce.example.com`; pick one.
+> 3. **Test recipient** — an email address you can actually open, to receive the first message.
+
+**MUST NOT ask for mail type or website URL before Step 3 — not even when the user says they want production
+sending.** Production access requires a verified domain first, so asking up front delays the identity
+creation that has to happen anyway.
+
+**If the user overrides the From address, check it against the sending domain.** An override not at
+`{DOMAIN}` is held until the state read below — an address at another identity already verified in this
+Region is also legitimate. At no verified identity, say so and ask for one that is.
+
+Then read state before doing anything:
+
+```bash
+aws sts get-caller-identity
+aws configure get region          # last resort only, after AWS_REGION and AWS_DEFAULT_REGION; add --profile '{PROFILE}' if named
+aws sesv2 get-account --region '{REGION}'
+aws sesv2 list-email-identities --region '{REGION}'
+```
+
+From `get-account` read `ProductionAccessEnabled`, `Details.ReviewDetails.Status`,
+`SendQuota.SentLast24Hours` and `SendQuota.MaxSendRate`, and record `CASE_ID` and
+`MAX_24_HOUR_SEND` — read the account's own limits here rather than asserting a figure
+later — then route with the table above. Two fields decide whether the journey can run at all:
+`SendingEnabled: false` means sending is switched off in this Region and no send will succeed;
+`EnforcementStatus` of `PROBATION` or `SHUTDOWN` means a reputation problem this workflow does not address
+(`HEALTHY` is the good value). Surface either and stop.
+
+From `list-email-identities`, note whether `{DOMAIN}` is present. If it is, read it with
+`get-email-identity` before deciding anything — presence alone does not mean the gate passes.
+
+## Step 2: Verify the sending domain
+
+Create a domain identity with Easy DKIM, add a custom MAIL FROM subdomain for SPF alignment, and publish a
+DMARC record — then present **all** DNS records in a single batch.
+
+**Do not run any create or put call from here, and do not improvise the record shapes.** The whole procedure
+lives in `setting-up-ses-domain-identity.md`, which owns the entire DNS leg — including asking the user to add
+the records and confirm they are live, so **do not ask for either a second time here**. Follow it, then return
+carrying whatever its handoff produces.
+
+SES detects the records on its own once they resolve; there is no API to force a re-check. **Do not wait
+open-endedly:** re-read the identity once the lookups resolve rather than polling on a timer, and if every
+record resolves publicly while the status has not moved, go to that file's DKIM troubleshooting section.
+
+Step 2 is complete when the domain-setup-complete gate in SKILL.md's "Invariants" passes — all three
+of its fields true in one response:
+
+```bash
+aws sesv2 get-email-identity --email-identity '{DOMAIN}' --region '{REGION}'
+```
+
+**The send prerequisite — stated here, and applied rather than redefined elsewhere.** A send may proceed when
+the identity is verified for sending with `DkimAttributes.Status: SUCCESS`, **and** either
+`MailFromAttributes.MailFromDomainStatus` is `SUCCESS` or it is unresolved with `BehaviorOnMxFailure` set to
+`USE_DEFAULT_VALUE`. It may **not** proceed while MAIL FROM is unresolved and `BehaviorOnMxFailure` is
+`REJECT_MESSAGE`: AWS documents that SES then returns `MailFromDomainNotVerified` and does not attempt
+delivery. **`MailFromAttributes` absent entirely** → no custom MAIL FROM in effect, and this journey routes
+to Step 2 because custom MAIL FROM is a MUST here. In the `USE_DEFAULT_VALUE` case SES falls back to a
+subdomain of `amazonses.com` as the envelope sender — say plainly that it will not align with `{DOMAIN}` and
+DMARC must pass on DKIM alignment alone, then go to Step 5. Never report the domain as complete in either
+state.
+
+**Why DKIM `SUCCESS` is in that prerequisite when SES itself does not require it.** Per SKILL.md's sender
+invariant, the service minimum is a verified sender; this journey holds the higher bar because it promises a
+*delivered, authenticated* first email whose `Authentication-Results` shows `dkim=pass`. If the user
+explicitly wants to send sooner, say what they give up and never silently relax the prerequisite.
+
+**Scope gate — check the requested scope before going on to Step 3 or Step 5.** A **domain-setup-only**
+request ends here: report the result, name any outstanding field, and **stop**. Do not prompt for production
+access and do not offer or perform a test send — neither was asked for, and Step 3 opens an AWS Support case
+while Step 5 sends real mail. Say in one line that both are available on request. Continue only when the
+request asked for production access, a send, or the full journey.
+
+## Step 3: Request production access
+
+**MUST confirm the domain-setup-complete gate passes before submitting.** AWS documents that "verifying your
+domain with SES before requesting production access is a best practice that helps to get your production
+access request approved faster." If the user asks to submit first, explain that and complete the domain first.
+
+**MUST get explicit consent before submitting.** The console form makes the user tick an acknowledgement box;
+the API has no parameter for it, so submitting via the CLI makes that commitment on the user's behalf. Say
+this in one paragraph and wait for a yes:
+
+> Submitting this tells AWS you will only send to people who asked for your mail, and that you
+> have a way to handle bounces and complaints. It opens an AWS Support case, and AWS documents
+> that you cannot edit your details until the review completes — there is no API to cancel or
+> withdraw it. Shall I submit it? (You can also fill in the form yourself in the SES console.)
+
+**If the user declines, accept it and move on — do NOT re-propose it.** Production access is not needed for a
+first delivered email. Say that plainly, **set `PA_DECLINED`**, skip the rest of Step 3 (do not collect
+`MAIL_TYPE` or `WEBSITE_URL`), and go to **Step 4's "Sandbox recipient options"** to bind a permitted
+recipient, then Step 5 — the account is in the sandbox, so that binding is required before the send. Do not
+raise production access again this session unless the user brings it up.
+
+Two inputs are required and collected here. Ask now if the request did not supply them — never invent either.
+Explain each in one line, because the user is choosing:
+
+- `MAIL_TYPE` — `TRANSACTIONAL` for mail a user's own action triggers, such as password resets and receipts;
+  `MARKETING` for mail sent to a list, such as promotions and newsletters.
+- `WEBSITE_URL` — the business site the email relates to; it need not be at the sending domain.
+
+```bash
+aws sesv2 put-account-details \
+  --production-access-enabled \
+  --mail-type '{MAIL_TYPE}' \
+  --website-url '{WEBSITE_URL}' \
+  --region '{REGION}'
+```
+
+- **Do NOT pass `UseCaseDescription`.** The SESv2 API marks that parameter deprecated.
+- Optional: `--additional-contact-email-addresses` (up to 4) and `--contact-language EN|JA`. AWS uses those
+  contacts for correspondence about this account, so offer only addresses **controlled by authorized members
+  of the user's own team** — never an external recipient, a customer address, or a public list.
+- **Success looks like nothing.** The API returns an empty HTTP 200 — no case ID, no status. That is
+  expected, not a failure. Read the status back in Step 4.
+- **Whenever you present or run this command, tell the user two things:** how to check the review status
+  afterwards (`aws sesv2 get-account`, read `Details.ReviewDetails.Status`), and that they can already send
+  today — naming all three options from Step 4's "Sandbox recipient options", in that numbering.
+- A second call while a review is pending returns `ConflictException` (HTTP 409); there is no API to cancel
+  or withdraw. `BadRequestException` (HTTP 400) means an input is invalid, not a refusal — see
+  [Failure modes](#failure-modes).
+
+## Step 4: Check the decision
+
+Read the whole response, not a projection — these branches turn on several nested fields:
+
+```bash
+aws sesv2 get-account --region '{REGION}'
+```
+
+Read `ProductionAccessEnabled` at the top level, and `Details.ReviewDetails.Status` and `CaseId` if
+`Details.ReviewDetails` is present at all — it is optional, and its absence is a branch below.
+
+**`ProductionAccessEnabled` alone decides whether the sandbox applies, so read that field before the review
+status.** While it is `false`, SKILL.md's sandbox recipient rule and "Sandbox recipient options" below apply
+whatever `Details.ReviewDetails.Status` says, `GRANTED` included. A `GRANTED` status does still mean the
+request has been decided, so skip Step 3 and do not resubmit.
+
+**`ProductionAccessEnabled: true`** — and only this field — lifts the sandbox restriction, so "Sandbox
+recipient options" does not apply. Bind `CHOSEN_RECIPIENT` from the `TEST_RECIPIENT` collected in Step 1 if
+there is one, never from a null; if it was never collected, Step 5 asks. Any address works now, so offer to
+change it. Then Step 5.
+
+**`ReviewDetails.Status: PENDING`** — under review. Do not tell the user to wait, and never that the account
+will be out of review in 24 hours: AWS documents an initial response within 24 hours, grants inside that
+window only "If we're able to do so", and may take longer. After that window the Support case is where AWS
+responds — read it as the `DENIED` branch describes. The account is still in the sandbox, so **go to "Sandbox
+recipient options" below**, opening with: *"Your request is in. In the meantime you can test everything end to
+end right now — you just have to send to a recipient AWS already knows about."*
+
+**`ReviewDetails.Status: DENIED`** — do not resubmit. Read the Support case at `CASE_ID`. **`CaseId` is
+optional, so it may be absent — and the case may have been closed.** Either way do not stop at "read the
+case": have the user open the SES account dashboard in the console, which shows the production-access state,
+and re-engage AWS Support with a new case referencing the denial if they want the decision revisited. **This
+is not the end of the journey:** the account is still in the sandbox, not switched off. **Go to "Sandbox
+recipient options" below**, opening with: *"The review came back denied — nothing about sandbox testing is
+lost."*
+
+**`ReviewDetails.Status: FAILED`** — AWS did not receive the request; it is safe to submit again at Step 3.
+The resubmitted review is `PENDING`, which returns here.
+
+**`Details.ReviewDetails` absent** — no request has been submitted in this Region. If the user wants
+production access, Step 3 is the next action and it is not a resubmit. If they do not, or `PA_DECLINED` is
+set, do not send them back to Step 3 — **go to "Sandbox recipient options" below**, opening with:
+*"You're still in the SES sandbox, so the first send has to go to a recipient AWS already knows
+about."*
+
+### Sandbox recipient options
+
+**This subsection is state-neutral. It applies whenever `ProductionAccessEnabled` is `false` — on all six of
+these paths:** review `PENDING`; review `DENIED`; review `GRANTED` while `ProductionAccessEnabled` is still
+`false`; review `FAILED` where the user declines to resubmit at Step 3; `PA_DECLINED` set at Step 3; and
+`Details.ReviewDetails` absent. Where a branch above supplies its own
+opening sentence, use it; the options, numbering and binding rules are identical on every one of the six.
+**No sandbox path reaches Step 5 without binding `CHOSEN_RECIPIENT` here and reading it back.**
+
+Ask which option they want, and record `CHOSEN_RECIPIENT_OPTION` and the address it resolves to as
+`CHOSEN_RECIPIENT`:
+
+> Pick whichever fits:
+>
+> 1. **Verify the mailbox you want to test with, as its own email identity** — *recommended.* AWS
+>    sends a verification message to that address; open it and click the link, which expires 24
+>    hours after the message was sent. This is the option that lets you read the delivered message
+>    and check its authentication headers.
+> 2. **`success@simulator.amazonses.com`** — the Amazon SES mailbox simulator. Nothing lands in a
+>    real inbox, so it is a fast check of the send path only, with no authentication headers to
+>    read. It works while the account is in the sandbox, is billed like any other send, and does
+>    not count against the daily sending quota (the sending rate still applies).
+> 3. **A real mailbox at a domain already verified in this account** — only if such a mailbox
+>    actually exists. Verifying a domain in SES creates no mailboxes and no MX records, so an
+>    address at the domain you just set up receives nothing unless that domain already has real
+>    mail hosting. If it does, name that mailbox; no extra verification is needed.
+
+**Set `CHOSEN_RECIPIENT` per the session-state table and read it back before Step 5.** Step 5 sends to
+`CHOSEN_RECIPIENT`, not the Step 1 answer.
+
+**Inputs differ by option.** Option 1 needs an address the user can open — if `TEST_RECIPIENT` was never
+collected, ask for it in the same message as the option choice, so it stays one question. Option 2 needs no
+address. Option 3 needs a real mailbox at a verified domain. **Never invent an address, never derive one from
+`{DOMAIN}`, and never substitute the simulator for an option the user did not choose.**
+
+**Option 1 is check-then-do.** Read the identity before creating it:
+
+```bash
+aws sesv2 get-email-identity --email-identity '{TEST_RECIPIENT}' --region '{REGION}'
+```
+
+- `NotFoundException` → create it, which sends the verification message:
+  `aws sesv2 create-email-identity --email-identity '{TEST_RECIPIENT}' --region '{REGION}'`
+- Exists with `VerifiedForSendingStatus: true` → say so in one line and go to Step 5.
+- Exists with `false` → the verification link is outstanding. Do **not** re-create it.
+
+**Then gate the send on the verification completing.** The user clicks the link out of band, so read
+the state back and do not call `send-email` until it is `true`:
+
+```bash
+aws sesv2 get-email-identity --email-identity '{TEST_RECIPIENT}' --region '{REGION}' \
+  --query 'VerifiedForSendingStatus'
+```
+
+If still `false`, wait and re-read; sending first returns `MessageRejected`, which looks like a generic
+sandbox restriction and is not one. **Bound that wait rather than looping:** have the user check that
+mailbox's spam folder, and remember that AWS documents the link expiring 24 hours after the message was sent
+— that window is the escape point, not an interval to poll through. **There is no resend here:** re-running
+`create-email-identity` returns `AlreadyExistsException` and sends no second message, and
+`SendCustomVerificationEmail` is a separate templated feature this skill does not use. An expired link is
+handled from the SES console, per [Failure modes](#failure-modes).
+
+**Option 3 is check-then-do too — verify the domain rather than trusting the name.** The user names the
+mailbox; confirm the account can send to it with `aws sesv2 list-email-identities --region '{REGION}'`:
+
+- The domain part of the named address must appear in that list as an identity in this Region. If not, this
+  option does not apply: say so and have the user pick option 1 or 2.
+- Read that identity's state before relying on it
+  (`aws sesv2 get-email-identity --email-identity '{that-domain}' --region '{REGION}'`). An unverified domain
+  identity does not make its addresses permitted recipients.
+- **Whether a mailbox exists there is not something any API can tell you.** Confirm it with the user in words.
+
+While `ProductionAccessEnabled` is `false`, SKILL.md's sandbox recipient rule applies, per Region. If the user
+asks about limits, answer from the `SendQuota` values read in Step 1 rather than asserting a figure, and note
+that AWS counts that quota by **recipients**, not messages. A `MAX_24_HOUR_SEND` of `-1` means the daily quota
+is unlimited, so report it that way. Do not raise limits unprompted.
+
+## Step 5: Send the first email
+
+**A send must have been asked for** — Step 2's scope gate stops a domain-setup-only request.
+
+**Apply Step 2's send prerequisite first, re-reading the identity rather than trusting a carried value** —
+DKIM may have moved since:
+
+```bash
+aws sesv2 get-email-identity --email-identity '{DOMAIN}' --region '{REGION}'
+```
+
+If it is not met — `DkimAttributes.Status` not `SUCCESS`, or MAIL FROM unresolved with `BehaviorOnMxFailure`
+at `REJECT_MESSAGE` — do **not** send: name the outstanding field and go back to Step 2. In the sandbox a
+permitted recipient does not substitute for this; the recipient rule and the send prerequisite are separate
+gates and both apply.
+
+**Then bind the sender and recipient.** If `{FROM_ADDRESS}` is not bound, default it to
+`onboarding@{DOMAIN}` and STATE it with Step 1's override invitation — do not ask. If `{CHOSEN_RECIPIENT}` is
+not bound — a domain-setup-only request defers it — ask for it now, in ONE question, at the point of use; in
+the sandbox it must be bound by Step 4's "Sandbox recipient options" rather than asked for freely, because an
+arbitrary address is not a permitted recipient there. **Never invent a recipient**: the From default is the
+one derived value this skill permits, because any mailbox at the verified domain is a legal sender.
+
+`{FROM_ADDRESS}` must be at `{DOMAIN}` or at another identity verified in this Region, per SKILL.md's sender
+invariant; if it is not, ask for an address at `{DOMAIN}` rather than sending.
+
+**MUST ask before sending.** A real message is about to reach a real person:
+
+> The next command sends a real email from `{FROM_ADDRESS}` to `{CHOSEN_RECIPIENT}`.
+> Ready?
+
+**Use `aws sesv2 send-email`, never the v1 form**, per SKILL.md's Critical Rules.
+
+```bash
+aws sesv2 send-email \
+  --from-email-address '{FROM_ADDRESS}' \
+  --destination '{"ToAddresses":["{CHOSEN_RECIPIENT}"]}' \
+  --content '{"Simple":{"Subject":{"Data":"SES first send check"},"Body":{"Text":{"Data":"If you are reading this, Amazon SES is set up correctly."}}}}' \
+  --region '{REGION}'
+```
+
+`--feedback-forwarding-email-address` sets where SES sends bounce and complaint notifications; left off, they
+go to `{FROM_ADDRESS}`. If that is not a monitored mailbox, set it to a deliverable address at the verified
+`{DOMAIN}` controlled by an authorized member of the user's own team — bounce notifications carry recipient
+addresses, so never an external recipient or public list. Omit the flag rather than guessing. SES is billed
+per recipient — see [Amazon SES pricing](https://aws.amazon.com/ses/pricing/) — so say that before sending.
+
+**A returned `MessageId` means Amazon SES accepted the message — not that it was delivered.** Say that
+plainly, then run the check matching `CHOSEN_RECIPIENT_OPTION`:
+
+| Situation | How you know it worked |
+|---|---|
+| `ProductionAccessEnabled: true`, or option 1 (the mailbox just verified), or option 3 (a real mailbox at a verified domain) | Open the message and view its raw headers. Find `Authentication-Results` and confirm `dkim=pass`, `spf=pass` and `dmarc=pass`. This is the only check that proves authentication. |
+| Option 2, the mailbox simulator | `success@simulator.amazonses.com` has no inbox, so there is no `Authentication-Results` header. A `MessageId` proves the send path only and proves **nothing** about DKIM, SPF or DMARC. Say so, then send the user back to Step 4's "Sandbox recipient options" to pick **option 1 or option 3** — a mailbox they can open — re-bind `CHOSEN_RECIPIENT_OPTION` and `CHOSEN_RECIPIENT` there, and return here. Do not call authentication confirmed until that second send's headers have been read. |
+| Option 3, but nothing arrives because no real mailbox exists there | Verifying a domain creates no MX records and no mailboxes, so authentication is unproven. Go back to "Sandbox recipient options", pick **option 1**, re-bind `CHOSEN_RECIPIENT` there and return here. |
+
+Where raw headers live differs by mail client — in Gmail, **More** (three vertical dots) then **Show
+original**. `dmarc=pass` appears only if a `_dmarc` TXT record is published for `{DOMAIN}` — a precondition,
+not automatic; if DMARC is missing or shows `none`, go back to the DMARC step in
+`setting-up-ses-domain-identity.md`.
+
+**If it has not arrived:** check the spam folder first, then see [Failure modes](#failure-modes). A bounce,
+if there is one, arrives by email at the feedback-forwarding address.
+
+## Step 6: After it arrives — optional extras
+
+**Only offer these once the test send has landed.** Offer once, act on a yes, do not push. **Dedicated IPs and
+tenants** exist for higher volume and for isolating senders — one line each. Do not raise pricing plans.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `MessageRejected: Email address is not verified` | Two causes — read `ProductionAccessEnabled` and the address named in the error before choosing. `false` and the named address is the recipient: the sandbox restriction is on the **recipient**, and a verified sending domain does not change it. Otherwise the unverified identity is the **sender**, which must be verified in production too. | Recipient case: go to Step 4's "Sandbox recipient options" and re-bind `CHOSEN_RECIPIENT`. Production access removes the restriction but is not the only fix. Sender case: verify the named From or Return-Path identity in this Region, or send from an address at `{DOMAIN}`. **If that identity is verified but its `DkimAttributes.Status` is not `SUCCESS`, this is not the fix** — re-apply Step 2's send prerequisite and complete DKIM first, because this journey's bar is an authenticated message, not merely an accepted one. |
+| `MessageRejected` right after verifying a recipient address | The verification link has not been clicked. | Read `VerifiedForSendingStatus` on that identity and wait for `true` — Step 4's gate. |
+| `AlreadyExistsException` on `create-email-identity` | The identity already exists in this Region. | Read it with `get-email-identity` and add only what is missing. Never create over an existing identity. |
+| `ConflictException` on `put-account-details` | A review is in flight. | Read `Details.ReviewDetails.Status`. Do not resubmit. |
+| `BadRequestException` on `put-account-details` | An input is invalid — not a refusal. | `MailType` must be `MARKETING` or `TRANSACTIONAL`; `WebsiteURL` 1–1000 characters; at most 4 extra contacts; `ContactLanguage` `EN` or `JA`. Fix and resubmit. |
+| `MailFromDomainStatus: FAILED` or `TEMPORARY_FAILURE` | `FAILED` is terminal — AWS documents that SES then "no longer attempts to detect the required MX record", so re-reading never clears it. `TEMPORARY_FAILURE` means SES could not determine the status and is still searching. | Both belong to the MAIL FROM step in `setting-up-ses-domain-identity.md`: confirm **exactly one** MX record on the subdomain in the authoritative zone, then restart the setup there for `FAILED` only. Do not re-create the identity, and do not re-call `put-email-identity-mail-from-attributes` with unchanged values. |
+| `ThrottlingException` (HTTP 400), `Daily message quota exceeded` | Sends in the last 24 hours reached `SendQuota.Max24HourSend`. | Compare `SentLast24Hours` against `Max24HourSend` — **unless `Max24HourSend` is `-1`, which means the daily quota is unlimited: the comparison does not apply and this is not the cause, so look at `MaxSendRate` instead.** With a real limit, the quota is computed over a rolling 24-hour window, so it clears only as that window advances — do not present production access as an instant fix. |
+| `ThrottlingException` (HTTP 400), `Maximum sending rate exceeded` | Sends exceeded `SendQuota.MaxSendRate`. | Reduce the send rate and send one recipient per `SendEmail` call; AWS documents waiting an interval (up to 10 minutes) and then retrying. |
+| `MessageId` returned but nothing arrived | Accepted ≠ delivered. | Check spam, then the domain's DMARC policy, and read the bounce notification SES forwards to the feedback-forwarding address. |
+| Header shows `dmarc=none`, `dmarc=fail`, `spf=fail`/`neutral`, or `spf=pass` with DMARC's SPF leg failing | Missing or misaligned DNS, not a send problem: no `_dmarc` record; a From domain aligning with neither the DKIM `d=` domain nor SPF; an SPF record on the MAIL FROM subdomain that is missing, wrong or duplicated; or no custom MAIL FROM, so the `amazonses.com` envelope sender does not align. | All are fixed in `setting-up-ses-domain-identity.md` — its DMARC step for `_dmarc.{DOMAIN}`, its MAIL FROM step for SPF and envelope alignment. Also send from an address at the verified domain so `d=` matches. DKIM alignment alone can satisfy DMARC, so a failing SPF leg is not necessarily fatal. |
+| `AccessDeniedException` | Missing `ses:` permissions. | Compare the caller's policy against "Required IAM actions" above, plus `setting-up-ses-domain-identity.md`'s for the domain-setup leg. |
+| Works in one Region, fails in another | Identities, production access and quotas are per-Region. | Verify the domain and request production access in each Region you send from. |
+| Verification email link does not work | AWS documents the link expiring 24 hours after the message was sent. | Request a new verification message from the SES console identity details page; there is no SESv2 resend operation. |
+| Every send fails regardless of recipient | `SendingEnabled: false` for the account in this Region. | Read `aws sesv2 get-account`. This workflow cannot change that account-level state; contact AWS Support. |

--- a/skills/specialized-skills/messaging-and-streaming-skills/amazon-ses/references/setting-up-ses-domain-identity.md
+++ b/skills/specialized-skills/messaging-and-streaming-skills/amazon-ses/references/setting-up-ses-domain-identity.md
@@ -1,146 +1,284 @@
 # Setting Up SES Domain Identity
 
 > Operations below use AWS CLI syntax. For sandboxed execution, use the [AWS MCP Server](https://docs.aws.amazon.com/aws-mcp/latest/userguide/what-is-mcp-server.html).
-
-## Contents
-
-- [Overview](#overview)
-- [Required IAM Permissions](#required-iam-permissions)
-- [Parameters](#parameters)
-- [Step 1: Verify Prerequisites](#step-1-verify-prerequisites)
-- [Step 2: Check Existing Identity State](#step-2-check-existing-identity-state)
-- [Step 3: Create Domain Identity with DKIM](#step-3-create-domain-identity-with-dkim)
-- [Step 4: Configure Custom MAIL FROM](#step-4-configure-custom-mail-from)
-- [Step 5: Build DMARC Record](#step-5-build-dmarc-record)
-- [Step 6: Present ALL DNS Records Together](#step-6-present-all-dns-records-together)
-- [Step 7: Verify DNS Propagation](#step-7-verify-dns-propagation)
-- [Troubleshooting: DKIM Stuck in PENDING](#troubleshooting-dkim-stuck-in-pending)
-- [Security Considerations](#security-considerations)
+> SKILL.md's "Invariants" own the domain-setup-complete gate and the value-validation and single-quoting
+> rules this file relies on.
 
 ## Overview
 
-Complete workflow for domain-based email authentication in Amazon SES V2. Creates a domain identity with Easy DKIM, configures a custom MAIL FROM subdomain for SPF alignment, and establishes a DMARC monitoring policy — aligned with the SES Guided Onboarding wizard.
+This file owns the whole DNS and identity leg of SES domain setup. It assumes the sending domain is not yet
+fully set up in this Region, and it is finished when SKILL.md's domain-setup-complete gate passes.
 
-## Required IAM Permissions
+**Rules this file owns:**
 
-```
-ses:CreateEmailIdentity
-ses:GetEmailIdentity
-ses:PutEmailIdentityMailFromAttributes
-ses:PutEmailIdentityDkimSigningAttributes
-ses:DeleteEmailIdentity
-```
+- **MUST** ask which MAIL FROM subdomain to use; suggest one, never default it (Step 4).
+- **MUST** publish DMARC `p=none` or stronger, and preserve a stronger existing policy (Step 5).
+- **MUST** build each DKIM value as `{token}.{SIGNING_HOSTED_ZONE}` from the API response (Step 6).
+- **MUST** read `DkimAttributes.SigningAttributesOrigin` before any Easy DKIM handling (Step 2), and stop at the DKIM leg on any value other than `AWS_SES` — this file configures Easy DKIM only.
+- **MUST** present one batch containing only records absent or incorrect this run (Step 6).
+- **MUST NOT** use Route 53 `UPSERT` or `DELETE`. `CREATE` only.
+- **SHOULD** detect whether Route 53 hosts the domain and offer to create records there. **MUST** get permission before writing, after showing the zone, each record, TTL, conflicts, and no-overwrite or no-delete behavior.
+- **SHOULD NOT** present SES's documented 72-hour DNS search limit as the expected wait.
 
-Scope to the specific domain identity resource:
+## Required IAM actions
 
-```
-Resource: arn:aws:ses:{region}:{account-id}:identity/{domain}
-```
+Apply SKILL.md's IAM scoping, and grant only the actions the path actually taken reaches — a request that
+stops at reading state needs none of the writes. On the full journey the caller also needs `onboarding.md`'s
+list, because that file owns the account and send legs.
 
-Add `route53:ChangeResourceRecordSets` and `route53:ListHostedZonesByName` if automating DNS in Route 53. Scope to the hosted zone: `Resource: arn:aws:route53:::hostedzone/{hosted-zone-id}`
+| Condition | Actions |
+|---|---|
+| Always | `sts:GetCallerIdentity`, `ses:GetEmailIdentity` |
+| Direct invocation only | `ses:GetAccount` to read account state before a write. Reuse `onboarding.md`'s result when entering from there. |
+| Identity absent | `ses:CreateEmailIdentity` |
+| Easy DKIM status `FAILED` or `NOT_STARTED`, and `SigningAttributesOrigin` absent or exactly `AWS_SES` | `ses:PutEmailIdentityDkimSigningAttributes`. Never grant or call it for `SUCCESS`, `PENDING`, `TEMPORARY_FAILURE`, or any `SigningAttributesOrigin` other than `AWS_SES`. |
+| Configure custom MAIL FROM for the first time (`MailFromAttributes` absent), restart it, or change the fallback with consent | `ses:PutEmailIdentityMailFromAttributes` |
+
+Scope SES identity actions to `arn:aws:ses:{region}:{account-id}:identity/{domain}`.
+
+**Route 53 splits into reads and one write.** The reads — `route53:ListHostedZonesByName`,
+`route53:GetHostedZone`, `route53:ListResourceRecordSets` — are needed whenever the agent checks whether
+Route 53 hosts the domain, so grant them for that check alone. Add `route53:TestDNSAnswer` only for Step 1's
+narrow lookup fallback, and `route53:ChangeResourceRecordSets` only after the user has approved a write. Scope
+them per SKILL.md, using the **bare** zone ID; `ListHostedZonesByName` and `TestDNSAnswer` require
+`Resource: *`.
 
 ## Parameters
 
-Collect ALL parameters from user upfront before executing any steps. Present them together with explanations so the user can make informed choices in a single response.
+**Entry from `onboarding.md`:** reuse its `DOMAIN`, `REGION`, `MAIL_FROM` and `PROFILE`. Do not ask again.
 
-| Parameter | Required | Default | Description |
-|-----------|----------|---------|-------------|
-| `domain` | Yes | — | Domain to authenticate (e.g., `example.com`) |
-| `region` | Yes | from CLI config | AWS region (SES is region-scoped) |
-| `mail_from_subdomain` | No | — | Custom MAIL FROM subdomain. **MUST ask user** — suggest `mail.{domain}` or `bounce.{domain}` but let them choose. |
-| `behavior_on_mx_failure` | No | `USE_DEFAULT_VALUE` | Fallback behavior if MAIL FROM MX unreachable. |
-| `configure_dmarc` | No | `true` | Add DMARC TXT record. |
+**Direct invocation:** run `aws sts get-caller-identity` before collecting any inputs. If it fails, explain how
+to refresh credentials and ask which account and Region to use once they are back. Resolve the Region by
+SKILL.md's precedence chain — a Region the user named, `AWS_REGION`, `AWS_DEFAULT_REGION`, then
+`aws configure get region` with `--profile '{profile}'` when the user named a profile; that last command reads
+the CLI configuration files and not the environment, which is why the two environment variables come first.
+Only if none of them yields a value, ask for it in the same message as the other missing inputs. Ask once for
+the remaining scope, never for a profile or Region that resolved, and state the Region before any mutation.
+
+The user chooses `domain` and `mail_from_subdomain`; never derive either. Do not ask about `behavior_on_mx_failure` during normal setup. Validate and single-quote every substituted value per SKILL.md.
+
+| Parameter | Source and constraints |
+|---|---|
+| `domain` | User. DNS domain to authenticate. |
+| `region` | User if named, otherwise resolved by SKILL.md's precedence chain. SES state is Region-scoped. |
+| `profile` | User only if named. Append `--profile '{profile}'` to every command, including Route 53, so identity and DNS changes use the same account. |
+| `mail_from_subdomain` | User. Suggest `mail.{domain}` or `bounce.{domain}`. It must be a subdomain of `{domain}` — the domain being verified as this identity — and should not carry sent or received mail. |
+| `behavior_on_mx_failure` | The API defines no server default, so pass `USE_DEFAULT_VALUE` for a new identity or when `MailFromAttributes` is absent, and **preserve the existing value** on every re-setup of an identity that has it. While MAIL FROM is unresolved, `USE_DEFAULT_VALUE` sends from an `amazonses.com` subdomain and `REJECT_MESSAGE` returns `MailFromDomainNotVerified` without attempting delivery — so replacing `REJECT_MESSAGE` with the default changes sending behavior and needs Step 4's disclosure and consent. |
+
+Carry these values forward:
+
+| Value | Source |
+|---|---|
+| `DKIM_TOKENS` | `DkimAttributes.Tokens`, 3 tokens |
+| `SIGNING_HOSTED_ZONE` | `DkimAttributes.SigningHostedZone` |
+| `DKIM_ORIGIN` | `DkimAttributes.SigningAttributesOrigin`: `AWS_SES`, `EXTERNAL` (customer-managed BYODKIM keys), `AWS_SES_<REGION>` (a replica managed from another Region), or absent. Read it before any Easy DKIM handling; Step 2's gate turns on it. |
+| `hosted_zone_id` | Matched Route 53 `HostedZones[].Id` with `/hostedzone/` stripped: store the bare `Z123ABC`, which CLI flags and the IAM ARN both assume. |
+| `zone_name` | Zone matched for `{domain}` or by Step 6's parent walk; delegation and authority checks query it. |
+| `parent` | `{domain}` with its leftmost label removed, for the parent walk |
+| `RECORDS_NEEDED` | The records that are absent or incorrect this run. Step 6 owns the omission rules and presents this set, never an unconditional six records. |
 
 ## Step 1: Verify Prerequisites
 
 ```bash
 aws sts get-caller-identity
-aws sesv2 get-account --region {region}
+aws sesv2 get-account --region '{region}'   # direct invocation only — reuse onboarding.md's result when entering from there
 ```
 
-- Confirm AWS CLI v2 installed and configured
-- Confirm region supports SES
-- Note: account may be in sandbox mode (can only send to verified addresses) — inform user but proceed with identity setup
+Confirm AWS CLI v2 is configured, that the Region supports SES, and that `dig` is available — it ships in
+`bind-utils` or `dnsutils`. If `dig` is absent, use `nslookup -type=CNAME|MX|TXT '{name}'` wherever `dig`
+appears below, dropping `+short` and reading the answer section instead.
+
+If neither tool exists, do not skip or guess: ask the user to run the lookup or check the record at their DNS provider and report back. For a known Route 53 public zone, `aws route53 test-dns-answer` (which needs `route53:TestDNSAnswer`) covers record read-back only — it proves nothing about public propagation, returns no subdomain name servers, and does not work with private zones, so those still need the user's result.
+
+Stop and surface `SendingEnabled: false` or `EnforcementStatus: PROBATION|SHUTDOWN`; this workflow fixes neither. `onboarding.md` Step 1 owns `ProductionAccessEnabled`, `Details.ReviewDetails.Status`, `SendQuota` and their routing — do not repeat those reads. On direct invocation, read that step before finishing, because `ProductionAccessEnabled: false` restricts recipients even after domain verification.
 
 ## Step 2: Check Existing Identity State
 
+**Read before you create** — creating over an existing identity returns `AlreadyExistsException`:
+
 ```bash
-aws sesv2 get-email-identity --email-identity {domain} --region {region}
+aws sesv2 get-email-identity --email-identity '{domain}' --region '{region}'
 ```
 
-**If `NotFoundException`** → new identity, proceed to Step 3.
+**If `NotFoundException`** → the identity does not exist. This is the only route into Step 3.
 
-**If identity exists** → inspect and add only what's missing:
+**If identity exists** → skip Step 3 and add only what's missing.
 
-- `DkimAttributes.Status` is `SUCCESS` → DKIM verified, skip Step 3
-- `DkimAttributes.Status` is `PENDING` → DKIM creation done, DNS may be propagating. Check DNS records, skip Step 3.
-- `DkimAttributes.Status` is `FAILED` or `TEMPORARY_FAILURE` → first verify DNS records are correct (same steps as Troubleshooting section below). If DNS is correct but status remains FAILED, force re-verification:
+**First, before any DKIM status handling, read `DkimAttributes.SigningAttributesOrigin` into `DKIM_ORIGIN`.**
+This gate comes before the status branches: the whole Easy DKIM flow — the three DKIM CNAMEs and
+`put-email-identity-dkim-signing-attributes` — is wrong for an identity whose DKIM is managed elsewhere,
+whatever the status says.
 
-  ```bash
-  aws sesv2 put-email-identity-dkim-signing-attributes \
-    --email-identity {domain} \
-    --signing-attributes-origin AWS_SES \
-    --region {region}
-  ```
+- **`DKIM_ORIGIN` is exactly `AWS_SES`, or absent** → Easy DKIM. Continue with the status branches below.
+- **Any other value → this identity's DKIM is outside the scope of this onboarding. Leave DKIM entirely
+  alone.** Do **not** present the three DKIM CNAMEs, do **not** put them in `RECORDS_NEEDED`, and do **not**
+  call `put-email-identity-dkim-signing-attributes`. `EXTERNAL` means the customer manages their own signing
+  keys, which SES calls BYODKIM. An `AWS_SES_<REGION>` value means this identity is a replica whose DKIM is
+  managed from another Region, so there is no DNS or DKIM change to make here either. Tell the user which of
+  the two you read and that this workflow neither configures nor troubleshoots it, then split on
+  `DkimAttributes.Status`:
+  - `SUCCESS` → the DKIM leg is already satisfied. Continue with custom MAIL FROM (Step 4) and DMARC
+    (Step 5) only.
+  - Anything else → the domain-setup-complete gate cannot pass from here. Report that DKIM has to be
+    resolved outside this workflow, name `DkimAttributes.Status` as the outstanding field, and **stop**. The
+    full journey stops with it, because its send prerequisite needs `SUCCESS`.
 
-  This generates new tokens — present the updated CNAME records to the user.
-- `DkimAttributes.Status` is `NOT_STARTED` → DKIM not configured, proceed to Step 3
-- `MailFromAttributes.MailFromDomain` populated → MAIL FROM configured, skip Step 4
-- Check DMARC: `dig TXT _dmarc.{domain} +short` — if record exists, skip Step 5
+With `DKIM_ORIGIN` cleared, branch on `DkimAttributes.Status`:
+
+| Status | Do this |
+|---|---|
+| `SUCCESS` | DKIM verified. Do not touch DKIM, and **omit the DKIM CNAMEs from `RECORDS_NEEDED`** — they already resolve, so re-presenting them invites re-adding records the user has. |
+| `PENDING` | DKIM creation done, DNS may be propagating. Record `DkimAttributes.Tokens` and `SigningHostedZone`, check the DNS records, and re-create or re-initialise nothing. |
+| `TEMPORARY_FAILURE` | SES could not determine the status — a temporary issue determining it, not wrong records. Confirm the records resolve and re-read the identity. Do **not** re-initialise signing; that risks changing the tokens under an identity that is fine. |
+| `FAILED` | Verify the DNS records first (same steps as Troubleshooting below). If DNS is correct and the status stays `FAILED`, re-initialise signing with the call below — running it on a `FAILED` identity whose records *do* resolve is the intended path, because the published records are not being honoured anyway, which is what `FAILED` means. |
+| `NOT_STARTED` | The identity exists but signing was never initialised, so there are no tokens to publish. Do **not** go to Step 3 — that returns `AlreadyExistsException`. Enable Easy DKIM in place below. |
+
+**Re-initialising signing — the one call the `FAILED` and `NOT_STARTED` rows use.** The origin gate
+above has already been applied, so reaching here means the origin is absent or exactly `AWS_SES`:
+
+```bash
+aws sesv2 put-email-identity-dkim-signing-attributes \
+  --email-identity '{domain}' \
+  --signing-attributes-origin AWS_SES \
+  --region '{region}'
+```
+
+**Gate on status, not on whether the records resolve** — never run it on a `SUCCESS` identity, because
+re-initialising can change its tokens. The response returns `DkimStatus`, `DkimTokens` and
+`SigningHostedZone`: bind `DKIM_TOKENS` and `SIGNING_HOSTED_ZONE` from it, or re-read the identity. Compare
+those against what is published, put only the records that differ into `RECORDS_NEEDED`, and do not tell the
+user their DKIM records were rotated unless the values changed.
+
+Then branch on `MailFromAttributes`:
+
+| MAIL FROM state | Do this |
+|---|---|
+| `MailFromAttributes` **absent** | No custom MAIL FROM was ever configured. The field is optional, so this is not `PENDING`, and there is no `BehaviorOnMxFailure` to preserve. Treat it as a **fresh configuration**: run Step 4 with `USE_DEFAULT_VALUE`, and add the MAIL FROM MX and SPF TXT records to `RECORDS_NEEDED`. |
+| `MailFromDomain` equals the chosen `mail_from_subdomain` **and** `MailFromDomainStatus` is `SUCCESS` | MAIL FROM configured. Skip Step 4 and omit the MAIL FROM records from `RECORDS_NEEDED`. |
+| `MailFromDomain` is populated with a **different** subdomain | **Stop and ask.** Changing it re-points the envelope sender for every message from this identity, and setup returns to `PENDING` until the new subdomain's MX is detected; meanwhile this identity's `BehaviorOnMxFailure` governs sending. Disclose that, and offer keeping the existing subdomain as the default. **Only if the user confirms**, call `put-email-identity-mail-from-attributes` with the new subdomain (Step 4), **then** present its new MX and TXT records in Step 6 — attributes first, records after, because SES will not search a subdomain it has not been told about. |
+| `MailFromDomainStatus` is `PENDING` or `TEMPORARY_FAILURE` | SES has not finished searching for the MX record, or could not determine the status. Re-present the Step 6 MAIL FROM records, confirm they resolve, and re-read the identity. Do not re-call `put-email-identity-mail-from-attributes` **with the same values** — that does not force a re-check. Calling it to change `--behavior-on-mx-failure` is allowed here; that is Step 4's unblock. |
+| `MailFromDomainStatus` is `FAILED` | **Terminal.** AWS documents that in this state SES no longer attempts to detect the MX record and the setup process has to be restarted ([Using a custom MAIL FROM domain](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html)); re-reading will not clear it. Fix the DNS — exactly one MX record on the subdomain, in the authoritative zone — then re-run Step 4 with the same `--mail-from-domain`, preserving this identity's current `BehaviorOnMxFailure` per the Parameters table. |
+
+**The DMARC check is not in this branch** — it lives in Step 5 and runs on every path through this file.
 
 ## Step 3: Create Domain Identity with DKIM
 
+Run this only after Step 2 returns `NotFoundException`. Existing identities, including `NOT_STARTED`, stay in Step 2.
+
 ```bash
 aws sesv2 create-email-identity \
-  --email-identity {domain} \
-  --region {region}
+  --email-identity '{domain}' \
+  --region '{region}'
 ```
 
-This creates the identity with Easy DKIM (2048-bit RSA, SES-managed keys) by default.
-
-**After creation, extract DKIM tokens from the response:**
-
-- `DkimAttributes.Tokens` — array of 3 tokens used to build CNAME records
-
-**Do NOT tell user to wait 72 hours.** In practice, verification usually completes within minutes once DNS records propagate. The 72h figure is the maximum detection window (how long SES keeps polling before giving up) — see [AWS docs](https://docs.aws.amazon.com/ses/latest/dg/troubleshoot-dkim.html). If records are correct after 10 minutes, there is no API to force re-check — just wait briefly and re-query.
+This creates an Easy DKIM identity whose signing keys are SES-managed 2048-bit RSA keys. Bind `DKIM_TOKENS`
+from `DkimAttributes.Tokens` and `SIGNING_HOSTED_ZONE` from `DkimAttributes.SigningHostedZone`, re-reading the
+identity if either is absent from this response. Re-query once DNS has propagated; there is no API that forces
+a re-check. If a published record does not resolve, use "Troubleshooting: DKIM Stuck in PENDING".
 
 ## Step 4: Configure Custom MAIL FROM
 
-Use the `mail_from_subdomain` collected in the Parameters step. If user didn't specify one, ask now before proceeding:
-> "What subdomain would you like for MAIL FROM? Common choices are `mail.{domain}` or `bounce.{domain}`. This subdomain will appear in the envelope sender (Return-Path) and enables SPF alignment."
+Use the collected `mail_from_subdomain`. If missing, ask:
+
+> What subdomain would you like for MAIL FROM? Common choices are `mail.{domain}` or `bounce.{domain}`. It appears in the Return-Path and enables SPF alignment.
+
+Validate that the answer is at least one label below `{domain}`. SES rejects the apex, because MAIL FROM must
+be a subdomain of `{domain}` — the domain being verified as this identity. If the user answers with the apex,
+explain that and re-ask; never quietly substitute one of the suggestions. Left unvalidated, the call returns
+`BadRequestException` (HTTP 400), which is invalid input rather than a permissions or service failure.
 
 ```bash
 aws sesv2 put-email-identity-mail-from-attributes \
-  --email-identity {domain} \
-  --mail-from-domain {mail_from_subdomain} \
-  --behavior-on-mx-failure {behavior_on_mx_failure} \
-  --region {region}
+  --email-identity '{domain}' \
+  --mail-from-domain '{mail_from_subdomain}' \
+  --behavior-on-mx-failure '{behavior_on_mx_failure}' \
+  --region '{region}'
 ```
 
-**Note:** MAIL FROM can be configured at any time — it does not need to wait for DKIM verification.
+Preserve the identity's current `BehaviorOnMxFailure` on every re-setup, including Step 2's `FAILED` restart and subdomain-change paths, per the Parameters table. MAIL FROM configuration does not wait for DKIM verification.
+
+SES requires **exactly one MX record** on the MAIL FROM subdomain ([Using a custom MAIL FROM domain](https://docs.aws.amazon.com/ses/latest/dg/mail-from.html)). Check with `dig MX '{mail_from_subdomain}' +short`. **An existing MX takes the same show-user, user-removal path as an existing TXT — never a silent omission.** Show each MX record found and explain that SES needs only its own MX at this name. Removing MX can break inbound mail, so get explicit confirmation for each removal; the user performs removals themselves, because this skill issues no `DELETE` or `UPSERT`. If they decline, or the name receives mail, have them move MAIL FROM to a different empty subdomain and re-run Step 4 with that name. `CREATE` the SES MX only once nothing else answers there, and wait for status only after exactly the SES MX remains.
+
+If the MX cannot be published at all, offer the documented `USE_DEFAULT_VALUE` fallback only after disclosing its effect, and repeat the command with it **only on explicit agreement**. That is the allowed repeat while status is `PENDING` or `TEMPORARY_FAILURE`, because it changes fallback behavior rather than forcing detection.
+
+**The fallback does not complete domain setup — never report it as complete.** `MailFromDomainStatus` stays unresolved, so SKILL.md's gate does not pass. Report setup as **incomplete**, name `MailFromDomainStatus` as outstanding, and state the consequences: the envelope sender is a subdomain of `amazonses.com`, so SPF passes without aligning to `{domain}`, DMARC can pass only on its DKIM leg, and the Return-Path recipients see is not at `{domain}`. A **domain-setup-only** request **stops** there. On the **full journey** it is not a dead end — `onboarding.md`'s send prerequisite permits a send with `USE_DEFAULT_VALUE` and owns that decision — so return there rather than declaring the domain done.
 
 ## Step 5: Build DMARC Record
 
-Construct the DMARC TXT record for `_dmarc.{domain}`:
+**Check for an existing DMARC record first — on every path**, whether the identity was just created in
+Step 3 or already existed at Step 2, because a domain can carry a DMARC record long before SES:
+
+```bash
+dig TXT '_dmarc.{domain}' +short
+```
+
+**Normalise the answer one resource record at a time.** `dig TXT +short` prints **one line per TXT resource
+record**, and a long record appears within a line as several quoted character-strings. Strip the quotes and
+concatenate **within a single line only — never across lines**: joining two lines invents a record that does
+not exist and can make two broken records look valid. Test each line independently:
+
+- **No line begins `v=DMARC1`** → no effective DMARC policy. If some other TXT record sits on `_dmarc`,
+  say it is not a policy record and receivers will not evaluate it as one. Build the record below.
+- **More than one line begins `v=DMARC1`** → **invalid, and a blocking user action before Step 6.**
+  Receivers have no single policy to apply. Show **every** record found, in full, say that exactly one may
+  exist, and have the user decide which to keep and remove the others; this file issues no `DELETE`, so the
+  removal is their own action. **Do not put a `p=none` record into `RECORDS_NEEDED`** — a further record
+  deepens the ambiguity, and which policy survives is the user's choice. If any record found is valid with
+  `p=quarantine` or `p=reject`, **never propose the weaker policy**: what remains must be the stronger one.
+  Continue to Step 6 only after the user confirms exactly one effective policy is left, then re-run this
+  check and follow whichever single-record branch it lands on.
+- **Exactly one line begins `v=DMARC1`** → read it back. **Skip creating a record only when it is valid:
+  exactly one `p=` tag whose value is `none`, `quarantine` or `reject`.** No `p=` tag, more than one, or an
+  unrecognised value means the policy is unusable — warn, say which it is, and treat the existing record as
+  the value the user replaces.
+- **An existing valid `p=quarantine` or `p=reject` → preserve it. Never downgrade to `p=none`.** It is
+  stronger than what this file would create, and lowering it silently weakens the domain. Say it is in force
+  **now**, while the DKIM and MAIL FROM records are still propagating, so mail failing alignment meanwhile
+  may be quarantined or rejected rather than merely reported — and that changing it is the user's decision.
+- **It sets `aspf=s`** → the custom MAIL FROM subdomain will not align with a `From` at `{domain}`, so
+  DMARC's SPF leg fails even though SPF passes; DKIM alignment is then the only leg that can pass.
+
+A per-line string test is enough; do not build a DMARC parser. **Both DNS paths in Step 6
+follow this result**, and the DMARC record enters `RECORDS_NEEDED` only when the check found no
+`v=DMARC1` line at all, or found exactly one that is not valid — never while more than one exists,
+which is the blocking branch above.
+
+When a record is needed, construct the DMARC TXT record for `_dmarc.{domain}`:
 
 ```
 v=DMARC1; p=none;
 ```
 
-- `p=none` — monitoring only (reports but doesn't reject). Plan progression to `p=quarantine` → `p=reject` after confirming alignment.
-- **DMARC alignment**: MUST DKIM-align (identifier alignment between `d=` in DKIM signature and From header domain). SHOULD also SPF-align via custom MAIL FROM.
+Start at `p=none` to monitor, progress to `p=quarantine` once DKIM and SPF alignment pass consistently,
+and to `p=reject` when quarantine shows no legitimate mail failing. A domain left at `p=none` indefinitely
+has no spoofing protection.
+
+**What DMARC requires, and what this file chooses.** AWS documents that "a message passes DMARC if one or
+both of the described SPF or DKIM checks pass" — one aligned mechanism is enough. This file sets up both
+anyway, so forwarded mail (which breaks SPF) still authenticates on DKIM. That is this file's choice, not a
+DMARC requirement: never tell the user DKIM alignment is mandatory and SPF optional. The record omits
+`aspf` deliberately, because AWS documents SPF alignment as requiring the policy not to specify `aspf=s`.
+
+**No aggregate reports arrive** from that record — no `rua=` tag. Judge progression either by adding a
+`rua=mailto:` tag naming an address the user picks and accepts exposing in public DNS, or from the
+`Authentication-Results` header of test mail received; say which.
 
 ## Step 6: Present ALL DNS Records Together
 
-**Present as a single batch** — do not make the user add records one at a time:
+**Present `RECORDS_NEEDED` as a single batch** — never one record at a time, and never a record the user
+already has. Omit the DKIM CNAMEs when DKIM is `SUCCESS` with unchanged tokens, and omit all three whenever
+Step 2's origin gate read a `DKIM_ORIGIN` other than `AWS_SES`; omit the MAIL FROM MX and TXT when MAIL FROM
+is already `SUCCESS` on the chosen subdomain; omit DMARC when Step 5 found exactly one valid record, or found
+more than one `v=DMARC1` record — a blocking user action reached before this step, not a record to add. If
+`RECORDS_NEEDED` is empty, say the DNS side is complete and go to Step 7.
 
 ```
 ## DNS Records to Add
 
 ### DKIM (3 CNAME records)
-{token1}._domainkey.{domain}  CNAME  {token1}.dkim.amazonses.com
-{token2}._domainkey.{domain}  CNAME  {token2}.dkim.amazonses.com
-{token3}._domainkey.{domain}  CNAME  {token3}.dkim.amazonses.com
+{DKIM_TOKENS[0]}._domainkey.{domain}  CNAME  {DKIM_TOKENS[0]}.{SIGNING_HOSTED_ZONE}
+{DKIM_TOKENS[1]}._domainkey.{domain}  CNAME  {DKIM_TOKENS[1]}.{SIGNING_HOSTED_ZONE}
+{DKIM_TOKENS[2]}._domainkey.{domain}  CNAME  {DKIM_TOKENS[2]}.{SIGNING_HOSTED_ZONE}
 
 ### MAIL FROM (2 records)
 {mail_from_subdomain}         MX     10 feedback-smtp.{region}.amazonses.com
@@ -150,75 +288,249 @@ v=DMARC1; p=none;
 _dmarc.{domain}               TXT    "v=DMARC1; p=none;"
 ```
 
-**If Route 53 hosts the domain:**
+**Build each DKIM record value as `{token}.{SIGNING_HOSTED_ZONE}` from the values read in Step 2 or Step 3 —
+never from a remembered literal.** AWS documents this construction and states that the hosted-zone portion
+varies by AWS Region and cell
+([Creating and verifying identities](https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html)).
+If `SIGNING_HOSTED_ZONE` is missing, re-read the identity.
 
-1. Check: `aws route53 list-hosted-zones-by-name --dns-name {domain}`
-2. Verify the zone is authoritative (NS records for the domain match the hosted zone's NS records)
-3. **MUST ask user for explicit permission before creating DNS records.** Route 53 mutations can affect live traffic. Only proceed if user confirms.
-4. If permission granted, create all records via `aws route53 change-resource-record-sets`
+**Check for an existing TXT record on `{mail_from_subdomain}` before publishing the SPF record — on both
+paths below**, Route 53 and external provider alike:
+
+```bash
+dig TXT '{mail_from_subdomain}' +short
+```
+
+**Normalise one resource record at a time**, exactly as Step 5's DMARC check does. Pick the line beginning
+`v=spf1`; any other TXT record on the name is unrelated and left alone. Then:
+
+- Nothing published → add the SES SPF record as shown above.
+- An unrelated TXT record (a verification token, say) → the two may coexist, because the one-record rule
+  applies to SPF records specifically. The existing value must still be preserved.
+- Another record starting with `v=spf1` → **merge it; never publish a second.** Two SPF records on one name
+  is a `permerror`, which fails SPF outright. Show the user the existing value and merge the mechanisms into
+  one record by inserting `include:amazonses.com` **immediately before the terminal `all` mechanism**
+  (`~all`, `-all` or `?all`) — evaluation stops at `all`, so a mechanism after it is unreachable. If
+  `include:amazonses.com` is already present, no change is needed.
+
+**In Route 53, every TXT value for one name lives in a single record set**, so `CREATE` cannot add a value to
+a name that already has one. A merge — and equally, keeping an unrelated TXT value alongside the SES one — is
+therefore the **user's** action: present the complete updated value list, have them confirm it, and have them
+apply it. Never publish only the SES record on a name that already carries a TXT value; that drops what was
+there.
+
+**Determine whether Route 53 hosts the domain (steps below); if no authoritative zone is found, use the
+external DNS provider path:**
+
+1. Find the zone: `aws route53 list-hosted-zones-by-name --dns-name '{domain}'`
+
+   **Pick the zone explicitly — never the first result.** This call returns zones from that name onward in
+   lexical order, so it can include neighbouring domains and private zones, and one domain can have more
+   than one zone. Take only the entry whose `Name` is exactly `{domain}.` **and** whose
+   `Config.PrivateZone` is `false`. **Normalise its `Id` before storing it as `{hosted_zone_id}`: strip the
+   `/hostedzone/` prefix and keep the bare `Z123ABC`**, which CLI flags and the IAM ARN both assume. If more
+   than one entry matches, stop and ask.
+
+   **If no entry matches `{domain}.` exactly, walk up to the parent before concluding Route 53 cannot host
+   the records.** A sending domain is often a subdomain whose records live in an ancestor's zone: strip the
+   leftmost label to get `{parent}` and search again (`list-hosted-zones-by-name --dns-name '{parent}'`),
+   applying the same exact-name, public-zone rule at each level until a zone matches or no labels remain.
+   Record the matched zone's `Name` as `{zone_name}` — every later delegation and authority check queries
+   that name, not `{domain}`. Records for `{domain}` live in that zone as fully-qualified names.
+
+   **If the walk matched an ancestor, check it has not delegated the branch away before writing anything
+   into it** — records placed in a parent for a delegated name are never served. Either of these is a
+   **STOP**:
+
+   - In the `list-resource-record-sets` read below, an `NS` record set whose `Name` is `{domain}.` or any
+     intermediate label between `{zone_name}` and `{domain}` — with `{domain}` = `mail.sub.example.com` and
+     `{zone_name}` = `example.com`, an NS set on `sub.example.com.` counts. Ignore the NS set on
+     `{zone_name}.` itself; that is the zone's own delegation.
+   - `dig NS '{domain}' +short` returning name servers that **differ** from the found zone's
+     `DelegationSet.NameServers`. **Empty output is not a STOP** — a subdomain with no zone of its own has
+     no NS record, the normal case this walk serves.
+
+   On either signal, do not write to the ancestor zone. If the delegated child zone is in this account, find
+   it under the same exact-name, public-zone rule and use it; otherwise use the external DNS provider path
+   below.
+
+   **MUST NOT create a hosted zone — out of scope.** A child zone does not resolve until the parent
+   publishes NS delegation for it, it adds a monthly charge, and an undelegated parent zone can carry the
+   records directly. Say all of that, and if the user wants separately delegated management have them create
+   the zone and publish its delegation themselves, then return here. Never call `route53:CreateHostedZone`:
+   it is deliberately absent from this file's Required IAM actions.
+2. Verify the zone is authoritative — its delegated name servers must match what public DNS answers:
+
+   ```bash
+   aws route53 get-hosted-zone --id '{hosted_zone_id}' --query 'DelegationSet.NameServers'
+   dig NS '{zone_name}' +short   # the found zone's own name — an ancestor, not '{domain}', when the walk matched one
+   ```
+
+   A null or empty `DelegationSet.NameServers` means the zone is **not** authoritative for public DNS — what a
+   private hosted zone returns — not that the command produced no output. Treat it as not authoritative and use
+   the external-provider path.
+
+3. **If they do not match, do not write to the zone.** Records added there will not resolve and SES will never
+   detect them. Say which name servers the domain actually delegates to, and use the external DNS provider
+   path below.
+4. **Read what already exists before building the batch:**
+
+   ```bash
+   aws route53 list-resource-record-sets --hosted-zone-id '{hosted_zone_id}'
+   ```
+
+   Apply step 1's delegation check to this output **first**: an `NS` record set whose `Name` is `{domain}.` or
+   an intermediate label below `{zone_name}` is a STOP, not a record to skip over. Otherwise include only
+   absent records — the change batch is transactional ("either makes all or none of the changes"), so one
+   already-existing record set fails every other change in the request. For any record that exists with a
+   different value, show the user that value and what SES needs, and let them decide. Two collisions must
+   never be silently omitted, because omitting them leaves the SES record unpublished: **a TXT set on
+   `{mail_from_subdomain}`** goes to the merge rule above, and **an MX set on `{mail_from_subdomain}`** goes to
+   Step 4's MX rule.
+5. **MUST ask for explicit permission before creating DNS records — and show the whole change first.**
+   Route 53 mutations can affect live traffic. Present all of this before asking:
+
+   - the zone: `{zone_name}` and `{hosted_zone_id}`;
+   - every record to be created, each with its **name, type, value and TTL** — the TTL is part of the change
+     batch, so disclosing it for **every** record is what makes the consent informed, and a user who wants a
+     different TTL has to say so before the write;
+   - any conflict the `list-resource-record-sets` read found, and what happens to it (left alone and taken to
+     the show-user path, not overwritten);
+   - the confirmation that nothing existing is overwritten or deleted.
+
+   Then ask in these terms, and proceed only on an explicit yes:
+
+   > I'll add these records to `{zone_name}` (`{hosted_zone_id}`) as new records only, each with the
+   > TTL shown above — this CREATEs them and replaces or deletes nothing already in the zone. Go
+   > ahead?
+
+   If the user declines, use the external DNS provider path below.
+6. If permission is granted, write the absent records with an explicit `CREATE` action in one call.
+   **Never use `UPSERT`:** AWS documents it as updating a record set that already exists with the request's
+   values, so it silently replaces a live record. This file issues no `UPSERT` and no `DELETE`. Pass the change
+   batch **inline** — `file://` is AWS-CLI-specific and does not resolve through the AWS MCP server:
+
+   ```bash
+   aws route53 change-resource-record-sets \
+     --hosted-zone-id '{hosted_zone_id}' \
+     --change-batch '{
+       "Comment": "Amazon SES domain authentication records",
+       "Changes": [
+         {"Action": "CREATE", "ResourceRecordSet": {
+           "Name": "{DKIM_TOKENS[0]}._domainkey.{domain}", "Type": "CNAME", "TTL": 1800,
+           "ResourceRecords": [{"Value": "{DKIM_TOKENS[0]}.{SIGNING_HOSTED_ZONE}"}]}},
+         {"Action": "CREATE", "ResourceRecordSet": {
+           "Name": "{mail_from_subdomain}", "Type": "MX", "TTL": 1800,
+           "ResourceRecords": [{"Value": "10 feedback-smtp.{region}.amazonses.com"}]}},
+         {"Action": "CREATE", "ResourceRecordSet": {
+           "Name": "{mail_from_subdomain}", "Type": "TXT", "TTL": 1800,
+           "ResourceRecords": [{"Value": "\"v=spf1 include:amazonses.com ~all\""}]}}
+       ]
+     }'
+   ```
+
+   Repeat the CNAME entry for `DKIM_TOKENS[1]` and `DKIM_TOKENS[2]`, and add `_dmarc.{domain}` as a TXT entry
+   unless **Step 5's DMARC check** found exactly one valid existing record, or found more than one
+   `v=DMARC1` record — that is its blocking branch, where the extras come down to one effective policy
+   before any record is added here. Up to six records, but **only
+   those in `RECORDS_NEEDED` that the `list-resource-record-sets` read showed absent**: the batch is
+   all-or-nothing, so one already-present record fails every change with `InvalidChangeBatch`, whose response
+   carries one error message per failed change — read them to see which record collided. An existing but
+   **invalid** `_dmarc` record is not omitted by that rule: like an existing TXT on the MAIL FROM name it
+   takes the show-user path, where Step 5's record is the replacement value. Two shapes matter: **TXT values
+   keep their own enclosing double quotes inside `Value`**, escaped as shown, and the MX priority `10` is part
+   of the value string. `TTL` is the caller's choice; 1800 is an example, and whatever is used must be what
+   the consent step disclosed.
 
 **If external DNS provider:**
 
-- Present records clearly and instruct user to add them at their provider
-- Warn about common DNS provider quirks: some append the domain name automatically (so `{token}._domainkey` becomes `{token}._domainkey.example.com.example.com`)
+- Present the records in `RECORDS_NEEDED` — **only those**, each with name, type, value **and the TTL to
+  set** — and have the user add them at their provider, applying the same omissions as the Route 53 path.
+- Apply the SPF-collision check above before the SPF TXT record is added: the user publishes the merged value
+  rather than a second record. Apply Step 4's MX rule the same way — another MX on the MAIL FROM name is
+  removed, or MAIL FROM moves to another empty subdomain, before the SES MX is added.
+- Apply Step 5's DMARC result the same way: a valid record means do not ask for another; more than one
+  `v=DMARC1` record is the blocking branch, so the extras come down to one effective policy first.
+- Warn about provider quirks: some append the domain automatically, so `{token}._domainkey` becomes
+  `{token}._domainkey.example.com.example.com`.
+- Once the user confirms the records are live, go to Step 7.
 
 ## Step 7: Verify DNS Propagation
 
-After user confirms records are added:
+After the user confirms the records are added:
 
 ```bash
-# Check DKIM
-dig CNAME {token1}._domainkey.{domain} +short
+# DKIM — all three, not just the first. Status cannot reach SUCCESS until all three resolve.
+dig CNAME '{DKIM_TOKENS[0]}._domainkey.{domain}' +short
+dig CNAME '{DKIM_TOKENS[1]}._domainkey.{domain}' +short
+dig CNAME '{DKIM_TOKENS[2]}._domainkey.{domain}' +short
 
-# Check MAIL FROM MX
-dig MX {mail_from_subdomain} +short
-
-# Check MAIL FROM SPF
-dig TXT {mail_from_subdomain} +short
-
-# Check DMARC
-dig TXT _dmarc.{domain} +short
+dig MX  '{mail_from_subdomain}' +short   # MAIL FROM MX
+dig TXT '{mail_from_subdomain}' +short   # MAIL FROM SPF
+dig TXT '_dmarc.{domain}' +short         # DMARC
 ```
 
 Then confirm SES has picked up the changes:
 
 ```bash
-aws sesv2 get-email-identity --email-identity {domain} --region {region}
+aws sesv2 get-email-identity --email-identity '{domain}' --region '{region}'
 ```
 
-Look for `DkimAttributes.Status: SUCCESS` and `MailFromAttributes.MailFromDomainStatus: SUCCESS`.
+Domain setup is complete only when all three fields in SKILL.md's domain-setup-complete gate are true in this
+one response. Report which are outstanding rather than reporting "verified" on two.
 
 ## Troubleshooting: DKIM Stuck in PENDING
 
-If DKIM remains PENDING after DNS records are added:
+If DKIM remains PENDING after the records are added:
 
-1. **Get the expected tokens:**
-
-   ```bash
-   aws sesv2 get-email-identity --email-identity {domain} --region {region} \
-     --query 'DkimAttributes.Tokens'
-   ```
-
-2. **Check each CNAME resolves correctly:**
+1. **Get the expected values from the API, not from memory:**
 
    ```bash
-   dig CNAME {token}._domainkey.{domain} +short
+   aws sesv2 get-email-identity --email-identity '{domain}' --region '{region}' \
+     --query 'DkimAttributes.{tokens:Tokens, zone:SigningHostedZone}'
    ```
 
-   Expected: `{token}.dkim.amazonses.com`
+2. **Check that all three CNAMEs resolve** — Step 7's three `dig CNAME` lookups. All three must resolve
+   before the status can reach `SUCCESS`. Expected value: `{token}.{SIGNING_HOSTED_ZONE}`, built from the
+   zone read in this session, never a literal remembered from another Region or account.
 
 3. **Common causes:**
-   - DNS provider appended the domain (record is `{token}._domainkey.example.com.example.com` instead of `{token}._domainkey.example.com`)
-   - Records in wrong hosted zone (zone exists but isn't authoritative — check NS records)
-   - TTL propagation delay (typically resolves within minutes, not hours)
-   - Wildcard CNAME conflict overriding the specific DKIM record
+   - Value built from the wrong signing zone (a remembered literal, not this identity's `SigningHostedZone`)
+   - DNS provider appended the domain (record is `{token}._domainkey.example.com.example.com`)
+   - Records in a zone that exists but isn't authoritative — re-run Step 6's authority check, querying `{zone_name}`, not `{domain}`; if the name servers differ, add the records at the authoritative provider
+   - Wildcard CNAME conflict overriding the specific DKIM record, or TTL propagation delay
+   - More than one MX record on the MAIL FROM subdomain — does not affect DKIM, but blocks the MAIL FROM half of the gate
 
-4. **If records are correct but SES still shows PENDING:** SES polls DNS periodically. There is no API to force re-verification — wait a few minutes and re-query. In rare cases, SES can take up to 72 hours to detect records ([see docs](https://docs.aws.amazon.com/ses/latest/dg/troubleshoot-dkim.html)), but this typically means minutes, not hours.
+4. **If the records are correct but SES still shows `PENDING`:** there is no API to force re-verification;
+   SES will find them on its own. The SESv2 API reference documents SES searching the domain's DNS
+   configuration "for up to 72 hours"
+   ([DkimAttributes](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_DkimAttributes.html)) —
+   the outer bound of the search, not the expected wait. Re-query after DNS propagates.
 
 ## Security Considerations
 
-- Scope IAM to the specific SES actions listed in the Required IAM Permissions section above — never use `ses:*` wildcards
-- Use IAM roles (ephemeral credentials via STS) — never long-lived access keys
-- DMARC `p=none` is monitoring only — inform user to plan progression to `p=quarantine` after alignment is confirmed
-- For senders exceeding 5,000 messages/day to Gmail/Yahoo: DMARC alignment is mandatory per bulk-sender requirements. This workflow establishes the prerequisite.
-- Enable CloudTrail for SES API call auditing
+Apply SKILL.md's IAM, credential, CloudTrail and value-validation rules; the consent gate for any DNS write is
+owned by Step 6 and must not be bypassed. When a domain identity is deleted or its DKIM keys are rotated, tell
+the user to remove the DKIM CNAMEs the retired tokens point at: a CNAME left pointing at a target nobody owns
+any more is a dangling-DNS record, the same class of exposure as a subdomain takeover. Large mailbox providers
+publish their own authentication requirements for bulk senders, DMARC among them — check each provider's
+current requirements rather than assuming a threshold.
+
+## Next: what happens after the domain is set up
+
+**This depends on what the user asked for — check the requested scope first.**
+
+- **Domain setup only** (the common direct-invocation case: "set up my domain", "fix my DKIM") → **report the
+  gate result as it stands, naming all three gate fields, and stop.** Say "complete" only when all three are
+  true in one response; otherwise say it is incomplete and name the outstanding field. Step 4's
+  `USE_DEFAULT_VALUE` fallback ends here **incomplete**, and so does an identity whose DKIM is out of scope
+  per Step 2's origin gate and not already `SUCCESS`. Do not raise production access, do not offer a test
+  send, and do not route into `onboarding.md`: neither was asked for, and one opens an AWS Support case while
+  the other sends real mail. Say in one line that both are available when they want them.
+- **The user asked for the full journey, production access, or a first/test send** → a verified domain is not
+  yet a delivered email. Return to `onboarding.md` carrying `region` and `domain`; it re-reads identity state
+  with `get-email-identity` rather than relying on values carried back, so hand back no DKIM tokens or signing
+  zone. Report the gate result as it stands, and when Step 2's origin gate read a `DKIM_ORIGIN` other than
+  `AWS_SES`, report that origin and `DkimAttributes.Status` with it.
+
+If the scope is ambiguous, ask one question rather than assuming the larger one.


### PR DESCRIPTION
## Description
Extend the `amazon-ses` skill from domain identity setup to a guided onboarding journey covering account preflight, production-access requests, options for testing while the account remains in the SES sandbox, and an optional first send.

Require explicit user confirmation before requesting production access, changing DNS records, or sending a real email.


## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [x] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [ ] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
