### PR TITLE
docs(setup-instructions): split troubleshooting from onboarding runbook and streamline

### DIFF
--- a/rules/aws-agent-rules.md
+++ b/rules/aws-agent-rules.md
@@ -1,5 +1,7 @@
 # AWS Guidance
 
+- Where these AWS rules conflict with the project's own instructions, the
+  project's instructions take precedence.
 - Prefer the AWS MCP Server for AWS interactions — it provides sandboxed
   execution, observability, and audit logging. If unavailable, use the
   AWS CLI directly.

--- a/rules/aws-starter-rules.md
+++ b/rules/aws-starter-rules.md
@@ -2,6 +2,8 @@
 
 This user has signed up for the new AWS experience. This experience lets you sign into AWS using a social provider and requires the following additional context.
 
+Where this guidance conflicts with the project's own instructions, the project's instructions take precedence.
+
 ## Context
 
 ### Terminology:

--- a/setup-instructions/setup-troubleshooting.md
+++ b/setup-instructions/setup-troubleshooting.md
@@ -2,9 +2,11 @@
 
 This file contains the per-step error handling for the setup runbook. Each section corresponds to a
 step in [setup.md](setup.md). When a step fails, find the matching section below, apply the
-resolution, and resume the runbook at that step.
+resolution, and resume the runbook at that step. Each section links back to its step.
 
 ## General error handling
+
+Return to [setup.md](setup.md).
 
 If any step fails with an error not covered in that step's table below, report the full error output
 to the user and do not proceed to the next step. If installation fails, tell the customer to re-run
@@ -12,11 +14,15 @@ the set up file.
 
 ## Step 1: Determine operating system
 
