### PR TITLE
feat: 90-minute async/ESM timeout guidance for aws-lambda-managed-instances

### DIFF
--- a/skills/specialized-skills/serverless-skills/aws-lambda-managed-instances/SKILL.md
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-managed-instances/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aws-lambda-managed-instances
-description: "Evaluates, configures, and migrates workloads to AWS Lambda Managed Instances (LMI). Runs Lambda functions on EC2 instances in the user's account while AWS manages provisioning, patching, scaling, routing, and load balancing. Triggers when queries mention Lambda Managed Instances, LMI, capacity providers, multi-concurrent execution environments, EC2-backed Lambda, persistent Lambda instances, PerExecutionEnvironmentMaxConcurrency, CapacityProviderConfig, cold start elimination via dedicated instances, migrating standard Lambda to managed instances, or cost comparison between standard Lambda and LMI with Savings Plans or Reserved Instances."
-version: 1
+description: "Evaluates, configures, and migrates workloads to AWS Lambda Managed Instances (LMI). Runs Lambda functions on EC2 instances in the user's account while AWS manages provisioning, patching, scaling, routing, and load balancing. Triggers when queries mention Lambda Managed Instances, LMI, capacity providers, multi-concurrent execution environments, EC2-backed Lambda, persistent Lambda instances, PerExecutionEnvironmentMaxConcurrency, CapacityProviderConfig, cold start elimination via dedicated instances, migrating standard Lambda to managed instances, or cost comparison between standard Lambda and LMI with Savings Plans or Reserved Instances. Also covers long-running and asynchronous workloads and the 90-minute (5400s) function timeout for asynchronous and event-source-mapping (SQS, Kinesis, DynamoDB Streams / ESM) invocations, including how to raise the function timeout up to 90 minutes / 5400s and the related duration limits."
+version: 2
 ---
 
 # AWS Lambda Managed Instances (LMI)
@@ -17,6 +17,7 @@ Runs Lambda functions on EC2 instances in the user's account while AWS manages p
 | Signal | LMI is a strong fit | Standard Lambda is better |
 |--------|---------------------|---------------------------|
 | Traffic | Steady, predictable, 50M+ req/mo | Bursty, unpredictable, long periods of no traffic |
+| Duration | Long-running asynchronous/ESM jobs that exceed 15 min (up to 90 min on LMI): ETL/data processing, media transcoding, ML inference, financial calc, web scraping | Short invocations; synchronous work needing >15 min (not supported on any Lambda) |
 | Cost | Duration-heavy spend at scale | Low or sporadic invocations |
 | Cold starts | Unacceptable (LMI eliminates for provisioned capacity) | Tolerable |
 | Compute | Latest CPUs, specific families, high network bandwidth, GPU requirements | Standard Lambda memory/CPU sufficient |
@@ -57,6 +58,8 @@ Gather these signals before recommending:
 6. **Concurrency readiness**: Thread safety? Shared `/tmp` paths? Per-invocation DB connections?
 7. **VPC**: Already in a VPC? Private resource access needed?
 
+**Long-running asynchronous/ESM jobs that exceed 15 min are a positive fit** — LMI supports a function timeout up to 90 min (5400s) for asynchronous and event-source-mapping invocations (ETL/data processing, media transcoding, ML inference, financial calc, web scraping). Duration is the key differentiator here, not just cost.
+
 When recommending LMI, ALWAYS mention: minimum 3 execution environments for AZ resiliency (cannot go below 3 in production).
 
 ### Step 2: Build the Cost Comparison
@@ -74,6 +77,7 @@ Rule of thumb: LMI becomes cost-competitive at 50-100M+ req/month with steady tr
 - **For I/O-bound workloads**: use the runtime default or higher PerExecutionEnvironmentMaxConcurrency (e.g., 10 for Node.js) since each request uses minimal CPU while waiting on network.
 - **For CPU-bound workloads**: set PerExecutionEnvironmentMaxConcurrency to 1-2 per vCPU since each request saturates CPU.
 - **Scaling**: MinExecutionEnvironments (default 3), MaxVCpuCount (optional, default 400 — set explicitly as best practice), TargetResourceUtilization.
+- **Function timeout up to 5400s (90 min)** — set via the existing `Timeout` field (CLI `update-function-configuration --timeout 5400`, SAM/CFN `Timeout: 5400`, or console). Uses the existing `Timeout` field — no separate API, property, tag, or code change is required. Applies to **asynchronous and ESM invocations only**; synchronous and On-Demand invocations stay capped at 15 min (even if `Timeout` is higher; `GetFunctionConfiguration` still reports the configured value). The Init phase is still capped at 15 min. Durable Functions: each step can run up to 90 min; a multi-step workflow up to 1 year.
 
 ### Step 4: Migrate the Code
 
@@ -143,11 +147,30 @@ Review code for concurrency safety. LMI runs multiple invocations concurrently p
 - Never manually terminate LMI EC2 instances (delete the capacity provider instead)
 - Always publish a version — unpublished functions cannot run on LMI
 
