### PR TITLE
fix(aws-agents-for-devsecops): missing S3 bucket ownership verification

### DIFF
--- a/plugins/aws-agents-for-devsecops/.claude-plugin/plugin.json
+++ b/plugins/aws-agents-for-devsecops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-agents-for-devsecops",
   "description": "Investigate incidents, review code and execute UAT for release readiness, scan code for vulnerabilities, and run penetration tests with AWS DevOps Agent and AWS Security Agent.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Amazon Web Services"
   },

--- a/plugins/aws-agents-for-devsecops/.codex-plugin/plugin.json
+++ b/plugins/aws-agents-for-devsecops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-agents-for-devsecops",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Investigate incidents, review code and execute UAT for release readiness, scan code for vulnerabilities, and run penetration tests with AWS DevOps Agent and AWS Security Agent.",
   "author": {
     "name": "Amazon Web Services",

--- a/plugins/aws-agents-for-devsecops/.cursor-plugin/plugin.json
+++ b/plugins/aws-agents-for-devsecops/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "aws-agents-for-devsecops",
   "displayName": "AWS Agents for DevSecOps",
   "description": "Investigate incidents, review code and execute UAT for release readiness, scan code for vulnerabilities, and run penetration tests with AWS DevOps Agent and AWS Security Agent.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Amazon Web Services"
   },