+Back to [Step 1 in setup.md](setup.md#step-1-determine-operating-system).
+
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
 | Cannot determine OS | No shell access or unknown environment | Ask the user what operating system they are using |
 
 ## Step 2 (macOS or Linux): Install the AWS CLI
+
+Back to [Step 2 (macOS or Linux) in setup.md](setup.md#step-2-if-using-macos-or-linux).
 
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
@@ -35,6 +41,8 @@ the set up file.
 
 ## Step 2 (Windows): Install the AWS CLI
 
+Back to [Step 2 (Windows) in setup.md](setup.md#step-2-if-using-windows).
+
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
 | `irm` or `iex` not recognized | Running in cmd.exe instead of PowerShell | Re-run from a PowerShell session |
@@ -47,6 +55,8 @@ the set up file.
 
 ## Step 3: Log in to AWS
 
+Back to [Step 3 in setup.md](setup.md#step-3-log-in-to-aws).
+
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
 | Region not provided in prompt | User pasted the prompt without region context | Ask the user the relevant follow up question depending on their AWS experience parameter. Then, set it with `aws configure set region <value> --profile <profile_name>` |
@@ -57,12 +67,16 @@ the set up file.
 
 ## Step 4: Verify access
 
+Back to [Step 4 in setup.md](setup.md#step-4-verify-access).
+
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
 | `Unable to locate credentials` or `ExpiredToken` | `aws login` did not complete successfully | Re-run Step 3 |
 | `command not found: aws` | PATH not set correctly | Re-run `export PATH="$HOME/.local/bin:$PATH"` and retry |
 
 ## Step 5: Set up the Agent Toolkit
+
+Back to [Step 5 in setup.md](setup.md#step-5-set-up-the-agent-toolkit).
 
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
@@ -73,12 +87,16 @@ the set up file.
 
 ## Step 6: Verify Agent Toolkit installation
 
+Back to [Step 6 in setup.md](setup.md#step-6-verify-agent-toolkit-installation).
+
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
 | `Unable to locate credentials` or `ExpiredToken` | Session expired | Re-run Step 3, then retry Step 6 |
 | `Invalid choice` or `argument not recognized` | AWS CLI version doesn't include agent-toolkit commands | Re-run Step 2 to update to the latest version, then retry |
 
 ## Step 7: Get AWS experience rule
+
+Back to [Step 7 in setup.md](setup.md#step-7-get-aws-experience-rule).
 
 | Symptom | Cause | Resolution |
 |---------|-------|------------|

--- a/setup-instructions/setup-troubleshooting.md
+++ b/setup-instructions/setup-troubleshooting.md
@@ -1,0 +1,88 @@
+# Set up AWS credentials for AI tools — Troubleshooting
+
+This file contains the per-step error handling for the setup runbook. Each section corresponds to a
+step in [setup.md](setup.md). When a step fails, find the matching section below, apply the
+resolution, and resume the runbook at that step.
+
+## General error handling
+
+If any step fails with an error not covered in that step's table below, report the full error output
+to the user and do not proceed to the next step. If installation fails, tell the customer to re-run
+the set up file.
+
+## Step 1: Determine operating system
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| Cannot determine OS | No shell access or unknown environment | Ask the user what operating system they are using |
+
+## Step 2 (macOS or Linux): Install the AWS CLI
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| `command not found: curl` | Download tool is not installed | Install `curl` via the system package manager, then re-run |
+| curl exits with non-zero (e.g., exit code 22) | HTTP error or no internet connectivity | Verify network access to the download URL |
+| `missing required dependencies: ...` | `unzip` (Linux) or `pkgutil` (macOS) not installed | Install the listed dependencies, then re-run |
+| `unsupported OS` or `unsupported architecture` | Script only supports Linux (x86_64, aarch64) and macOS | Cannot proceed on this system |
+| `musl-based Linux detected` | Alpine or similar musl distro | Cannot use prebuilt binaries; direct user to source install |
+| `--system requires root` | User passed `--system` without sudo | Re-run with `sudo` or omit `--system` for user-local install |
+| `post-install check failed` | `aws --version` didn't succeed after install | Check that `$HOME/.local/bin` is on PATH; re-run the script |
+| `aws --version` returns an older version than just installed | A previous AWS CLI installation exists in a different location (e.g., `/usr/local/bin/aws` or Homebrew) and takes precedence on PATH | Run `which -a aws` to show all install locations. Inform the user which locations were found and offer two options: (1) remove the old installation, or (2) reorder PATH so the new install takes precedence. Ask which they prefer before proceeding |
+| PATH warning in output | `$HOME/.local/bin` not first on PATH | Add it to shell rc file as the script suggests, then open a new shell |
+| `Permission denied` when writing to rc file | File or directory permissions prevent writing | Check file permissions with `ls -la "$SHELL_RC"` and fix with `chmod u+w "$SHELL_RC"` |
+| RC file does not exist | File hasn't been created yet (fresh system) | Create it first with `touch "$SHELL_RC"`, then re-run the echo command |
+| Duplicate PATH entries in rc file | Step was run multiple times | Not harmful, but user can manually remove duplicate lines from their shell rc file |
+
+## Step 2 (Windows): Install the AWS CLI
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| `irm` or `iex` not recognized | Running in cmd.exe instead of PowerShell | Re-run from a PowerShell session |
+| Download/network failure | No internet connectivity or firewall blocking the URL | Verify network access to the download URL |
+| `-System requires admin privileges` | User passed `-System` without elevation | Re-run from an elevated PowerShell, or omit `-System` for user-local install |
+| `msiexec failed with exit code ...` | MSI installation failed | Check Windows Event Log for MSI errors; ensure no other AWS CLI installer is running |
+| `post-install check failed` | `aws --version` didn't succeed after install | Restart the shell so PATH changes from the MSI take effect, then retry |
+| `aws --version` returns an older version than just installed | A previous AWS CLI installation exists in a different location (e.g., `C:\Program Files\Amazon\AWSCLIV2\`) and takes precedence on PATH | Run `Get-Command aws -All` to show all install locations. Inform the user which locations were found and offer two options: (1) uninstall the old version via Apps & Features, or (2) reorder PATH so the new install takes precedence. Ask which they prefer before proceeding |
+| `LOCALAPPDATA is not set` | Rare environment issue | Set the variable or use `-System` for a Program Files install |
+
+## Step 3: Log in to AWS
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| Region not provided in prompt | User pasted the prompt without region context | Ask the user the relevant follow up question depending on their AWS experience parameter. Then, set it with `aws configure set region <value> --profile <profile_name>` |
+| command not found: `aws` | PATH not set correctly after install | Re-run `export PATH="$HOME/.local/bin:$PATH"` and retry |
+| `Profile '<profile_name>' is already configured with Access Key credentials` | User previously configured static access keys for this profile via `aws configure` | Offer the user two options: (1) Use a different profile name and re-run `aws login --profile <new_name>`, or (2) Remove the `aws_access_key_id` and `aws_secret_access_key` lines from `~/.aws/credentials` (under the `[<profile_name>]` section), then re-run `aws login --profile <profile_name>` |
+| aws login exits with non-zero | User closed the browser without completing auth, or timed out | Re-run `aws login --profile <profile_name>` and instruct the user to complete authentication in the browser |
+| Browser did not open | Headless environment or no default browser configured | Run `aws login --region <region from prompt> --profile <profile_name> --remote`. Then let the human user finish the process. |
+
+## Step 4: Verify access
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| `Unable to locate credentials` or `ExpiredToken` | `aws login` did not complete successfully | Re-run Step 3 |
+| `command not found: aws` | PATH not set correctly | Re-run `export PATH="$HOME/.local/bin:$PATH"` and retry |
+
+## Step 5: Set up the Agent Toolkit
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| `--yes` not recognized or `invalid choice` | CLI version doesn't support this flag yet | Remove the flag and retry: `aws configure agent-toolkit --region us-east-1 --profile <profile_name>` |
+| Exit code 253 or "requires interactive terminal" | Agent's bash tool runs in a non-interactive subshell; wizard cannot prompt for input | Inform the user: "Almost done! Run this command in your terminal to finish setup: `aws configure agent-toolkit --region us-east-1 --profile <profile_name>`. It's a one-time interactive wizard (~30 seconds). Once complete, come back here and I'll verify everything is working." Then proceed to Step 6 only after the user confirms completion. |
+| `Unable to locate credentials` or `ExpiredToken` | Session expired during setup | Re-run Step 3, then retry Step 5 |
+| `command not found: aws` | PATH not set correctly | Re-run `export PATH="$HOME/.local/bin:$PATH"` and retry |
+
+## Step 6: Verify Agent Toolkit installation
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| `Unable to locate credentials` or `ExpiredToken` | Session expired | Re-run Step 3, then retry Step 6 |
+| `Invalid choice` or `argument not recognized` | AWS CLI version doesn't include agent-toolkit commands | Re-run Step 2 to update to the latest version, then retry |
+
+## Step 7: Get AWS experience rule
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| HTTP 404 or download failure | URL changed or no internet connectivity | Verify network access; check if the URL is still valid at the GitHub repository |
+| Permission denied when saving file | No write access to the target directory | Create the directory with mkdir -p or run with appropriate permissions |
+| Cannot determine AI tool configuration directory | Unknown or unsupported AI coding tool | Ask the user which AI tool they are using and where its configuration directory is |
+| File saved but tool doesn't recognize it | Incorrect file path or naming convention | Verify the path matches the tool's expected location per the Agent Toolkit documentation |

--- a/setup-instructions/setup.md
+++ b/setup-instructions/setup.md
@@ -206,12 +206,20 @@ Identify which AI coding tool is in use and its rules file location (this is not
 | Cursor      | .cursor/rules/\*.mdc | .cursor/rules/ directory  |
 | Kiro        | .kiro/steering/\*.md | .kiro/steering/ directory |
 
-Retrieve the AWS experience rules file based on the AWS experience parameter, read its full contents, and save them to each detected tool's rules file (creating the directory if needed):
+Retrieve the AWS experience rules file based on the AWS experience parameter and read its full contents:
 
 - New AWS experience: <https://raw.githubusercontent.com/aws/agent-toolkit-for-aws/refs/heads/main/rules/aws-starter-rules.md>
 - Advanced AWS experience: <https://raw.githubusercontent.com/aws/agent-toolkit-for-aws/refs/heads/main/rules/aws-agent-rules.md>
 
-**Success:** Rule file is saved to the correct location for each AI tool. End the set up by telling the user:
+Then add the rules to each detected tool's rules file **without destroying existing content**. `CLAUDE.md`, `AGENTS.md`, and files under `.cursor/rules/` or `.kiro/steering/` are the project's own agent instructions — often committed to version control and carrying accumulated project rules. You MUST NOT overwrite them.
+
+- If the rules file does **not** exist, create it (creating the directory if needed) and write the retrieved rules.
+- If the rules file **already exists**, append the retrieved rules under a clearly delimited heading rather than replacing the file. Use a stable marker so the operation is idempotent — for example, wrap the content between `<!-- BEGIN AWS Agent Toolkit rules -->` and `<!-- END AWS Agent Toolkit rules -->`. If that marked block is already present, replace only the content between the markers instead of appending a second copy.
+- If you cannot determine whether appending is safe (for example, an unfamiliar rules format), ask the user how they want to proceed before writing.
+
+Where a project's own instructions conflict with the AWS rules, the project's instructions take precedence.
+
+**Success:** The AWS rules are present in the correct location for each AI tool, and any pre-existing project instructions are preserved. End the set up by telling the user:
 
 > Setup is complete! Close this session and start a new one. Your AI tool will automatically use the rules and skill files we just installed. Try this as your first prompt:
 >

--- a/setup-instructions/setup.md
+++ b/setup-instructions/setup.md
@@ -13,73 +13,70 @@ The workflow includes:
 - Installing the Agent Toolkit which bundles AWS MCP server configuration and agent skills
 - Verifying the Agent Toolkit installation
 
-## Parameters
+Per-step error handling lives in [setup-troubleshooting.md](setup-troubleshooting.md). If a step fails, open the matching section there, apply the resolution, then resume at that step.
 
-- operating_system (optional): macOS, Linux, or Windows. If not provided, Step 1 detects it automatically
-- profile_name (required): The AWS CLI profile name to use for all commands. You MUST ask the user: "What profile name do you want to use for your AWS CLI credentials?"
-- AWS experience (required): The user has access to either our new AWS experience or our advanced AWS experience. If not provided in the prompt, you MUST ask the user: "Did you sign up recently for AWS using a social provider like Google or GitHub, and did you create a project?" If they say yes, they are using our new AWS experience. If they say no, they are using our advanced AWS experience.
-- Region (required): The default AWS Region for the user's account. If not provided in the prompt, you MUST ask the user for it before proceeding
-  - If the AWS experience parameter is our advanced AWS experience, ask the user: "What AWS Region do you want to use as your default Region?"
-  - If the AWS experience parameter is our new AWS experience, ask the user: "What AWS Region was your project created in?" They can find this value in the additional info tab of their project in AWS Settings.
+## Before you start
 
-Constraints for parameter acquisition:
+Gather the following inputs and confirm prerequisites **before** running any step. Ask for all required inputs in a single message, then proceed autonomously.
 
-- You MUST detect the OS automatically before asking the user
-- The user MUST either provide the AWS Region in the prompt or you MUST ask for it
-- You MUST NOT ask the user for AWS credentials, access keys, or secret keys — authentication is handled entirely through `aws login` browser flow
-- You MUST inform the user that credentials are valid for 12 hours and can be renewed for 90 days without re-authenticating in the browser
+### Required inputs
 
-## Dependencies
+- **profile_name** (required): The AWS CLI profile name to use for all commands. You MUST ask the user: "What profile name do you want to use for your AWS CLI credentials?"
+- **AWS experience** (required): The user has access to either our new AWS experience or our advanced AWS experience. If not provided in the prompt, you MUST ask the user: "Did you sign up recently for AWS using a social provider like Google or GitHub, and did you create a project?" If they say yes, they are using our new AWS experience. If they say no, they are using our advanced AWS experience.
+- **Region** (required): The default AWS Region for the user's account. If not provided in the prompt, you MUST ask for it before proceeding:
+  - If the AWS experience parameter is our advanced AWS experience, ask: "What AWS Region do you want to use as your default Region?"
+  - If the AWS experience parameter is our new AWS experience, ask: "What AWS Region was your project created in?" They can find this value in the additional info tab of their project in AWS Settings.
+- **operating_system** (optional): macOS, Linux, or Windows. If not provided, Step 1 detects it automatically. You MUST detect the OS automatically before asking the user.
 
-Constraints:
+### Input constraints
 
-- You MUST verify the following tools are available: curl (macOS/Linux) or PowerShell (Windows), and uv (all platforms)
+- You MUST NOT ask the user for AWS credentials, access keys, or secret keys — authentication is handled entirely through the `aws login` browser flow.
+- You MUST inform the user that credentials are valid for 12 hours and can be renewed for 90 days without re-authenticating in the browser.
+- IF the AWS experience parameter is "our new AWS experience" THEN the user's account is part of a "project". Always use the term "project" when talking to the user.
+
+### Prerequisites
+
+- You MUST verify the following tools are available: curl (macOS/Linux) or PowerShell (Windows), and uv (all platforms).
 - If uv is not installed, install it before proceeding:
   - macOS/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`
   - Windows: `irm https://astral.sh/uv/install.ps1 | iex`
-- You MUST verify internet connectivity to `https://awscli.amazonaws.com`
-- You MUST inform the user about any missing tools with a clear message
-- You MUST ask if the user wants to proceed despite missing tools
-- You MUST respect the customer's decision to abort at any point
-- You MUST explain to the customer what step is being executed, why, and which tool is being called
-- You MUST NOT require node, python3, or any other runtime beyond the shell and uv — the installer handles all other dependencies
-- IF the AWS experience parameter is "our new AWS experience" THEN the user's account is part of a "project". Always use the term "project" when talking to the user.
+- You MUST verify internet connectivity to `https://awscli.amazonaws.com`.
+- You MUST inform the user about any missing tools with a clear message, ask if they want to proceed despite missing tools, and respect the customer's decision to abort at any point.
+- You MUST NOT require node, python3, or any other runtime beyond the shell and uv — the installer handles all other dependencies.
 
-## General error handling
+## How to run this file
 
-If any step fails with an error not covered in that step's error handling table, report the full error output to the user and do not proceed to the next step. If installation fails, tell the customer to re-run the set up file.
+- After you gather the required inputs above, complete the steps yourself by running the commands directly. You MUST explain to the customer what step is being executed, why, and which tool is being called.
+- Two steps require the human user to act; pause and let them complete these:
+  - **Step 3 (`aws login`)** opens a browser for sign-in.
+  - **Step 5 (`aws configure agent-toolkit`)** is an interactive wizard.
+- If a step fails, consult [setup-troubleshooting.md](setup-troubleshooting.md) for that step, apply the resolution, and resume. For errors not covered there, report the full error output and do not proceed.
 
 ## Steps
 
-### Step 1 : Determine operating system
+### Step 1: Determine operating system
 
 Determine the operating system. Check session context first; if it's not there, run a detection command:
 
 - On Unix-like shell: `uname -s`
 - On Powershell: `$env:OS`
 
-**Success:** OS identified as macOS, Linux, or Windows
-
-**Error handling**:
-
-| Symptom | Cause | Resolution |
-|---------|-------|------------|
-| Cannot determine OS | No shell access or unknown environment | Ask the user what operating system they are using |
-
-Then:
+**Success:** OS identified as macOS, Linux, or Windows. Then:
 
 - **macOS or Linux** → Proceed to Step 2 (macOS/Linux)
 - **Windows** → Proceed to Step 2 (Windows)
 
-### Step 2 (if using macOS or Linux):
+If this step fails, see [Troubleshooting: Step 1](setup-troubleshooting.md#step-1-determine-operating-system).
 
-Determine if the user has the AWS CLI installed. Run a detection command:
+### Step 2 (if using macOS or Linux)
+
+Determine if the user has the AWS CLI installed:
 
 ```bash
 aws --version
 ```
 
-If the AWS CLI is installed, the step is complete. If the AWS CLI is not installed, download and run the shell installer:
+If the AWS CLI is installed, this step is complete. If not, download and run the shell installer:
 
 ```bash
 curl -fsSL 'https://awscli.amazonaws.com/v2/install.sh' | bash
@@ -101,26 +98,13 @@ fi
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_RC" && source "$SHELL_RC"
 ```
 
-**Success**: Installer exits with code 0 and prints the installed version.
+**Success:** Installer exits with code 0 and prints the installed version.
 
-**Error handling:**
+> **Note on the piped installer:** The command above runs AWS's official install script directly. Security-conscious users can instead download the script first, inspect it, and then run it, or follow the manual steps on the [official AWS CLI install page](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
-| Symptom | Cause | Resolution |
-|---------|-------|------------|
-| `command not found: curl` | Download tool is not installed | Install `curl` via the system package manager, then re-run |
-| curl exits with non-zero (e.g., exit code 22) | HTTP error or no internet connectivity | Verify network access to the download URL |
-| `missing required dependencies: ...` | `unzip` (Linux) or `pkgutil` (macOS) not installed | Install the listed dependencies, then re-run |
-| `unsupported OS` or `unsupported architecture` | Script only supports Linux (x86_64, aarch64) and macOS | Cannot proceed on this system |
-| `musl-based Linux detected` | Alpine or similar musl distro | Cannot use prebuilt binaries; direct user to source install |
-| `--system requires root` | User passed `--system` without sudo | Re-run with `sudo` or omit `--system` for user-local install |
-| `post-install check failed` | `aws --version` didn't succeed after install | Check that `$HOME/.local/bin` is on PATH; re-run the script |
-| `aws --version` returns an older version than just installed | A previous AWS CLI installation exists in a different location (e.g., `/usr/local/bin/aws` or Homebrew) and takes precedence on PATH | Run `which -a aws` to show all install locations. Inform the user which locations were found and offer two options: (1) remove the old installation, or (2) reorder PATH so the new install takes precedence. Ask which they prefer before proceeding |
-| PATH warning in output | `$HOME/.local/bin` not first on PATH | Add it to shell rc file as the script suggests, then open a new shell |
-| `Permission denied` when writing to rc file | File or directory permissions prevent writing | Check file permissions with `ls -la "$SHELL_RC"` and fix with `chmod u+w "$SHELL_RC"` |
-| RC file does not exist | File hasn't been created yet (fresh system) | Create it first with `touch "$SHELL_RC"`, then re-run the echo command |
-| Duplicate PATH entries in rc file | Step was run multiple times | Not harmful, but user can manually remove duplicate lines from their shell rc file |
+If this step fails, see [Troubleshooting: Step 2 (macOS or Linux)](setup-troubleshooting.md#step-2-macos-or-linux-install-the-aws-cli).
 
-### Step 2 (if using Windows):
+### Step 2 (if using Windows)
 
 Download and run the PowerShell installer:
 
@@ -128,54 +112,29 @@ Download and run the PowerShell installer:
 irm 'https://awscli.amazonaws.com/v2/install.ps1' | iex
 ```
 
-**Success**: Installer exits successfully and prints the installed version.
+**Success:** Installer exits successfully and prints the installed version.
 
-**Error handling:**
+> **Note on the piped installer:** The command above runs AWS's official install script directly. Security-conscious users can instead download the script first, inspect it, and then run it, or follow the manual steps on the [official AWS CLI install page](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
-| Symptom | Cause | Resolution |
-|---------|-------|------------|
-| `irm` or `iex` not recognized | Running in cmd.exe instead of PowerShell | Re-run from a PowerShell session |
-| Download/network failure | No internet connectivity or firewall blocking the URL | Verify network access to the download URL |
-| `-System requires admin privileges` | User passed `-System` without elevation | Re-run from an elevated PowerShell, or omit `-System` for user-local install |
-| `msiexec failed with exit code ...` | MSI installation failed | Check Windows Event Log for MSI errors; ensure no other AWS CLI installer is running |
-| `post-install check failed` | `aws --version` didn't succeed after install | Restart the shell so PATH changes from the MSI take effect, then retry |
-| `aws --version` returns an older version than just installed | A previous AWS CLI installation exists in a different location (e.g., `C:\Program Files\Amazon\AWSCLIV2\`) and takes precedence on PATH | Run `Get-Command aws -All` to show all install locations. Inform the user which locations were found and offer two options: (1) uninstall the old version via Apps & Features, or (2) reorder PATH so the new install takes precedence. Ask which they prefer before proceeding |
-| `LOCALAPPDATA is not set` | Rare environment issue | Set the variable or use `-System` for a Program Files install |
+If this step fails, see [Troubleshooting: Step 2 (Windows)](setup-troubleshooting.md#step-2-windows-install-the-aws-cli).
 
-### **Step 3: Log in to AWS**
+### Step 3: Log in to AWS
 
-Check if the user's prompt includes their AWS Region (e.g., "Your AWS Region is: us-east-2").
-
-- If not provided and the AWS experience parameter is our advanced AWS experience, ask the user: "What AWS Region do you want to use as your default Region?"
-- If not provided and the AWS experience parameter is our new AWS experience, ask the user: "What AWS Region was your project created in?" They can find this value in the additional info tab of their project in AWS Settings.
-
-Then configure it before logging in:
+Configure the Region (gathered in "Before you start"), then sign in:
 
 ```bash
 aws configure set region <region from prompt> --profile <profile_name>
 ```
 
-Then sign in to the AWS CLI using the dedicated profile, passing the Region explicitly:
-
 ```bash
 aws login --region <region from prompt> --profile <profile_name>
 ```
 
-A browser window will open for authentication. The human user will authenticate. If the human user wants to cancel this command at any time, let them.
+A browser window will open for authentication. The human user will authenticate. If the human user wants to cancel this command at any time, let them. Wait for the command to exit before proceeding to Step 4.
 
-Wait for the command to exit before proceeding to Step 4.
+**Success:** `aws login` exits with code 0.
 
-**Success**: `aws login` exits with code 0.
-
-**Error handling:**
-
-| Symptom | Cause | Resolution |
-|---------|-------|------------|
-| Region not provided in prompt | User pasted the prompt without region context | Ask the user the relevant follow up question depending on their AWS experience parameter. Then, set it with `aws configure set region <value> --profile <profile_name>` |
-| command not found: `aws` | PATH not set correctly after install | Re-run `export PATH="$HOME/.local/bin:$PATH"` and retry |
-| `Profile '<profile_name>' is already configured with Access Key credentials` | User previously configured static access keys for this profile via `aws configure` | Offer the user two options: (1) Use a different profile name and re-run `aws login --profile <new_name>`, or (2) Remove the `aws_access_key_id` and `aws_secret_access_key` lines from `~/.aws/credentials` (under the `[<profile_name>]` section), then re-run `aws login --profile <profile_name>` |
-| aws login exits with non-zero | User closed the browser without completing auth, or timed out | Re-run `aws login --profile <profile_name>` and instruct the user to complete authentication in the browser |
-| Browser did not open | Headless environment or no default browser configured | Run `aws login --region <region from prompt> --profile <profile_name> --remote`. Then let the human user finish the process. |
+If this step fails, see [Troubleshooting: Step 3](setup-troubleshooting.md#step-3-log-in-to-aws).
 
 ### Step 4: Verify access
 
@@ -185,18 +144,13 @@ Verify AWS CLI access:
 aws sts get-caller-identity --profile <profile_name>
 ```
 
-**Success**: Returns AccountId, Arn, and UserId. Confirm to the user that credentials are working.
+**Success:** Returns AccountId, Arn, and UserId. Confirm to the user that credentials are working.
 
-**Error handling**:
-
-| Symptom | Cause | Resolution |
-|---------|-------|------------|
-| `Unable to locate credentials` or `ExpiredToken` | `aws login` did not complete successfully | Re-run Step 3 |
-| `command not found: aws` | PATH not set correctly | Re-run `export PATH="$HOME/.local/bin:$PATH"` and retry |
+If this step fails, see [Troubleshooting: Step 4](setup-troubleshooting.md#step-4-verify-access).
 
 ### Step 5: Set up the Agent Toolkit
 
-Run the following command to install AI coding agents, install default AWS skills, and configure the AWS MCP Server connection.
+Run the following command to install AI coding agents, install default AWS skills, and configure the AWS MCP Server connection. This is an interactive wizard; let the human user complete any prompts.
 
 ```bash
 aws configure agent-toolkit --yes --region us-east-1 --profile <profile_name>
@@ -206,53 +160,32 @@ aws configure agent-toolkit --yes --region us-east-1 --profile <profile_name>
 
 **Success:** Command exits with code 0.
 
-**Error handling**:
-
-| Symptom | Cause | Resolution |
-|---------|-------|------------|
-| `--yes` not recognized or `invalid choice` | CLI version doesn't support this flag yet | Remove the flag and retry: `aws configure agent-toolkit --region us-east-1 --profile <profile_name>` |
-| Exit code 253 or "requires interactive terminal" | Agent's bash tool runs in a non-interactive subshell; wizard cannot prompt for input | Inform the user: "Almost done! Run this command in your terminal to finish setup: `aws configure agent-toolkit --region us-east-1 --profile <profile_name>`. It's a one-time interactive wizard (~30 seconds). Once complete, come back here and I'll verify everything is working." Then proceed to Step 6 only after the user confirms completion. |
-| `Unable to locate credentials` or `ExpiredToken` | Session expired during setup | Re-run Step 3, then retry Step 5 |
-| `command not found: aws` | PATH not set correctly | Re-run `export PATH="$HOME/.local/bin:$PATH"` and retry |
+If this step fails, see [Troubleshooting: Step 5](setup-troubleshooting.md#step-5-set-up-the-agent-toolkit).
 
 #### Point the AWS MCP Server at the user's profile
 
-After the command completes, the Agent Toolkit writes an `aws-mcp` server entry into each detected AI tool's MCP configuration file. This entry does NOT reference the profile the user authenticated with in Step 3 — it falls back to the `default` profile. Because this set up file always authenticates under a named `<profile_name>`, you MUST propagate that profile into each generated `aws-mcp` entry, or the MCP server will fail to start with `JSON-RPC error: -32602: Invalid request parameters("")` (it cannot locate credentials under the `default` profile).
+The command above writes an `aws-mcp` server entry into each detected AI tool's MCP configuration file. That generated entry falls back to the `default` profile. Because this set up file always authenticates under a named `<profile_name>`, you MUST add that profile to each generated `aws-mcp` entry, or the MCP server will fail to start with `JSON-RPC error: -32602: Invalid request parameters("")` (it cannot locate credentials under the `default` profile).
 
-For each MCP configuration file the Agent Toolkit updated, open the file, locate the `aws-mcp` entry under `mcpServers`, and add an `env` block that sets `AWS_MCP_PROXY_PROFILES` to `<profile_name>`. You MUST NOT remove or modify any other server entries. Only add the `env` block — leave `command`, `args`, `timeout`, and `transport` exactly as generated:
+For each MCP configuration file the Agent Toolkit updated, open the file, locate the `aws-mcp` entry under `mcpServers`, and add (or merge in) an `env` block that sets `AWS_MCP_PROXY_PROFILES` to `<profile_name>`. You MUST NOT remove or modify any other server entries, and you MUST leave the generated `command`, `args`, `timeout`, and `transport` values exactly as written — only add the `env` block:
 
 ```json
-"aws-mcp": {
-  "command": "uvx",
-  "args": ["mcp-proxy-for-aws-cli@latest", "https://aws-mcp.us-east-1.api.aws/mcp", "--metadata", "INSTALL_SOURCE=agent-toolkit"],
-  "env": {
-    "AWS_MCP_PROXY_PROFILES": "<profile_name>"
-  },
-  "timeout": 100000,
-  "transport": "stdio"
+"env": {
+  "AWS_MCP_PROXY_PROFILES": "<profile_name>"
 }
 ```
-
-MCP configuration file locations by tool (Note: it is not an exhaustive list):
-
-| Agent       | MCP configuration file    |
-| ----------- | ------------------------- |
-| Claude Code | ~/.claude.json            |
-| Cline       | ~/.cline/mcp.json         |
-| Cursor      | ~/.cursor/mcp.json        |
-| Kiro        | ~/.kiro/settings/mcp.json |
 
 Notes:
 
 - Use `AWS_MCP_PROXY_PROFILES` (not `AWS_PROFILE`) because it also enables cross-account switching later.
-- If you run into an existing entry for the aws-mcp, directly as the user how they want to reconsile the new changes.
+- If you find an existing `aws-mcp` entry, ask the user how they want to reconcile the new changes.
 - If the MCP configuration file uses OpenCode, follow the OpenCode schema to modify the profile.
+- The Agent Toolkit determines each tool's MCP configuration file location automatically. If you need to locate or confirm a file, see the [Agent Toolkit documentation](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/).
 
-After adding the `env` block, tell the user: "To use another AWS account later, run `aws login --profile <name>`, add that profile name to the space-separated `AWS_MCP_PROXY_PROFILES` list in each MCP configuration file above, and restart your AI tool."
+After adding the `env` block, tell the user: "To use another AWS account later, run `aws login --profile <name>`, add that profile name to the space-separated `AWS_MCP_PROXY_PROFILES` list in each MCP configuration file, and restart your AI tool."
 
 ### Step 6: Verify Agent Toolkit installation
 
-Run the following command to list all available skills in the remote catalog.
+Run the following command to list all available skills in the remote catalog:
 
 ```bash
 aws agent-toolkit list-available-skills --region us-east-1 --profile <profile_name>
@@ -260,16 +193,11 @@ aws agent-toolkit list-available-skills --region us-east-1 --profile <profile_na
 
 **Success:** Returns a JSON of skills with name, description, skillVersion, and categories values.
 
-**Error handling:**
-
-| Symptom | Cause | Resolution |
-|---------|-------|------------|
-| `Unable to locate credentials` or `ExpiredToken` | Session expired | Re-run Step 3, then retry Step 6 |
-| `Invalid choice` or `argument not recognized` | AWS CLI version doesn't include agent-toolkit commands | Re-run Step 2 to update to the latest version, then retry |
+If this step fails, see [Troubleshooting: Step 6](setup-troubleshooting.md#step-6-verify-agent-toolkit-installation).
 
 ### Step 7: Get AWS experience rule
 
-First, identify which AI coding tool is in use and its rules files per this table (which is not an exhaustive list):
+Identify which AI coding tool is in use and its rules file location (this is not an exhaustive list):
 
 | Agent       | Project rules        | Location                  |
 | ----------- | -------------------- | ------------------------- |
@@ -278,28 +206,17 @@ First, identify which AI coding tool is in use and its rules files per this tabl
 | Cursor      | .cursor/rules/\*.mdc | .cursor/rules/ directory  |
 | Kiro        | .kiro/steering/\*.md | .kiro/steering/ directory |
 
-Retrieve the AWS experience rules file based on their AWS experience parameter. Read its full contents, and
-save them to each detected tool’s rules file (creating the directory if needed):
+Retrieve the AWS experience rules file based on the AWS experience parameter, read its full contents, and save them to each detected tool's rules file (creating the directory if needed):
 
-If the AWS experience parameter is our new AWS experience, fetch the rule file. The rule file is located at:
-https://raw.githubusercontent.com/aws/agent-toolkit-for-aws/refs/heads/main/rules/aws-starter-rules.md
+- New AWS experience: <https://raw.githubusercontent.com/aws/agent-toolkit-for-aws/refs/heads/main/rules/aws-starter-rules.md>
+- Advanced AWS experience: <https://raw.githubusercontent.com/aws/agent-toolkit-for-aws/refs/heads/main/rules/aws-agent-rules.md>
 
-If the AWS experience parameter is our advanced AWS experience, the rule file is located at:
-https://raw.githubusercontent.com/aws/agent-toolkit-for-aws/refs/heads/main/rules/aws-agent-rules.md
+**Success:** Rule file is saved to the correct location for each AI tool. End the set up by telling the user:
 
-**Success**: Rule file is saved to the correct location for each AI tool. End the set up by telling the user:
+> Setup is complete! Close this session and start a new one. Your AI tool will automatically use the rules and skill files we just installed. Try this as your first prompt:
+>
+> Please make a single page webapp game and deploy it to AWS.
+>
+> If you're looking to explore what you can do on AWS, that prompt will get you started with a fun project. You can replace the game request with anything you'd like to build.
 
-"Setup is complete! Close this session and start a new one. Your AI tool will automatically use the rules and skill files we just installed. Try this as your first prompt:
-
-Please make a single page webapp game and deploy it to AWS.
-
-If you’re looking to explore what you can do on AWS, that prompt will get you started with a fun project. You can replace the game request with anything you’d like to build"
-
-**Error handling:**
-
-| Symptom | Cause | Resolution |
-|---------|-------|------------|
-| HTTP 404 or download failure | URL changed or no internet connectivity | Verify network access; check if the URL is still valid at the GitHub repository |
-| Permission denied when saving file | No write access to the target directory | Create the directory with mkdir -p or run with appropriate permissions |
-| Cannot determine AI tool configuration directory | Unknown or unsupported AI coding tool | Ask the user which AI tool they are using and where its configuration directory is |
-| File saved but tool doesn't recognize it | Incorrect file path or naming convention | Verify the path matches the tool's expected location per the Agent Toolkit documentation |
+If this step fails, see [Troubleshooting: Step 7](setup-troubleshooting.md#step-7-get-aws-experience-rule).


### PR DESCRIPTION
## Summary

Refactors the agent onboarding runbook (`setup-instructions/setup.md`) for clarity and leanness, **and** fixes a data-loss bug in Step 7.

Fixes #282.

### Refactor (behavior-preserving except the Step 7 fix below)

- Move the per-step error tables into a new `setup-instructions/setup-troubleshooting.md`, linked from each step, with "Back to Step N" links in both directions so navigation is near-zero-cost.
- Consolidate "Parameters" and "Dependencies" into a single "Before you start" block, and add a "How to run this file" note stating one autonomy mode: gather inputs up front, then run autonomously, pausing only for the browser `aws login` and the interactive `aws configure agent-toolkit` wizard.
- Add a note that the piped AWS CLI installer can be downloaded and inspected first (default one-liner unchanged).
- De-duplicate the generated `aws-mcp` MCP entry: describe only the `env`/`AWS_MCP_PROXY_PROFILES` edit the agent must add, instead of restating the full JSON the wizard writes.

All install/config commands are unchanged in set, flags, and order.

### Fix for #282 — Step 7 no longer overwrites project instruction files

`CLAUDE.md` / `AGENTS.md` (and files under `.cursor/rules/`, `.kiro/steering/`) are the project's own agent instructions, often committed and carrying accumulated rules. The previous Step 7 said to *save* the AWS rules to those paths, which an agent following literally would use to **overwrite** them — a quiet, sometimes unrecoverable data loss. Step 7 now:

- Creates the file only if it does not exist.
- If it exists, **appends** the AWS rules under idempotent markers (`<!-- BEGIN/END AWS Agent Toolkit rules -->`), replacing only the marked block on re-run instead of duplicating or clobbering.
- Asks the user if it cannot determine whether appending is safe.
- States that project instructions take precedence on conflict.

Also addresses the issue's related point: added a one-line precedence note to `rules/aws-agent-rules.md` and `rules/aws-starter-rules.md` (project instructions win where they conflict with the AWS rules).

This is the only behavior change in the PR; it is confined to how Step 7 writes the rules file. No CLI command was added, removed, or altered.

## Validation

- `python3 tools/validate.py` passes.
- `markdownlint-cli2` (repo config) reports 0 issues.
- All step ↔ troubleshooting links resolve in both directions.
- Command-for-command diff vs. the previous `setup.md`: identical set/flags/order (the Step 7 change is the write behavior, not a command).

## Coordination

Please check for in-flight `setup.md` work before merging — this file changed recently (#248 / #280 / #292).

## Phase 2 (proposals, not in this PR)

1. Reduce shell-rc mutation (appending PATH to `.bashrc`/`.zshrc` touches user dotfiles).
2. Simplify the two-"AWS experience" (new vs. advanced) branching.
3. Standardize the interactive-wizard hand-off / confirm-completion pattern.
4. Add a self-verification hook stating the file's canonical URL.