+### Long-duration invocations (asynchronous/ESM up to 90 min)
+
+- **SQS**: the queue visibility timeout MUST be ≥ the function timeout (≥ 5400s for a 90-min function). The ESM validates this on create and update — but once the ESM exists, the SQS visibility timeout and the function timeout can each be changed independently (outside the ESM API), which bypasses the check and can reintroduce a mismatch, causing messages to reappear and duplicate invokes.
+- **Kinesis / DynamoDB Streams**: enable **partial batch failure reporting** (`ReportBatchItemFailures`) and tune the max batching window and parallelization factor — otherwise one failed record retries the whole batch, re-running up to ~80 min of already-completed work.
+- **Asynchronous invocations**: failed or timed-out invocations follow the retry policy (up to 2 retries by default), then route to the DLQ / on-failure destination.
+- **Not all ESM sources qualify**: Amazon MQ and Amazon DocumentDB ESM remain limited to 15 min; only SQS, Kinesis, and DynamoDB Streams ESM (and asynchronous invocations) get 90 min.
+- **Observability is unchanged**: CloudWatch, CloudTrail (one Invoke event on completion/timeout), and X-Ray (single trace) behave identically. Use X-Ray sub-segments to find slow phases near the 90-min limit.
+
+### Long-running networking (functions now run for tens of minutes)
+
+- **NAT Gateway idle timeout** — send periodic keep-alive packets on long-lived TCP connections through a NAT Gateway.
+- **Idle connection timeouts** (RDS, ElastiCache, external APIs) — add connection health checks / reconnection logic for connections that may go idle mid-computation.
+- **DNS TTL** — re-resolve external hostnames periodically; the AWS SDK does this, but custom HTTP clients may cache beyond TTL.
+- **Credentials** — rely on the execution role's ephemeral credentials (automatically refreshed by the runtime). For non-IAM secrets (DB passwords, API keys), retrieve them from AWS Secrets Manager or SSM Parameter Store with SDK caching and periodic refresh; never embed long-lived credentials in code or environment variables.
+
 ## Limits Quick Reference
 
 | Resource | Limit |
 |----------|-------|
 | Memory | 2 GB min, 32 GB max |
+| Asynchronous/ESM invoke timeout | 90 min (5400s), via the existing Timeout field |
+| Sync + On-Demand invoke timeout | 15 min |
+| Init phase | 15 min |
+| ESM sources capped at 15 min | Amazon MQ, Amazon DocumentDB (SQS/Kinesis/DynamoDB Streams get 90 min) |
 | Execution environments | 3 minimum (MinExecutionEnvironments, AZ resiliency) |
 | Instance lifespan | 14 days (auto-replaced) |
 | Concurrency/vCPU | 64 (Node.js), 32 (Java/.NET), 16 (Python) |

--- a/skills/specialized-skills/serverless-skills/aws-lambda-managed-instances/assets/sqs-processor/template.yaml
+++ b/skills/specialized-skills/serverless-skills/aws-lambda-managed-instances/assets/sqs-processor/template.yaml
@@ -55,7 +55,10 @@ Resources:
       CodeUri: src/
       Architectures: [arm64]
       MemorySize: 4096
-      Timeout: 900
+      # Up to 5400 (90 min) for async + ESM invocations on Managed Instances (SQS is an ESM source).
+      # Uses the existing Timeout field - no separate API/property/tag/code change required.
+      # Sync/On-Demand invokes stay capped at 15 min.
+      Timeout: 5400
       CapacityProviderConfig:
         LambdaManagedInstancesCapacityProviderConfig:
           CapacityProviderArn: !GetAtt CapacityProvider.Arn
@@ -74,7 +77,10 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub sqs-processor-queue-${Environment}
-      VisibilityTimeout: 960
+      # MUST be >= the function Timeout (5400s above), or messages reappear mid-processing and are
+      # invoked again. The ESM validates this on create/update, but later independent edits to either
+      # value can reintroduce a mismatch, so keep them in sync here.
+      VisibilityTimeout: 5400
       SqsManagedSseEnabled: true
 
   ProcessorLogGroup:


### PR DESCRIPTION
## Description

Adds guidance to the `aws-lambda-managed-instances` skill for the 90-minute (5400s) Lambda function timeout for asynchronous and event-source-mapping (SQS, Kinesis, DynamoDB Streams) invocations on Managed Instances:

- Quick Decision "Duration" fit signal and a Step 1 long-running-workload note
- Configuration guidance: raise the existing `Timeout` field up to 5400s (async/ESM only; sync and On-Demand stay 15 min; Init stays 15 min)
- Limits Quick Reference rows for the new duration limits (incl. Amazon MQ / DocumentDB ESM staying at 15 min)
- Long-duration invocation caveats: SQS visibility-timeout ≥ function-timeout coupling, Kinesis/DynamoDB Streams partial batch failure reporting, async retry/DLQ behavior
- A "Long-running networking" section (NAT Gateway idle timeouts, idle connection handling, DNS TTL, credentials)
- Updates the `sqs-processor` example template to illustrate the Timeout + SQS visibility-timeout coupling

Skill `version` 1 → 2.

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [x] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