--- a/plugins/aws-agents-for-devsecops/plugin.json
+++ b/plugins/aws-agents-for-devsecops/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "aws-agents-for-devsecops",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Investigate incidents, review code and execute UAT for release readiness, scan code for vulnerabilities, and run penetration tests with AWS DevOps Agent and AWS Security Agent.",
   "author": {
     "name": "Amazon Web Services"

--- a/plugins/aws-agents-for-devsecops/skills/diff-scanning-with-aws-security-agent/SKILL.md
+++ b/plugins/aws-agents-for-devsecops/skills/diff-scanning-with-aws-security-agent/SKILL.md
@@ -63,8 +63,8 @@ Track scans in `.security-agent/scans.json`.
 
    ```bash
    SCAN_ID="diff-$(date +%s)-$(openssl rand -hex 3)"
-   aws s3 cp /tmp/source.zip s3://<bucket>/security-scans/source/<WORKSPACE_ID>/source.zip
-   aws s3 cp /tmp/diff.patch s3://<bucket>/security-scans/diffs/${SCAN_ID}/diff.patch
+   aws s3 cp /tmp/source.zip s3://<bucket>/security-scans/source/<WORKSPACE_ID>/source.zip --expected-bucket-owner <account>
+   aws s3 cp /tmp/diff.patch s3://<bucket>/security-scans/diffs/${SCAN_ID}/diff.patch --expected-bucket-owner <account>
    ```
 
 6. **Get or create per-workspace CodeReview** (same logic as full scan — lookup `config.json → code_reviews[<abs_path>]`, create if absent):

--- a/plugins/aws-agents-for-devsecops/skills/scanning-with-aws-security-agent/SKILL.md
+++ b/plugins/aws-agents-for-devsecops/skills/scanning-with-aws-security-agent/SKILL.md
@@ -98,7 +98,7 @@ For scanning only changed code, use the `diff-scanning-with-aws-security-agent` 
 3. **Upload** to the per-workspace stable key (overwrites any prior upload):
 
    ```bash
-   aws s3 cp /tmp/source.zip s3://<bucket>/security-scans/source/<WORKSPACE_ID>/source.zip
+   aws s3 cp /tmp/source.zip s3://<bucket>/security-scans/source/<WORKSPACE_ID>/source.zip --expected-bucket-owner <account>
    ```
 
 4. **Get or create the per-workspace CodeReview.** Look up `config.json → code_reviews[<abs_path>]`.
@@ -308,6 +308,7 @@ Read `.security-agent/scans.json`. Show in a compact table:
 
 - **"Not configured" / `config.json` missing** → run `setup-security-agent` skill first
 - **`AccessDenied` on `s3 cp`** → bucket not registered on agent space, or trust policy wrong. Re-run setup.
+- **`403` / `ExpectedBucketOwner` mismatch on `s3 cp`** → the derived bucket is owned by a different account (bucket-squatting). The upload is rejected by design — do not retry without the guard. Re-run `setup-security-agent`, which aborts on foreign-owned buckets.
 - **`ResourceNotFoundException` on agent space** → it was deleted. Re-run setup.
 - **Scan stuck in PREFLIGHT for >10 min** → backend issue, not client. Show `batch-get-code-review-jobs` output and tell user to escalate.
 - **Code too large (zip > 2 GB)** → run on a subdirectory instead.

--- a/plugins/aws-agents-for-devsecops/skills/setup-security-agent/SKILL.md
+++ b/plugins/aws-agents-for-devsecops/skills/setup-security-agent/SKILL.md
@@ -99,20 +99,56 @@ Why minimal config: the role name and bucket name are deterministic, so storing 
      ```
 
 5. **S3 bucket** (`security-agent-scans-$ACCOUNT-$REGION`):
-   - Probe:
+
+   > **Bucket-ownership enforcement (required).** The bucket name is derived from
+   > the caller's AWS account ID and region — both non-secret and publicly
+   > derivable from ARNs / ECR URIs — so any third party can pre-register
+   > ("squat") the predictable name in their own account. Every S3 call MUST
+   > pass `--expected-bucket-owner "$ACCOUNT"` so the operation fails closed if
+   > the bucket is owned by someone else. A `403 Forbidden` on a bucket that
+   > exists but is foreign-owned is **fatal** — abort setup and never upload.
+
+   - Probe (asserts ownership):
 
      ```bash
      BUCKET="security-agent-scans-${ACCOUNT}-${REGION}"
-     aws s3api head-bucket --bucket "$BUCKET"
+     NEED_CREATE=0
+     if aws s3api head-bucket --bucket "$BUCKET" --expected-bucket-owner "$ACCOUNT" 2>/tmp/sa-head.err; then
+       : # bucket exists and is owned by this account — safe to reuse
+     elif grep -q '404' /tmp/sa-head.err; then
+       NEED_CREATE=1
+     elif grep -Eq '403|Forbidden' /tmp/sa-head.err; then
+       echo "FATAL: bucket $BUCKET exists but is owned by another account (403). Possible bucket-squatting — aborting. Nothing was uploaded." >&2
+       exit 1
+     else
+       cat /tmp/sa-head.err >&2; exit 1
+     fi
      ```
 
-   - If 404, create:
+   - If not found, create it. A `BucketAlreadyExists` error means another account
+     already holds the global name — treat it as **fatal** and distinct from
+     `BucketAlreadyOwnedByYou` (which is a safe no-op). Re-assert ownership after
+     creation before any further use:
 
      ```bash
-     # us-east-1: no LocationConstraint
-     aws s3api create-bucket --bucket "$BUCKET"
-     # other regions:
-     aws s3api create-bucket --bucket "$BUCKET" --create-bucket-configuration LocationConstraint="$REGION"
+     if [ "$NEED_CREATE" = "1" ]; then
+       if [ "$REGION" = "us-east-1" ]; then
+         # us-east-1: no LocationConstraint
+         aws s3api create-bucket --bucket "$BUCKET" 2>/tmp/sa-create.err || true
+       else
+         # other regions:
+         aws s3api create-bucket --bucket "$BUCKET" \
+           --create-bucket-configuration LocationConstraint="$REGION" 2>/tmp/sa-create.err || true
+       fi
+       if grep -q 'BucketAlreadyExists' /tmp/sa-create.err; then
+         echo "FATAL: bucket name $BUCKET is already owned by another account (BucketAlreadyExists). Possible bucket-squatting — aborting." >&2
+         exit 1
+       elif [ -s /tmp/sa-create.err ] && ! grep -q 'BucketAlreadyOwnedByYou' /tmp/sa-create.err; then
+         cat /tmp/sa-create.err >&2; exit 1
+       fi
+       # Confirm ownership of the freshly created bucket before using it.
+       aws s3api head-bucket --bucket "$BUCKET" --expected-bucket-owner "$ACCOUNT"
+     fi
      ```
 
    - Always (re)apply public access block + 30-day lifecycle:
@@ -166,6 +202,7 @@ Why minimal config: the role name and bucket name are deterministic, so storing 
 
 - Never auto-select an agent space when multiple exist — always ask the user
 - Never disable safety protections (the public-access-block stays on)
+- Every S3 call against the derived bucket MUST pass `--expected-bucket-owner "$ACCOUNT"`. The bucket name is derived from a non-secret account ID, so a third party can pre-register it; a `403`/`BucketAlreadyExists` on a foreign-owned bucket is fatal — abort and never upload.
 - Trust policy must allow `securityagent.amazonaws.com` (production service principal) and include the `aws:SourceAccount` confused-deputy guard
 - If the user provides their own role name or bucket name (different from the conventional defaults), tell them: this plugin uses convention-based defaults (`SecurityAgentScanRole` / `security-agent-scans-${ACCOUNT}-${REGION}`). Either accept those defaults or extend the skill — the other skills derive these names rather than reading them from config.
 - The scan and pentest skills can call this skill inline if `config.json` is missing — first-time users don't need to run setup separately.
@@ -176,5 +213,6 @@ Why minimal config: the role name and bucket name are deterministic, so storing 
 
 - **`AccessDenied` calling `iam:CreateRole`** → user lacks IAM permissions. Ask them to run setup with their own role ARN, or to grant `iam:CreateRole` + `iam:PutRolePolicy`.
 - **`AccessDenied` on `s3api create-bucket`** → either the bucket name is taken globally, or the user lacks `s3:CreateBucket`. Suggest using an existing bucket they own and pass it explicitly.
+- **`403 Forbidden` / `BucketAlreadyExists` on the derived bucket** → the predictable name is owned by a *different* account (bucket-squatting). This is fatal by design — do not upload. Have the user pick a bucket name they own (or run from the expected account/region) and re-run setup.
 - **Role exists but trust policy is wrong** → `update-assume-role-policy` (step 4 fallback). If they don't want that role updated, ask them for a different role ARN.
 - **Agent space exists but in a different region** → tell the user; suggest using the right region or creating a new space in the current region.

--- a/plugins/aws-agents-for-devsecops/skills/threat-modeling-with-aws-security-agent/SKILL.md
+++ b/plugins/aws-agents-for-devsecops/skills/threat-modeling-with-aws-security-agent/SKILL.md
@@ -46,14 +46,14 @@ Read `.security-agent/config.json` for `agent_space_id` and `region`. If missing
    ```bash
    SCAN_ID="tm-$(date +%s)-$(openssl rand -hex 3)"
    WORKSPACE_ID=$(printf '%s' "$(pwd)" | md5sum | cut -c1-12)
-   aws s3 cp /tmp/source.zip s3://<bucket>/security-scans/source/${WORKSPACE_ID}/source.zip
+   aws s3 cp /tmp/source.zip s3://<bucket>/security-scans/source/${WORKSPACE_ID}/source.zip --expected-bucket-owner <account>
    ```
 
 5. **Upload spec files:**
 
    ```bash
-   aws s3 cp /path/to/requirements.md s3://<bucket>/security-scans/threat-models/${SCAN_ID}/specs/requirements.md
-   aws s3 cp /path/to/design.md s3://<bucket>/security-scans/threat-models/${SCAN_ID}/specs/design.md
+   aws s3 cp /path/to/requirements.md s3://<bucket>/security-scans/threat-models/${SCAN_ID}/specs/requirements.md --expected-bucket-owner <account>
+   aws s3 cp /path/to/design.md s3://<bucket>/security-scans/threat-models/${SCAN_ID}/specs/design.md --expected-bucket-owner <account>
    ```
 
 6. **Create threat model:**


### PR DESCRIPTION
The Security Agent skills derive a deterministic scan bucket name (security-agent-scans-<account>-<region>) from the non-secret caller account ID. Because S3's namespace is global, a third party can pre-register the predictable name; the skills validated the bucket by existence only, so source archives (containing .env, *.pem, terraform.tfstate) could be uploaded into an attacker-owned bucket.

- setup-security-agent: head-bucket now asserts --expected-bucket-owner and a 403 on a foreign-owned bucket is fatal; create-bucket treats BucketAlreadyExists as fatal (distinct from BucketAlreadyOwnedByYou) and re-asserts ownership after creation before any use.
- scanning / diff-scanning / threat-modeling: every 'aws s3 cp' upload now passes --expected-bucket-owner <account> so writes fail closed if the bucket is not owned by the caller.
- Added ownership Rules and troubleshooting notes.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
