### PR TITLE
docs: add fx setup to the quick start and skills guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Help AI coding agents build, deploy, and manage applications on AWS.
 
-The Agent Toolkit for AWS gives AI coding agents the tools, knowledge, and guardrails they need to work with AWS services. It works with the coding agents developers already use — including Claude Code, Codex, Cursor, and Kiro.
+The Agent Toolkit for AWS gives AI coding agents the tools, knowledge, and guardrails they need to work with AWS services. It works with the coding agents developers already use — including Claude Code, Codex, Cursor, Kiro, and fx.
 
 ## Quick start
 
@@ -111,6 +111,47 @@ npx skills add aws/agent-toolkit-for-aws/skills
 ```
 
 This installs skill files to `~/.kiro/skills/` (global) or `.kiro/skills/` (project-level). Each skill is a directory containing a `SKILL.md` file and optionally a `references/` subdirectory with additional context the agent reads from the local filesystem when needed. Kiro discovers installed skills automatically and activates them on demand when a task matches.
+
+> **Prerequisites:** You need [uv](https://docs.astral.sh/uv/) installed. An AWS account with credentials configured locally is required for API calls and script execution, but not for documentation search or skill discovery. See the [user guide](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/) for detailed setup instructions.
+
+### fx
+
+[fx](https://fx.sh) setup has the same two independent parts as Kiro: the AWS MCP Server (for runtime AWS API access and documentation search) and local skills (for task-specific agent guidance). Skills don't require the MCP server, and the MCP server doesn't serve locally-installed skills.
+
+**1. Add the AWS MCP Server** from your terminal. fx stores MCP servers in `~/.fx/mcp.json`, so the server is available in every project:
+
+```
+fx mcp add aws uvx mcp-proxy-for-aws-cli@latest https://aws-mcp.us-east-1.api.aws/mcp --metadata AWS_REGION=us-west-2
+```
+
+Or add it to `~/.fx/mcp.json` by hand. fx uses the `mcp` key rather than `mcpServers`, `type` to select the transport, and a single `command` array holding the executable and its arguments:
+
+```json
+{
+  "mcp": {
+    "aws": {
+      "type": "local",
+      "command": [
+        "uvx",
+        "mcp-proxy-for-aws-cli@latest",
+        "https://aws-mcp.us-east-1.api.aws/mcp",
+        "--metadata",
+        "AWS_REGION=us-west-2"
+      ]
+    }
+  }
+}
+```
+
+If a session is already open when you edit the file, run `/mcp reload` to pick up the change. The MCP server gives your agent access to AWS APIs, sandboxed script execution, and real-time documentation search.
+
+**2. Install skills** from this repository:
+
+```
+npx skills add aws/agent-toolkit-for-aws/skills -a fx
+```
+
+This installs skill files to `.fx/skills/` (project-level); add `-g` to install to `~/.fx/skills/` (global). fx also discovers skills already installed for other agents in `.agents/skills/`, `.claude/skills/`, and `.codex/skills/`, so a project set up for Codex or Claude Code needs no second copy. Each skill is a directory containing a `SKILL.md` file and optionally a `references/` subdirectory with additional context the agent reads from the local filesystem when needed. fx reads skill metadata at startup and loads a skill's instructions when you or the agent invokes it; type `$` in the composer or run `/skills` to browse what's installed.
 
 > **Prerequisites:** You need [uv](https://docs.astral.sh/uv/) installed. An AWS account with credentials configured locally is required for API calls and script execution, but not for documentation search or skill discovery. See the [user guide](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/) for detailed setup instructions.
 

--- a/setup-instructions/setup.md
+++ b/setup-instructions/setup.md
@@ -205,6 +205,7 @@ Identify which AI coding tool is in use and its rules file location (this is not
 | Codex       | AGENTS.md            | Project root              |
 | Cursor      | .cursor/rules/\*.mdc | .cursor/rules/ directory  |
 | Kiro        | .kiro/steering/\*.md | .kiro/steering/ directory |
+| fx          | AGENTS.md            | Project root              |
 
 Retrieve the AWS experience rules file based on the AWS experience parameter and read its full contents:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -20,6 +20,7 @@ To install skills locally, copy the skill directory to your agent's skills locat
 | Codex | `~/.codex/skills/` | `.agents/skills/` |
 | Cursor | `~/.cursor/skills/` | `.cursor/skills/` |
 | Kiro | `~/.kiro/skills/` | `.kiro/skills/` |
+| fx | `~/.fx/skills/` | `.fx/skills/` |
 
 ## Skill categories
 


### PR DESCRIPTION
## Description

Adds [fx](https://fx.sh), Vercel Labs' open source coding agent, to the setup guides via the skills route, modeled on the Kiro entry:

- `README.md`: adds fx to the intro list of supported agents and a **fx** quick-start section after Kiro with the two independent parts: the AWS MCP Server (`fx mcp add` one-liner plus the hand-written `~/.fx/mcp.json` equivalent, same `mcp-proxy-for-aws-cli` command the Kiro entry uses) and skills (`npx skills add aws/agent-toolkit-for-aws/skills -a fx`).
- `skills/README.md`: adds the fx row to the skills path table (`~/.fx/skills/` global, `.fx/skills/` project).
- `setup-instructions/setup.md`: adds the fx row to the rules-file table (fx reads `AGENTS.md` at the project root).

fx has no plugin marketplace, so it is not added to the plugin marketplaces or the "Plugins are currently available for..." line.

Verified with fx v0.0.8 on 2026-09-09: `fx mcp add aws uvx mcp-proxy-for-aws-cli@latest https://aws-mcp.us-east-1.api.aws/mcp --metadata AWS_REGION=us-west-2` writes the `type: local` entry shown in the README, `fx status` reports the server with no configuration issues, and `npx skills add aws/agent-toolkit-for-aws/skills -a fx` copies skills into `.fx/skills/` (`-g` into `~/.fx/skills/`), both of which fx lists among its skill discovery roots.

Context: Vercel asked for fx to appear wherever Claude Code, Cursor and Kiro do (awslabs/mcp#4531, awslabs/mcp#4532).

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [x] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
